### PR TITLE
Updated comment to reflect implementation

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -29,8 +29,8 @@ class FakeFeatureFlagsModule(
    *
    * Usage:
    * ```
-   * install(FakeFeatureFlagsModule().withOverrides { flags ->
-   *   flags.overrideBool(Feature("foo"), true)
+   * install(FakeFeatureFlagsModule().withOverrides {
+   *   override(Feature("foo"), true)
    * })
    * ```
    */


### PR DESCRIPTION
Small fix to the example comment as it reference a function that no longer exists and reflects the fact that there is an implicit `this` as opposed to having to reference `flags` directly.

Example usage here: https://github.com/cashapp/misk/blob/master/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt#L13