### PR TITLE
Ensure that SQS job handlers do not run until healthy

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -2,6 +2,7 @@ package misk.jobqueue.sqs
 
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.ServiceManager
 import io.opentracing.Tracer
 import io.opentracing.tag.StringTag
 import io.opentracing.tag.Tags
@@ -15,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.concurrent.thread
 
@@ -24,7 +26,13 @@ internal class SqsJobConsumer @Inject internal constructor(
   private val queues: QueueResolver,
   @ForSqsConsumer private val dispatchThreadPool: ExecutorService,
   private val tracer: Tracer,
-  private val metrics: SqsMetrics
+  private val metrics: SqsMetrics,
+  /**
+   * [SqsJobConsumer] is itself a [Service], but it needs the [ServiceManager] in order to check
+   * that all services are running and the system is in a healthy state before it starts handling
+   * jobs. We use a provider here to avoid a dependency cycle.
+   */
+  private val serviceManagerProvider: Provider<ServiceManager>
 ) : AbstractIdleService(), JobConsumer {
   private val subscriptions = ConcurrentHashMap<QueueName, JobConsumer.Subscription>()
 
@@ -62,6 +70,10 @@ internal class SqsJobConsumer @Inject internal constructor(
     private val running = AtomicBoolean(true)
 
     override fun run() {
+      // Don't call handlers until all services are ready, otherwise handlers will crash because the
+      // services they might need (databases, etc.) won't be ready.
+      serviceManagerProvider.get().awaitHealthy()
+
       while (running.get()) {
         val messages = queue.call { client ->
           client.receiveMessage(ReceiveMessageRequest()

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueServiceTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueServiceTest.kt
@@ -1,0 +1,92 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.google.common.util.concurrent.AbstractService
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.util.Modules
+import misk.ServiceModule
+import misk.jobqueue.JobConsumer
+import misk.jobqueue.JobQueue
+import misk.jobqueue.QueueName
+import misk.jobqueue.subscribe
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.lang.Thread.sleep
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** This is separate from [SqsJobQueueTest] because we don't want the services started automatically. */
+@MiskTest
+internal class SqsJobQueueServiceTest {
+  @MiskExternalDependency private val dockerSqs = DockerSqs
+  @MiskTestModule private val module =
+      Modules.combine(SqsJobQueueTestModule(dockerSqs.credentials, dockerSqs.client), ServiceModule<ManualStartService>())
+  @Inject private lateinit var sqs: AmazonSQS
+  @Inject private lateinit var queue: JobQueue
+  @Inject private lateinit var consumer: JobConsumer
+  @Inject private lateinit var serviceManager: ServiceManager
+  @Inject private lateinit var manualStartService: ManualStartService
+
+  private val queueName = QueueName("sqs_job_queue_service_test")
+
+  @BeforeEach fun createQueues() {
+    sqs.createQueue(queueName.value)
+  }
+
+  @AfterEach
+  internal fun tearDown() {
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped(20, TimeUnit.SECONDS)
+  }
+
+  @Test fun jobsNotHandledUntilAllServicesAreRunning() {
+    val log = LinkedBlockingDeque<String>()
+
+    sleep(100)
+    log.put("about to subscribe")
+    consumer.subscribe(queueName) { job ->
+      log.put("handling job")
+      job.acknowledge()
+    }
+
+    sleep(100)
+    log.put("about to enqueue")
+    queue.enqueue(queueName, "this is a job")
+
+    sleep(100)
+    log.put("about to start the service manager")
+    serviceManager.startAsync()
+
+    sleep(100)
+    log.put("about to start the manual start service")
+    manualStartService.manualStart()
+
+    assertThat(log.poll()).isEqualTo("about to subscribe")
+    assertThat(log.poll()).isEqualTo("about to enqueue")
+    assertThat(log.poll()).isEqualTo("about to start the service manager")
+    assertThat(log.poll()).isEqualTo("about to start the manual start service")
+    assertThat(log.poll()).isEqualTo("handling job") // Called by the handler thread.
+  }
+
+  @Singleton
+  class ManualStartService @Inject constructor() : AbstractService() {
+    override fun doStart() {
+      // Note this doesn't call NotifyStarted.
+    }
+
+    fun manualStart() {
+      notifyStarted()
+    }
+
+    override fun doStop() {
+      notifyStopped()
+    }
+  }
+}

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
@@ -1,0 +1,37 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.sqs.AmazonSQS
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.cloud.aws.AwsEnvironmentModule
+import misk.cloud.aws.FakeAwsEnvironmentModule
+import misk.inject.KAbstractModule
+import misk.testing.MockTracingBackendModule
+
+class SqsJobQueueTestModule(
+  private val credentials: AWSCredentialsProvider,
+  private val client: AmazonSQS
+) : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(MockTracingBackendModule())
+    install(AwsEnvironmentModule())
+    install(FakeAwsEnvironmentModule())
+    install(
+        Modules.override(
+            AwsSqsJobQueueModule(AwsSqsJobQueueConfig()))
+            .with(SqsTestModule(credentials, client))
+    )
+  }
+}
+
+class SqsTestModule(
+  private val credentials: AWSCredentialsProvider,
+  private val client: AmazonSQS
+) : KAbstractModule() {
+  override fun configure() {
+    bind<AWSCredentialsProvider>().toInstance(credentials)
+    bind<AmazonSQS>().toInstance(client)
+  }
+}


### PR DESCRIPTION
`JobHandlers` can be totally arbitrary and might depend on services in a misk application (e.g. database, etc.). This patch ensures `SqsJobConsumer` doesn't start consuming jobs until all services are up and running in a healthy state.