### PR TITLE
Allow to set vitess docker image via environment variable when starti…

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/StartVitessService.kt
@@ -207,7 +207,9 @@ class DockerVitessCluster(
     if (containerId == null) {
       StartVitessService.logger.info(
           "Starting Vitess cluster with command: ${cmd.joinToString(" ")}")
-      containerId = docker.createContainerCmd(VITESS_IMAGE)
+      val vitessImage: String = System.getenv("VITESS_IMAGE") ?: VITESS_IMAGE
+
+      containerId = docker.createContainerCmd(vitessImage)
           .withCmd(cmd.toList())
           .withVolumes(schemaVolume)
           .withBinds(Bind(cluster.schemaDir.toAbsolutePath().toString(), schemaVolume))


### PR DESCRIPTION
Allow to set the Vitess docker image via environment variable when starting Vitess services

This helps testing some vitess changes via Misk services