### PR TITLE
Make Hibernate not connected error friendlier

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -198,7 +198,9 @@ internal class SessionFactoryService(
   }
 
   override fun get(): SessionFactory {
-    return sessionFactory ?: throw IllegalStateException(
-        "@${qualifier.simpleName} Hibernate not connected: did you forget to start the service?")
+    return sessionFactory ?: throw IllegalStateException("""
+      |@${qualifier.simpleName} Hibernate not connected: did you forget to start the service?
+      |    If this is a test, then annotate your test class with @MiskTest(startService = true)
+      |""".trimMargin())
   }
 }


### PR DESCRIPTION
It's easy enough to forget to add `startService = true` to a `MiskTest`, so this adds a hint if you've forgotten :)