### PR TITLE
RFC: Request deadlines

### DIFF
--- a/misk/src/main/kotlin/misk/Deadline.kt
+++ b/misk/src/main/kotlin/misk/Deadline.kt
@@ -9,19 +9,66 @@ import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 
-class Deadline(
+/**
+ * Deadline for an action. A deadline can be overridden, with the caveat that the overridden deadline
+ * does not propagate to other threads.
+ *
+ * All actions have [ActionDeadline]s available even if there is initially no deadline.
+ */
+class ActionDeadline(
   private val clock: Clock,
-  val deadline: Instant
+  deadline: Instant?
 ) {
 
-  constructor(clock: Clock, duration: Duration) :
-      this(clock, clock.instant().plusNanos(duration.toNanos()))
+  constructor(clock: Clock, duration: Duration) : this(clock, clock.instant().plus(duration))
 
-  fun expired() = !clock.instant().isBefore(deadline)
+  private val threadDeadline: ThreadLocal<Instant?> = ThreadLocal.withInitial { deadline }
 
-  fun remaining(): Duration {
+  /**
+   * Get the current deadline, or null if there is none.
+   *
+   * If the deadline is currently being overridden in the same thread, that value is returned.
+   */
+  fun current(): Instant? = threadDeadline.get()
+
+  /** @return If the deadline is expired. If there is no deadline this returns false */
+  fun expired(): Boolean = current()?.let { it < clock.instant() } ?: false
+
+  /** @return Get the duration until the deadline is hit, or null if there is no deadline */
+  fun remaining(): Duration? = current()?.let { deadline ->
     val left = Duration.between(clock.instant(), deadline)
-    return if (left.isNegative) Duration.ZERO else left
+    if (left.isNegative) Duration.ZERO else left
+  }
+
+  /**
+   * Override the deadline for the given block. The overridden deadline only applies to the current
+   * thread.
+   *
+   * The lesser of the given deadline and current deadline is used.
+   */
+  fun <T> overriding(newDeadline: Instant, fn: () -> T): T {
+    val current = threadDeadline.get()
+    if (current != null && newDeadline >= current) {
+      return fn()
+    }
+
+    threadDeadline.set(newDeadline)
+    return try {
+      fn()
+    } finally {
+      threadDeadline.set(current)
+    }
+  }
+
+  /**
+   * Override the deadline for the given block. The overridden deadline only applies to the current
+   * thread.
+   *
+   * The lesser of the given deadline and current deadline is used.
+   */
+  fun <T> overriding(duration: Duration, fn: () -> T): T {
+    check(!duration.isZero && !duration.isNegative) { "duration must be positive" }
+    return overriding(clock.instant().plus(duration), fn)
   }
 }
 
@@ -29,21 +76,25 @@ class Deadline(
  * Provides an optional deadline scoped to the current action, determined by the optional
  * "X-Request-Timeout-Ms" HTTP header.
  */
-class DeadlineProvider @Inject constructor(
+class ActionDeadlineProvider @Inject constructor(
   private val clock: Clock,
   var currentRequest: ActionScoped<HttpCall>
-) : ActionScopedProvider<Deadline?> {
-  override fun get(): Deadline? = currentRequest.get().requestHeaders[HTTP_HEADER]?.let {
-    try {
-      val duration = Duration.ofMillis(it.toLong())
-      if (duration.isNegative || duration.isZero) {
-        throw BadRequestException(
-            "Invalid header value for $HTTP_HEADER; deadline must be positive")
+) : ActionScopedProvider<ActionDeadline> {
+  override fun get(): ActionDeadline {
+    val deadline = currentRequest.get().requestHeaders[HTTP_HEADER]?.let {
+      try {
+        val timeoutMs = it.toLong()
+        if (timeoutMs <= 0) {
+          throw BadRequestException(
+              "Invalid header value for $HTTP_HEADER; deadline must be positive")
+        }
+        clock.instant().plusMillis(timeoutMs)
+      } catch (ex: NumberFormatException) {
+        throw BadRequestException("Invalid header value for $HTTP_HEADER")
       }
-      Deadline(clock, duration)
-    } catch (ex: NumberFormatException) {
-      throw BadRequestException("Invalid header value for $HTTP_HEADER")
     }
+
+    return ActionDeadline(clock, deadline)
   }
 
   companion object {

--- a/misk/src/main/kotlin/misk/Deadline.kt
+++ b/misk/src/main/kotlin/misk/Deadline.kt
@@ -1,0 +1,52 @@
+package misk
+
+import misk.exceptions.BadRequestException
+import misk.scope.ActionScoped
+import misk.scope.ActionScopedProvider
+import misk.web.HttpCall
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import javax.inject.Inject
+
+class Deadline(
+  private val clock: Clock,
+  val deadline: Instant
+) {
+
+  constructor(clock: Clock, duration: Duration) :
+      this(clock, clock.instant().plusNanos(duration.toNanos()))
+
+  fun expired() = !clock.instant().isBefore(deadline)
+
+  fun remaining(): Duration {
+    val left = Duration.between(clock.instant(), deadline)
+    return if (left.isNegative) Duration.ZERO else left
+  }
+}
+
+/**
+ * Provides an optional deadline scoped to the current action, determined by the optional
+ * "X-Request-Timeout-Ms" HTTP header.
+ */
+class DeadlineProvider @Inject constructor(
+  private val clock: Clock,
+  var currentRequest: ActionScoped<HttpCall>
+) : ActionScopedProvider<Deadline?> {
+  override fun get(): Deadline? = currentRequest.get().requestHeaders[HTTP_HEADER]?.let {
+    try {
+      val duration = Duration.ofMillis(it.toLong())
+      if (duration.isNegative || duration.isZero) {
+        throw BadRequestException(
+            "Invalid header value for $HTTP_HEADER; deadline must be positive")
+      }
+      Deadline(clock, duration)
+    } catch (ex: NumberFormatException) {
+      throw BadRequestException("Invalid header value for $HTTP_HEADER")
+    }
+  }
+
+  companion object {
+    const val HTTP_HEADER = "X-Request-Timeout-Ms"
+  }
+}

--- a/misk/src/main/kotlin/misk/client/ClientDeadlineAppInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientDeadlineAppInterceptor.kt
@@ -1,0 +1,81 @@
+package misk.client
+
+import com.google.inject.Inject
+import misk.Deadline
+import misk.DeadlineProvider
+import misk.exceptions.ActionException
+import misk.exceptions.StatusCode
+import misk.scope.ActionScoped
+import okhttp3.Response
+import retrofit2.Call
+import java.lang.Long.min
+import javax.inject.Provider
+
+/**
+ * Interceptor that prevents an outgoing request from occurring if the deadline for the current
+ * action has been reached or passed.
+ */
+class ClientDeadlineAppInterceptor(
+  private val deadlineProvider: Provider<ActionScoped<Deadline?>>
+) : ClientApplicationInterceptor {
+
+  class Factory @Inject constructor(
+    private val deadlineProvider: Provider<ActionScoped<Deadline?>>
+  ) : ClientApplicationInterceptor.Factory {
+    override fun create(action: ClientAction) =
+        ClientDeadlineAppInterceptor(deadlineProvider)
+  }
+
+  override fun interceptBeginCall(chain: BeginClientCallChain): Call<Any> {
+    val deadline = deadlineProvider.get().get()
+    if (deadline == null) {
+      return chain.proceed(chain.args)
+    }
+
+    val remaining = deadline.remaining().toMillis()
+    if (remaining == 0L) {
+      // TODO: Different status code?
+      throw ActionException(StatusCode.SERVICE_UNAVAILABLE, "deadline exceeded; skipping call")
+    }
+
+    return chain.proceed(chain.args)
+  }
+
+  override fun intercept(chain: ClientChain) {
+    chain.proceed(chain.args, chain.callback)
+  }
+}
+
+/**
+ * Interceptor that propagates the remaining deadline to downstream services.
+ */
+class ClientDeadlineNetworkInterceptor(
+  private val deadlineProvider: Provider<ActionScoped<Deadline?>>
+) : ClientNetworkInterceptor {
+
+  class Factory @Inject constructor(
+    private val deadlineProvider: Provider<ActionScoped<Deadline?>>
+  ) : ClientNetworkInterceptor.Factory {
+    override fun create(action: ClientAction): ClientNetworkInterceptor? =
+        ClientDeadlineNetworkInterceptor(deadlineProvider)
+  }
+
+  override fun intercept(chain: ClientNetworkChain): Response {
+    if (chain.request.headers[DeadlineProvider.HTTP_HEADER] != null) {
+      return chain.proceed(chain.request)
+    }
+
+    val deadline = deadlineProvider.get().get()
+    if (deadline == null) {
+      return chain.proceed(chain.request)
+    }
+
+    // TODO(alec): Hacky for the time being. Deadline may have passed between early check.
+    // This could return a 503 here, although that feels slightly weird.
+    val millisLeft = min(deadline.remaining().toMillis(), 1)
+    val request = chain.request.newBuilder()
+        .addHeader(DeadlineProvider.HTTP_HEADER, millisLeft.toString())
+        .build()
+    return chain.proceed(request)
+  }
+}

--- a/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -22,7 +22,7 @@ open class ActionException(
   val statusCode: StatusCode,
   message: String = statusCode.name,
   cause: Throwable? = null
-) : Exception(message, cause)
+) : RuntimeException(message, cause)
 
 /** Base exception for when resources are not found */
 open class NotFoundException(message: String = "", cause: Throwable? = null) :

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -2,6 +2,8 @@ package misk.web
 
 import com.google.inject.Provides
 import com.google.inject.TypeLiteral
+import misk.Deadline
+import misk.DeadlineProvider
 import misk.ApplicationInterceptor
 import misk.MiskCaller
 import misk.MiskDefault
@@ -70,6 +72,7 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
         bindSeedData(HttpCall::class)
         bindSeedData(HttpServletRequest::class)
         bindProvider(miskCallerType, MiskCallerProvider::class)
+        bindProvider(actionDeadlineType, DeadlineProvider::class)
         newMultibinder<MiskCallerAuthenticator>()
       }
     })
@@ -164,5 +167,6 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
 
   private companion object {
     val miskCallerType = object : TypeLiteral<MiskCaller?>() {}
+    val actionDeadlineType = object : TypeLiteral<Deadline?>() {}
   }
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -2,8 +2,8 @@ package misk.web
 
 import com.google.inject.Provides
 import com.google.inject.TypeLiteral
-import misk.Deadline
-import misk.DeadlineProvider
+import misk.ActionDeadline
+import misk.ActionDeadlineProvider
 import misk.ApplicationInterceptor
 import misk.MiskCaller
 import misk.MiskDefault
@@ -72,7 +72,7 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
         bindSeedData(HttpCall::class)
         bindSeedData(HttpServletRequest::class)
         bindProvider(miskCallerType, MiskCallerProvider::class)
-        bindProvider(actionDeadlineType, DeadlineProvider::class)
+        bindProvider(actionDeadlineType, ActionDeadlineProvider::class)
         newMultibinder<MiskCallerAuthenticator>()
       }
     })
@@ -167,6 +167,6 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
 
   private companion object {
     val miskCallerType = object : TypeLiteral<MiskCaller?>() {}
-    val actionDeadlineType = object : TypeLiteral<Deadline?>() {}
+    val actionDeadlineType = object : TypeLiteral<ActionDeadline>() {}
   }
 }

--- a/misk/src/test/kotlin/misk/client/ClientDeadlineInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/ClientDeadlineInterceptorTest.kt
@@ -1,0 +1,106 @@
+package misk.client
+
+import com.google.inject.Provides
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import helpers.protos.Dinosaur
+import misk.Deadline
+import misk.MiskTestingServiceModule
+import misk.exceptions.ActionException
+import misk.inject.KAbstractModule
+import misk.scope.ActionScoped
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.FakeClock
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest
+class ClientDeadlineInterceptorTest {
+
+  @MiskTestModule
+  val module = TestModule()
+
+  @Named("dinos") @Inject private lateinit var client: DinosaurService
+  @Inject private lateinit var mockWebServer: MockWebServer
+  @Inject private lateinit var clock: FakeClock
+
+  @BeforeEach
+  fun before() {
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("hello"))
+  }
+
+  @Test fun `no deadline`() {
+    assertThat(client.postDinosaur(Dinosaur.Builder().build()).execute().code()).isEqualTo(200)
+  }
+
+  @Test fun `within deadline`() {
+    TestModule.deadline = Deadline(clock, Duration.ofMillis(5))
+    assertThat(client.postDinosaur(Dinosaur.Builder().build()).execute().code()).isEqualTo(200)
+  }
+
+  @Test fun `at deadline`() {
+    val timeout = Duration.ofMillis(5)
+    TestModule.deadline = Deadline(clock, timeout)
+    clock.add(timeout)
+
+    assertThrows<ActionException> {
+      client.postDinosaur(Dinosaur.Builder().build()).execute()
+    }
+  }
+
+  @Test fun `after deadline`() {
+    val timeout = Duration.ofMillis(5)
+    TestModule.deadline = Deadline(clock, timeout)
+    clock.add(timeout.plusMillis(1))
+
+    assertThrows<ActionException> {
+      client.postDinosaur(Dinosaur.Builder().build()).execute()
+    }
+  }
+
+  class TestModule : KAbstractModule() {
+
+    companion object {
+      @Volatile var deadline: Deadline? = null
+    }
+
+    override fun configure() {
+      install(TypedHttpClientModule.create<DinosaurService>("dinos", Names.named("dinos")))
+      multibind<ClientApplicationInterceptor.Factory>().to<ClientDeadlineAppInterceptor.Factory>()
+
+      install(MiskTestingServiceModule())
+      bind<MockWebServer>().toInstance(MockWebServer())
+    }
+
+    @Provides
+    fun deadline(): ActionScoped<Deadline?> = object : ActionScoped<Deadline?> {
+      override fun get(): Deadline? = deadline
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(server: MockWebServer): HttpClientsConfig {
+      val url = server.url("/")
+      return HttpClientsConfig(
+          endpoints = mapOf("dinos" to HttpClientEndpointConfig(
+              url = url.toString(),
+              readTimeout = Duration.ofMillis(100)
+          )))
+    }
+  }
+
+  interface DinosaurService {
+    @POST("/cooldinos") fun postDinosaur(@Body request: Dinosaur): Call<Void>
+  }
+}

--- a/misk/src/test/kotlin/misk/web/actions/DeadlineTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DeadlineTest.kt
@@ -1,0 +1,102 @@
+package misk.web.actions
+
+import misk.Deadline
+import misk.DeadlineProvider
+import misk.inject.KAbstractModule
+import misk.scope.ActionScoped
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.WebActionModule
+import misk.web.WebTestingModule
+import misk.web.jetty.JettyService
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class DeadlineTest {
+
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject lateinit var clock: Clock
+
+  @Test
+  fun `no deadline`() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/hello").build())
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code).isEqualTo(200)
+
+    val responseContent = response.body!!.source().readString(Charsets.UTF_8)
+    assertThat(responseContent).isEqualTo("no deadline")
+  }
+
+  @Test
+  fun deadline() {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(serverUrlBuilder().encodedPath("/hello").build())
+        .addHeader(DeadlineProvider.HTTP_HEADER, "123")
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code).isEqualTo(200)
+
+    val responseContent = response.body!!.source().readString(Charsets.UTF_8)
+    val expectedDeadline = clock.millis() + 123
+    assertThat(responseContent).isEqualTo("$expectedDeadline")
+  }
+
+  @Test
+  fun `invalid deadline`() {
+    listOf("-1", "0", "123ms", "oops").forEach { deadline ->
+      val httpClient = OkHttpClient()
+      val request = Request.Builder()
+          .get()
+          .url(serverUrlBuilder().encodedPath("/hello").build())
+          .addHeader(DeadlineProvider.HTTP_HEADER, deadline)
+          .build()
+
+      val response = httpClient.newCall(request).execute()
+      assertThat(response.code).isEqualTo(400)
+
+      val responseContent = response.body!!.source().readString(Charsets.UTF_8)
+      assertThat(responseContent)
+          .contains("Invalid header value for ${DeadlineProvider.HTTP_HEADER}")
+    }
+  }
+
+  @Inject
+  lateinit var jettyService: JettyService
+
+  private fun serverUrlBuilder(): HttpUrl.Builder {
+    return jettyService.httpServerUrl.newBuilder()
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebTestingModule())
+      install(WebActionModule.create<GetHello>())
+    }
+  }
+
+  class GetHello @Inject constructor(
+    val deadline: ActionScoped<Deadline?>
+  ) : WebAction {
+    @Get("/hello")
+    fun hello(): String {
+      return "${deadline.get()?.deadline?.toEpochMilli() ?: "no deadline"}"
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/actions/DeadlineTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DeadlineTest.kt
@@ -1,7 +1,7 @@
 package misk.web.actions
 
-import misk.Deadline
-import misk.DeadlineProvider
+import misk.ActionDeadline
+import misk.ActionDeadlineProvider
 import misk.inject.KAbstractModule
 import misk.scope.ActionScoped
 import misk.testing.MiskTest
@@ -47,7 +47,7 @@ class DeadlineTest {
     val request = Request.Builder()
         .get()
         .url(serverUrlBuilder().encodedPath("/hello").build())
-        .addHeader(DeadlineProvider.HTTP_HEADER, "123")
+        .addHeader(ActionDeadlineProvider.HTTP_HEADER, "123")
         .build()
 
     val response = httpClient.newCall(request).execute()
@@ -65,7 +65,7 @@ class DeadlineTest {
       val request = Request.Builder()
           .get()
           .url(serverUrlBuilder().encodedPath("/hello").build())
-          .addHeader(DeadlineProvider.HTTP_HEADER, deadline)
+          .addHeader(ActionDeadlineProvider.HTTP_HEADER, deadline)
           .build()
 
       val response = httpClient.newCall(request).execute()
@@ -73,7 +73,7 @@ class DeadlineTest {
 
       val responseContent = response.body!!.source().readString(Charsets.UTF_8)
       assertThat(responseContent)
-          .contains("Invalid header value for ${DeadlineProvider.HTTP_HEADER}")
+          .contains("Invalid header value for ${ActionDeadlineProvider.HTTP_HEADER}")
     }
   }
 
@@ -92,11 +92,11 @@ class DeadlineTest {
   }
 
   class GetHello @Inject constructor(
-    val deadline: ActionScoped<Deadline?>
+    val deadline: ActionScoped<ActionDeadline>
   ) : WebAction {
     @Get("/hello")
     fun hello(): String {
-      return "${deadline.get()?.deadline?.toEpochMilli() ?: "no deadline"}"
+      return "${deadline.get().current()?.toEpochMilli() ?: "no deadline"}"
     }
   }
 }


### PR DESCRIPTION
This is not meant to be a final PR. Instead, the goal is to drive discussion on interfaces and behavior.

Applications often have upper bounds for how long a request can take before giving up or retrying. This upper bound is a deadline: a wall-clock instant by which work is completed or considered failed. Since work for a request may span multiple systems, it's useful to have a uniform way to propagate and adhere to deadlines. This PR starts to explore what deadline propagation could look like in Misk.

**Setting and passing deadlines**
Deadlines are passed through request side channels as timeouts in milliseconds. They are not passed as timestamps due to clock skew.

This PR uses a non-standard HTTP header, `X-Request-Timeout-Ms`, to pass the timeout in milliseconds. This does not use the standard HTTP header `Request-Timeout` as that uses _seconds_ as a time unit. A Misk server receiving a request will then set its own deadline of `clock.now().plusMillis(timeoutMs)`. The absence of this header indicates the request has no deadline.

GRPC has a standard sidechannel for passing timeouts as nanoseconds. Future GRPC-Misk integration would use that side channel.

**Deadlines in code**
Misk will be responsible for exposing timeouts from a request and scoping them to an action in a way that is abstracted from the transport. This PR has an `ActionDeadline` type that is scoped to an action using `ActionScoped<ActionDeadline>`. This is available even if there is no deadline for the action. Using `ActionScoped` fits with existing Misk patterns for request metadata.

If a client-determined deadline passes, Misk will not necessarily return an error to the caller and abort code. However, some Misk-wired components, such as HTTP clients, may choose to check deadlines and try and abort a request early by raising `ActionException`s. See `ClientDeadlineAppInterceptor` in this PR as an example.

**Overriding deadlines**
Actions often interact with other systems or databases and they may want to set tighter deadlines for some of those calls. For example, an action may to make two client calls in parallel, each with a different short deadline.

This PR allows overriding a deadline for a block of code. Importantly, this overridden deadline does not propagate to other threads. This supports an action doing work on concurrent threads with different deadlines, at the expense of framework code _possibly_ having to propagate deadlines to threads they spawm.

```
// This line is subject to the action's deadline
actionDeadline.get().overriding(Duration.ofMillis(100)) {
  // This block now has a 100ms deadline
  actionDeadline.get().overriding(Duration.ofMillis(5)) {
    // This block has a 5 ms deadline
  }
  // This is subject to the earlier 100ms deadline

  Thread(Runnable {
    // This thread is subject to the action's deadline (not the 100ms deadline!)
  }).start()
}
```

**Propagating deadlines**
This PR illustrates how deadlines can be propagated outwards in HTTP client calls. Future work could include:
* Having typed HTTP clients not only propagate timeouts but actually timeout on the calling side.
* Using timeouts in Transacter-created DB sessions.
* Passing timeouts to GRPC calls.

**Misc**

Deadlines and latency. Calls to the systems have varying latency overhead that eats into the deadline. E.g. if a client has a 100ms deadline and network RTT is 25ms, the server handling the request only has ~75ms to handle the request; longer than that and the client may time out. This PR does not have an opinion on managing this. It would naively pass alog a 100ms timeout to the server.