### PR TITLE
exclude log4j from transitive dependencies of curator

### DIFF
--- a/misk-zookeeper/build.gradle
+++ b/misk-zookeeper/build.gradle
@@ -7,7 +7,9 @@ buildscript {
 apply plugin: 'kotlin-jpa'
 
 dependencies {
-  compile dep.curatorFramework
+  compile(dep.curatorFramework) {
+    exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+  }
   compile project(':misk')
   compile dep.zookeeper
 


### PR DESCRIPTION
Don't know if this does what I want. I want misk to not include
`slf4j-log4j12`, which comes from curator:

```
 |    +--- org.apache.curator:curator-framework:4.0.1
|    |    \--- org.apache.curator:curator-client:4.0.1
|    |         +--- org.apache.zookeeper:zookeeper:3.5.3-beta -> 3.5.4-beta
|    |         |    +--- org.slf4j:slf4j-api:1.7.25
|    |         |    +--- org.slf4j:slf4j-log4j12:1.7.25
```

I also want any apps that depend on both Misk and Curator, to
automatically exclude `slf4j-log4j12`, without needing a similar clause
to what I'm adding here in the app's build.gradle.

Relevant Zookeeper ticket that seems to be abandoned https://issues.apache.org/jira/browse/ZOOKEEPER-1371