### PR TITLE
Make HTTP/2 opt-in, not opt-out

### DIFF
--- a/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteGuideMiskServiceModule.kt
+++ b/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteGuideMiskServiceModule.kt
@@ -10,7 +10,9 @@ import javax.inject.Named
 /** A module that runs a Misk gRPC server: Wire protos and a Jetty backend. */
 class RouteGuideMiskServiceModule : KAbstractModule() {
   override fun configure() {
-    install(WebTestingModule())
+    install(WebTestingModule(webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        http2 = true
+    )))
     install(WebActionModule.create<GetFeatureGrpcAction>())
     install(WebActionModule.create<RouteChatGrpcAction>())
   }

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -18,7 +18,7 @@ data class WebConfig(
   val ssl: WebSslConfig? = null,
 
   /** HTTP/2 support is currently opt-in because we can't load balance it dynamically. */
-  val http2: Boolean = true,
+  val http2: Boolean = false,
 
   /** Number of NIO selector threads. */
   val selectors: Int? = null,

--- a/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
@@ -108,7 +108,9 @@ class GrpcConnectivityTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebTestingModule(webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+          http2 = true
+      )))
       install(WebActionModule.create<HelloRpcAction>())
     }
   }


### PR DESCRIPTION
Waiting on graceful shutdown in Jetty
https://github.com/eclipse/jetty.project/issues/2788