### PR TITLE
Fix ReadinessCheckAction

### DIFF
--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -1,7 +1,7 @@
 package misk.web.actions
 
-import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.Service.State
+import com.google.common.util.concurrent.ServiceManager
 import misk.logging.getLogger
 import misk.security.authz.Unauthenticated
 import misk.web.Get
@@ -9,23 +9,23 @@ import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 private val logger = getLogger<LivenessCheckAction>()
-private val failedServiceStates = listOf(State.FAILED, State.TERMINATED)
 
 @Singleton
 class LivenessCheckAction @Inject internal constructor(
-  private val services: List<Service>
+  private val serviceManagerProvider: Provider<ServiceManager>
 ) : WebAction {
 
   @Get("/_liveness")
   @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
   @Unauthenticated
   fun livenessCheck(): Response<String> {
-    val failedServices = services.filter {
-      failedServiceStates.contains(it.state())
-    }
+    val serviceManager = serviceManagerProvider.get()
+    val failedServices = serviceManager.servicesByState().get(State.FAILED) +
+        serviceManager.servicesByState().get(State.TERMINATED)
 
     if (failedServices.isEmpty()) {
       return Response("", statusCode = 200)

--- a/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
+++ b/misk/src/test/kotlin/misk/services/FakeServiceModule.kt
@@ -1,10 +1,10 @@
 package misk.services
 
-import com.google.common.util.concurrent.Service
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 
 class FakeServiceModule : KAbstractModule() {
   override fun configure() {
-    multibind<Service>().to<FakeService>()
+    install(ServiceModule<FakeService>())
   }
 }

--- a/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ReadinessCheckActionTest.kt
@@ -27,8 +27,7 @@ class ReadinessCheckActionTest {
   @Inject lateinit var serviceManager: ServiceManager
   @Inject lateinit var healthCheck: FakeHealthCheck
 
-  @Test
-  fun readinessDependsOnServiceStateAndHealthChecksPassing() {
+  @Test fun readinessDependsOnServiceStateAndHealthChecksPassing() {
     serviceManager.startAsync()
     serviceManager.awaitHealthy()
     assertThat(readinessCheckAction.readinessCheck().statusCode).isEqualTo(200)


### PR DESCRIPTION
`ReadinessCheckAction` was incorrectly looking for a list of `Service`
provided by multibindings. It now looks for a service manager and gets
the services from there.

Also fixes `LivenessCheckAction` and `StatusAction`.

---

Closes #1056 