### PR TITLE
Add DataSourceConfig field for hibernate.jdbc.batch_size with default

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -89,6 +89,12 @@ internal class SessionFactoryService(
       applySetting(AvailableSettings.USE_GET_GENERATED_KEYS, "true")
       applySetting(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "false")
       applySetting(AvailableSettings.JDBC_TIME_ZONE, "UTC")
+      if (config.jdbc_statement_batch_size != null) {
+        require(config.jdbc_statement_batch_size > 0) {
+          "Invalid jdbc_statement_batch_size: must be > 0."
+        }
+        applySetting(AvailableSettings.STATEMENT_BATCH_SIZE, config.jdbc_statement_batch_size)
+      }
     }
 
     val registry = registryBuilder.build()

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -60,7 +60,9 @@ data class DataSourceConfig(
   // going forward
   val trust_certificate_key_store_path: String? = null,
   val client_certificate_key_store_path: String? = null,
-  val show_sql: String? = "false"
+  val show_sql: String? = "false",
+  // Consider using this if you want Hibernate to automagically batch inserts/updates when it can.
+  val jdbc_statement_batch_size: Int? = null
 ) {
   fun withDefaults(): DataSourceConfig {
     return when (type) {


### PR DESCRIPTION
#1242 

Adds pass-through of `hibernate.jdbc.batch_size` with default-off configuration.
(For more on this config key, see [AvailableSettings.html#STATEMENT_BATCH_SIZE](https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/cfg/AvailableSettings.html#STATEMENT_BATCH_SIZE))

It seems like you can either write bespoke `INSERT INTO ... VALUES (...)` for bulk inserts, or rely on hibernate's internal batching mechanisms (which are not enabled by default). I don't love that this is "magic" but I think application developers _should_ be able to benefit from hibernate when it's possible.. even if they don't realize they're benefiting! 

One thing I dislike about specifying this in `DataSourceConfig` is that it will be the app-wide common denominator for batching. In my experience, batching size is useful to specify in application level code and the most appropriate value may vary in different code paths. However, I can't see an obvious path through our `Session` abstraction (or its composed `hibernateSession` field) that support overriding this on a per-use-case basis.

Anyway, this PR should support pass-through of this overrides for this value, and opt-in any `misk-hibernate` usages into utilizing batching. 

My key open questions are informed by being new to both Vitess and Hibernate:
* If we're going to default to enabling batching, do we need to also enable [insert ordering](https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/cfg/AvailableSettings.html#ORDER_INSERTS)? Same question for [update ordering](https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/cfg/AvailableSettings.html#ORDER_UPDATES).
* Does Vitess actually support this? I've validated some Vitess-based services' integration tests against this branch of misk-hibernate, but I'm not sure how much confidence that should give us.
