### PR TITLE
split deterministic and non-deterministic annotations

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SelectableSecretColumn.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SelectableSecretColumn.kt
@@ -1,0 +1,34 @@
+package misk.hibernate
+
+/**
+ * This annotation is used to get Hibernate ti encrypt a field before being persisted to the database.
+ *
+ * The [keyName] string is used to specify the name of the key used to encrypt and decrypt the value.
+ *
+ * *This annotation uses deterministic encryption*: encrypting the same plaintext will produce the same ciphertext.
+ * This is weaker than non-deterministic encryption, but makes searching for encrypted values possible.
+ * If searching for ciphertexts is not something your use case requires, use [SecretColumn] instead.
+ *
+ * INstall [misk.crypto.CryptoModule] to configure the key to use here.
+ * Example:
+ * ```
+ * crypto:
+ *   keys:
+ *     - key_name: "secretKey"
+ *     - key_type: DAEAD
+ * ```
+ * Then, in an entity class:
+ * ```
+ * @SelectableSecretColumn(keyName = "secretKey")
+ * @Column(name = "my_secret_column")
+ * var mySecretColumn: ByteArray
+ * ```
+ * Add a migration file to create the corresponding table:
+ * ```
+ * CREATE TABLE my_table(
+ *   id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+ *   my_secret_column VARBINARY(250)
+ * ```
+ */
+@Target(AnnotationTarget.FIELD)
+annotation class SelectableSecretColumn(val keyName: String)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SelectableSecretColumnType.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SelectableSecretColumnType.kt
@@ -1,0 +1,90 @@
+package misk.hibernate
+
+import com.google.crypto.tink.DeterministicAead
+import misk.crypto.DeterministicAeadKeyManager
+import org.hibernate.HibernateException
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.type.spi.TypeConfiguration
+import org.hibernate.type.spi.TypeConfigurationAware
+import org.hibernate.usertype.ParameterizedType
+import org.hibernate.usertype.UserType
+import java.io.Serializable
+import java.security.GeneralSecurityException
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Types
+import java.util.Objects
+import java.util.Properties
+
+class SelectableSecretColumnType : UserType, ParameterizedType, TypeConfigurationAware {
+  companion object {
+    const val FIELD_ENCRYPTION_KEY_NAME: String = "key_name"
+  }
+  private lateinit var keyName: String
+  private lateinit var daead: DeterministicAead
+  private lateinit var typeConfig: TypeConfiguration
+
+  override fun hashCode(x: Any?) = (x as ByteArray).hashCode()
+
+  override fun deepCopy(value: Any?) = (value as ByteArray?)?.copyOf()
+
+  override fun replace(original: Any?, target: Any?, owner: Any?) = (original as ByteArray).copyOf()
+
+  override fun equals(x: Any?, y: Any?) = Objects.equals(x, y)
+
+  override fun returnedClass() = ByteArray::class.java
+
+  override fun assemble(cached: Serializable?, owner: Any?) =
+      daead.decryptDeterministically(cached as ByteArray, byteArrayOf())
+
+  override fun disassemble(value: Any?) =
+      daead.encryptDeterministically(value as ByteArray, byteArrayOf())
+
+  override fun nullSafeSet(
+    st: PreparedStatement?,
+    value: Any?,
+    index: Int,
+    session: SharedSessionContractImplementor?
+  ) {
+    if (value == null) {
+      st?.setNull(index, Types.VARBINARY)
+    } else {
+      value as ByteArray
+      val encrypted = daead.encryptDeterministically(value, byteArrayOf())
+      st?.setBytes(index, encrypted)
+    }
+  }
+
+  override fun nullSafeGet(
+    rs: ResultSet?,
+    names: Array<out String>,
+    session: SharedSessionContractImplementor?,
+    owner: Any?
+  ): Any? {
+    val result = rs?.getBytes(names[0])
+    return result?.let {
+      try {
+        daead.decryptDeterministically(result, byteArrayOf())
+      } catch (e: GeneralSecurityException) {
+        throw HibernateException(e)
+      }
+    }
+  }
+
+  override fun isMutable() = false
+
+  override fun sqlTypes() = intArrayOf(Types.VARBINARY)
+
+  override fun setParameterValues(parameters: Properties) {
+    keyName = parameters.getProperty(FIELD_ENCRYPTION_KEY_NAME)
+    val keyManager = typeConfig.metadataBuildingContext.bootstrapContext
+        .serviceRegistry.injector.getInstance(DeterministicAeadKeyManager::class.java)
+    daead = keyManager[keyName]
+  }
+
+  override fun setTypeConfiguration(typeConfiguration: TypeConfiguration) {
+    typeConfig = typeConfiguration
+  }
+
+  override fun getTypeConfiguration() = typeConfig
+}

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -170,8 +170,14 @@ internal class SessionFactoryService(
       }
       value.typeParameters.setProperty(SecretColumnType.FIELD_ENCRYPTION_KEY_NAME,
           field.getAnnotation(SecretColumn::class.java).keyName)
-      value.typeParameters.setProperty(SecretColumnType.FIELD_ENCRYPTION_INDEXABLE,
-          field.getAnnotation(SecretColumn::class.java).indexable.toString())
+    } else if (field.isAnnotationPresent(SelectableSecretColumn::class.java)) {
+      value.typeName = SelectableSecretColumnType::class.java.name
+
+      if (value.typeParameters == null) {
+        value.typeParameters = Properties()
+      }
+      value.typeParameters.setProperty(SelectableSecretColumnType.FIELD_ENCRYPTION_KEY_NAME,
+          field.getAnnotation(SelectableSecretColumn::class.java).keyName)
     }
   }
 

--- a/misk-hibernate/src/test/resources/misk/hibernate/encryptedcolumn-migrations/v1__create_table.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/encryptedcolumn-migrations/v1__create_table.sql
@@ -3,5 +3,8 @@ CREATE TABLE jerry_garcia_songs(
   title VARCHAR(64) NOT NULL,
   length INT NOT NULL,
   album VARBINARY(250),
-  reviewer VARBINARY(250)
+  album_aad VARBINARY(36),
+  reviewer VARBINARY(250),
+
+  CONSTRAINT UNIQUE (album_aad)
 )


### PR DESCRIPTION
When using deterministic encryption in hibernate, we cannot provide authentication data because it changes the resulting ciphertext which makes the data unsearchable.

Therefore, I decided to split this functionality to a separate annotation that also doesn't require an additional column for authentication.

I think this provides a more explicit setup process and makes it easier to reason when looking at the code that uses these features.

Also in this PR - updated the documentation a little.