### PR TITLE
Expose Session in Transacter

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -102,6 +102,15 @@ internal class RealTransacter private constructor(
   override val inTransaction: Boolean
     get() = threadLatestSession.get()?.inTransaction ?: false
 
+  override val session: Session?
+    get() {
+      val latestSession = threadLatestSession.get()
+      if (latestSession?.inTransaction == true) {
+        return latestSession
+      }
+      return null
+    }
+
   override fun isCheckEnabled(check: Check): Boolean {
     val session = threadLatestSession.get()
     return session == null || !session.inTransaction || !session.disabledChecks.contains(check)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Transacter.kt
@@ -15,6 +15,11 @@ interface Transacter {
   val inTransaction: Boolean
 
   /**
+   * Returns the active [Session] if one exists, null otherwise.
+   */
+  val session: Session?
+
+  /**
    * Is the scalability check currently enabled. Use [Session.withoutChecks] to disable checks.
    */
   fun isCheckEnabled(check: Check): Boolean

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TransacterTest.kt
@@ -347,6 +347,17 @@ abstract class TransacterTest {
   }
 
   @Test
+  fun session() {
+    assertThat(transacter.session).isNull()
+
+    transacter.transaction {
+      assertThat(transacter.session).isNotNull
+    }
+
+    assertThat(transacter.session).isNull()
+  }
+
+  @Test
   fun noFailSafeReadInTransaction() {
     assertThat(transacter.inTransaction).isFalse()
 


### PR DESCRIPTION
In order to add pre-commit hooks or post-commit hooks, the Transacter needs to expose the underlying active Session for injected classes that can have a different behavior inside or outside a transaction.

Example that prompted this change:

```
val job = getJobToPublish()

if (transacter.inTransaction) {
  transacter.session.onPostCommit(job)
} else {
  job()
}
```

Otherwise I will need to add `session` as a parameter to my `JobPublisher` interface functions, which exposes the implementation.