### PR TITLE
Increase the maxRetryDelayMillis in RealTransacter

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -209,7 +209,7 @@ internal class RealTransacter private constructor(
     val maxAttempts: Int = 2,
     val disabledChecks: EnumSet<Check> = EnumSet.noneOf(Check::class.java),
     val minRetryDelayMillis: Long = 100,
-    val maxRetryDelayMillis: Long = 100,
+    val maxRetryDelayMillis: Long = 200,
     val retryJitterMillis: Long = 400,
     val readOnly: Boolean = false
   )


### PR DESCRIPTION
The current value nullifies the use of exponential backoff in transaction retries.
The new value will allow the first two retries (2nd and 3rd attempts) to take
advantage of exponential backoff. All other retries will be capped at the new max + jitter (currently 600ms).