### PR TITLE
tracing: do not extract span from headers if already done

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
@@ -2,6 +2,7 @@ package misk.web.interceptors
 
 import com.google.inject.Inject
 import com.google.inject.Singleton
+import io.opentracing.Span
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
 import io.opentracing.propagation.Format
@@ -30,22 +31,29 @@ internal class TracingInterceptor internal constructor(private val tracer: Trace
   }
 
   override fun intercept(chain: NetworkChain) {
-    val parentContext: SpanContext? = try {
-      tracer.extract(Format.Builtin.HTTP_HEADERS,
-          TextMultimapExtractAdapter(chain.httpCall.requestHeaders.toMultimap()))
-    } catch (e: Exception) {
-      logger.warn("Failure attempting to extract span context. Existing context, if any," +
-          " will be ignored in creation of span", e)
-      null
-    }
-
     val scopeBuilder = tracer.buildSpan(chain.webAction.javaClass.name)
         .withTag(Tags.HTTP_METHOD.key, chain.httpCall.dispatchMechanism.method.toString())
         .withTag(Tags.HTTP_URL.key, chain.httpCall.url.toString())
         .withTag(Tags.SPAN_KIND.key, SPAN_KIND_SERVER)
 
-    if (parentContext != null) {
-      scopeBuilder.asChildOf(parentContext)
+    val parentSpan: Span? = tracer.activeSpan()
+    if (parentSpan != null) {
+      // Certain tracing implementations (Datadog) do their own header extraction. Skip our custom
+      // one if that happened.
+      scopeBuilder.asChildOf(parentSpan)
+    } else {
+      val parentContext: SpanContext? = try {
+        tracer.extract(Format.Builtin.HTTP_HEADERS,
+            TextMultimapExtractAdapter(chain.httpCall.requestHeaders.toMultimap()))
+      } catch (e: Exception) {
+        logger.warn("Failure attempting to extract span context. Existing context, if any," +
+            " will be ignored in creation of span", e)
+        null
+      }
+
+      if (parentContext != null) {
+        scopeBuilder.asChildOf(parentContext)
+      }
     }
 
     val scope = scopeBuilder.startActive(true)

--- a/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
@@ -31,7 +31,7 @@ internal class TracingInterceptor internal constructor(private val tracer: Trace
   }
 
   override fun intercept(chain: NetworkChain) {
-    val scopeBuilder = tracer.buildSpan(chain.webAction.javaClass.name)
+    val scopeBuilder = tracer.buildSpan("http.action")
         .withTag(Tags.HTTP_METHOD.key, chain.httpCall.dispatchMechanism.method.toString())
         .withTag(Tags.HTTP_URL.key, chain.httpCall.url.toString())
         .withTag(Tags.SPAN_KIND.key, SPAN_KIND_SERVER)
@@ -57,6 +57,9 @@ internal class TracingInterceptor internal constructor(private val tracer: Trace
     }
 
     val scope = scopeBuilder.startActive(true)
+    // This is a datadog convention. Must be set after span is created because otherwise it would
+    // be overwritten by the method/url
+    scope.span().setTag("resource.name", chain.webAction.javaClass.name)
     scope.use {
       try {
         chain.proceed(chain.httpCall)

--- a/misk/src/test/kotlin/misk/web/interceptors/TracingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/TracingInterceptorTest.kt
@@ -39,7 +39,7 @@ class TracingInterceptorTest {
   @Inject private lateinit var jettyService: JettyService
 
   companion object {
-    // Not exposed: https://github.com/opentracing/opentracing-java/blob/master/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java#L228-L229
+    // Not exposed: https://github.com/opentracing/opentracing-java/blob/2df2a8983e35dff23c4fb894e5f5ae3f98f1cf7b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java#L228-L229
     val SPAN_ID_KEY = "spanid"
     val TRACE_ID_KEY = "traceid"
   }
@@ -57,6 +57,7 @@ class TracingInterceptorTest {
     val span = tracer.take()
     assertThat(span.parentId()).isEqualTo(0)
     assertThat(span.tags()).isEqualTo(mapOf(
+        "resource.name" to "misk.web.interceptors.TracingInterceptorTest\$TracingTestAction",
         "http.method" to "GET",
         "http.status_code" to 200,
         "http.url" to "http://foo.bar/",


### PR DESCRIPTION
Datadog has reflection + byte-code generation magic to do this automatically, I think https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/jetty-8/src/main/java/datadog/trace/instrumentation/jetty8/JettyHandlerInstrumentation.java