### PR TITLE
DashboardMetadataAction to support multiple tab groupings

### DIFF
--- a/misk/src/main/kotlin/misk/web/DashboardTab.kt
+++ b/misk/src/main/kotlin/misk/web/DashboardTab.kt
@@ -8,47 +8,89 @@ import kotlin.reflect.KClass
 class DashboardTab(
   slug: String,
   url_path_prefix: String,
+  val dashboard: String,
   val name: String,
   val category: String = "Admin",
   capabilities: Set<String> = setOf(),
   services: Set<String> = setOf()
 ) : WebTab(slug, url_path_prefix, capabilities, services)
 
+inline fun <reified DA : Annotation> DashboardTab(
+  slug: String,
+  url_path_prefix: String,
+  name: String,
+  category: String = "Admin",
+  capabilities: Set<String> = setOf(),
+  services: Set<String> = setOf()
+) = DashboardTab(
+  slug = slug,
+  url_path_prefix = url_path_prefix,
+  dashboard = DA::class.simpleName!!,
+  name = name,
+  category = category,
+  capabilities = capabilities,
+  services = services
+)
+
 /**
  * Sets the tab's authentication based on the injected AdminDashboardAccess access annotation entry
  */
-class DashboardTabProvider(
+class DashboardTabProviderBuilder(
   val slug: String,
   val url_path_prefix: String,
   val name: String,
   val category: String = "Admin",
-  val accessAnnotation: KClass<out Annotation>
+  val dashboardAnnotation: KClass<out Annotation>,
+  val accessAnnotation: KClass<out Annotation>? = null,
+  val capabilities: Set<String> = setOf(),
+  val services: Set<String> = setOf()
 ) : Provider<DashboardTab> {
   @Inject
   lateinit var registeredEntries: List<AccessAnnotationEntry>
 
   override fun get(): DashboardTab {
-    val accessAnnotationEntry = registeredEntries.find { it.annotation == accessAnnotation }!!
+    val accessAnnotationEntry = registeredEntries.find { it.annotation == accessAnnotation }
     return DashboardTab(
       slug = slug,
       url_path_prefix = url_path_prefix,
+      dashboard = dashboardAnnotation.simpleName!!,
       name = name,
       category = category,
-      capabilities = accessAnnotationEntry.capabilities.toSet(),
-      services = accessAnnotationEntry.services.toSet()
+      capabilities = accessAnnotationEntry?.capabilities?.toSet() ?: capabilities,
+      services = accessAnnotationEntry?.services?.toSet() ?: services
     )
   }
 }
 
-inline fun <reified A : Annotation> DashboardTabProvider(
+/** Binds a DashboardTab for Dashboard [DA] with access annotation [AA] */
+inline fun <reified DA : Annotation, reified AA : Annotation> DashboardTabAccessProvider(
   slug: String,
   url_path_prefix: String,
   name: String,
   category: String = "Admin"
-) = DashboardTabProvider(
+) = DashboardTabProviderBuilder(
   slug = slug,
   url_path_prefix = url_path_prefix,
   name = name,
   category = category,
-  accessAnnotation = A::class
+  dashboardAnnotation = DA::class,
+  accessAnnotation = AA::class
+)
+
+/** Binds a DashboardTab for Dashboard [DA] */
+inline fun <reified DA : Annotation> DashboardTabProvider(
+  slug: String,
+  url_path_prefix: String,
+  name: String,
+  category: String = "Admin",
+  capabilities: Set<String> = setOf(),
+  services: Set<String> = setOf()
+) = DashboardTabProviderBuilder(
+  slug = slug,
+  url_path_prefix = url_path_prefix,
+  name = name,
+  category = category,
+  capabilities = capabilities,
+  services = services,
+  dashboardAnnotation = DA::class
 )

--- a/misk/src/main/kotlin/misk/web/actions/DashboardMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/DashboardMetadataAction.kt
@@ -5,6 +5,7 @@ import misk.scope.ActionScoped
 import misk.security.authz.Unauthenticated
 import misk.web.DashboardTab
 import misk.web.Get
+import misk.web.PathParam
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
@@ -13,7 +14,7 @@ import javax.inject.Qualifier
 import javax.inject.Singleton
 
 /**
- * Returns list of all Admin Tabs visible to current calling authenticated user
+ * Returns list of all authenticated dashboard tabs for a given [dashboard]
  *
  * Used in computing topbar nav menu and in inferring tab compiled JS paths
  *
@@ -21,21 +22,23 @@ import javax.inject.Singleton
  * - name should start with a capital letter unless it is a proper noun (ie. iOS)
  * - category is a string, no enforcement on consistency of names
  */
-
 @Singleton
-class AdminDashboardTabAction @Inject constructor() : WebAction {
-  @Inject @AdminDashboardTab private lateinit var adminDashboardTabs: List<DashboardTab>
+class DashboardMetadataAction @Inject constructor() : WebAction {
+  @Inject private lateinit var allDashboardTabs: List<DashboardTab>
   @Inject lateinit var callerProvider: @JvmSuppressWildcards ActionScoped<MiskCaller?>
 
-  @Get("/api/admindashboardtabs")
+  @Get("/api/dashboard/metadata/{dashboard}")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
-  fun getAll(): Response {
+  fun getAll(
+    @PathParam dashboard: String
+  ): Response {
     val caller = callerProvider.get() ?: return Response()
-    val authorizedAdminDashboardTabs =
-      adminDashboardTabs.filter { caller.isAllowed(it.capabilities, it.services) }
-    return Response(adminDashboardTabs = authorizedAdminDashboardTabs)
+    val dashboardTabs = allDashboardTabs.filter { it.dashboard == dashboard }
+    val authorizedDashboardTabs =
+      dashboardTabs.filter { caller.isAllowed(it.capabilities, it.services) }
+    return Response(adminDashboardTabs = authorizedDashboardTabs)
   }
 
   data class Response(val adminDashboardTabs: List<DashboardTab> = listOf())
@@ -43,4 +46,4 @@ class AdminDashboardTabAction @Inject constructor() : WebAction {
 
 @Qualifier
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
-annotation class AdminDashboardTab
+annotation class AdminDashboard

--- a/misk/src/test/kotlin/misk/web/actions/ConfigMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ConfigMetadataActionTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 @MiskTest(startService = true)
 class ConfigMetadataActionTest {
   @MiskTestModule
-  val module = AdminDashboardActionTestingModule()
+  val module = DashboardMetadataActionTestingModule()
 
   val testConfig = TestConfig(
       IncludedConfig("foo"),

--- a/misk/src/test/kotlin/misk/web/actions/DashboardMetadataActionTestingModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DashboardMetadataActionTestingModule.kt
@@ -4,17 +4,32 @@ import misk.config.AppName
 import misk.config.Config
 import misk.environment.Environment
 import misk.inject.KAbstractModule
+import misk.web.DashboardTab
+import misk.web.DashboardTabProvider
 import misk.web.metadata.AdminDashboardTestingModule
+import javax.inject.Qualifier
 
 // Common test module used to be able to test admin dashboard WebActions
-class AdminDashboardActionTestingModule : KAbstractModule() {
+class DashboardMetadataActionTestingModule : KAbstractModule() {
   override fun configure() {
     install(TestWebActionModule())
     install(AdminDashboardTestingModule(Environment.TESTING))
     bind<Config>().toInstance(TestAdminDashboardConfig())
     // TODO(wesley): Remove requirement for AppName to bind AdminDashboard APIs
     bind<String>().annotatedWith<AppName>().toInstance("testApp")
+
+    // Bind test dashboard tab
+    multibind<DashboardTab>().toProvider(DashboardTabProvider<DashboardMetadataActionTestDashboard>(
+      "slug",
+      "/url-path-prefix/",
+      "Test Dashboard Tab",
+      "test category"
+    ))
   }
 }
 
 class TestAdminDashboardConfig : Config
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class DashboardMetadataActionTestDashboard

--- a/misk/src/test/kotlin/misk/web/actions/DashboardTabTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DashboardTabTest.kt
@@ -7,33 +7,33 @@ import kotlin.test.assertFailsWith
 internal class DashboardTabTest {
   @Test
   internal fun tabGoodSlug() {
-    DashboardTab("good-1-slug-test", url_path_prefix = "/a/path/", name = "Name")
+    DashboardTab<AdminDashboard>("good-1-slug-test", url_path_prefix = "/a/path/", name = "Name")
   }
 
   @Test
   internal fun tabSlugWithSpace() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab("bad slug", url_path_prefix = "/a/path/", name = "Name")
+      DashboardTab<AdminDashboard>("bad slug", url_path_prefix = "/a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabSlugWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab("BadSlug", url_path_prefix = "/a/path/", name = "Name")
+      DashboardTab<AdminDashboard>("BadSlug", url_path_prefix = "/a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabGoodCategory() {
-    DashboardTab(slug = "slug", url_path_prefix = "/a/path/", name = "Name",
+    DashboardTab<AdminDashboard>(slug = "slug", url_path_prefix = "/a/path/", name = "Name",
       category = "@tea-pot_418")
   }
 
   @Test
   internal fun tabCategoryWithSpace() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "bad slug", url_path_prefix = "/a/path/", name = "Name",
+      DashboardTab<AdminDashboard>(slug = "bad slug", url_path_prefix = "/a/path/", name = "Name",
         category = "bad icon")
     }
   }
@@ -41,27 +41,27 @@ internal class DashboardTabTest {
   @Test
   internal fun tabCategoryWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "BadSlug", url_path_prefix = "/a/path/", name = "Name",
+      DashboardTab<AdminDashboard>(slug = "BadSlug", url_path_prefix = "/a/path/", name = "Name",
         category = "Bad-Icon")
     }
   }
 
   @Test
   internal fun tabGoodPath() {
-    DashboardTab(slug = "slug", url_path_prefix = "/a/path/", name = "Name")
+    DashboardTab<AdminDashboard>(slug = "slug", url_path_prefix = "/a/path/", name = "Name")
   }
 
   @Test
   internal fun tabPathWithoutLeadingSlash() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "slug", url_path_prefix = "a/path/", name = "Name")
+      DashboardTab<AdminDashboard>(slug = "slug", url_path_prefix = "a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabPathWithoutTrailingSlash() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "slug", url_path_prefix = "/a/path", name = "Name")
+      DashboardTab<AdminDashboard>(slug = "slug", url_path_prefix = "/a/path", name = "Name")
     }
   }
 }

--- a/misk/src/test/kotlin/misk/web/actions/WebActionMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/WebActionMetadataActionTest.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 class WebActionMetadataActionTest {
   @MiskTestModule
-  val module = AdminDashboardActionTestingModule()
+  val module = DashboardMetadataActionTestingModule()
 
   @Inject lateinit var webActionMetadataAction: WebActionMetadataAction
 

--- a/misk/web/tabs/admin-dashboard/src/containers/AdminDashboardContainer.tsx
+++ b/misk/web/tabs/admin-dashboard/src/containers/AdminDashboardContainer.tsx
@@ -1,13 +1,9 @@
-import {
-  MiskNavbarContainer,
-  miskAdminDashboardTabsUrl,
-  miskServiceMetadataUrl
-} from "@misk/core"
+import { MiskNavbarContainer, miskServiceMetadataUrl } from "@misk/core"
 import * as React from "react"
 
 export const AdminDashboardContainer = () => (
   <MiskNavbarContainer
-    adminDashboardTabsUrl={miskAdminDashboardTabsUrl}
+    adminDashboardTabsUrl={"/api/dashboard/metadata/AdminDashboard"}
     serviceMetadataUrl={miskServiceMetadataUrl}
   />
 )


### PR DESCRIPTION
* Deprecate `AdminDashboardTabAction` in favor of more generic `DashboardMetadataAction` that returns a list of authenticated dashboard tabs per a path parameter for the dashboard
* For example, this now supports from one endpoint, returning tabs for the `_admin/` dashboard and an `app/` dashboard