### PR TITLE
Enhanced shard targeting

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Destination.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Destination.kt
@@ -18,7 +18,7 @@ data class Destination(
   constructor(shard: Shard, tabletType: TabletType) : this(shard.keyspace, shard, tabletType)
 
   override fun toString(): String {
-    val tabletType = if (tabletType != null) "@$tabletType" else ""
+    val tabletType = (if (tabletType != null) "@$tabletType" else "").toLowerCase()
     if (shard != null) {
       return "$shard$tabletType"
     }

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -128,6 +128,7 @@ class HibernateModule(
       override fun get(): RealTransacter = RealTransacter(
           qualifier = qualifier,
           sessionFactoryProvider = sessionFactoryProvider,
+          config = config,
           queryTracingListener = queryTracingListener,
           tracer = tracer
       )

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -67,6 +67,9 @@ internal class RealTransacter private constructor(
   }
 
   override fun <T> replicaRead(block: (session: Session) -> T): T {
+    check(!inTransaction) {
+      "Can't do replica reads inside a transaction"
+    }
     if (!options.readOnly) {
       return readOnly().replicaRead(block)
     }

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -405,11 +405,11 @@ internal class RealTransacter private constructor(
         val target = if (config.type == DataSourceType.VITESS_MYSQL) {
           connection.catalog
         } else {
-          statement.executeQuery("SHOW VITESS_TARGET").uniqueString()
+          withoutChecks {
+            statement.executeQuery("SHOW VITESS_TARGET").uniqueString()
+          }
         }
-        withoutChecks {
-          Destination.parse(target)
-        }
+        Destination.parse(target)
       }
     }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -388,7 +388,7 @@ internal class RealTransacter private constructor(
       check(config.type.isVitess)
       connection.createStatement().use { statement ->
         if (config.type == DataSourceType.VITESS_MYSQL) {
-          val catalog = if (destination.isBlank()) "" else destination.toString()
+          val catalog = if (destination.isBlank()) "@master" else destination.toString()
           connection.catalog = catalog
         } else {
           withoutChecks {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Shard.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Shard.kt
@@ -77,7 +77,7 @@ data class Shard(val keyspace: Keyspace, val name: String) {
     val SINGLE_SHARD_SET = ImmutableSet.of(SINGLE_SHARD)
 
     fun parse(string: String): Shard {
-      val (keyspace, shard) = string.split('/', limit = 2)
+      val (keyspace, shard) = string.split('/', ':', limit = 2)
       return Shard(Keyspace(keyspace), shard)
     }
   }

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -74,7 +74,7 @@ data class DataSourceConfig(
         copy(
             port = port ?: 27003,
             host = host ?: "127.0.0.1",
-            database = database ?: ""
+            database = database ?: "@master"
         )
       }
       DataSourceType.HSQLDB -> {

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -7,23 +7,28 @@ import java.time.Duration
 /** Defines a type of datasource */
 enum class DataSourceType(
   val driverClassName: String,
-  val hibernateDialect: String
+  val hibernateDialect: String,
+  val isVitess: Boolean
 ) {
   MYSQL(
       driverClassName = "io.opentracing.contrib.jdbc.TracingDriver",
-      hibernateDialect = "org.hibernate.dialect.MySQL57Dialect"
+      hibernateDialect = "org.hibernate.dialect.MySQL57Dialect",
+      isVitess = false
   ),
   HSQLDB(
       driverClassName = "org.hsqldb.jdbcDriver",
-      hibernateDialect = "org.hibernate.dialect.H2Dialect"
+      hibernateDialect = "org.hibernate.dialect.H2Dialect",
+      isVitess = false
   ),
   VITESS(
       driverClassName = "io.vitess.jdbc.VitessDriver",
-      hibernateDialect = "misk.hibernate.VitessDialect"
+      hibernateDialect = "misk.hibernate.VitessDialect",
+      isVitess = true
   ),
   VITESS_MYSQL(
       driverClassName = MYSQL.driverClassName,
-      hibernateDialect = "misk.hibernate.VitessDialect"
+      hibernateDialect = "misk.hibernate.VitessDialect",
+      isVitess = true
   ),
 }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DestinationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DestinationTest.kt
@@ -19,7 +19,7 @@ class DestinationTest {
   fun testToString() {
     assertThat(Destination(null, null, null).toString()).isEqualTo("")
     assertThat(Destination(Shard(Keyspace("ks"), "-80")).toString()).isEqualTo("ks/-80")
-    assertThat(Destination(Shard(Keyspace("ks"), "-80"), TabletType.REPLICA).toString()).isEqualTo("ks/-80@REPLICA")
-    assertThat(Destination(Keyspace("ks"), null, TabletType.REPLICA).toString()).isEqualTo("ks@REPLICA")
+    assertThat(Destination(Shard(Keyspace("ks"), "-80"), TabletType.REPLICA).toString()).isEqualTo("ks/-80@replica")
+    assertThat(Destination(Keyspace("ks"), null, TabletType.REPLICA).toString()).isEqualTo("ks@replica")
   }
 }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MovieQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MovieQuery.kt
@@ -3,6 +3,9 @@ package misk.hibernate
 import java.time.LocalDate
 
 interface MovieQuery : Query<DbMovie> {
+  @Constraint("name")
+  fun name(name: String): MovieQuery
+
   @Constraint(path = "release_date", operator = Operator.LT)
   fun releaseDateBefore(date: LocalDate): MovieQuery
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -15,7 +15,8 @@ import misk.time.FakeClockModule
 
 /** This module creates movies, actors, and characters tables for several Hibernate tests. */
 class MoviesTestModule(
-  private val type: DataSourceType = DataSourceType.VITESS_MYSQL
+  // TODO(jontirsen): Make this VITESS_MYSQL when this is merged: https://github.com/vitessio/vitess/pull/5136
+  private val type: DataSourceType = DataSourceType.VITESS
 ) : KAbstractModule() {
   override fun configure() {
     install(LogCollectorModule())

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ScaleSafetyTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ScaleSafetyTest.kt
@@ -223,7 +223,7 @@ class ScaleSafetyTest {
       }
 }
 
-private fun <T : DbEntity<T>> Transacter.save(entity: T): Id<T> = transaction { it.save(entity) }
+fun <T : DbEntity<T>> Transacter.save(entity: T): Id<T> = transaction { it.save(entity) }
 
 fun Transacter.createInSeparateShard(
   id: Id<DbMovie>,

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -72,10 +72,11 @@ internal class SchemaValidatorTest {
         @Inject lateinit var queryTracingListener: QueryTracingListener
         @com.google.inject.Inject(optional = true) val tracer: Tracer? = null
         override fun get(): RealTransacter = RealTransacter(
-            qualifier,
-            sessionFactoryProvider,
-            queryTracingListener,
-            tracer
+            qualifier = qualifier,
+            sessionFactoryProvider = sessionFactoryProvider,
+            config = config.data_source,
+            queryTracingListener = queryTracingListener,
+            tracer = tracer
         )
       }).asSingleton()
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TimestampListenerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TimestampListenerTest.kt
@@ -1,10 +1,12 @@
 package misk.hibernate
 
+import jnr.ffi.annotations.IgnoreError
 import misk.jdbc.DataSourceType
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
@@ -79,6 +81,8 @@ class MySQLTimestampListenerTest : TimestampListenerTest() {
 }
 
 @MiskTest(startService = true)
+// TODO(jontirsen): Re-enable this test when this has been merged: https://github.com/vitessio/vitess/pull/5136
+@Disabled
 class VitessMySQLTimestampListenerTest : TimestampListenerTest() {
   @MiskTestModule
   val module = MoviesTestModule(DataSourceType.VITESS_MYSQL)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -209,7 +209,7 @@ class TransacterTest {
       // Make sure this doesn't trigger a transaction
       val target = session.useConnection { c -> c.createStatement().use {
         it.executeQuery("SHOW VITESS_TARGET").uniqueString() } }
-      assertThat(target).isEqualTo("@REPLICA")
+      assertThat(target).isEqualTo("@replica")
 
       queryFactory.newQuery<CharacterQuery>()
           .allowTableScan()
@@ -235,9 +235,9 @@ class TransacterTest {
     }
 
     transacter.replicaRead { session ->
-      queryFactory.newQuery<CharacterQuery>()
+      assertThat(queryFactory.newQuery<CharacterQuery>()
           .allowTableScan()
-          .name("Ian Malcolm 2").uniqueResult(session)!!
+          .name("Ian Malcolm 2").uniqueResult(session)).isNotNull()
     }
   }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.assertFailsWith
 @MiskTest(startService = true)
 class TransacterTest {
   @MiskTestModule
-  val module = MoviesTestModule(DataSourceType.VITESS_MYSQL)
+  val module = MoviesTestModule()
 
   @Inject @Movies lateinit var transacter: Transacter
   @Inject lateinit var queryFactory: Query.Factory
@@ -226,7 +226,7 @@ class TransacterTest {
       // Make sure this doesn't trigger a transaction
       val target = session.useConnection { c -> c.createStatement().use {
         it.executeQuery("SHOW VITESS_TARGET").uniqueString() } }
-      assertThat(target).isEqualTo("")
+      assertThat(target).isEqualTo("@master")
 
       val character = queryFactory.newQuery<CharacterQuery>()
           .allowTableScan()

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -78,7 +78,17 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
 
     override fun beforeEach(context: ExtensionContext) {
       if (context.startService()) {
-        serviceManager.startAsync().awaitHealthy(60, TimeUnit.SECONDS)
+        try {
+          serviceManager.startAsync().awaitHealthy(60, TimeUnit.SECONDS)
+        } catch (e: IllegalStateException) {
+          // Unwrap and throw the real service failure
+          val suppressed = e.suppressed.firstOrNull()
+          val cause = suppressed?.cause
+          if (cause != null) {
+            throw cause
+          }
+          throw e
+        }
       }
     }
   }


### PR DESCRIPTION
More tests and using a more robust strategy for the MySQL driver.

When deploying read replicas to contacts production we started getting these errors about not being able to start a transaction on replica tablets. My suspicion is that somehow we leave the connection in a bad state when we return it to the connection pool. Hikari automatically resets the catalog when you return the connection to the pool so my theory is that using the catalog will be more robust. Testing in production is required to confirm or reject this.