### PR TITLE
Fix flaky SqsJobQueueServiceTest

### DIFF
--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueServiceTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueServiceTest.kt
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.lang.Thread.sleep
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -46,25 +46,25 @@ internal class SqsJobQueueServiceTest {
     serviceManager.awaitStopped(20, TimeUnit.SECONDS)
   }
 
-  @Test fun jobsNotHandledUntilAllServicesAreRunning() {
+  @Test fun `jobs are not handled until all services are running`() {
     val log = LinkedBlockingDeque<String>()
+    val jobRan = CountDownLatch(1)
 
-    sleep(100)
     log.put("about to subscribe")
     consumer.subscribe(queueName) { job ->
       log.put("handling job")
       job.acknowledge()
+      jobRan.countDown()
     }
 
-    sleep(100)
+    // This job should not run until all the services are healthy, meaning we should see the "about to enqueue" message
+    // now, and the "handling job" message at the end
     log.put("about to enqueue")
     queue.enqueue(queueName, "this is a job")
 
-    sleep(100)
     log.put("about to start the service manager")
     serviceManager.startAsync()
 
-    sleep(100)
     log.put("about to start the manual start service")
     manualStartService.manualStart()
 
@@ -72,7 +72,10 @@ internal class SqsJobQueueServiceTest {
     assertThat(log.poll()).isEqualTo("about to enqueue")
     assertThat(log.poll()).isEqualTo("about to start the service manager")
     assertThat(log.poll()).isEqualTo("about to start the manual start service")
-    assertThat(log.poll()).isEqualTo("handling job") // Called by the handler thread.
+
+    // Wait for the job consumer to run and execute the job
+    jobRan.await(1, TimeUnit.SECONDS)
+    assertThat(log.poll()).isEqualTo("handling job") // Called by the handler thread
   }
 
   @Singleton


### PR DESCRIPTION
The test was flaky because it wasn't guaranteed that the JobConsumer had had a chance to run the job
in between the polls. The fix here is to add a CountDownLatch that'll wait until the job has had a
chance to run.

To test flaky-ness, I ran this test 300 times without failure.

![image](https://user-images.githubusercontent.com/4147338/67311914-636c6800-f4ce-11e9-9905-1348e18ff337.png)