### PR TITLE
Use a RepeatedTaskQueue in SqsJobConsumer

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -18,8 +18,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 ) : KAbstractModule() {
   override fun configure() {
     newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
-    install(ServiceModule<AwsSqsJobHandlerSubscriptionService>()
-        .dependsOn<SqsJobConsumer>())
+    install(ServiceModule<AwsSqsJobHandlerSubscriptionService>())
   }
 
   companion object {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -1,6 +1,7 @@
 package misk.jobqueue.sqs
 
 import misk.config.Config
+import misk.tasks.RepeatedTaskQueueConfig
 
 /**
  * [AwsSqsJobQueueConfig] is the configuration for job queueing backed by Amazon's
@@ -22,6 +23,8 @@ class AwsSqsJobQueueConfig(
   /**
    * Number of jobs that can be processed concurrently.
    */
-  val consumer_thread_pool_size: Int = 4
+  val consumer_thread_pool_size: Int = 4,
+
+  val task_queue: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig()
 ) : Config
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsConsumer.kt
@@ -3,4 +3,5 @@ package misk.jobqueue.sqs
 import javax.inject.Qualifier
 
 @Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
 internal annotation class ForSqsConsumer

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -15,8 +15,8 @@ import misk.time.timed
 import misk.tracing.traceWithSpan
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -50,22 +50,25 @@ internal class SqsJobConsumer @Inject internal constructor(
 
     for (i in (0 until config.concurrent_receivers_per_queue)) {
       taskQueue.scheduleWithBackoff(Duration.ZERO) {
+        // Don't call handlers until all services are ready, otherwise handlers will crash because the
+        // services they might need (databases, etc.) won't be ready.
+        serviceManagerProvider.get().awaitHealthy()
         receiver.runOnce()
       }
     }
   }
 
-  private inner class QueueReceiver(
+  internal fun getReceiver(queueName: QueueName): QueueReceiver {
+    return subscriptions[queueName]!!
+  }
+
+  internal inner class QueueReceiver(
     private val queueName: QueueName,
     private val handler: JobHandler
   ) {
     private val queue = queues[queueName]
 
     fun runOnce(): Status {
-      // Don't call handlers until all services are ready, otherwise handlers will crash because the
-      // services they might need (databases, etc.) won't be ready.
-      serviceManagerProvider.get().awaitHealthy()
-
       val messages = queue.call { client ->
         client.receiveMessage(ReceiveMessageRequest()
             .withAttributeNames("All")
@@ -75,8 +78,11 @@ internal class SqsJobConsumer @Inject internal constructor(
             .messages
       }
 
-      val failure = AtomicBoolean(false)
-      messages.map { SqsJob(queueName, queues, metrics, it) }.forEach { message ->
+      if (messages.size == 0) {
+        return Status.NO_WORK
+      }
+
+      val futures = messages.map { SqsJob(queueName, queues, metrics, it) }.map { message ->
         dispatchThreadPool.submit {
           metrics.jobsReceived.labels(queueName.value).inc()
 
@@ -94,20 +100,25 @@ internal class SqsJobConsumer @Inject internal constructor(
               val (duration, _) = timed { handler.handleJob(message) }
               metrics.handlerDispatchTime.record(duration.toMillis().toDouble(), queueName.value)
             } catch (th: Throwable) {
-              failure.set(true)
               log.error(th) { "error handling job from ${queueName.value}" }
               metrics.handlerFailures.labels(queueName.value).inc()
               Tags.ERROR.set(span, true)
+              throw th
             }
           }
         }
       }
 
-      return when {
-        failure.get() -> Status.FAILED
-        messages.size == 0 -> Status.NO_WORK
-        else -> Status.OK
+      for (future in futures) {
+        try {
+          future.get()
+        } catch (e: ExecutionException) {
+          // the exception was already logged when the dispatched task failed above
+          return Status.FAILED
+        }
       }
+
+      return Status.OK
     }
   }
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -1,7 +1,6 @@
 package misk.jobqueue.sqs
 
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
-import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.ServiceManager
 import io.opentracing.Tracer
 import io.opentracing.tag.StringTag
@@ -10,21 +9,24 @@ import misk.jobqueue.JobConsumer
 import misk.jobqueue.JobHandler
 import misk.jobqueue.QueueName
 import misk.logging.getLogger
+import misk.tasks.RepeatedTaskQueue
+import misk.tasks.Status
 import misk.time.timed
 import misk.tracing.traceWithSpan
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
-import kotlin.concurrent.thread
 
 @Singleton
 internal class SqsJobConsumer @Inject internal constructor(
   private val config: AwsSqsJobQueueConfig,
   private val queues: QueueResolver,
   @ForSqsConsumer private val dispatchThreadPool: ExecutorService,
+  @ForSqsConsumer private val taskQueue: RepeatedTaskQueue,
   private val tracer: Tracer,
   private val metrics: SqsMetrics,
   /**
@@ -33,16 +35,10 @@ internal class SqsJobConsumer @Inject internal constructor(
    * jobs. We use a provider here to avoid a dependency cycle.
    */
   private val serviceManagerProvider: Provider<ServiceManager>
-) : AbstractIdleService(), JobConsumer {
-  private val subscriptions = ConcurrentHashMap<QueueName, JobConsumer.Subscription>()
+) : JobConsumer {
+  private val subscriptions = ConcurrentHashMap<QueueName, QueueReceiver>()
 
-  override fun startUp() {}
-
-  override fun shutDown() {
-    subscriptions.values.forEach { it.close() }
-  }
-
-  override fun subscribe(queueName: QueueName, handler: JobHandler): JobConsumer.Subscription {
+  override fun subscribe(queueName: QueueName, handler: JobHandler) {
     val receiver = QueueReceiver(queueName, handler)
     if (subscriptions.putIfAbsent(queueName, receiver) != null) {
       throw IllegalStateException("already subscribed to queue ${queueName.value}")
@@ -53,70 +49,65 @@ internal class SqsJobConsumer @Inject internal constructor(
     }
 
     for (i in (0 until config.concurrent_receivers_per_queue)) {
-      thread(name = "sqs-receiver-${queueName.value}-$i", start = true) {
-        log.info { "launching receiver $i for ${queueName.value}" }
-        receiver.run()
+      taskQueue.scheduleWithBackoff(Duration.ZERO) {
+        receiver.runOnce()
       }
     }
-
-    return receiver
   }
 
   private inner class QueueReceiver(
     private val queueName: QueueName,
     private val handler: JobHandler
-  ) : Runnable, JobConsumer.Subscription {
+  ) {
     private val queue = queues[queueName]
-    private val running = AtomicBoolean(true)
 
-    override fun run() {
+    fun runOnce(): Status {
       // Don't call handlers until all services are ready, otherwise handlers will crash because the
       // services they might need (databases, etc.) won't be ready.
       serviceManagerProvider.get().awaitHealthy()
 
-      while (running.get()) {
-        val messages = queue.call { client ->
-          client.receiveMessage(ReceiveMessageRequest()
-              .withAttributeNames("All")
-              .withMessageAttributeNames("All")
-              .withQueueUrl(queue.url)
-              .withMaxNumberOfMessages(10))
-              .messages
-        }
+      val messages = queue.call { client ->
+        client.receiveMessage(ReceiveMessageRequest()
+            .withAttributeNames("All")
+            .withMessageAttributeNames("All")
+            .withQueueUrl(queue.url)
+            .withMaxNumberOfMessages(10))
+            .messages
+      }
 
-        messages.map { SqsJob(queueName, queues, metrics, it) }.forEach { message ->
-          dispatchThreadPool.submit {
-            metrics.jobsReceived.labels(queueName.value).inc()
+      val failure = AtomicBoolean(false)
+      messages.map { SqsJob(queueName, queues, metrics, it) }.forEach { message ->
+        dispatchThreadPool.submit {
+          metrics.jobsReceived.labels(queueName.value).inc()
 
-            tracer.traceWithSpan("handle-job-${queueName.value}") { span ->
-              // If the incoming job has an original trace id, set that as a tag on the new span.
-              // We don't turn that into the parent of the current span because that would
-              // incorrectly include the execution time of the job in the execution time of the
-              // action that triggered the job
-              message.attributes[SqsJob.ORIGINAL_TRACE_ID_ATTR]?.let {
-                ORIGINAL_TRACE_ID_TAG.set(span, it)
-              }
+          tracer.traceWithSpan("handle-job-${queueName.value}") { span ->
+            // If the incoming job has an original trace id, set that as a tag on the new span.
+            // We don't turn that into the parent of the current span because that would
+            // incorrectly include the execution time of the job in the execution time of the
+            // action that triggered the job        q
+            message.attributes[SqsJob.ORIGINAL_TRACE_ID_ATTR]?.let {
+              ORIGINAL_TRACE_ID_TAG.set(span, it)
+            }
 
-              // Run the handler and record timing
-              try {
-                val (duration, _) = timed { handler.handleJob(message) }
-                metrics.handlerDispatchTime.record(duration.toMillis().toDouble(), queueName.value)
-              } catch (th: Throwable) {
-                log.error(th) { "error handling job from ${queueName.value}" }
-                metrics.handlerFailures.labels(queueName.value).inc()
-                Tags.ERROR.set(span, true)
-              }
+            // Run the handler and record timing
+            try {
+              val (duration, _) = timed { handler.handleJob(message) }
+              metrics.handlerDispatchTime.record(duration.toMillis().toDouble(), queueName.value)
+            } catch (th: Throwable) {
+              failure.set(true)
+              log.error(th) { "error handling job from ${queueName.value}" }
+              metrics.handlerFailures.labels(queueName.value).inc()
+              Tags.ERROR.set(span, true)
             }
           }
         }
       }
-    }
 
-    override fun close() {
-      if (!subscriptions.remove(queueName, this)) return
-
-      log.info { "closing subscription to queue ${queueName.value}" }
-      running.set(false)
+      return when {
+        failure.get() -> Status.FAILED
+        messages.size == 0 -> Status.NO_WORK
+        else -> Status.OK
+      }
     }
   }
 

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -8,6 +8,7 @@ import misk.jobqueue.JobQueue
 import misk.jobqueue.QueueName
 import misk.jobqueue.subscribe
 import misk.tasks.RepeatedTaskQueue
+import misk.tasks.Status
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -181,8 +182,7 @@ internal class SqsJobQueueTest {
     }
 
     // Close the subscription and wait for any currently outstanding long-polls to complete
-    taskQueue.stopAsync()
-    taskQueue.awaitTerminated()
+    turnOffTaskQueue()
     Thread.sleep(1001)
 
     // Send 10 jobs, then wait again for the long-poll to complete make sure none of them are delivered
@@ -221,5 +221,29 @@ internal class SqsJobQueueTest {
     assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(3.0)
     assertThat(sqsMetrics.jobsDeadLettered.labels(queueName.value).get()).isEqualTo(0.0)
     assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(2.0)
+  }
+
+  @Test fun waitsForDispatchedTasksToFail() {
+    turnOffTaskQueue()
+    consumer.subscribe(queueName) {
+      throw IllegalStateException("boom!")
+    }
+    queue.enqueue(queueName, "fail away")
+    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    assertThat(receiver.runOnce()).isEqualTo(Status.FAILED)
+  }
+
+  @Test fun noWork() {
+    turnOffTaskQueue()
+    consumer.subscribe(queueName) {
+      throw IllegalStateException("boom!")
+    }
+    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    assertThat(receiver.runOnce()).isEqualTo(Status.NO_WORK)
+  }
+
+  private fun turnOffTaskQueue() {
+    taskQueue.stopAsync()
+    taskQueue.awaitTerminated()
   }
 }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
@@ -7,9 +7,10 @@ import misk.MiskTestingServiceModule
 import misk.cloud.aws.AwsEnvironmentModule
 import misk.cloud.aws.FakeAwsEnvironmentModule
 import misk.inject.KAbstractModule
+import misk.tasks.RepeatedTaskQueueConfig
 import misk.testing.MockTracingBackendModule
 
-class SqsJobQueueTestModule(
+class SqsJobQueueTestModule (
   private val credentials: AWSCredentialsProvider,
   private val client: AmazonSQS
 ) : KAbstractModule() {
@@ -20,7 +21,8 @@ class SqsJobQueueTestModule(
     install(FakeAwsEnvironmentModule())
     install(
         Modules.override(
-            AwsSqsJobQueueModule(AwsSqsJobQueueConfig()))
+            AwsSqsJobQueueModule(
+                AwsSqsJobQueueConfig(task_queue = RepeatedTaskQueueConfig(default_jitter_ms = 0))))
             .with(SqsTestModule(credentials, client))
     )
   }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobConsumer.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobConsumer.kt
@@ -4,21 +4,10 @@ package misk.jobqueue
 interface JobConsumer {
   /**
    * Registers a handler to receive messages. Once registered, the consumer will immediately
-   * begin receiving messages from the underyling job queue and dispatch them to the provided
+   * begin receiving messages from the underlying job queue and dispatch them to the provided
    * handler. A service may only have one subscription outstanding per queue
-   *
-   * @return a [Subscription] that can be closed to stop receiving jobs
    */
-  fun subscribe(queueName: QueueName, handler: JobHandler): Subscription
-
-  interface Subscription {
-    /**
-     * Closes the  subscription and stops receiving jobs from the underlying queue. Jobs
-     * that are already in flight will continue to be dispatched to the handler, but
-     * no new messages will be retrieved
-     */
-    fun close()
-  }
+  fun subscribe(queueName: QueueName, handler: JobHandler)
 }
 
 inline fun JobConsumer.subscribe(queueName: QueueName, crossinline handler: (Job) -> Unit) =

--- a/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueueConfig.kt
+++ b/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueueConfig.kt
@@ -1,0 +1,33 @@
+package misk.tasks
+
+import misk.backoff.Backoff
+import misk.backoff.ExponentialBackoff
+import java.time.Duration
+
+data class RepeatedTaskQueueConfig(
+  /**
+   * The default amount of jitter to use when scheduling backoffs.
+   *
+   * Can be overridden when scheduling a tasks.
+   */
+  val default_jitter_ms: Long = 50,
+
+  /**
+   * The default maximum backoff time.
+   *
+   * Can be overridden when scheduling a task.
+   */
+  val default_max_delay_sec: Long = 60
+
+) {
+
+  /**
+   * Construct an [ExponentialBackoff] from the initial delay using the default configs.
+   */
+  fun defaultBackoff(initialDelay: Duration): Backoff {
+    return ExponentialBackoff(
+        initialDelay,
+        Duration.ofSeconds(default_max_delay_sec),
+        Duration.ofMillis(default_jitter_ms))
+  }
+}


### PR DESCRIPTION
This fixes #1069, which was originally a bug in RepeatedTaskQueue back
in the day. We should prefer using RepeatedTaskQueue instead of hand
rolling threads to prevent repeating the same mistakes. In addition, job
consumers will backoff if there is no work or run into errors.

Now every parallel job consumer runs as a RepeatedTask and each Task
consumes N messages and dispatches them to separate executor service for
running.