### PR TITLE
Add QuerySniper and TransactionRunner

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
@@ -42,8 +42,8 @@ class TruncateTablesService(
   private fun truncateUserTables() {
     val stopwatch = Stopwatch.createStarted()
 
-    val truncatedTableNames = transacterProvider.get().shards().flatMap { shard ->
-      transacterProvider.get().transaction(shard) { session ->
+    val truncatedTableNames = transacterProvider.get().noTimeouts().shards().flatMap { shard ->
+      transacterProvider.get().noTimeouts().transaction(shard) { session ->
         session.withoutChecks {
           val config = connector.config()
           val tableNamesQuery = when (config.type) {
@@ -94,7 +94,7 @@ class TruncateTablesService(
   private fun executeStatements(statements: List<String>, name: String) {
     val stopwatch = Stopwatch.createStarted()
 
-    transacterProvider.get().transaction {
+    transacterProvider.get().noTimeouts().transaction {
       it.withoutChecks {
         it.useConnection { connection ->
           for (s in statements) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/QuerySniper.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/QuerySniper.kt
@@ -1,0 +1,87 @@
+package misk.hibernate
+
+import misk.logging.getLogger
+import org.hibernate.BaseSessionEventListener
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+/**
+ * Hooks on the start and end of query executions. Queries that take too long will be logged or
+ * cancelled. Time limits are configured by the [misk.jdbc.DataSourceConfig].
+ *
+ * In a transaction, wrap a query with [Session.runSlowQuery] to run it with higher time limits.
+ *
+ * ```
+ * transacter.transaction { session -> {
+ *   session.runSlowQuery { superSlowQuery(session) }
+ * }
+ * ```
+ */
+internal class QuerySniper constructor(
+  val executor: ScheduledExecutorService,
+  val onWarn: (() -> Unit)? = null,
+  val onKill: (() -> Unit)? = null
+) {
+  /** Watch a [session] so that slow queries may be killed if they exceed its timeouts. */
+  fun watch(session: Session) {
+    session.hibernateSession.addEventListeners(object : BaseSessionEventListener() {
+      private var warnFuture: ScheduledFuture<*>? = null
+      private var killFuture: ScheduledFuture<*>? = null
+      private val timeouts get() = session.timeouts()
+
+      private val warnCallback: () -> Unit = onWarn ?: this::onWarn
+      private val killCallback: () -> Unit = onKill ?: this::onKill
+
+      private fun onWarn() {
+        logger.warn {
+          "Query has exceeded ${timeouts.warnAfter.toMillis()} ms. " + if (killFuture != null) {
+            "Will kill if it exceeds ${timeouts.killAfter.toMillis()} ms."
+          } else {
+            "Won't kill."
+          }
+        }
+      }
+
+      private fun onKill() {
+        session.hibernateSession.cancelQuery()
+        logger.warn { "Query exceeded ${timeouts.killAfter.toMillis()} ms. Killed it!" }
+      }
+
+      override fun jdbcExecuteStatementStart() {
+        check(warnFuture == null && killFuture == null) { "Re-entrant JDBC statement!" }
+
+        warnFuture = if (timeouts.warnTimeoutEnabled()) {
+          executor.schedule(warnCallback, timeouts.warnAfter.toMillis(), TimeUnit.MILLISECONDS)
+        } else {
+          null
+        }
+
+        killFuture = if (timeouts.killTimeoutEnabled()) {
+          executor.schedule(killCallback, timeouts.killAfter.toMillis(), TimeUnit.MILLISECONDS)
+        } else {
+          null
+        }
+      }
+
+      override fun jdbcExecuteStatementEnd() {
+        warnFuture?.cancel(false)
+        warnFuture = null
+        killFuture?.cancel(false)
+        killFuture = null
+      }
+    })
+  }
+
+  internal class Factory @Inject constructor(
+    @ForHibernate private val executor: ScheduledExecutorService
+  ) {
+    fun create() = QuerySniper(executor)
+    fun create(onWarn: (() -> Unit)?, onKill: (() -> Unit)?) = QuerySniper(executor, onWarn, onKill)
+  }
+
+  companion object {
+    val logger = getLogger<QuerySniper>()
+  }
+}

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaValidator.kt
@@ -25,9 +25,11 @@ internal class SchemaValidator {
 
     val allDbTables = LinkedHashSet<TableDeclaration>()
 
-    transacter.shards().forEach { shard ->
-      val dbSchema = transacter.transaction(shard) { s ->
-        s.withoutChecks { s.hibernateSession.doReturningWork { readDeclarationFromDatabase(it) } }
+    transacter.noTimeouts().shards().forEach { shard ->
+      val dbSchema = transacter.noTimeouts().transaction(shard) { session ->
+        session.withoutChecks {
+          session.hibernateSession.doReturningWork { readDeclarationFromDatabase(it) }
+        }
       }
 
       withDeclaration(path.copy(schema = dbSchema.name)) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -50,6 +50,20 @@ interface Session {
    * @throws IllegalStateException when delete is called on a read only session.
    */
   fun <T : DbEntity<T>> delete(entity: T)
+
+  /** Retrieve the current timeouts used by this. */
+  fun timeouts(): Timeouts
+
+  /**
+   * Marks a query as slow. If a [QuerySniper] is watching this session, then it will not warn
+   * or kill it.
+   */
+  fun <T> runSlowQuery(query: Session.() -> T): T
+}
+
+internal interface CancellableSession : Session {
+  /** Will cause any subsequent operations on this to throw. */
+  fun cancel()
 }
 
 enum class Check {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Timeouts.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Timeouts.kt
@@ -1,0 +1,55 @@
+package misk.hibernate
+
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+data class Timeouts internal constructor(val warnAfter: Duration, val killAfter: Duration) {
+  fun warnTimeoutEnabled(): Boolean = warnAfter.isNatural()
+  fun killTimeoutEnabled(): Boolean = killAfter.isNatural()
+
+  companion object {
+    /** Zero valued timeouts. */
+    val NONE = Timeouts(Duration.ZERO, Duration.ZERO)
+
+    fun create(warnAfter: Duration): Timeouts {
+      require(warnAfter.isNatural()) {
+        "warnAfter must be a positive non-zero duration"
+      }
+      return Timeouts(warnAfter, Duration.ZERO)
+    }
+
+    fun create(warnAfter: Duration, killAfter: Duration): Timeouts {
+      require(warnAfter.isNatural()) {
+        "warnAfter must be a positive non-zero duration"
+      }
+      require(killAfter.isNatural()) {
+        "killAfter must be a positive non-zero duration"
+      }
+      return Timeouts(warnAfter, killAfter)
+    }
+
+    private fun Duration.isNatural(): Boolean = !this.isNegative && !this.isZero
+  }
+}
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class TransactionTimeouts
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class QueryTimeouts
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class SlowQueryTimeouts
+
+@Singleton
+/** Timeouts policies. Setting [Timeouts.NONE] disables the field's timeout policy. */
+data class TimeoutsConfig @Inject constructor(
+  @TransactionTimeouts val transaction: Timeouts,
+  @QueryTimeouts val query: Timeouts,
+  @SlowQueryTimeouts val slowQuery: Timeouts
+)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/TransactionRunner.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/TransactionRunner.kt
@@ -1,0 +1,99 @@
+package misk.hibernate
+
+import misk.logging.getLogger
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+/**
+ * Times a [session], checking if it has exceeded its [timeouts].
+ *
+ * An owner [Transacter] should catch any exceptions coming from this and rollback accordingly.
+ */
+internal class TransactionRunner constructor(
+  val executor: ScheduledExecutorService,
+  val session: CancellableSession,
+  val timeouts: Timeouts
+) {
+  private val isCancellable = AtomicBoolean(true)
+  private val warnFuture: ScheduledFuture<*>? = null
+  private val killFuture: ScheduledFuture<*>? = null
+
+  private fun warnCallback() {
+    logger.warn {
+      "Running transaction has exceeded ${timeouts.warnAfter.toMillis()} ms. " +
+          "Performance may be degraded?"
+    }
+  }
+
+  private fun killCallback() {
+    // Cancel the session so that the next operation will throw and rollback the transaction.
+    session.hibernateSession.cancelQuery()
+    if (isCancellable.get()) {
+      session.cancel()
+      isCancellable.set(false)
+      logger.warn {
+        "Cancelled session for this transaction because it took too long " +
+            "(${timeouts.killAfter.toMillis()} ms)"
+      }
+    }
+  }
+
+  /**
+   * Runs the body of a transaction with the [session] owned by this runner.
+   *
+   * When the [timeouts] warn after duration is exceeded, a warning will be logged.
+   * When the [timeouts] kill after duration is exceeded, the [session] will be cancelled, and the
+   * transaction will be rolled back.
+   */
+  fun <T> doWork(work: (Session) -> T): T {
+    return doWork(work, ::warnCallback, ::killCallback)
+  }
+
+  // Exposed for testing.
+  internal fun <T> doWork(
+    work: (Session) -> T,
+    warnCallback: () -> Unit,
+    killCallback: () -> Unit
+  ): T {
+    check(warnFuture == null && killFuture == null) {
+      "A new runner is required for each transaction!"
+    }
+
+    val warnFuture = if (timeouts.warnTimeoutEnabled()) {
+      executor.schedule(warnCallback, timeouts.warnAfter.toMillis(), TimeUnit.MILLISECONDS)
+    } else {
+      null
+    }
+    val killFuture = if (timeouts.killTimeoutEnabled()) {
+      executor.schedule(killCallback, timeouts.killAfter.toMillis(), TimeUnit.MILLISECONDS)
+    } else {
+      null
+    }
+
+    try {
+      val result = work(session)
+      isCancellable.set(false)
+      return result
+    } finally {
+      warnFuture?.cancel(false)
+      killFuture?.cancel(false)
+    }
+  }
+
+  internal class Factory @Inject constructor(
+    @ForHibernate private val executor: ScheduledExecutorService
+  ) {
+    fun create(session: CancellableSession, timeouts: Timeouts) = TransactionRunner(
+        executor = executor,
+        session = session,
+        timeouts = timeouts
+    )
+  }
+
+  companion object {
+    val logger = getLogger<TransactionRunner>()
+  }
+}

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -54,7 +54,14 @@ data class DataSourceConfig(
   // going forward
   val trust_certificate_key_store_path: String? = null,
   val client_certificate_key_store_path: String? = null,
-  val show_sql: String? = "false"
+  val show_sql: String? = "false",
+  // Default warn and kill timeouts for transactions and queries
+  val transaction_timeout: Duration = Duration.ZERO,
+  val transaction_timeout_warning: Duration = Duration.ZERO,
+  val query_timeout: Duration = Duration.ZERO,
+  val query_timeout_warning: Duration = Duration.ZERO,
+  val slow_query_timeout: Duration = Duration.ZERO,
+  val slow_query_timeout_warning: Duration = Duration.ZERO
 ) {
   fun withDefaults(): DataSourceConfig {
     return when (type) {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/QuerySniperTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/QuerySniperTest.kt
@@ -1,0 +1,140 @@
+package misk.hibernate
+
+import com.google.inject.Module
+import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.SessionFactory
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.LinkedBlockingDeque
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.persistence.PersistenceException
+import kotlin.test.fail
+
+@MiskTest(startService = true)
+class QuerySniperTest {
+  @Suppress("unused")
+  @MiskTestModule val module: Module = object : KAbstractModule() {
+    override fun configure() {
+      install(MoviesTestModule())
+      val qualifier = Movies::class
+      val querySniperFactoryProvider = getProvider(QuerySniper.Factory::class.java)
+      val timeoutsConfigProvider = getProvider(TimeoutsConfig::class.java)
+      val transactionRunnerFactoryProvider = getProvider(TransactionRunner.Factory::class.java)
+      val sessionFactoryProvider = getProvider(keyOf<SessionFactory>(qualifier))
+
+      bind(keyOf<RealTransacter>(qualifier)).toProvider(object : Provider<RealTransacter> {
+        @Inject lateinit var queryTracingListener: QueryTracingListener
+        override fun get() = RealTransacter(
+            qualifier = qualifier,
+            sessionFactoryProvider = sessionFactoryProvider,
+            queryTracingListener = queryTracingListener,
+            tracer = null,
+            transactionRunnerFactory = transactionRunnerFactoryProvider.get(),
+            querySniperFactory = querySniperFactoryProvider.get(),
+            timeoutsConfig = timeoutsConfigProvider.get()
+        )
+      })
+    }
+  }
+
+  @Inject @Movies internal lateinit var transacter: RealTransacter
+  @Inject lateinit var queryFactory: Query.Factory
+
+  @Test fun sniperTriggersCallbacksAfterThreshold() {
+    val log = LinkedBlockingDeque<String>()
+
+    transacter.timed(log).transaction { session ->
+      session.hibernateSession.createNativeQuery("SELECT sleep(0.3)").uniqueResult()
+    }
+
+    assertThat(log).containsExactly(
+        "Warning fired",
+        "Kill callback fired"
+    )
+  }
+
+  @Test fun markedSlowQueriesAreNotKilledOrWarned() {
+    val log = LinkedBlockingDeque<String>()
+
+    transacter.timed(log).transaction { session ->
+      session.runSlowQuery {
+        hibernateSession.createNativeQuery("SELECT sleep(0.3)").uniqueResult()
+      }
+    }
+
+    assertThat(log).isEmpty()
+  }
+
+  @Test fun warnOnlyTimeout() {
+    val log = LinkedBlockingDeque<String>()
+
+    transacter.warnOnly(log).transaction { session ->
+      session.hibernateSession.createNativeQuery("SELECT sleep(0.3)").uniqueResult()
+    }
+
+    assertThat(log).containsExactly("Warning fired")
+  }
+
+  @Test fun querySniperWatchesStatementsNotTheTransaction() {
+    val log = LinkedBlockingDeque<String>()
+
+    transacter.timed(log).transaction { session ->
+      // This will take about 10 seconds to run. Timeouts for this transaction are (15s, 30s).
+      for (i in 1..100) {
+        session.hibernateSession.createNativeQuery("SELECT sleep(0.1)").uniqueResult()
+      }
+    }
+
+    assertThat(log).isEmpty()
+  }
+
+  @Test fun malformedQueriesNotAffected() {
+    val log = LinkedBlockingDeque<String>()
+
+    transacter.timed(log).transaction { session ->
+      try {
+        session.hibernateSession.createNativeQuery("Not valid sql").uniqueResult()
+        fail()
+      } catch (_: PersistenceException) {
+      }
+      session.hibernateSession.createNativeQuery("SELECT sleep(0.3)").uniqueResult()
+    }
+
+    assertThat(log).containsExactly(
+        "Warning fired",
+        "Kill callback fired"
+    )
+  }
+
+  /**
+   * For these tests, we specify custom callbacks for the [QuerySniper] that is installed on each
+   * session of the transacter. This is done so that we can assert state. In this test, the queries
+   * are not killed; we only care that the events fire. Outside of this test, [QuerySniper.watch]
+   * will install callbacks that actually do log warnings and kill queries.
+   */
+  private fun RealTransacter.timed(log: LinkedBlockingDeque<String>): Transacter {
+    return this.withSniperActions(log)
+        .withTimeouts(Timeouts.create(Duration.ofSeconds(15), Duration.ofSeconds(30)))
+        .withQueryTimeouts(Timeouts.create(Duration.ofMillis(200), Duration.ofMillis(250)))
+        .withSlowQueryTimeouts(Timeouts.NONE)
+  }
+
+  private fun RealTransacter.warnOnly(log: LinkedBlockingDeque<String>): Transacter {
+    return this.withSniperActions(log)
+        .withTimeouts(Timeouts.NONE)
+        .withQueryTimeouts(Timeouts.create(warnAfter = Duration.ofMillis(150)))
+        .withSlowQueryTimeouts(Timeouts.NONE)
+  }
+
+  private fun RealTransacter.withSniperActions(log: LinkedBlockingDeque<String>): Transacter {
+    return this.withOptions(options.copy(
+        sniperWarning = { log.add("Warning fired") },
+        sniperAction = { log.add("Kill callback fired") }
+    ))
+  }
+}

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransactionRunnerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransactionRunnerTest.kt
@@ -1,0 +1,132 @@
+package misk.hibernate
+
+import com.google.inject.Module
+import com.google.inject.util.Modules
+import misk.concurrent.FakeScheduledExecutorService
+import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.mockito.Mockito
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.FakeClock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.time.LocalDate
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.ScheduledExecutorService
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class TransactionRunnerTest {
+  @Suppress("unused")
+  @MiskTestModule val module: Module =
+      Modules.override(MoviesTestModule())
+          .with(object : KAbstractModule() {
+            override fun configure() {
+              bind(keyOf<ScheduledExecutorService>(ForHibernate::class))
+                  .to(keyOf<FakeScheduledExecutorService>(ForHibernate::class))
+              bind(keyOf<FakeScheduledExecutorService>(ForHibernate::class)).to(keyOf())
+            }
+          })
+
+  @Inject @Movies lateinit var transacter: Transacter
+  @Inject @ForHibernate lateinit var executor: FakeScheduledExecutorService
+  @Inject lateinit var queryFactory: Query.Factory
+  @Inject lateinit var clock: FakeClock
+
+  val timeoutsConfig = TimeoutsConfig(
+      transaction = Timeouts.create(
+          warnAfter = Duration.ofSeconds(2),
+          killAfter = Duration.ofSeconds(10)
+      ),
+      query = Timeouts.NONE,
+      slowQuery = Timeouts.NONE
+  )
+
+  @Test fun runnerTriggersCallbacks() {
+    val log = LinkedBlockingDeque<String>()
+    val factory = TransactionRunner.Factory(executor)
+    val runner = factory.create(
+        session = Mockito.mock(),
+        timeouts = Timeouts.create(Duration.ofSeconds(10), Duration.ofSeconds(30))
+    )
+    runner.doWork({
+      clock.add(Duration.ofSeconds(31))
+      executor.tick()
+    }, warnCallback = {
+      log.add("Warning fired")
+    }, killCallback = {
+      log.add("Kill callback fired")
+    })
+
+    assertThat(log).containsExactly(
+        "Warning fired",
+        "Kill callback fired"
+    )
+  }
+
+  @Test fun killsTransactionsAfterThreshold() {
+    // Assert this transaction is killed by the built in runner.
+    assertThrows<IllegalStateException> {
+      transacter.timed().transaction { session ->
+        val movie = DbMovie("Star Wars", LocalDate.of(1993, 6, 9))
+        clock.add(Duration.ofHours(1)) // Make this a ridiculously long transaction.
+        executor.tick()
+        session.save(movie)
+      }
+    }
+
+    // Assert that the killed transaction was rolled back and no data was saved.
+    assertThat(transacter.transaction { session: Session ->
+      queryFactory.newQuery<MovieQuery>()
+          .allowFullScatter()
+          .allowTableScan()
+          .list(session)
+    }).isEmpty()
+  }
+
+  @Test fun transactionsNotKilledWhenNoTimeoutsSet() {
+    val starWars = DbMovie("Star Wars", LocalDate.of(1993, 6, 9))
+    transacter.noTimeouts().transaction { session ->
+      clock.add(Duration.ofHours(1)) // Make this a ridiculously long transaction.
+      executor.tick()
+      session.save(starWars)
+    }
+
+    val lookup = transacter.noTimeouts().transaction { session: Session ->
+      val query = queryFactory.newQuery<MovieQuery>()
+      clock.add(Duration.ofHours(1)) // Make this a ridiculously long transaction.
+      executor.tick()
+      query.allowFullScatter()
+          .allowTableScan()
+          .uniqueResult(session)
+    }
+    assertThat(lookup).isEqualToComparingFieldByField(starWars)
+  }
+
+  @Test fun transactionsAreSafeIfWithinTimeouts() {
+    val starWars = DbMovie("Star Wars", LocalDate.of(1993, 6, 9))
+
+    transacter.timed().transaction { session ->
+      clock.add(Duration.ofSeconds(5))
+      executor.tick()
+      session.save(starWars)
+    }
+
+    val lookup = transacter.transaction { session: Session ->
+      val query = queryFactory.newQuery<MovieQuery>()
+      query.allowFullScatter()
+          .allowTableScan()
+          .uniqueResult(session)
+    }
+    assertThat(lookup).isEqualToComparingFieldByField(starWars)
+  }
+
+  private fun Transacter.timed(): Transacter {
+    return this.withTimeouts(timeoutsConfig.transaction)
+        .withQueryTimeouts(timeoutsConfig.query)
+        .withSlowQueryTimeouts(timeoutsConfig.slowQuery)
+  }
+}


### PR DESCRIPTION
This change addresses issue (#230) and modifies the `Transacter` to:
 1. Run transactions with configurable time limits (entire transaction)
 2. Run individual queries with configurable time limits

Some new internal classes have been introduced to accomplish this:

 - `TransactionRunner`
 - `QuerySniper`

## TransactionRunner

Every transacter gets one. As its name suggests, it runs the transaction block. It also schedules events to warn about or cancel its transaction if the Timeouts are exceeded.

## QuerySniper

Every session gets one. This is like `TransactionRunner`, but it listens on individual hibernate queries.

## How do these work?

`Timeouts` are specified in the `DataSourceConfig`. The `HibernateModule` will bind a `TimeoutsConfig` object based on the values configured there.

There are three kinds of timeouts:
 - transaction timeouts: the time allotted for a transaction as a whole
 - query timeouts: the time allotted for a regular query
 - slow query timeouts: the time allotted for markedly slow queries

By default, these timeouts are all disabled.

When the timeouts are active, the runner attached to a transacter will automatically kill long running transactions, and each session's sniper will automatically kill long running queries.

### Transaction timeout runtime configuration

You can opt out of a transaction's timeouts with

    transacter.noTimeouts().transaction { ... }

or specify custom transaction timeouts with

    transacter.withTimeouts(Timeouts.create(...)).transaction { ... }

Note that these timeouts do _NOT_ affect query timeouts, which must be configured separately. It is possible to never have a transaction timeout, but still have query timeouts, or vice versa.

### Query timeout runtime configuration

If you know that a particular query is slow running, you can tell it to use the slow query timeout configuration by

    transacter.transaction { session ->
      session.runSlowQuery { ... }
    }

The `runSlowQuery` lambda uses the session as a reciever.

If you want to change the query or slow query timeouts at runtime, you can do so on the transacter:

    transacter.withQueryTimeouts(Timeouts.create(...))
         .withSlowQueryTimeouts(Timeouts.create(...))
         .transaction { ... }

That's it!