### PR TITLE
Improve source information on bindings.

### DIFF
--- a/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -1,6 +1,7 @@
 package misk.inject
 
 import com.google.inject.AbstractModule
+import com.google.inject.Binder
 import com.google.inject.Key
 import com.google.inject.TypeLiteral
 import com.google.inject.binder.AnnotatedBindingBuilder
@@ -110,6 +111,8 @@ abstract class KAbstractModule : AbstractModule() {
       else -> MapBinder.newMapBinder(binder(), keyType, valueType, annotation.java)
     }
   }
+
+  override fun binder(): Binder = super.binder().skipSources(KAbstractModule::class.java)
 
   @Suppress("UNCHECKED_CAST") // The type system isn't aware of constructed types.
   private fun <K, V> mapOfType(keyType: Type, valueType: Type): TypeLiteral<Map<K, V>> =

--- a/misk/src/main/kotlin/misk/moshi/MoshiAdapterModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiAdapterModule.kt
@@ -1,5 +1,6 @@
 package misk.moshi
 
+import com.google.inject.Binder
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -10,6 +11,8 @@ class MoshiAdapterModule(private val jsonAdapter: Any) : KAbstractModule() {
   override fun configure() {
     multibind<Any>(MoshiJsonAdapter::class).toInstance(jsonAdapter)
   }
+
+  override fun binder(): Binder = super.binder().skipSources(MoshiAdapterModule::class.java)
 
   companion object {
     inline operator fun <reified T> invoke(adapter: JsonAdapter<T>): MoshiAdapterModule =

--- a/misk/src/main/kotlin/misk/web/WebActionModule.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionModule.kt
@@ -1,5 +1,6 @@
 package misk.web
 
+import com.google.inject.Binder
 import misk.inject.KAbstractModule
 import misk.web.actions.WebAction
 import misk.web.actions.WebActionEntry
@@ -12,8 +13,10 @@ class WebActionModule<A : WebAction> private constructor(
   override fun configure() {
     multibind<WebActionEntry>().toInstance(WebActionEntry(actionClass, url_path_prefix))
     // Ensures that the action has an @Inject annotation and that its dependencies are satisfied
-    binder().skipSources(WebActionModule::class.java).getProvider(actionClass.java)
+    binder().getProvider(actionClass.java)
   }
+
+  override fun binder(): Binder = super.binder().skipSources(WebActionModule::class.java)
 
   companion object {
     inline fun <reified A : WebAction> create(): WebActionModule<A> = create(A::class)


### PR DESCRIPTION
Previously lots of bindings had a source of KAbstractModule.kt which
is not very useful for troubleshooting.