### PR TITLE
Allow misk tests to use new database between runs

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
@@ -1,0 +1,68 @@
+package misk.jdbc
+
+import com.zaxxer.hikari.util.DriverDataSource
+import misk.environment.Environment
+import java.sql.Connection
+import java.sql.SQLException
+import java.util.Properties
+import javax.inject.Inject
+import javax.inject.Singleton
+import javax.sql.DataSource
+
+/**
+ * Implementation of [TestDatabasePool.Backend] for SQL databases.
+ */
+@Singleton
+internal class MySqlTestDatabasePoolBackend @Inject constructor(
+  val config: DataSourceConfig
+) : TestDatabasePool.Backend {
+  private val connection: Connection by lazy {
+    try {
+      DriverDataSource(
+          config.buildJdbcUrl(Environment.TESTING),
+          config.type.driverClassName,
+          Properties(),
+          config.username,
+          config.password
+      ).connect()
+    } catch (e: SQLException) {
+      throw IllegalStateException("Could not connect to test MySQL server!", e)
+    }
+  }
+
+  /** Kotlin think's that getConnection is a val, but it's really a function. */
+  @Suppress("UsePropertyAccessSyntax")
+  private fun DataSource.connect() = this.getConnection()
+
+  override fun showDatabases(): Set<String> {
+    return connection.showDatabases()
+  }
+
+  override fun dropDatabase(name: String) {
+    return connection.dropDatabase(name)
+  }
+
+  override fun createDatabase(name: String) {
+    return connection.createDatabase(name)
+  }
+
+  private fun Connection.showDatabases(): Set<String> {
+    return createStatement().use { statement ->
+      statement.executeQuery("SHOW DATABASES")
+          .map { resultSet -> resultSet.getString(1) }
+          .toSet()
+    }
+  }
+
+  private fun Connection.createDatabase(name: String) {
+    return createStatement().use { statement ->
+      statement.execute("CREATE DATABASE $name")
+    }
+  }
+
+  private fun Connection.dropDatabase(name: String) {
+    return createStatement().use { statement ->
+      statement.execute("DROP DATABASE $name")
+    }
+  }
+}

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TestDatabasePool.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TestDatabasePool.kt
@@ -1,0 +1,180 @@
+package misk.jdbc
+
+import misk.logging.getLogger
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.Period
+import java.time.format.DateTimeFormatter
+import java.util.Collections
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.regex.Pattern
+import javax.persistence.PersistenceException
+
+/**
+ * A [DatabasePool] that is used in tests to get a unique database for each test suite.
+ *
+ * See [misk.hibernate.HibernateTestingModule] for usage instructions. */
+val SHARED_TEST_DATABASE_POOL = TestDatabasePool(
+    MySqlTestDatabasePoolBackend(
+        DataSourceConfig(type = DataSourceType.MYSQL, username = "root").withDefaults()),
+    Clock.systemUTC()
+)
+
+/**
+ * Manages an inventory of databases for testing. Databases are named like
+ * `movies__20190730__5` where `movies` is the database name in a [DataSourceConfig], `20190730` is
+ * today's date, and 5 is a sequence number.
+ *
+ * These are used _only_ in tests, so that each test gets a reserved database to avoid
+ * parallelism issues.
+ *
+ * Thread-safe.
+ */
+class TestDatabasePool(
+  val backend: Backend,
+  val clock: Clock
+) : DatabasePool {
+  /** The key is the config's database name. */
+  private val poolsByKey = Collections.synchronizedMap(mutableMapOf<String, ConfigSpecificPool>())
+
+  override fun takeDatabase(config: DataSourceConfig): DataSourceConfig {
+    // We don't yet have a mechanism to create Vitess databases from Misk.
+    // TODO: Supporting pooled Vitess DBs would be pretty rad.
+    if (config.type != DataSourceType.MYSQL) return config
+
+    val pooled = getPool(config)
+    return config.copy(database = pooled.takeDatabase())
+  }
+
+  override fun releaseDatabase(config: DataSourceConfig) {
+    getPool(config).releaseDatabase(config.database!!)
+  }
+
+  /**
+   * Drops all databases that were created by an allocator which are older than the retention
+   * duration of this allocator.
+   *
+   * @param retention Must be longer than any test could possibly run for.
+   */
+  @Throws(PersistenceException::class)
+  fun pruneOldDatabases(retention: Duration = Duration.ofDays(2)) {
+    for (pool in poolsByKey.values) {
+      pool.pruneOldDatabases(retention)
+    }
+  }
+
+  /** Return a config-specific pool, creating it if necessary. */
+  internal fun getPool(config: DataSourceConfig): ConfigSpecificPool {
+    val key = config.database!!
+    return poolsByKey.computeIfAbsent(key) { ConfigSpecificPool(key, config.type) }
+  }
+
+  /** A pool of databases for a particular config. Thread-safe. */
+  internal inner class ConfigSpecificPool(
+    val key: String,
+    val type: DataSourceType
+  ) {
+    private val databaseNameRegex = Regex("""(${Pattern.quote(key)})__([0-9]{8})__([0-9]{1,5})""")
+
+    private val formatter = DateTimeFormatter.BASIC_ISO_DATE
+
+    /** Database names that are available. */
+    private val pool = LinkedBlockingDeque<String>()
+
+    /** Decodes a database name string. */
+    fun decode(databaseName: String): DatabaseName? {
+      val matchResult = databaseNameRegex.matchEntire(databaseName) ?: return null
+      return DatabaseName(
+          matchResult.groups[1]!!.value,
+          matchResult.groups[2]!!.value.toLong(),
+          matchResult.groups[3]!!.value.toInt()
+      )
+    }
+
+    /** Returns all databases for this key. */
+    fun getDatabases(): List<DatabaseName> {
+      return backend.showDatabases().mapNotNull { decode(it) }
+    }
+
+    fun takeDatabase(): String {
+      val pooled = pool.poll()
+      if (pooled != null) return pooled
+
+      return allocateDatabase()
+    }
+
+    fun releaseDatabase(databaseName: String) {
+      pool.add(databaseName)
+    }
+
+    /** Creates a database and returns its name. */
+    fun allocateDatabase(): String {
+      val today = LocalDate.now(clock)
+      val todayYearMonthDay = today.format(formatter).toLong()
+
+      val todaysLatest = getDatabases()
+          .filter { it.yearMonthDay == todayYearMonthDay }
+          .maxBy { it.version }
+
+      val nextVersion = (todaysLatest?.version ?: 0) + 1
+
+      var databaseName =
+          DatabaseName(key, todayYearMonthDay, nextVersion)
+
+      // Keep trying to create a database until we have found an unused name.
+      while (true) {
+        try {
+          backend.createDatabase(databaseName.toString())
+          break
+        } catch (_: PersistenceException) {
+          logger.info { "Lost a race trying to allocate a test database $databaseName" }
+          databaseName = databaseName.copy(version = databaseName.version + 1)
+        }
+      }
+
+      return databaseName.toString()
+    }
+
+    fun pruneOldDatabases(retention: Duration = Duration.ofDays(2)) {
+      val evictBefore = LocalDate.now(clock).minus(Period.ofDays(retention.toDays().toInt()))
+      val evictBeforeYearMonthDay = evictBefore.format(formatter).toLong()
+
+      val oldDatabases = getDatabases().filter { it.yearMonthDay < evictBeforeYearMonthDay }
+
+      for (database in oldDatabases) {
+        backend.dropDatabase("$database")
+      }
+    }
+  }
+
+  /** A backend for a [ConfigSpecificPool]. */
+  interface Backend {
+    /** Returns a list of *all* databases present in the data source. */
+    fun showDatabases(): Set<String>
+
+    /**
+     * Drops the indicated database from the data source.
+     *
+     * Throws [PersistenceException] if the database cannot be dropped (i.e. it does not exist).
+     */
+    @Throws(PersistenceException::class)
+    fun dropDatabase(name: String)
+
+    /**
+     * Attempts to create the indicated database in the data source.
+     *
+     * Throws [PersistenceException] if the database already exists.
+     */
+    @Throws(PersistenceException::class)
+    fun createDatabase(name: String)
+  }
+
+  companion object {
+    private val logger = getLogger<ConfigSpecificPool>()
+  }
+
+  data class DatabaseName(val name: String, val yearMonthDay: Long, val version: Int) {
+    override fun toString() = "${name}__${yearMonthDay}__$version"
+  }
+}

