### PR TITLE
Allow disabling maxRows check in query

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -126,8 +126,11 @@ internal class ReflectionQuery<T : DbEntity<T>>(
   }
 
   private fun checkRowCount(returnList: Boolean, rowCount: Int) {
+    val disabledChecks = this.disabledChecks
     if (!returnList) {
       check(rowCount <= 1) { "query expected a unique result but was $rowCount" }
+    } else if (disabledChecks != null && disabledChecks.contains(Check.MAX_ROWS)) {
+      return
     } else if (maxRows == -1) {
       if (rowCount > queryLimitsConfig.maxMaxRows) {
         throw IllegalStateException("query truncated at $rowCount rows")

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -55,7 +55,8 @@ interface Session {
 enum class Check {
   FULL_SCATTER,
   TABLE_SCAN,
-  COWRITE
+  COWRITE,
+  MAX_ROWS
 }
 
 inline fun <reified T : DbEntity<T>> Session.load(id: Id<T>): T = load(id, T::class)


### PR DESCRIPTION
Sometimes you do want to have an unbounded query, and logging a warning is too noisy.

This change makes it possible to disable the max row count check on per-query basis.