### PR TITLE
Fix TestDatabasePool

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
@@ -16,7 +16,7 @@ import javax.sql.DataSource
 internal class MySqlTestDatabasePoolBackend @Inject constructor(
   val config: DataSourceConfig
 ) : TestDatabasePool.Backend {
-  private val connection: Connection by lazy {
+  internal val connection: Connection by lazy {
     try {
       DriverDataSource(
           config.buildJdbcUrl(Environment.TESTING),


### PR DESCRIPTION
TestDatabasePool was:
 1. Catching the wrong exception (`PersistenceException` instead of `SQLException`)
 2. Not releasing database names for re-use to the correct pool (instead they would be released to a brand new pool)

This change fixes both of these issues and adds an integration test that works on a real MySQL database, and a regression test for database name releases.

---

Related: https://github.com/cashapp/misk/pull/1123