--- a/misk-hibernate-testing/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
+++ b/misk-hibernate-testing/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
@@ -1,0 +1,142 @@
+package misk.jdbc
+
+import com.google.inject.Module
+import com.google.inject.Singleton
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import javax.inject.Inject
+import javax.persistence.PersistenceException
+
+@MiskTest(startService = false)
+class TestDatabasePoolTest {
+  @Suppress("unused")
+  @MiskTestModule val module: Module = Modules.combine(
+      MiskTestingServiceModule(),
+      object : KAbstractModule() {
+        override fun configure() {
+          bind<TestDatabasePool.Backend>().to<FakeDatabaseBackend>()
+        }
+      }
+  )
+  @Inject private lateinit var clock: Clock
+  @Inject private lateinit var backend: FakeDatabaseBackend
+
+  private val config = DataSourceConfig(type = DataSourceType.MYSQL, database = "test")
+
+  private lateinit var testDatabasePool: TestDatabasePool
+
+  @BeforeEach fun setUp() {
+    testDatabasePool = TestDatabasePool(backend, clock)
+  }
+
+  @Test fun listsExistingDatabases() {
+    backendHasDatabases()
+
+    assertThat(getAllDatabasesFromPool()).containsExactly(
+        TestDatabasePool.DatabaseName("test", 20171227L, 1),
+        TestDatabasePool.DatabaseName("test", 20171228L, 1),
+        TestDatabasePool.DatabaseName("test", 20171229L, 1),
+        TestDatabasePool.DatabaseName("test", 20171230L, 1),
+        TestDatabasePool.DatabaseName("test", 20171231L, 1),
+        TestDatabasePool.DatabaseName("test", 20180101L, 1),
+        TestDatabasePool.DatabaseName("test", 20180101L, 2),
+        TestDatabasePool.DatabaseName("test", 20180101L, 3)
+    )
+  }
+
+  @Test fun dropsDatabasesOlderThan48Hours() {
+    backendHasDatabases()
+    testDatabasePool.takeDatabase(config)
+
+    testDatabasePool.pruneOldDatabases()
+
+    assertThat(getAllDatabasesFromPool()).containsExactly(
+        TestDatabasePool.DatabaseName("test", 20171230L, 1), // Existing
+        TestDatabasePool.DatabaseName("test", 20171231L, 1), // Existing
+        TestDatabasePool.DatabaseName("test", 20180101L, 1), // Existing
+        TestDatabasePool.DatabaseName("test", 20180101L, 2), // Existing
+        TestDatabasePool.DatabaseName("test", 20180101L, 3), // Existing
+        TestDatabasePool.DatabaseName("test", 20180101L, 4) // New
+    )
+  }
+
+  @Test fun poolRequiresRegistrationBeforeItCanBeDropped() {
+    // Add databases to the backend.
+    backend.databases.add("movies__20171225__1")
+    backend.databases.add("directors__20171225__1")
+    backend.databases.add("actors__20171225__1")
+
+    // Do not register these with the database pool. The pool should be empty.
+    assertThat(getAllDatabasesFromPool()).isEmpty()
+
+    // This should be a no-op.
+    testDatabasePool.pruneOldDatabases()
+
+    assertThat(backend.databases).containsExactlyInAnyOrder(
+        "movies__20171225__1",
+        "directors__20171225__1",
+        "actors__20171225__1"
+    )
+  }
+
+  @Test fun allocatesNewDatabasesWithIncrementalNames() {
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__1")
+    assertThat(backend.databases).containsExactly("test__20180101__1")
+
+    assertThat(getAllDatabasesFromPool()).contains(TestDatabasePool.DatabaseName(
+        name = "test",
+        yearMonthDay = 20180101L,
+        version = 1
+    ))
+
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__2")
+    assertThat(backend.databases).containsExactly(
+        "test__20180101__1",
+        "test__20180101__2"
+    )
+  }
+
+  private fun backendHasDatabases() {
+    val todaysDatabases = listOf(
+        "test__20180101__1",
+        "test__20180101__2",
+        "test__20180101__3"
+    )
+    val oldDatabases = listOf(
+        "test__20171231__1",
+        "test__20171230__1",
+        "test__20171229__1",
+        "test__20171228__1",
+        "test__20171227__1"
+    )
+    backend.databases.addAll(todaysDatabases)
+    backend.databases.addAll(oldDatabases)
+  }
+
+  private fun getAllDatabasesFromPool(): List<TestDatabasePool.DatabaseName> {
+    return testDatabasePool.getPool(config).getDatabases()
+  }
+}
+
+@Singleton
+private class FakeDatabaseBackend @Inject constructor() : TestDatabasePool.Backend {
+  val databases = mutableSetOf<String>()
+
+  override fun showDatabases(): Set<String> = databases.sorted().toSet()
+
+  override fun dropDatabase(name: String) {
+    databases.remove(name)
+  }
+
+  override fun createDatabase(name: String) {
+    if (name in databases) throw PersistenceException()
+    databases.add(name)
+  }
+}

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/ConfigSpecificPool.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/ConfigSpecificPool.kt
@@ -1,0 +1,21 @@
+package misk.jdbc
+
+/**
+ * Figures out what database name to use for a given config. Tests use this to pool many databases
+ * for concurrent execution. In development, staging, and production the database never changes.
+ */
+interface DatabasePool {
+  /** Finds a database to satisfy [config] and returns a new config that targets it. */
+  fun takeDatabase(config: DataSourceConfig): DataSourceConfig
+
+  /** Releases a config created by [takeDatabase]. */
+  fun releaseDatabase(config: DataSourceConfig)
+}
+
+object RealDatabasePool : DatabasePool {
+  override fun takeDatabase(config: DataSourceConfig) = config
+
+  override fun releaseDatabase(config: DataSourceConfig) {
+    // Do nothing.
+  }
+}

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -14,6 +14,7 @@ import misk.inject.toKey
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceService
 import misk.jdbc.PingDatabaseService
