### PR TITLE
Support multiple dashboards with AdminDashboardTabAction 

### DIFF
--- a/misk/src/main/kotlin/misk/web/DashboardTab.kt
+++ b/misk/src/main/kotlin/misk/web/DashboardTab.kt
@@ -8,47 +8,89 @@ import kotlin.reflect.KClass
 class DashboardTab(
   slug: String,
   url_path_prefix: String,
+  val dashboard: String,
   val name: String,
   val category: String = "Admin",
   capabilities: Set<String> = setOf(),
   services: Set<String> = setOf()
 ) : WebTab(slug, url_path_prefix, capabilities, services)
 
+inline fun <reified DA : Annotation> DashboardTab(
+  slug: String,
+  url_path_prefix: String,
+  name: String,
+  category: String = "Admin",
+  capabilities: Set<String> = setOf(),
+  services: Set<String> = setOf()
+) = DashboardTab(
+  slug = slug,
+  url_path_prefix = url_path_prefix,
+  dashboard = DA::class.simpleName!!,
+  name = name,
+  category = category,
+  capabilities = capabilities,
+  services = services
+)
+
 /**
- * Sets the tab's authentication based on the injected AdminDashboardAccess access annotation entry
+ * Sets the tab's dashboard group by annotation and authentication by injected access annotation entry
  */
