### PR TITLE
Increase default retries to 3 and max backoff delay to 500ms

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -330,10 +330,10 @@ internal class RealTransacter private constructor(
 
   // NB: all options should be immutable types as copy() is shallow.
   internal data class TransacterOptions(
-    val maxAttempts: Int = 2,
+    val maxAttempts: Int = 3,
     val disabledChecks: EnumSet<Check> = EnumSet.noneOf(Check::class.java),
     val minRetryDelayMillis: Long = 100,
-    val maxRetryDelayMillis: Long = 200,
+    val maxRetryDelayMillis: Long = 500,
     val retryJitterMillis: Long = 400,
     val readOnly: Boolean = false
   )


### PR DESCRIPTION
3 retries matches the retries that Franklin uses. 500 ms is a conservative increase in the max delay which should increase the probability that the retries survive temporary disruptions from the layers below (i.e. Vitess or Aurora). The opposing force is that any retries can potentially cascade errors by: 1) increasing the load on tiers below and 2) hold on to resources (e.g. http threads) in the current tier. We need to find the right balance here.