### PR TITLE
Reduce web-actions tab typing latency by 98%

### DIFF
--- a/misk/web/tabs/web-actions/src/containers/RequestFormFieldBuilderContainer.tsx
+++ b/misk/web/tabs/web-actions/src/containers/RequestFormFieldBuilderContainer.tsx
@@ -79,6 +79,11 @@ const repeatableFieldButtons = (
           simpleType.boolean
         )}
         css={css(cssButton)}
+        defaultValue={simpleSelect(
+          props.simpleForm,
+          `${tag}::${padId(id)}`,
+          "data"
+        )}
         icon={IconNames.MORE}
         onClick={onChangeToggleFnCall(
           props.simpleFormToggle,
@@ -162,9 +167,14 @@ const EditRawInput = (
     return (
       <TextArea
         css={css(cssWrapTextArea)}
+        defaultValue={simpleSelect(
+          props.simpleForm,
+          `${tag}::${padId(id)}`,
+          "data"
+        )}
         fill={true}
         growVertically={true}
-        onChange={onChangeFnCall(props.simpleFormInput, `${tag}::${padId(id)}`)}
+        onBlur={onChangeFnCall(props.simpleFormInput, `${tag}::${padId(id)}`)}
       />
     )
   } else {
@@ -224,6 +234,11 @@ const UnconnectedRequestFormFieldBuilderContainer = (
             <EditRawInput {...props} id={id} tag={tag}>
               <Button
                 css={css(cssButton)}
+                defaultValue={simpleSelect(
+                  props.simpleForm,
+                  `${tag}::${padId(id)}`,
+                  "data"
+                )}
                 intent={
                   simpleSelect(
                     props.simpleForm,
@@ -262,8 +277,13 @@ const UnconnectedRequestFormFieldBuilderContainer = (
             {...repeatableFieldButtons({ ...props, id })}
             <EditRawInput {...props} id={id} tag={tag}>
               <InputGroup
+                defaultValue={simpleSelect(
+                  props.simpleForm,
+                  `${tag}::${padId(id)}`,
+                  "data"
+                )}
                 onClick={onChangeFnCall(clickDirtyInputFns(props))}
-                onChange={onChangeFnCall(
+                onBlur={onChangeFnCall(
                   props.simpleFormInput,
                   `${tag}::${padId(id)}`
                 )}
@@ -283,8 +303,13 @@ const UnconnectedRequestFormFieldBuilderContainer = (
             {...repeatableFieldButtons({ ...props, id })}
             <EditRawInput {...props} id={id} tag={tag}>
               <InputGroup
+                defaultValue={simpleSelect(
+                  props.simpleForm,
+                  `${tag}::${padId(id)}`,
+                  "data"
+                )}
                 onClick={onChangeFnCall(clickDirtyInputFns(props))}
-                onChange={onChangeFnCall(
+                onBlur={onChangeFnCall(
                   props.simpleFormInput,
                   `${tag}::${padId(id)}`
                 )}
@@ -405,7 +430,7 @@ const UnconnectedRequestFormFieldBuilderContainer = (
                     css={css(cssWrapTextArea)}
                     fill={true}
                     growVertically={true}
-                    onClick={onClickFnCall(clickDirtyInputFns(props))}
+                    onBlur={onClickFnCall(clickDirtyInputFns(props))}
                     onChange={onChangeFnCall(
                       props.simpleFormInput,
                       `${tag}::RawRequestBody`
@@ -439,7 +464,7 @@ const UnconnectedRequestFormFieldBuilderContainer = (
               fill={true}
               growVertically={true}
               onClick={onClickFnCall(clickDirtyInputFns(props))}
-              onChange={onChangeFnCall(
+              onBlur={onChangeFnCall(
                 props.simpleFormInput,
                 `${tag}::${padId(id)}`
               )}

--- a/misk/web/tabs/web-actions/tests/containers/__snapshots__/RequestFormFieldBuilderContainer.test.tsx.snap
+++ b/misk/web/tabs/web-actions/tests/containers/__snapshots__/RequestFormFieldBuilderContainer.test.tsx.snap
@@ -242,6 +242,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form int field 1`] = `
                   placeholder="Int"
                   style="padding-right: 10px;"
                   type="text"
+                  value=""
                 />
               </div>
             </div>
@@ -438,6 +439,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form multiple top level 
                   placeholder="Short"
                   style="padding-right: 10px;"
                   type="text"
+                  value=""
                 />
               </div>
             </div>
@@ -541,6 +543,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form multiple top level 
                   placeholder="Int"
                   style="padding-right: 10px;"
                   type="text"
+                  value=""
                 />
               </div>
             </div>
@@ -644,6 +647,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form multiple top level 
                   placeholder="Long"
                   style="padding-right: 10px;"
                   type="text"
+                  value=""
                 />
               </div>
             </div>
@@ -747,6 +751,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form multiple top level 
                   placeholder="Short"
                   style="padding-right: 10px;"
                   type="text"
+                  value=""
                 />
               </div>
             </div>
@@ -947,6 +952,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form nested int field 1`
                       placeholder="Int"
                       style="padding-right: 10px;"
                       type="text"
+                      value=""
                     />
                   </div>
                 </div>
@@ -1361,6 +1367,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form repeated nested int
                               placeholder="Int"
                               style="padding-right: 10px;"
                               type="text"
+                              value=""
                             />
                           </div>
                         </div>
@@ -1813,6 +1820,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form repeated nested rep
                                 placeholder="Short"
                                 style="padding-right: 10px;"
                                 type="text"
+                                value=""
                               />
                             </div>
                           </div>
@@ -2050,6 +2058,7 @@ exports[`RequestFormFieldBuilderContainer Renders typed form repeated short fiel
                     placeholder="Short"
                     style="padding-right: 10px;"
                     type="text"
+                    value=""
                   />
                 </div>
               </div>


### PR DESCRIPTION
* Latency typing performance improved from >140ms for `keypress` to <2ms
* Use `onBlur` calls for Redux update functions instead of `onChange` which means the expensive Redux update only happens when the text field is exited, instead of on every keypress
* `defaultValue` instead of `value` is used to support existing functionality with the above `onBlur` change