### PR TITLE
Fall back to replica to fix the spare region health check issue

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -1,6 +1,5 @@
 package misk.hibernate
 
-import com.google.common.base.Supplier
 import com.google.common.base.Suppliers
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import io.opentracing.Tracer
@@ -13,7 +12,6 @@ import misk.jdbc.map
 import misk.jdbc.uniqueString
 import misk.logging.getLogger
 import misk.tracing.traceWithSpan
-import okhttp3.internal.threadFactory
 import org.hibernate.FlushMode
 import org.hibernate.SessionFactory
 import org.hibernate.StaleObjectStateException
@@ -26,7 +24,6 @@ import java.util.EnumSet
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
-import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import javax.inject.Provider
 import javax.persistence.OptimisticLockException

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SchemaMigrator.kt
@@ -173,7 +173,7 @@ internal class SchemaMigrator(
    * if the migrations table has not been initialized.
    */
   fun appliedMigrations(shard: Shard): SortedSet<NamedspacedMigration> {
-    return transacter.get().transaction(shard) { session ->
+    return transacter.get().failSafeRead(shard) { session ->
       @Suppress("UNCHECKED_CAST") // createNativeQuery returns a raw Query.
       val query = session.hibernateSession.createNativeQuery(
           "SELECT version FROM schema_version") as Query<String>

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -219,6 +219,35 @@ data class DataSourceConfig(
 
     return pathToUse
   }
+
+  fun asReplica(): DataSourceConfig {
+      if (this.type != DataSourceType.VITESS_MYSQL) {
+        throw Exception("Replica database config only available for VITESS_MYSQL type")
+      }
+
+      return DataSourceConfig(
+              this.type,
+              this.host,
+              this.port,
+              "@replica",
+              this.username,
+              this.password,
+              this.fixed_pool_size,
+              this.connection_timeout,
+              this.connection_max_lifetime,
+              this.migrations_resource,
+              this.migrations_resources,
+              this.vitess_schema_dir,
+              this.vitess_schema_resource_root,
+              this.trust_certificate_key_store_url,
+              this.trust_certificate_key_store_password,
+              this.client_certificate_key_store_url,
+              this.client_certificate_key_store_password,
+              this.trust_certificate_key_store_path,
+              this.client_certificate_key_store_path,
+              this.show_sql
+      )
+  }
 }
 
 /** Configuration element for a cluster of DataSources */

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -39,12 +39,16 @@ class DataSourceService(
     logger.info("Starting @${qualifier.simpleName} connection pool")
 
     require(dataSource == null)
-    createDataSource()
-
+    try {
+      createDataSource(baseConfig)
+    } catch (e: Exception) {
+      logger.warn("Fail to start the data source to master tablet, trying to do it with replica")
+      createDataSource(baseConfig.asReplica())
+    }
     logger.info("Started @${qualifier.simpleName} connection pool in $stopwatch")
   }
 
-  private fun createDataSource() {
+  private fun createDataSource(baseConfig: DataSourceConfig) {
     // Rewrite the caller's config to get a database name like "movies__20190730__5" in tests.
     config = databasePool.takeDatabase(baseConfig)
 

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/PingDatabaseService.kt
@@ -24,27 +24,43 @@ class PingDatabaseService @Inject constructor(
 ) : AbstractIdleService() {
   override fun startUp() {
     val jdbcUrl = config.buildJdbcUrl(environment)
-    val dataSource = DriverDataSource(
-        jdbcUrl, config.type.driverClassName, Properties(), config.username, config.password)
+    val dataSource = createDataSource(jdbcUrl)
+
     retry(10, ExponentialBackoff(Duration.ofMillis(20), Duration.ofMillis(1000))) {
       try {
-        dataSource.connect().use { c ->
-          check(c.createStatement().use { s ->
-            s.executeQuery("SELECT 1 FROM dual").uniqueInt()
-          } == 1)
-          // During cluster start up we sometimes have an empty list of shards so lets also
-          // wait until the shards are loaded (this is generally only an issue during tests)
-          if (config.type.isVitess) {
-            check(c.createStatement().use { s ->
-              s.executeQuery("SHOW VITESS_SHARDS").map { rs -> rs.getString(1) }
-            }.isNotEmpty())
-          }
-        }
+          connectToDataSource(dataSource)
       } catch (e: Exception) {
-        logger.error(e) { "error attempting to ping the database" }
-        throw RuntimeException(e.describe(jdbcUrl), e)
+        if (config.type == DataSourceType.VITESS_MYSQL && config.database == "@master") {
+          logger.warn("ping master database unsuccessful, trying to ping the replica")
+          val replicaDataSource = createDataSource(config.asReplica().buildJdbcUrl(environment))
+
+          connectToDataSource(replicaDataSource)
+        } else {
+          logger.error(e) { "error attempting to ping the database" }
+          throw RuntimeException(e.describe(jdbcUrl), e)
+        }
       }
     }
+  }
+
+  private fun connectToDataSource(dataSource: DriverDataSource) {
+    dataSource.connect().use { c ->
+      check(c.createStatement().use { s ->
+        s.executeQuery("SELECT 1 FROM dual").uniqueInt()
+      } == 1)
+      // During cluster start up we sometimes have an empty list of shards so lets also
+      // wait until the shards are loaded (this is generally only an issue during tests)
+      if (config.type.isVitess) {
+        check(c.createStatement().use { s ->
+          s.executeQuery("SHOW VITESS_SHARDS").map { rs -> rs.getString(1) }
+        }.isNotEmpty())
+      }
+    }
+  }
+
+  private fun createDataSource(jdbcUrl: String): DriverDataSource {
+    return DriverDataSource(
+            jdbcUrl, config.type.driverClassName, Properties(), config.username, config.password)
   }
 
   /** Kotlin thinks getConnection() is a val but it's really a function. */


### PR DESCRIPTION
This PR address the health check connectivity problem on the spare region, where vitess cluster doesn't have a master tablet inside. Proposed way to solve it is to fall back the connection/transaction to point to replicas when fails to connect to master tablet.

Major changes happens in the following class.
1. `PingDatabaseService`
2. `DataSourceService`
3. `Transacter` having a `failSafeReal` method for `SchemaMigratorService` to use 
