### PR TITLE
Add count/latency metric for PendingTasks

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -17,6 +17,7 @@ import misk.jobqueue.JobQueue
 import misk.jobqueue.QueueName
 import misk.jobqueue.TransactionalJobQueue
 import misk.tasks.RepeatedTaskQueue
+import misk.tasks.RepeatedTaskQueueFactory
 import java.time.Clock
 import java.util.concurrent.Executors
 import javax.inject.Inject
@@ -68,13 +69,10 @@ class AwsSqsJobQueueModule(
   }
 
   @Provides @ForSqsConsumer @Singleton
-  fun consumerRepeatedTaskQueue(clock: Clock, config: AwsSqsJobQueueConfig): RepeatedTaskQueue {
-    return RepeatedTaskQueue(
+  fun consumerRepeatedTaskQueue(queueFactory: RepeatedTaskQueueFactory,
+    config: AwsSqsJobQueueConfig): RepeatedTaskQueue {
+    return queueFactory.new(
         "sqs-consumer-poller",
-        clock,
-        Executors.newCachedThreadPool(ThreadFactoryBuilder()
-            .setNameFormat("sqs-consumer-%d")
-            .build()),
         config.task_queue)
   }
 

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseModule.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseModule.kt
@@ -6,13 +6,11 @@ import misk.ServiceModule
 import misk.clustering.ClusterService
 import misk.clustering.lease.LeaseManager
 import misk.clustering.weights.ClusterWeightService
-import misk.concurrent.ExecutorServiceModule
 import misk.inject.KAbstractModule
 import misk.tasks.RepeatedTaskQueue
+import misk.tasks.RepeatedTaskQueueFactory
 import misk.zookeeper.ZkService
 import misk.zookeeper.ZookeeperDefaultModule
-import java.time.Clock
-import java.util.concurrent.ExecutorService
 import javax.inject.Singleton
 
 /**
@@ -22,7 +20,6 @@ import javax.inject.Singleton
 class ZkLeaseModule : KAbstractModule() {
   override fun configure() {
     install(ZkLeaseCommonModule())
-    install(ExecutorServiceModule.withFixedThreadPool(ForZkLease::class, "zk-lease-poller", 1))
   }
 
   companion object {
@@ -31,11 +28,8 @@ class ZkLeaseModule : KAbstractModule() {
   }
 
   @Provides @ForZkLease @Singleton
-  fun provideTaskQueue(
-    clock: Clock,
-    @ForZkLease executorService: ExecutorService
-  ): RepeatedTaskQueue {
-    return RepeatedTaskQueue("zk-lease-poller", clock, executorService)
+  fun provideTaskQueue(queueFactory: RepeatedTaskQueueFactory): RepeatedTaskQueue {
+    return queueFactory.new("zk-lease-poller")
   }
 }
 

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
@@ -11,7 +11,6 @@ import misk.tasks.DelayedTask
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
 import misk.zookeeper.testing.ZkTestModule
-import java.time.Clock
 
 internal class ZkLeaseTestModule : KAbstractModule() {
   override fun configure() {

--- a/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
+++ b/misk-zookeeper/src/test/kotlin/misk/clustering/zookeeper/ZkLeaseTestModule.kt
@@ -9,6 +9,7 @@ import misk.config.AppName
 import misk.inject.KAbstractModule
 import misk.tasks.DelayedTask
 import misk.tasks.RepeatedTaskQueue
+import misk.tasks.RepeatedTaskQueueFactory
 import misk.zookeeper.testing.ZkTestModule
 import java.time.Clock
 
@@ -23,10 +24,10 @@ internal class ZkLeaseTestModule : KAbstractModule() {
 
   @Provides @ForZkLease @Singleton
   fun provideTaskQueue(
-    clock: Clock,
+    queueFactory: RepeatedTaskQueueFactory,
     @ForZkLease delayQueue: ExplicitReleaseDelayQueue<DelayedTask>
   ): RepeatedTaskQueue {
-    return RepeatedTaskQueue.forTesting("zk-lease-poller", clock, delayQueue)
+    return queueFactory.forTesting("zk-lease-poller", delayQueue)
   }
 
   @Provides @ForZkLease

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -1,15 +1,9 @@
 package misk
 
-import com.google.common.util.concurrent.Service
-import com.google.common.util.concurrent.ServiceManager
-import com.google.inject.Injector
-import com.google.inject.Provides
-import com.google.inject.Scopes
 import misk.concurrent.SleeperModule
 import misk.environment.RealEnvVarModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 import misk.metrics.MetricsModule
 import misk.moshi.MoshiModule
 import misk.prometheus.PrometheusHistogramRegistryModule
@@ -17,9 +11,6 @@ import misk.resources.ResourceLoaderModule
 import misk.time.ClockModule
 import misk.time.TickerModule
 import misk.tokens.TokenGeneratorModule
-import mu.KotlinLogging
-import javax.inject.Provider
-import javax.inject.Singleton
 
 /**
  * Install this module in real environments.

--- a/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueue.kt
+++ b/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueue.kt
@@ -4,9 +4,13 @@ import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService
 import com.google.common.util.concurrent.Service
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import misk.backoff.Backoff
+import misk.backoff.FlatBackoff
 import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.logging.getLogger
+import misk.metrics.Metrics
+import misk.time.timed
 import java.time.Clock
 import java.time.Duration
 import java.util.concurrent.BlockingQueue
@@ -16,6 +20,8 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Executors.newSingleThreadExecutor
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * A [RepeatedTaskQueue] runs repeated tasks at a user controlled rate. Internally it uses
@@ -31,6 +37,8 @@ class RepeatedTaskQueue @VisibleForTesting internal constructor(
   private val taskExecutor: ExecutorService,
   private val dispatchExecutor: Executor?, // visible internally for testing only
   private val pendingTasks: BlockingQueue<DelayedTask>, // visible internally for testing only
+  // TODO(rhall): make required when all callers are using the Factory
+  metrics: Metrics?,
   private val config: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig()
 
 ) : AbstractExecutionThreadService() {
@@ -38,15 +46,21 @@ class RepeatedTaskQueue @VisibleForTesting internal constructor(
    * Creates a [RepeatedTaskQueue] backed by a real [DelayQueue], with tasks dequeued on the
    * service background thread and executed via the provided [ExecutorService]
    */
+  @Deprecated("use the factory instead", replaceWith = ReplaceWith("RepeatedTaskQueueFactory"))
   constructor(
     name: String,
     clock: Clock,
     taskExecutor: ExecutorService,
     config: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig()
   ) :
-      this(name, clock, taskExecutor, null, DelayQueue<DelayedTask>(), config)
+      this(name, clock, taskExecutor, null, DelayQueue<DelayedTask>(), null, config)
 
   private val running = AtomicBoolean(false)
+  internal val taskLatency = metrics?.histogram(
+      "task_latency",
+      "count and duration in ms of periodic tasks",
+      listOf("name", "result"))
+
 
   override fun startUp() {
     if (!running.compareAndSet(false, true)) return
@@ -117,12 +131,17 @@ class RepeatedTaskQueue @VisibleForTesting internal constructor(
    */
   fun schedule(delay: Duration, retryDelayOnFailure: Duration? = null, task: () -> Result) {
     val wrappedTask: () -> Result = {
-      try {
-        task()
-      } catch (th: Throwable) {
-        log.error(th) { "error running repeated task on queue $name" }
-        Result(Status.FAILED, retryDelayOnFailure ?: delay)
+      val timedResult = timed {
+        try {
+          task()
+        } catch (th: Throwable) {
+          log.error(th) { "error running repeated task on queue $name" }
+          Result(Status.FAILED, retryDelayOnFailure ?: delay)
+        }
       }
+      taskLatency?.record(timedResult.first.toMillis().toDouble(), name,
+          timedResult.second.status.metricLabel())
+      timedResult.second
     }
     enqueue(delay, wrappedTask)
   }
@@ -143,30 +162,34 @@ class RepeatedTaskQueue @VisibleForTesting internal constructor(
     task: () -> Status
   ) {
     enqueue(delay = initialDelay) {
-      try {
-        val status = task()
-        when (status) {
-          Status.OK -> {
-            noWorkBackoff.reset()
-            failureBackoff.reset()
-            Result(status, timeBetweenRuns)
+      val timedResult = timed {
+        try {
+          when (val status = task()) {
+            Status.OK -> {
+              noWorkBackoff.reset()
+              failureBackoff.reset()
+              Result(status, timeBetweenRuns)
+            }
+            Status.NO_WORK -> {
+              failureBackoff.reset()
+              Result(status, noWorkBackoff.nextRetry())
+            }
+            Status.FAILED -> {
+              noWorkBackoff.reset()
+              Result(status, failureBackoff.nextRetry())
+            }
+            Status.NO_RESCHEDULE -> // NB(mmihic): The delay doesn't matter since we aren't rescheduling
+              Result(status, Duration.ofMillis(0))
           }
-          Status.NO_WORK -> {
-            failureBackoff.reset()
-            Result(status, noWorkBackoff.nextRetry())
-          }
-          Status.FAILED -> {
-            noWorkBackoff.reset()
-            Result(status, failureBackoff.nextRetry())
-          }
-          Status.NO_RESCHEDULE -> // NB(mmihic): The delay doesn't matter since we aren't rescheduling
-            Result(status, Duration.ofMillis(0))
+        } catch (th: Throwable) {
+          log.error(th) { "error running repeated task on queue $name" }
+          noWorkBackoff.reset()
+          Result(Status.FAILED, failureBackoff.nextRetry())
         }
-      } catch (th: Throwable) {
-        log.error(th) { "error running repeated task on queue $name" }
-        noWorkBackoff.reset()
-        Result(Status.FAILED, failureBackoff.nextRetry())
       }
+      taskLatency?.record(timedResult.first.toMillis().toDouble(), name,
+          timedResult.second.status.metricLabel())
+      timedResult.second
     }
   }
 
@@ -182,38 +205,74 @@ class RepeatedTaskQueue @VisibleForTesting internal constructor(
      * to explicitly control when tasks are released for execution. Tasks are executed in a single
      * thread in the order in which they expire
      */
+    @Deprecated("use the factory instead", replaceWith = ReplaceWith("RepeatedTaskQueueFactory"))
     @JvmStatic fun forTesting(
       name: String,
       clock: Clock,
-      backingStorage: ExplicitReleaseDelayQueue<DelayedTask>
+      backingStorage: ExplicitReleaseDelayQueue<DelayedTask>,
+      metrics: Metrics? = null
     ): RepeatedTaskQueue {
-      val queue = RepeatedTaskQueue(
-          name,
-          clock,
-          newDirectExecutorService(),
-          newSingleThreadExecutor(),
-          backingStorage
-      )
-
-      // Install a status listener that will explicitly release all of the tasks from the
-      // underlying delay queue at shutdown, ensuring that the termination action runs and
-      // allowing the task queue itself to shutdown
-      val fullyTerminated = AtomicBoolean(false)
-      queue.addListener(object : Service.Listener() {
-        override fun stopping(from: Service.State) {
-          // Keep kicking the storage until the task queue finally shuts down
-          while (!fullyTerminated.get()) {
-            backingStorage.releaseAll()
-            Thread.sleep(500)
-          }
-        }
-
-        override fun terminated(from: Service.State) {
-          fullyTerminated.set(true)
-        }
-      }, Executors.newSingleThreadExecutor())
-
-      return queue
+      return RepeatedTaskQueueFactory(clock, metrics).forTesting(name, backingStorage)
     }
   }
 }
+
+@Singleton
+class RepeatedTaskQueueFactory @Inject constructor(
+  private val clock: Clock,
+  private val metrics: Metrics?
+) {
+
+  /**
+   * Builds a new instance of a [RepeatedTaskQueue]
+   */
+  fun new(name: String, config: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig())
+      : RepeatedTaskQueue {
+    return RepeatedTaskQueue(name,
+        clock,
+        newSingleThreadExecutor(ThreadFactoryBuilder()
+            .setNameFormat("$name-%d")
+            .build()),
+        null,
+        DelayQueue<DelayedTask>(),
+        metrics,
+        config)
+  }
+
+  /**
+   * Builds a new instance of a [RepeatedTaskQueue] for testing
+   */
+  fun forTesting(name: String, backingStorage: ExplicitReleaseDelayQueue<DelayedTask>)
+      : RepeatedTaskQueue {
+    val queue = RepeatedTaskQueue(
+        name,
+        clock,
+        newDirectExecutorService(),
+        newSingleThreadExecutor(),
+        backingStorage,
+        metrics,
+        RepeatedTaskQueueConfig()
+    )
+
+    // Install a status listener that will explicitly release all of the tasks from the
+    // underlying delay queue at shutdown, ensuring that the termination action runs and
+    // allowing the task queue itself to shutdown
+    val fullyTerminated = AtomicBoolean(false)
+    queue.addListener(object : Service.Listener() {
+      override fun stopping(from: Service.State) {
+        // Keep kicking the storage until the task queue finally shuts down
+        while (!fullyTerminated.get()) {
+          backingStorage.releaseAll()
+          Thread.sleep(500)
+        }
+      }
+
+      override fun terminated(from: Service.State) {
+        fullyTerminated.set(true)
+      }
+    }, newSingleThreadExecutor())
+
+    return queue
+  }
+}
+

--- a/misk/src/main/kotlin/misk/tasks/Tasks.kt
+++ b/misk/src/main/kotlin/misk/tasks/Tasks.kt
@@ -18,7 +18,7 @@ enum class Status(private val metricLabel: String) {
   /**
    * The metric label for the status. This is used instead of name() in case the code is refactored.
    */
-  fun metricLabel() : String {
+  fun metricLabel(): String {
     return metricLabel
   }
 }

--- a/misk/src/main/kotlin/misk/tasks/Tasks.kt
+++ b/misk/src/main/kotlin/misk/tasks/Tasks.kt
@@ -2,18 +2,25 @@ package misk.tasks
 
 import java.time.Duration
 
-enum class Status {
+enum class Status(private val metricLabel: String) {
   /** The task completed successfully and processed work */
-  OK,
+  OK("ok"),
 
   /** The task had no work to complete */
-  NO_WORK,
+  NO_WORK("no_work"),
 
   /** The task resulted in an error */
-  FAILED,
+  FAILED("failed"),
 
   /** The task should not be rescheduled */
-  NO_RESCHEDULE
+  NO_RESCHEDULE("no_reschedule");
+
+  /**
+   * The metric label for the status. This is used instead of name() in case the code is refactored.
+   */
+  fun metricLabel() : String {
+    return metricLabel
+  }
 }
 
 data class Result(val status: Status, val nextDelay: Duration)

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -9,6 +9,7 @@ import misk.backoff.FlatBackoff
 import misk.backoff.retry
 import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.inject.KAbstractModule
+import misk.metrics.Metrics
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
@@ -49,6 +50,50 @@ internal class RepeatedTaskQueueTest {
 
     clock.add(Duration.ofSeconds(7))
     assertThat(scheduled.getDelay(TimeUnit.SECONDS)).isEqualTo(3)
+  }
+
+  @Test fun scheduleMetrics() {
+    var counter = 0
+    taskQueue.schedule(Duration.ofSeconds(10)) {
+      val status = when (counter) {
+        0 -> Status.OK
+        1 -> Status.FAILED
+        2 -> Status.NO_RESCHEDULE
+        else -> Status.NO_WORK
+      }
+      counter++
+      Result(status, Duration.ofSeconds(5))
+    }
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "ok")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "failed")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_work")).isEqualTo(1)
+  }
+
+  @Test fun scheduleBackoffMetrics() {
+    var counter = 0
+    taskQueue.scheduleWithBackoff(Duration.ofSeconds(10)) {
+      val status = when (counter) {
+        0 -> Status.OK
+        1 -> Status.FAILED
+        2 -> Status.NO_RESCHEDULE
+        else -> Status.NO_WORK
+      }
+      counter++
+      status
+    }
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "ok")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "failed")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
+    waitForNextPendingTask().task()
+    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_work")).isEqualTo(1)
   }
 
   @Test fun ordersTasksByInitialDelay() {
@@ -495,10 +540,10 @@ internal class RepeatedTaskQueueTest {
 
     @Provides @Singleton
     fun repeatedTaskQueue(
-      clock: FakeClock,
+      queueFactory : RepeatedTaskQueueFactory,
       backingStorage: ExplicitReleaseDelayQueue<DelayedTask>
     ): RepeatedTaskQueue {
-      return RepeatedTaskQueue.forTesting("my-task-queue", clock, backingStorage)
+      return queueFactory.forTesting("my-task-queue", backingStorage)
     }
   }
 

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -9,7 +9,6 @@ import misk.backoff.FlatBackoff
 import misk.backoff.retry
 import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.inject.KAbstractModule
-import misk.metrics.Metrics
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
@@ -65,13 +64,13 @@ internal class RepeatedTaskQueueTest {
       Result(status, Duration.ofSeconds(5))
     }
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "ok")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "ok")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "failed")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "failed")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_work")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "no_work")).isEqualTo(1)
   }
 
   @Test fun scheduleBackoffMetrics() {
@@ -87,13 +86,13 @@ internal class RepeatedTaskQueueTest {
       status
     }
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "ok")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "ok")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "failed")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "failed")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "no_reschedule")).isEqualTo(1)
     waitForNextPendingTask().task()
-    assertThat(taskQueue.taskLatency!!.count("my-task-queue", "no_work")).isEqualTo(1)
+    assertThat(taskQueue.taskDuration!!.count("my-task-queue", "no_work")).isEqualTo(1)
   }
 
   @Test fun ordersTasksByInitialDelay() {
@@ -540,7 +539,7 @@ internal class RepeatedTaskQueueTest {
 
     @Provides @Singleton
     fun repeatedTaskQueue(
-      queueFactory : RepeatedTaskQueueFactory,
+      queueFactory: RepeatedTaskQueueFactory,
       backingStorage: ExplicitReleaseDelayQueue<DelayedTask>
     ): RepeatedTaskQueue {
       return queueFactory.forTesting("my-task-queue", backingStorage)


### PR DESCRIPTION
Also added a RepeatedTaskQueueFactory to make it easier for clients to
construct a RepeatedTaskQueue. In the future we don't have to update
every call site when we add a new dependency to RepeatedTaskQueue.