-class DashboardTabProvider(
+class DashboardTabProviderBuilder(
   val slug: String,
   val url_path_prefix: String,
   val name: String,
   val category: String = "Admin",
-  val accessAnnotation: KClass<out Annotation>
+  val dashboardAnnotation: KClass<out Annotation>,
+  val accessAnnotation: KClass<out Annotation>? = null,
+  val capabilities: Set<String> = setOf(),
+  val services: Set<String> = setOf()
 ) : Provider<DashboardTab> {
   @Inject
   lateinit var registeredEntries: List<AccessAnnotationEntry>
 
   override fun get(): DashboardTab {
-    val accessAnnotationEntry = registeredEntries.find { it.annotation == accessAnnotation }!!
+    val accessAnnotationEntry = registeredEntries.find { it.annotation == accessAnnotation }
     return DashboardTab(
       slug = slug,
       url_path_prefix = url_path_prefix,
+      dashboard = dashboardAnnotation.simpleName!!,
       name = name,
       category = category,
-      capabilities = accessAnnotationEntry.capabilities.toSet(),
-      services = accessAnnotationEntry.services.toSet()
+      capabilities = accessAnnotationEntry?.capabilities?.toSet() ?: capabilities,
+      services = accessAnnotationEntry?.services?.toSet() ?: services
     )
   }
 }
 
-inline fun <reified A : Annotation> DashboardTabProvider(
+/** Binds a DashboardTab for Dashboard [DA] with access annotation [AA] */
+inline fun <reified DA : Annotation, reified AA : Annotation> DashboardTabProvider(
   slug: String,
   url_path_prefix: String,
   name: String,
   category: String = "Admin"
-) = DashboardTabProvider(
+) = DashboardTabProviderBuilder(
   slug = slug,
   url_path_prefix = url_path_prefix,
   name = name,
   category = category,
-  accessAnnotation = A::class
+  dashboardAnnotation = DA::class,
+  accessAnnotation = AA::class
+)
+
+/** Binds a DashboardTab for Dashboard Group annotation [DA] */
+inline fun <reified DA : Annotation> DashboardTabProvider(
+  slug: String,
+  url_path_prefix: String,
+  name: String,
+  category: String = "Admin",
+  capabilities: Set<String> = setOf(),
+  services: Set<String> = setOf()
+) = DashboardTabProviderBuilder(
+  slug = slug,
+  url_path_prefix = url_path_prefix,
+  name = name,
+  category = category,
+  capabilities = capabilities,
+  services = services,
+  dashboardAnnotation = DA::class
 )

--- a/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/AdminDashboardModule.kt
@@ -27,9 +27,14 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
     // Adds open CORS headers in development to allow through API calls from webpack servers
     multibind<NetworkInterceptor.Factory>().to<WideOpenDevelopmentInterceptorFactory>()
 
-    // Admin Dashboard Tab
+    // Initialize DashboardTab multibinding list
+    newMultibinder<DashboardTab>()
+
+    // Add metadata actions to support dashboards
     install(WebActionModule.create<AdminDashboardTabAction>())
     install(WebActionModule.create<ServiceMetadataAction>())
+
+    // Admin Dashboard Tab
     install(WebTabResourceModule(
       environment = environment,
       slug = "admin-dashboard",
@@ -54,8 +59,8 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
 
     // Config
     install(WebActionModule.create<ConfigMetadataAction>())
-    multibind<DashboardTab, AdminDashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboardAccess>(
+    multibind<DashboardTab>().toProvider(
+      DashboardTabProvider<AdminDashboardTab, AdminDashboardAccess>(
         slug = "config",
         url_path_prefix = "/_admin/config/",
         name = "Config",
@@ -69,8 +74,8 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
 
     // Web Actions
     install(WebActionModule.create<WebActionMetadataAction>())
-    multibind<DashboardTab, AdminDashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboardAccess>(
+    multibind<DashboardTab>().toProvider(
+      DashboardTabProvider<AdminDashboardTab, AdminDashboardAccess>(
         slug = "web-actions",
         url_path_prefix = "/_admin/web-actions/",
         name = "Web Actions",
@@ -87,9 +92,9 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
 // Module that allows testing/development environments to bind up the admin dashboard
 class AdminDashboardTestingModule(val environment: Environment) : KAbstractModule() {
   override fun configure() {
+    // Set dummy values for access, these shouldn't matter,
+    // as test environments should prefer to use the FakeCallerAuthenticator.
     multibind<AccessAnnotationEntry>()
-      // Set dummy values for access, these shouldn't matter,
-      // as test environments should prefer to use the FakeCallerAuthenticator.
       .toInstance(AccessAnnotationEntry<AdminDashboardAccess>(capabilities = listOf("admin_access")))
     install(AdminDashboardModule(environment))
   }

--- a/misk/src/test/kotlin/misk/web/actions/AdminDashboardActionTestingModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/AdminDashboardActionTestingModule.kt
@@ -4,7 +4,10 @@ import misk.config.AppName
 import misk.config.Config
 import misk.environment.Environment
 import misk.inject.KAbstractModule
+import misk.web.DashboardTab
+import misk.web.DashboardTabProvider
 import misk.web.metadata.AdminDashboardTestingModule
+import javax.inject.Qualifier
 
 // Common test module used to be able to test admin dashboard WebActions
 class AdminDashboardActionTestingModule : KAbstractModule() {
@@ -14,7 +17,20 @@ class AdminDashboardActionTestingModule : KAbstractModule() {
     bind<Config>().toInstance(TestAdminDashboardConfig())
     // TODO(wesley): Remove requirement for AppName to bind AdminDashboard APIs
     bind<String>().annotatedWith<AppName>().toInstance("testApp")
+
+    // Bind test dashboard tab
+    multibind<DashboardTab>().toProvider(DashboardTabProvider<DashboardMetadataActionTestDashboard>(
+      slug = "slug",
+      url_path_prefix = "/url-path-prefix/",
+      name = "Test Dashboard Tab",
+      category = "test category",
+      capabilities = setOf("test_admin_access")
+    ))
   }
 }
 
 class TestAdminDashboardConfig : Config
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class DashboardMetadataActionTestDashboard

--- a/misk/src/test/kotlin/misk/web/actions/DashboardTabTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DashboardTabTest.kt
@@ -7,33 +7,33 @@ import kotlin.test.assertFailsWith
 internal class DashboardTabTest {
   @Test
   internal fun tabGoodSlug() {
-    DashboardTab("good-1-slug-test", url_path_prefix = "/a/path/", name = "Name")
+    DashboardTab<AdminDashboardTab>("good-1-slug-test", url_path_prefix = "/a/path/", name = "Name")
   }
 
   @Test
   internal fun tabSlugWithSpace() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab("bad slug", url_path_prefix = "/a/path/", name = "Name")
+      DashboardTab<AdminDashboardTab>("bad slug", url_path_prefix = "/a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabSlugWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab("BadSlug", url_path_prefix = "/a/path/", name = "Name")
+      DashboardTab<AdminDashboardTab>("BadSlug", url_path_prefix = "/a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabGoodCategory() {
-    DashboardTab(slug = "slug", url_path_prefix = "/a/path/", name = "Name",
+    DashboardTab<AdminDashboardTab>(slug = "slug", url_path_prefix = "/a/path/", name = "Name",
       category = "@tea-pot_418")
   }
 
   @Test
   internal fun tabCategoryWithSpace() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "bad slug", url_path_prefix = "/a/path/", name = "Name",
+      DashboardTab<AdminDashboardTab>(slug = "bad slug", url_path_prefix = "/a/path/", name = "Name",
         category = "bad icon")
     }
   }
@@ -41,27 +41,27 @@ internal class DashboardTabTest {
   @Test
   internal fun tabCategoryWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "BadSlug", url_path_prefix = "/a/path/", name = "Name",
+      DashboardTab<AdminDashboardTab>(slug = "BadSlug", url_path_prefix = "/a/path/", name = "Name",
         category = "Bad-Icon")
     }
   }
 
   @Test
   internal fun tabGoodPath() {
-    DashboardTab(slug = "slug", url_path_prefix = "/a/path/", name = "Name")
+    DashboardTab<AdminDashboardTab>(slug = "slug", url_path_prefix = "/a/path/", name = "Name")
   }
 
   @Test
   internal fun tabPathWithoutLeadingSlash() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "slug", url_path_prefix = "a/path/", name = "Name")
+      DashboardTab<AdminDashboardTab>(slug = "slug", url_path_prefix = "a/path/", name = "Name")
     }
   }
 
   @Test
   internal fun tabPathWithoutTrailingSlash() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab(slug = "slug", url_path_prefix = "/a/path", name = "Name")
+      DashboardTab<AdminDashboardTab>(slug = "slug", url_path_prefix = "/a/path", name = "Name")
     }
   }
 }

--- a/misk/web/tabs/admin-dashboard/src/containers/AdminDashboardContainer.tsx
+++ b/misk/web/tabs/admin-dashboard/src/containers/AdminDashboardContainer.tsx
@@ -7,7 +7,7 @@ import * as React from "react"
 
 export const AdminDashboardContainer = () => (
   <MiskNavbarContainer
-    adminDashboardTabsUrl={miskAdminDashboardTabsUrl}
+    adminDashboardTabsUrl={`${miskAdminDashboardTabsUrl}/AdminDashboardTab`}
     serviceMetadataUrl={miskServiceMetadataUrl}
   />
 )


### PR DESCRIPTION
* Action returns a list of authenticated dashboard tabs per a path parameter for the dashboard
* This allows support from one endpoint, of tabs for the `_admin/` dashboard and an `app/` dashboard
* Needed to support Misk services that have dedicated front end apps, ie. https://github.com/cashapp/backfila