### PR TITLE
Query zk connection directly for ZkLeaseManager connection state

### DIFF
--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTest.kt
@@ -144,8 +144,7 @@ internal class ZkLeaseTest {
     val lease = leaseManager.requestLease(LEASE_NAME)
     assertThat(lease.checkHeld()).isTrue()
 
-    // Fake a disconnect from zk
-    leaseManager.handleConnectionStateChanged(false)
+    curator.close()
 
     // Should no longer hold the lease
     assertThat(lease.checkHeld()).isFalse()
@@ -157,14 +156,12 @@ internal class ZkLeaseTest {
     val lease = leaseManager.requestLease(LEASE_NAME)
     assertThat(lease.checkHeld()).isTrue()
 
-    // Fake a disconnect from zk
-    leaseManager.handleConnectionStateChanged(false)
+    curator.zookeeperClient.reset()
 
     // Should no longer hold the lease
     assertThat(lease.checkHeld()).isFalse()
 
-    // Reconnect to zk
-    leaseManager.handleConnectionStateChanged(true)
+    curator.zookeeperClient.blockUntilConnectedOrTimedOut()
 
     // Should reacquire the lease
     assertThat(lease.checkHeld()).isTrue()


### PR DESCRIPTION
There is no need to track the state locally in the manager, since the
curator client is already tracking it locally. In addition, there is a
chance for them to be out of sync, resulting in nasty race conditions.
If the manager does not think the connection is established, no leases
are acquired!

Previously this was relying on the connection listener to update the
local manager state. However, there was a race between the manager
starting and the connection being established. If the connection was
established before the manager started, the listener to update the local
state was never dispatched.