### PR TITLE
Prevent multiple Actions with identical routing annotations

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -76,6 +76,26 @@ internal class BoundAction<A : WebAction>(
     )
   }
 
+  /**
+   * Returns true if this [BoundAction] has identical routing annotations as the provided
+   * [BoundAction].
+   */
+  fun hasIdenticalRouting(other: BoundAction<*>): Boolean {
+    if (pathPattern.pattern != other.pathPattern.pattern) {
+      return false
+    }
+    if (action.dispatchMechanism != other.action.dispatchMechanism) {
+      return false
+    }
+    if (action.acceptedMediaRanges != other.action.acceptedMediaRanges) {
+      return false
+    }
+    if (action.responseContentType != other.action.responseContentType) {
+      return false
+    }
+    return true
+  }
+
   internal fun scopeAndHandle(
     request: HttpServletRequest,
     httpCall: HttpCall,

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -46,6 +46,16 @@ internal class WebActionsServlet @Inject constructor(
     for (entry in webActionEntries) {
       boundActions += webActionFactory.newBoundAction(entry.actionClass, entry.url_path_prefix)
     }
+    // Verify no two Actions have identical routing annotations, which is most likely a bad
+    // copy/paste error and results in unexpected results for a developer. This fails the service
+    // startup, which should be caught with a unit test.
+    for (action in boundActions) {
+      for (other in boundActions) {
+        check(action === other || !action.hasIdenticalRouting(other)) {
+          "Actions [${action.action.name}, ${other.action.name}] have identical routing annotations."
+        }
+      }
+    }
   }
 
   override fun doGet(request: HttpServletRequest, response: HttpServletResponse) {

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -1,0 +1,50 @@
+package misk.web
+
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Injector
+import com.google.inject.ProvisionException
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import javax.inject.Inject
+
+@MiskTest(startService = false)
+class InvalidActionsTest {
+
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject private lateinit var injector: Injector
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebTestingModule())
+      install(WebActionModule.create<SomeAction>())
+      install(WebActionModule.create<IdenticalAction>())
+    }
+  }
+
+  @Test fun failIdenticalActions() {
+    assertThrows<ProvisionException>(
+        "Actions [SomeAction, IdenticalAction] have identical routing annotations.") {
+      injector.getInstance(ServiceManager::class.java)
+    }
+  }
+
+  class SomeAction @Inject constructor() : WebAction {
+    @Post("/hello")
+    @RequestContentType("application/json")
+    @ResponseContentType("application/json")
+    fun hello() = "hello"
+  }
+
+  class IdenticalAction @Inject constructor() : WebAction {
+    @Post("/hello")
+    @RequestContentType("application/json")
+    @ResponseContentType("application/json")
+    fun hello() = "hello"
+  }
+}

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -180,7 +180,6 @@ class NotFoundActionTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(WebTestingModule())
-      install(WebActionModule.create<NotFoundAction>())
       install(WebActionModule.create<EchoAction>())
       install(WebActionModule.create<EchoFooAction>())
     }

--- a/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
@@ -11,7 +11,6 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
 import misk.web.WebTestingModule
-import misk.web.actions.NotFoundAction
 import misk.web.jetty.JettyService
 import misk.web.resources.StaticResourceAction
 import misk.web.resources.StaticResourceEntry
@@ -216,8 +215,6 @@ class StaticResourceActionTest {
           ))))
       install(HttpClientModule("static_resource_action",
           Names.named("static_resource_action")))
-
-      install(WebActionModule.create<NotFoundAction>())
 
       install(WebActionModule.createWithPrefix<StaticResourceAction>("/hi/"))
       multibind<StaticResourceEntry>()


### PR DESCRIPTION
This causes a server start up failure, which should result in catching
the error in a unit test before committing the bug.

2 actions with identical routing annotations is most likely a bug
introduced by bad copy/paste. One of the Actions will never be
dispatched, so it provides no value.