### PR TITLE
Exclude junit4 so it stops getting accidentally imported

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,7 @@ ext.dep = [
   "jettyWebsocketServer": "org.eclipse.jetty.websocket:websocket-server:9.4.18.v20190429",
   "jettyWebsocketServlet": "org.eclipse.jetty.websocket:websocket-servlet:9.4.18.v20190429",
   "jnrUnixsocket": "com.github.jnr:jnr-unixsocket:0.22",
+  "junit4": "junit:junit:4.12",
   "junitApi": "org.junit.jupiter:junit-jupiter-api:5.3.1",
   "junitEngine": "org.junit.jupiter:junit-jupiter-engine:5.3.1",
   "junitGradlePlugin": "org.junit.platform:junit-platform-gradle-plugin:1.0.2",

--- a/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
@@ -17,16 +17,20 @@ import misk.environment.EnvironmentModule
 import misk.logging.LogCollector
 import misk.logging.LogCollectorService
 import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.security.GeneralSecurityException
 
 @MiskTest(startService = true)
 class CryptoModuleTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module = CryptoTestModule()
 
   @Test
   fun testImportAeadKey() {
@@ -104,7 +108,7 @@ class CryptoModuleTest {
     assertThat(out).contains("using obsolete key format")
   }
 
-  @Ignore
+  @Disabled
   @Test // Currently disabled since the env check is as well
   fun testRaisesInWrongEnv() {
     val plainKey = Key("name", KeyType.AEAD, MiskConfig.RealSecret(""))

--- a/misk-crypto/src/test/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CryptoTestModule.kt
@@ -9,13 +9,16 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.daead.DeterministicAeadConfig
 import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.tokens.FakeTokenGeneratorModule
 
 /**
  * Test module that binds [FakeKmsClient] to be used as the [KmsClient]
  */
 class CryptoTestModule : KAbstractModule() {
-
   override fun configure() {
+    install(Modules.override(MiskTestingServiceModule()).with(FakeTokenGeneratorModule()))
     install(LogCollectorModule())
     install(object : KAbstractModule() {
       @Provides @Singleton

--- a/misk-hibernate-testing/src/test/kotlin/misk/jdbc/ParseQueryPlansTest.kt
+++ b/misk-hibernate-testing/src/test/kotlin/misk/jdbc/ParseQueryPlansTest.kt
@@ -2,7 +2,7 @@ package misk.jdbc
 
 import com.squareup.moshi.Moshi
 import okio.Buffer
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/misk-testing/build.gradle
+++ b/misk-testing/build.gradle
@@ -5,10 +5,14 @@ dependencies {
   compile dep.junitEngine
   compile dep.assertj
   compile dep.logbackClassic
-  compile dep.okHttpMockWebServer
+  compile (dep.okHttpMockWebServer) {
+    exclude group: 'junit'
+  }
   compile dep.okio
   compile dep.openTracingMock
   compile dep.mockitoCore
-  compile dep.guavaTestLib
+  compile(dep.guavaTestLib) {
+    exclude group: 'junit'
+  }
   compile project(':misk')
 }

--- a/misk-testing/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
+++ b/misk-testing/src/test/kotlin/org/assertj/core/api/AssertExtensionsTest.kt
@@ -37,7 +37,12 @@ internal class AssertExtensionsTest {
 }
 """)
     }).hasMessage(
-        """expected:<"{ "my_structure[]" : [ "this" , 45, "...> but was:<"{ "my_structure[2]" : [ "this" , 45, "...>""")
+        """
+Expecting:
+ <"{ "my_structure2" : [ "this" , 45, "zip" ], "my_value" : "another value" }">
+to be equal to:
+ <"{ "my_structure" : [ "this" , 45, "zip" ], "my_value" : "another value" }">
+but was not.""")
   }
 
   @Test
@@ -55,7 +60,12 @@ internal class AssertExtensionsTest {
 }
 """)
     }).hasMessage(
-        """expected:<...structure" : [ "this[]" , 45, "zip" ], "my...> but was:<...structure" : [ "this[isit]" , 45, "zip" ], "my...>""")
+        """
+Expecting:
+ <"{ "my_structure" : [ "thisisit" , 45, "zip" ], "my_value" : "another value" }">
+to be equal to:
+ <"{ "my_structure" : [ "this" , 45, "zip" ], "my_value" : "another value" }">
+but was not.""")
   }
 
   @Test
@@ -73,6 +83,11 @@ internal class AssertExtensionsTest {
 }
 """)
     }).hasMessage(
-        """expected:<..._structure" : [ "thi[  ]s" , 45, "zip" ], "m...> but was:<..._structure" : [ "thi[]s" , 45, "zip" ], "m...>""")
+  """
+Expecting:
+ <"{ "my_structure" : [ "this" , 45, "zip" ], "my_value" : "another value" }">
+to be equal to:
+ <"{ "my_structure" : [ "thi  s" , 45, "zip" ], "my_value" : "another value" }">
+but was not.""")
   }
 }

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -54,4 +54,5 @@ dependencies {
   testCompile dep.kotlinxCoroutines
   testCompile dep.mockitoCore
   testCompile project(':misk-testing')
+  testImplementation dep.junit4
 }

--- a/misk/src/test/kotlin/misk/okio/OkioExtensionsTest.kt
+++ b/misk/src/test/kotlin/misk/okio/OkioExtensionsTest.kt
@@ -2,7 +2,7 @@ package misk.okio
 
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class OkioExtensionsTest {

--- a/misk/src/test/kotlin/misk/security/cert/X509CertificateExtensionsTest.kt
+++ b/misk/src/test/kotlin/misk/security/cert/X509CertificateExtensionsTest.kt
@@ -4,7 +4,7 @@ import misk.security.ssl.PemComboFile
 import okio.buffer
 import okio.source
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.security.cert.X509Certificate
 
 internal class X509CertificateExtensionsTest {


### PR DESCRIPTION
I think using `implementation` also fixes this but that's a bigger change.

People have been accidentally importing the wrong `@Test` which leads to injection stuff not getting set up which is a very confusing error message