### PR TITLE
Use ServiceModule throughout Misk

### DIFF
--- a/misk-eventrouter/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
+++ b/misk-eventrouter/src/main/kotlin/misk/eventrouter/EventRouterTestingModule.kt
@@ -1,9 +1,9 @@
 package misk.eventrouter
 
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.squareup.moshi.Moshi
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import misk.moshi.MoshiAdapterModule
@@ -44,7 +44,7 @@ class EventRouterTestingModule internal constructor(val distributed: Boolean) : 
     } else {
       bind<EventRouter>().to<RealEventRouter>().asSingleton()
       bind<RealEventRouter>().asSingleton()
-      multibind<Service>().to<TestingService>()
+      install(ServiceModule<TestingService>())
     }
 
     bind<ClusterConnector>().to<FakeClusterConnector>()

--- a/misk-eventrouter/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
+++ b/misk-eventrouter/src/main/kotlin/misk/eventrouter/RealEventRouterModule.kt
@@ -1,8 +1,8 @@
 package misk.eventrouter
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.squareup.moshi.Moshi
+import misk.ServiceModule
 import misk.environment.Environment
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
@@ -21,7 +21,7 @@ class RealEventRouterModule(val environment: Environment) : KAbstractModule() {
   override fun configure() {
     bind<EventRouter>().to<RealEventRouter>().asSingleton()
     bind<RealEventRouter>().asSingleton()
-    multibind<Service>().to<EventRouterService>()
+    install(ServiceModule<EventRouterService>())
     if (environment == Environment.DEVELOPMENT) {
       bind<ClusterConnector>().to<LocalClusterConnector>()
     } else {

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/datastore/FakeDatastoreModule.kt
@@ -3,16 +3,16 @@ package misk.cloud.gcp.datastore
 import com.google.cloud.datastore.Datastore
 import com.google.cloud.datastore.testing.LocalDatastoreHelper
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import javax.inject.Inject
 
 /** Installs a version of the [Datastore] that works off an in-memory local store */
 class FakeDatastoreModule : KAbstractModule() {
   override fun configure() {
-    multibind<Service>().to<FakeDatastoreService>()
+    install(ServiceModule<FakeDatastoreService>())
   }
 
   @Provides
@@ -28,7 +28,6 @@ class FakeDatastoreModule : KAbstractModule() {
   class FakeDatastoreService @Inject constructor(
     private val datastoreHelper: LocalDatastoreHelper
   ) : AbstractIdleService() {
-
     override fun startUp() {
       // Reset on every restart / test run
       datastoreHelper.reset()

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -9,9 +9,9 @@ import com.google.cloud.http.HttpTransportOptions
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
 import com.google.common.util.concurrent.AbstractIdleService
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ServiceModule
 import misk.cloud.gcp.datastore.DatastoreConfig
 import misk.cloud.gcp.storage.LocalStorageRpc
 import misk.cloud.gcp.storage.StorageConfig
@@ -29,7 +29,7 @@ class GoogleCloudModule(
   override fun configure() {
     bind<DatastoreConfig>().toInstance(datastoreConfig)
     bind<StorageConfig>().toInstance(storageConfig)
-    multibind<Service>().to<GoogleCloud>()
+    install(ServiceModule<GoogleCloud>())
   }
 
   @Provides

--- a/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
+++ b/misk-jaeger/src/main/kotlin/misk/tracing/backends/jaeger/JaegerBackendModule.kt
@@ -1,16 +1,16 @@
 package misk.tracing.backends.jaeger
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import com.uber.jaeger.Configuration
 import io.opentracing.Tracer
+import misk.ServiceModule
 import misk.config.AppName
 import misk.inject.KAbstractModule
 
 class JaegerBackendModule(val config: JaegerBackendConfig?) : KAbstractModule() {
   override fun configure() {
-    multibind<Service>().to<JaegerTracingService>()
+    install(ServiceModule<JaegerTracingService>())
   }
 
   @Provides

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsModule.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsModule.kt
@@ -1,6 +1,6 @@
 package misk.metrics.backends.prometheus
 
-import com.google.common.util.concurrent.Service
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 
 /**
@@ -13,6 +13,6 @@ import misk.inject.KAbstractModule
 class PrometheusMetricsModule(private val config: PrometheusConfig) : KAbstractModule() {
   override fun configure() {
     bind<PrometheusConfig>().toInstance(config)
-    multibind<Service>().to<PrometheusHttpService>()
+    install(ServiceModule<PrometheusHttpService>())
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -1,8 +1,8 @@
 package misk.redis
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
@@ -18,7 +18,7 @@ class RedisModule(
 ) : KAbstractModule() {
   override fun configure() {
     bind<RedisConfig>().toInstance(redisConfig)
-    multibind<Service>().to<RedisService>()
+    install(ServiceModule<RedisService>())
   }
 
   @Provides @Singleton

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollector.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollector.kt
@@ -2,6 +2,7 @@ package misk.logging
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
+import com.google.common.util.concurrent.Service
 import kotlin.reflect.KClass
 
 /**
@@ -75,3 +76,6 @@ interface LogCollector {
     pattern: Regex? = null
   ): ILoggingEvent
 }
+
+/** Marker interface for the service that produces a [LogCollector]. */
+interface LogCollectorService : Service

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -1,11 +1,12 @@
 package misk.logging
 
-import com.google.common.util.concurrent.Service
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 
 class LogCollectorModule : KAbstractModule() {
   override fun configure() {
     bind<LogCollector>().to<RealLogCollector>()
-    multibind<Service>().to<RealLogCollector>()
+    bind<LogCollectorService>().to<RealLogCollector>()
+    install(ServiceModule<LogCollectorService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
@@ -14,7 +14,10 @@ import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 @Singleton
-internal class RealLogCollector @Inject constructor() : AbstractIdleService(), LogCollector {
+internal class RealLogCollector @Inject constructor() :
+    AbstractIdleService(),
+    LogCollector,
+    LogCollectorService {
   private val queue = LinkedBlockingDeque<ILoggingEvent>()
 
   private val appender = object : UnsynchronizedAppenderBase<ILoggingEvent>() {

--- a/misk-zipkin/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinTracingModule.kt
+++ b/misk-zipkin/src/main/kotlin/misk/tracing/backends/zipkin/ZipkinTracingModule.kt
@@ -2,9 +2,9 @@ package misk.tracing.backends.zipkin
 
 import brave.Tracing
 import brave.opentracing.BraveTracer
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import io.opentracing.Tracer
+import misk.ServiceModule
 import misk.config.AppName
 import misk.inject.KAbstractModule
 import zipkin2.reporter.AsyncReporter
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 class ZipkinTracingModule(val config: ZipkinBackendConfig) : KAbstractModule() {
   override fun configure() {
-    multibind<Service>().to<ZipkinTracingService>()
+    install(ServiceModule<ZipkinTracingService>())
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/time/ClockModule.kt
+++ b/misk/src/main/kotlin/misk/time/ClockModule.kt
@@ -1,13 +1,12 @@
 package misk.time
 
-import com.google.common.util.concurrent.Service
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import java.time.Clock
 
 internal class ClockModule : KAbstractModule() {
   override fun configure() {
-    multibind<Service>().to<ForceUtcTimeZoneService>()
-
+    install(ServiceModule<ForceUtcTimeZoneService>())
     bind<Clock>().toInstance(Clock.systemUTC())
   }
 }

--- a/misk/src/test/kotlin/misk/client/HttpClientEnvoyTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientEnvoyTest.kt
@@ -1,11 +1,11 @@
 package misk.client
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.name.Named
 import com.google.inject.name.Names
 import helpers.protos.Dinosaur
 import misk.MiskTestingServiceModule
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -76,7 +76,7 @@ internal class HttpClientEnvoyTest {
       install(MiskTestingServiceModule())
 
       bind<MockWebServerService>().toInstance(MockWebServerService("@socket"))
-      multibind<Service>().to<MockWebServerService>()
+      install(ServiceModule<MockWebServerService>())
 
       bind<EnvoyClientEndpointProvider>().to<TestEnvoyClientEndpointProvider>()
 

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -1,9 +1,9 @@
 package misk.tasks
 
-import com.google.common.util.concurrent.Service
 import com.google.inject.Provides
 import com.google.inject.util.Modules
 import misk.MiskTestingServiceModule
+import misk.ServiceModule
 import misk.backoff.ExponentialBackoff
 import misk.backoff.FlatBackoff
 import misk.backoff.retry
@@ -485,7 +485,7 @@ internal class RepeatedTaskQueueTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(Modules.override(MiskTestingServiceModule()).with(FakeClockModule()))
-      multibind<Service>().to<RepeatedTaskQueue>()
+      install(ServiceModule<RepeatedTaskQueue>())
     }
 
     @Provides @Singleton


### PR DESCRIPTION
Should be a non-functional change. Just upgrading from the explicit service multibindings to the now-recommended `ServiceModule`.