### PR TITLE
Propagate config changes from DataSourceService

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
@@ -23,7 +23,7 @@ private val logger = getLogger<TruncateTablesService>()
  */
 class TruncateTablesService(
   private val qualifier: KClass<out Annotation>,
-  private val config: DataSourceConfig,
+  private val connector: DataSourceConnector,
   private val transacterProvider: Provider<Transacter>,
   private val startUpStatements: List<String> = listOf(),
   private val shutDownStatements: List<String> = listOf()
@@ -45,6 +45,7 @@ class TruncateTablesService(
     val truncatedTableNames = transacterProvider.get().shards().flatMap { shard ->
       transacterProvider.get().transaction(shard) { session ->
         session.withoutChecks {
+          val config = connector.config()
           val tableNamesQuery = when (config.type) {
             DataSourceType.MYSQL -> {
               "SELECT table_name FROM information_schema.tables where table_schema='${config.database}'"

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
@@ -3,7 +3,7 @@ package misk.hibernate
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.base.Stopwatch
 import com.google.common.collect.ImmutableList
-import misk.jdbc.DataSourceConfig
+import misk.jdbc.DataSourceConnector
 import misk.logging.getLogger
 import misk.resources.ResourceLoader
 import org.hibernate.query.Query
@@ -96,10 +96,11 @@ internal class SchemaMigrator(
   private val qualifier: KClass<out Annotation>,
   private val resourceLoader: ResourceLoader,
   private val transacter: Provider<Transacter>,
-  private val config: DataSourceConfig
+  private val connector: DataSourceConnector
 ) {
 
   private fun getMigrationsResources(keyspace: Keyspace): List<String> {
+    val config = connector.config()
     val migrationsResources = ImmutableList.builder<String>()
     if (config.migrations_resource != null) {
       migrationsResources.add(config.migrations_resource)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigratorService.kt
@@ -5,21 +5,24 @@ import com.google.common.util.concurrent.Service
 import misk.environment.Environment
 import misk.healthchecks.HealthCheck
 import misk.healthchecks.HealthStatus
+import misk.jdbc.DataSourceConnector
 import misk.jdbc.DataSourceType
+import javax.inject.Provider
 import kotlin.reflect.KClass
 
 class SchemaMigratorService internal constructor(
   private val qualifier: KClass<out Annotation>,
   private val environment: Environment,
-  private val schemaMigratorProvider: javax.inject.Provider<SchemaMigrator>, // Lazy!
-  private val config: misk.jdbc.DataSourceConfig
+  private val schemaMigratorProvider: Provider<SchemaMigrator>, // Lazy!
+  private val connectorProvider: Provider<DataSourceConnector>
 ) : AbstractIdleService(), HealthCheck {
   private lateinit var migrationState: MigrationState
 
   override fun startUp() {
     val schemaMigrator = schemaMigratorProvider.get()
+    val connector = connectorProvider.get()
     if (environment == Environment.TESTING || environment == Environment.DEVELOPMENT) {
-      if (config.type != DataSourceType.VITESS) {
+      if (connector.config().type != DataSourceType.VITESS) {
         val appliedMigrations = schemaMigrator.initialize()
         migrationState = schemaMigrator.applyAll("SchemaMigratorService", appliedMigrations)
       } else {

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConnector.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConnector.kt
@@ -1,0 +1,5 @@
+package misk.jdbc
+
+interface DataSourceConnector {
+  fun config(): DataSourceConfig
+}


### PR DESCRIPTION
`DataSourceService` can now modify the config to specify which database to use under test (as of #1123 and #1131), however these changes were not propagated to other services that were concerned with the current database under test (e.g. SchemaMigratorService, TruncateTablesService, SessionFactoryService, etc).

This change makes it so that the database name assigned by DataSourceService is actually used by other services in testing.