### PR TITLE
exclude log4j from transitive dependencies of curator (try again)

### DIFF
--- a/misk-zookeeper-testing/build.gradle
+++ b/misk-zookeeper-testing/build.gradle
@@ -7,8 +7,14 @@ buildscript {
 apply plugin: 'kotlin-jpa'
 
 dependencies {
-  compile dep.curatorFramework
-  compile dep.zookeeper
+  compile(dep.curatorFramework) {
+    exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+    exclude(group: 'log4j', module: 'log4j')
+  }
+  compile(dep.zookeeper) {
+    exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+    exclude(group: 'log4j', module: 'log4j')
+  }
   compile dep.docker
   compile project(':misk-testing')
   compile project(':misk-zookeeper')

--- a/misk-zookeeper/build.gradle
+++ b/misk-zookeeper/build.gradle
@@ -9,13 +9,20 @@ apply plugin: 'kotlin-jpa'
 dependencies {
   compile(dep.curatorFramework) {
     exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+    exclude(group: 'log4j', module: 'log4j')
   }
   compile project(':misk')
-  compile dep.zookeeper
+  compile(dep.zookeeper) {
+    exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+    exclude(group: 'log4j', module: 'log4j')
+  }
 
   testCompile dep.docker
   testCompile dep.junitApi
-  testCompile dep.zookeeper
+  testCompile(dep.zookeeper) {
+    exclude(group: 'org.slf4j', module: 'slf4j-log4j12')
+    exclude(group: 'log4j', module: 'log4j')
+  }
   testCompile project(':misk-testing')
   testCompile project(':misk-zookeeper-testing')
 }


### PR DESCRIPTION
The previous attempt didn't prune everything https://github.com/cashapp/misk/pull/1139