### PR TITLE
Adds docs and fixes exemplarchat example.

### DIFF
--- a/misk-eventrouter/src/main/kotlin/misk/eventrouter/ConsistentHashing.kt
+++ b/misk-eventrouter/src/main/kotlin/misk/eventrouter/ConsistentHashing.kt
@@ -6,11 +6,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ConsistentHashing @Inject constructor(
-  private val hashFunction: HashFunction = Hashing.murmur3_32(),
-  private val mod: Long = 65536L,
-  private val virtualPoints: Int = 16
+class ConsistentHashing(
+  private val hashFunction: HashFunction,
+  private val mod: Long,
+  private val virtualPoints: Int
 ) : ClusterMapper {
+
+  @Inject constructor() : this(Hashing.murmur3_32(), 65536L, 16)
+
   // TODO(tso): make this more efficient
   override fun topicToHost(clusterSnapshot: ClusterSnapshot, topic: String): String {
     val hosts = clusterSnapshot.hosts.sorted()

--- a/samples/exemplarchat/Dockerfile
+++ b/samples/exemplarchat/Dockerfile
@@ -6,4 +6,4 @@ RUN groupadd -g 999 appuser && \
     useradd -r -u 999 -g appuser appuser
 USER 999
 
-CMD ["java", "-jar", "/usr/local/chat/exemplarchat-0.2.5-SNAPSHOT.jar"]
+CMD ["java", "-jar", "/usr/local/chat/exemplarchat-0.8.0-SNAPSHOT.jar"]

--- a/samples/exemplarchat/README.md
+++ b/samples/exemplarchat/README.md
@@ -2,3 +2,21 @@
 
 This is a sample app that makes use of Misk. It demonstrates both web sockets and Misk's recommended
 patterns for embedded web UIs.
+
+## Usage
+
+1. Build the React app in the `web` directory.
+    ```
+    cd samples/exemplarchat/web
+    yarn
+    yarn run build
+    ```
+2. Build the project using gradle.
+    ```bash
+    ./gradlew :samples:exemplarchat:build    
+    ```
+2. Run the sample.
+    ```bash
+    java -jar samples/exemplarchat/build/libs/exemplarchat-0.8.0-SNAPSHOT.jar    
+    ```
+   

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -24,7 +24,7 @@ jar {
 shadowJar {
   exclude('module-info.class') // https://github.com/johnrengelman/shadow/issues/352
   mergeServiceFiles()
-  into("web/exemplarchat") {
+  into("web") {
     from("web/build")
   }
 }

--- a/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatModule.kt
+++ b/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatModule.kt
@@ -14,7 +14,7 @@ class ChatModule : KAbstractModule() {
     // TODO(adrw) finish testing this with the new StaticResourceAction
     install(WebActionModule.createWithPrefix<StaticResourceAction>("/room/"))
     multibind<StaticResourceEntry>().toInstance(
-        StaticResourceEntry("/room/", "classpath:/web/index.html"))
+        StaticResourceEntry("/room/", "classpath:/web/"))
 
     install(WebActionModule.create<ChatWebSocketAction>())
     install(WebActionModule.create<ToggleManualHealthCheckAction>())

--- a/samples/exemplarchat/web/package.json
+++ b/samples/exemplarchat/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "misk-webadmin",
   "version": "0.1.0",
+  "homepage": "/room/",
   "private": true,
   "dependencies": {
     "react": "16.8.6",
@@ -13,5 +14,17 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/samples/exemplarchat/web/src/App.js
+++ b/samples/exemplarchat/web/src/App.js
@@ -13,7 +13,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    const href = window.location.href;
+    const href = window.location.href.replace(/\/$/, ''); // Remove optional trailing `/`
     const ws_protocol = (window.location.protocol === "https:") ? "wss:" : "ws:";
     const hostname = window.location.hostname;
     const port = window.location.port;


### PR DESCRIPTION
I've been checking out Misk and had some trouble getting the `exemplarchat` example running. I've made a few changes to fix issues with the sample and added a `Usage` section to the readme that details how to start (biggest hurdle was realizing I had to build the web section independently, and run from jar to get the shaded assets).