### PR TITLE
Allow specifying env in HttpClientEnvoyConfig

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -49,5 +49,8 @@ data class HttpClientEndpointConfig(
 )
 
 data class HttpClientEnvoyConfig(
-  val app: String
+  val app: String,
+
+  /** Environment to target. If null, the same environment as the app is running in is assumed. */
+  val env: String? = null
 )


### PR DESCRIPTION
This doesn't change any behavior unless it is specified.

For example backfila will specify `production-jobs` as the env, not `production`