+import misk.jdbc.RealDatabasePool
 import misk.resources.ResourceLoader
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -48,8 +49,13 @@ internal class SchemaValidatorTest {
 
       val qualifier = ValidationDb::class
 
-      val dataSourceService =
-          DataSourceService(qualifier, config.data_source, Environment.TESTING, emptySet())
+      val dataSourceService = DataSourceService(
+          qualifier = qualifier,
+          baseConfig = config.data_source,
+          environment = Environment.TESTING,
+          dataSourceDecorators = emptySet(),
+          databasePool = RealDatabasePool
+      )
 
       val injectorServiceProvider = getProvider(HibernateInjectorAccess::class.java)
 


### PR DESCRIPTION
This change introduces a `DatabasePool` which is used by `DataSourceService` to obtain (and under test, allocate) database names.

In production, this changes nothing; we will always use the database that was specified by the config.

In test, each `MiskTest` annotation test will operate on a special database called `database_yyyyMMdd_s`, where `database` is the name specified by the `DataSourceConfig.database` property, `yyyyMMdd` is the current date, and `s` is a sequence number.

e.g. If two tests for a cinema service are running in parallel and they request access to the same database, then the first test will use a database called `movies_20190731_1`, and the second test will use a database called `movies_20190731_2`. These databases are released for usage by other tests that run afterwards, should they require them.

This feature can be opted into by configuring the `HibernateModule` as follows in a testing module:

```kotlin
install(HibernateModule(Movies::class, config, SHARED_TEST_DATABASE_POOL))
```