### PR TITLE
Separate errors for db connection and ping

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -50,8 +50,8 @@ internal class SqsJobConsumer @Inject internal constructor(
 
     for (i in (0 until config.concurrent_receivers_per_queue)) {
       taskQueue.scheduleWithBackoff(Duration.ZERO) {
-        // Don't call handlers until all services are ready, otherwise handlers will crash because the
-        // services they might need (databases, etc.) won't be ready.
+        // Don't call handlers until all services are ready, otherwise handlers will crash because
+        // the services they might need (databases, etc.) won't be ready.
         serviceManagerProvider.get().awaitHealthy()
         receiver.runOnce()
       }


### PR DESCRIPTION
This change separates the error cases for failing to obtain a db connection and failing to ping the database in `PingDatabaseService`. This should make diagnosing db errors easier.