### PR TITLE
Add an idempotenceKey to the JobQueue interface

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -17,10 +17,10 @@ internal class SqsJob(
   override val body: String = message.body
   override val id: String = message.messageId
   override val idempotenceKey =
-      message.messageAttributes[IDEMPOTENCY_KEY_ATTR]?.stringValue ?: randomIdempotenceKey
+      message.messageAttributes[Job.IDEMPOTENCY_KEY_ATTR]?.stringValue ?: randomIdempotenceKey
   override val attributes: Map<String, String> = message.messageAttributes
       .map { (key, value) -> key to value.stringValue }
-      .filter { (key, _) -> key != IDEMPOTENCY_KEY_ATTR }
+      .filter { (key, _) -> key != Job.IDEMPOTENCY_KEY_ATTR }
       .toMap()
 
   private val queue: ResolvedQueue = queues[queueName]
@@ -46,6 +46,5 @@ internal class SqsJob(
 
   companion object {
     const val ORIGINAL_TRACE_ID_ATTR = "x-original-trace-id"
-    const val IDEMPOTENCY_KEY_ATTR = "idempotencey_key"
   }
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
@@ -3,6 +3,7 @@ package misk.jobqueue.sqs
 import com.amazonaws.services.sqs.model.MessageAttributeValue
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import io.opentracing.Tracer
+import misk.jobqueue.Job
 import misk.jobqueue.JobQueue
 import misk.jobqueue.QueueName
 import misk.logging.getLogger
@@ -34,6 +35,9 @@ internal class SqsJobQueue @Inject internal constructor(
     deliveryDelay: Duration?,
     attributes: Map<String, String>
   ) {
+    check(!attributes.keys.contains(Job.IDEMPOTENCY_KEY_ATTR)) {
+      "${Job.IDEMPOTENCY_KEY_ATTR} is a reserved attribute key"
+    }
     tracer.traceWithSpan("enqueue-job-${queueName.value}") { span ->
       metrics.jobsEnqueued.labels(queueName.value).inc()
       try {
@@ -43,7 +47,7 @@ internal class SqsJobQueue @Inject internal constructor(
           client.sendMessage(SendMessageRequest().apply {
             queueUrl = queue.url
             messageBody = body
-            addMessageAttributesEntry(SqsJob.IDEMPOTENCY_KEY_ATTR, MessageAttributeValue()
+            addMessageAttributesEntry(Job.IDEMPOTENCY_KEY_ATTR, MessageAttributeValue()
                 .withDataType("String")
                 .withStringValue(idempotenceKey))
             if (deliveryDelay != null) delaySeconds = (deliveryDelay.toMillis() / 1000).toInt()

--- a/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -33,9 +33,17 @@ class FakeJobQueue @Inject constructor(
     body: String,
     deliveryDelay: Duration?,
     attributes: Map<String, String>
+  ) = enqueue(queueName, tokenGenerator.generate("fjq"), body, deliveryDelay, attributes)
+
+  override fun enqueue(
+    queueName: QueueName,
+    idempotenceKey: String,
+    body: String,
+    deliveryDelay: Duration?,
+    attributes: Map<String, String>
   ) {
     val id = tokenGenerator.generate("fakeJobQueue")
-    val job = FakeJob(queueName, id, body, attributes)
+    val job = FakeJob(queueName, id, idempotenceKey, body, attributes)
     jobQueues.getOrPut(queueName, ::ConcurrentLinkedDeque).add(job)
   }
 
@@ -61,6 +69,7 @@ class FakeJobQueue @Inject constructor(
 data class FakeJob(
   override val queueName: QueueName,
   override val id: String,
+  override val idempotenceKey: String,
   override val body: String,
   override val attributes: Map<String, String>,
   internal var acknowledged: Boolean = false

--- a/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -42,6 +42,9 @@ class FakeJobQueue @Inject constructor(
     deliveryDelay: Duration?,
     attributes: Map<String, String>
   ) {
+    check(!attributes.keys.contains(Job.IDEMPOTENCY_KEY_ATTR)) {
+      "${Job.IDEMPOTENCY_KEY_ATTR} is a reserved attribute key"
+    }
     val id = tokenGenerator.generate("fakeJobQueue")
     val job = FakeJob(queueName, id, idempotenceKey, body, attributes)
     jobQueues.getOrPut(queueName, ::ConcurrentLinkedDeque).add(job)

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -8,6 +8,12 @@ interface Job {
   /** system assigned globally unique id for the job */
   val id: String
 
+  /**
+   * idempotence key provided by the publisher to allow filtering duplicate jobs from the
+   * underlying job queueing system.
+   */
+  val idempotenceKey: String
+
   /** body of the job */
   val body: String
 

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -28,4 +28,9 @@ interface Job {
 
   /** Moves the job from the main queue onto the associated dead letter quque. May perform an RPC */
   fun deadLetter()
+
+
+  companion object {
+    const val IDEMPOTENCY_KEY_ATTR = "_misk_idempotency_key"
+  }
 }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
@@ -13,12 +13,33 @@ interface JobQueue {
    * Enqueue a job onto the given queue, along with a set of job attributes.
    *
    * @param queueName the name of the queue on which to place the job
+   * @param idempotenceKey Allows consumers to filter duplicate messages if the underlying job
+   * queueing system provides at least once delivery.
    * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
    * consumer to agree on the format of the body
    * @param deliveryDelay If specified, the job will only become visible to the consumer after
    * the provided duration. Used for jobs that should delay processing for a period of time.
    * @param attributes Arbitrary contextual attributes associated with the job
    */
+  fun enqueue(
+    queueName: QueueName,
+    idempotenceKey: String,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()
+  )
+
+  /**
+   * Enqueue a job onto the given queue, along with a set of job attributes.
+   *
+   * @param queueName the name of the queue on which to place the job
+   * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
+   * consumer to agree on the format of the body
+   * @param deliveryDelay If specified, the job will only become visible to the consumer after
+   * the provided duration. Used for jobs that should delay processing for a period of time.
+   * @param attributes Arbitrary contextual attributes associated with the job
+   */
+  // Deprecated. Provide an idempotence key.
   fun enqueue(
     queueName: QueueName,
     body: String,

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -23,10 +23,57 @@ interface TransactionalJobQueue {
    * @param queueName the name of the queue on which to place the job
    * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
    * consumer to agree on the format of the body
+   * @param idempotenceKey Allows consumers to filter duplicate messages if the underlying job
+   * queueing system provides at least once delivery.
    * @param deliveryDelay If specified, the job will only become visible to the consumer after
    * the provided duration. Used for jobs that should delay processing for a period of time.
    * @param attributes Arbitrary contextual attributes associated with the job
    */
+  fun enqueue(
+    session: Session,
+    gid: Gid<*, *>,
+    queueName: QueueName,
+    idempotenceKey: String,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()
+  )
+
+  /**
+   * Enqueues a job to the primary (unaffiliated) database shard . Will throw an exception if the
+   * session is associated with an entity group.
+   * @param session The database session to use in writing the job
+   * @param queueName the name of the queue on which to place the job
+   * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
+   * consumer to agree on the format of the body
+   * @param idempotenceKey Allows consumers to filter duplicate messages if the underlying job
+   * queueing system provides at least once delivery.
+   * @param deliveryDelay If specified, the job will only become visible to the consumer after
+   * the provided duration. Used for jobs that should delay processing for a period of time.
+   * @param attributes Arbitrary contextual attributes associated with the job
+   */
+  fun enqueue(
+    session: Session,
+    queueName: QueueName,
+    idempotenceKey: String,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()
+  )
+
+  /**
+   * Enqueues a job to the database shard associated with the given entity group. Will
+   * throw an exception if the session is associated with a different entity group.
+   * @param session The database session to use in writing the job
+   * @param gid The id of the entity group with which the job should be associated
+   * @param queueName the name of the queue on which to place the job
+   * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
+   * consumer to agree on the format of the body
+   * @param deliveryDelay If specified, the job will only become visible to the consumer after
+   * the provided duration. Used for jobs that should delay processing for a period of time.
+   * @param attributes Arbitrary contextual attributes associated with the job
+   */
+  // Deprecated. Provide an idempotenceKey.
   fun enqueue(
     session: Session,
     gid: Gid<*, *>,
@@ -47,6 +94,7 @@ interface TransactionalJobQueue {
    * the provided duration. Used for jobs that should delay processing for a period of time.
    * @param attributes Arbitrary contextual attributes associated with the job
    */
+  // Deprecated. Provide an idempotenceKey.
   fun enqueue(
     session: Session,
     queueName: QueueName,


### PR DESCRIPTION
Most likely the underlying queueing system (e.g SQS) supports at least
once delivery of a message. Consumers are going to need an idempotence
key in order to filter duplicate messages.

The eventual goal is to require the idempotence key, but for backwards
compatibility a random token is generated for messages without one. Once
we upgrade all clients to the new methods (and deploy the changes) we
can remove the old methods.

For the SQS impl, the idempotence key is added as a message attribute.