### PR TITLE
http metrics do not pre-aggregate

### DIFF
--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -20,13 +20,10 @@ class ClientMetricsInterceptor internal constructor(
     try {
       val result = chain.proceed(chain.request)
       val elapsedMillis = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS).toDouble()
-      requestDuration.record(elapsedMillis, actionName, "all")
-      requestDuration.record(elapsedMillis, actionName, "${result.code / 100}xx")
       requestDuration.record(elapsedMillis, actionName, "${result.code}")
       return result
     } catch (e: SocketTimeoutException) {
       val elapsedMillis = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS).toDouble()
-      requestDuration.record(elapsedMillis, actionName, "all")
       requestDuration.record(elapsedMillis, actionName, "timeout")
       throw e
     }

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -23,9 +23,7 @@ internal class MetricsInterceptor internal constructor(
     val callingPrincipal = caller.get()?.principal ?: "unknown"
 
     val statusCode = chain.httpCall.statusCode
-    arrayOf("all", "${statusCode / 100}xx", "$statusCode").forEach { code ->
-      requestDuration.record(elapsedTimeMillis, actionName, callingPrincipal, code)
-    }
+    requestDuration.record(elapsedTimeMillis, actionName, callingPrincipal, statusCode.toString())
     return result
   }
 

--- a/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
@@ -62,9 +62,7 @@ internal class ClientMetricsInterceptorTest {
     assertThat(client.ping(AppRequest(503)).execute().code()).isEqualTo(503)
 
     SoftAssertions.assertSoftly { softly ->
-      softly.assertThat(requestDuration.count("pinger.ping", "all")).isEqualTo(6)
       softly.assertThat(requestDuration.count("pinger.ping", "202")).isEqualTo(1)
-      softly.assertThat(requestDuration.count("pinger.ping", "4xx")).isEqualTo(2)
       softly.assertThat(requestDuration.count("pinger.ping", "404")).isEqualTo(1)
       softly.assertThat(requestDuration.count("pinger.ping", "403")).isEqualTo(1)
       softly.assertThat(requestDuration.count("pinger.ping", "403")).isEqualTo(1)
@@ -79,7 +77,6 @@ internal class ClientMetricsInterceptorTest {
     }.withCauseInstanceOf(SocketTimeoutException::class.java)
 
     SoftAssertions.assertSoftly { softly ->
-      softly.assertThat(requestDuration.count("pinger.ping", "all")).isEqualTo(1)
       softly.assertThat(requestDuration.count("pinger.ping", "timeout")).isEqualTo(1)
     }
   }

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -48,25 +48,15 @@ class MetricsInterceptorTest {
   @Test
   fun responseCodes() {
     val requestDuration = metricsInterceptorFactory.requestDuration
-    requestDuration.record(1.0, "TestAction", "unknown", "all")
-    assertThat(requestDuration.count("TestAction", "unknown", "all")).isEqualTo(7)
-    requestDuration.record(1.0, "TestAction", "unknown", "2xx")
-    assertThat(requestDuration.count("TestAction", "unknown", "2xx")).isEqualTo(4)
     requestDuration.record(1.0, "TestAction", "unknown", "200")
     assertThat(requestDuration.count("TestAction", "unknown", "200")).isEqualTo(3)
     requestDuration.record(1.0, "TestAction", "unknown", "202")
     assertThat(requestDuration.count("TestAction", "unknown", "202")).isEqualTo(2)
-    requestDuration.record(1.0, "TestAction", "unknown", "4xx")
-    assertThat(requestDuration.count("TestAction", "unknown", "4xx")).isEqualTo(4)
     requestDuration.record(1.0, "TestAction", "unknown", "404")
     assertThat(requestDuration.count("TestAction", "unknown", "404")).isEqualTo(2)
     requestDuration.record(1.0, "TestAction", "unknown", "403")
     assertThat(requestDuration.count("TestAction", "unknown", "403")).isEqualTo(3)
 
-    requestDuration.record(1.0, "TestAction", "my-peer", "all")
-    assertThat(requestDuration.count("TestAction", "my-peer", "all")).isEqualTo(5)
-    requestDuration.record(1.0, "TestAction", "my-peer", "2xx")
-    assertThat(requestDuration.count("TestAction", "my-peer", "2xx")).isEqualTo(5)
     requestDuration.record(1.0, "TestAction", "my-peer", "200")
     assertThat(requestDuration.count("TestAction", "my-peer", "200")).isEqualTo(5)
   }


### PR DESCRIPTION
We pre-aggregated status codes to `all`, `4xx`, `5xx` etc. This caused
confusion for users when they tried to do aggregations on the metric
like `sum(rate(http_request_latency_ms_count[1m]))` because it ended up
tripling the rate.

This PR removes pre-aggregation, prefering to let the monitoring system
to do aggregation.