### PR TITLE
disable SchemaValidatorService

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -148,20 +148,7 @@ class HibernateModule(
     install(ServiceModule<SchemaMigratorService>(qualifier)
         .dependsOn<DataSourceService>(qualifier))
 
-    // Bind SchemaValidatorService.
     val sessionFactoryServiceProvider = getProvider(keyOf<SessionFactoryService>(qualifier))
-    val schemaValidatorServiceKey = keyOf<SchemaValidatorService>(qualifier)
-    bind(schemaValidatorServiceKey)
-        .toProvider(Provider {
-          SchemaValidatorService(
-              qualifier = qualifier,
-              sessionFactoryServiceProvider = sessionFactoryServiceProvider,
-              transacterProvider = transacterProvider
-          )
-        }).asSingleton()
-    multibind<HealthCheck>().to(schemaValidatorServiceKey)
-    install(ServiceModule<SchemaValidatorService>(qualifier)
-        .dependsOn<SchemaMigratorService>(qualifier))
 
     // Bind SessionFactoryService as implementation of TransacterService.
     val entitiesProvider = getProvider(setOfType(HibernateEntity::class).toKey(qualifier))
@@ -186,7 +173,6 @@ class HibernateModule(
     }).asSingleton()
     install(ServiceModule<TransacterService>(qualifier)
         .enhancedBy<SchemaMigratorService>(qualifier)
-        .enhancedBy<SchemaValidatorService>(qualifier)
         .dependsOn<DataSourceService>(qualifier))
 
     // Install other modules.

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorSuccessTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorSuccessTest.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables.getOnlyElement
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -17,6 +18,7 @@ internal class SchemaValidatorSuccessTest {
   @Inject @Movies lateinit var service: SchemaValidatorService
 
   @Test
+  @Disabled("https://github.com/cashapp/misk/issues/1171")
   fun happyPath() {
     val report = SchemaValidator().validate(transacter, sessionFactoryService.hibernateMetadata)
     assertThat(report.schemas)


### PR DESCRIPTION
`SchemaValidatorService` lacks forwards compatibility. Adding a column to a table causes the service to fail to start. This caused a production outage when a service was mid-migration with no way to roll forward or back.

Let's disable temporarily until a fix has been made.