### PR TITLE
add validation to feature flag key

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.AbstractIdleService
 import misk.feature.Attributes
 import misk.feature.DynamicConfig
 import misk.feature.Feature
+import misk.feature.FeatureFlagValidation
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
 import java.util.concurrent.ConcurrentHashMap
@@ -56,12 +57,14 @@ class FakeFeatureFlags @Inject constructor() : AbstractIdleService(),
   override fun <T : Enum<T>> getEnum(feature: Feature, clazz: Class<T>): T = getEnum(feature, KEY, clazz, Attributes())
 
   private fun get(feature: Feature, key: String): Any? {
+    FeatureFlagValidation.checkValidKey(feature, key)
     return overrides.getOrElse(MapKey(feature, key)) {
       overrides[MapKey(feature)]
     }
   }
 
   private fun <V> getOrDefault(feature: Feature, key: String, defaultValue: V): V {
+    FeatureFlagValidation.checkValidKey(feature, key)
     @Suppress("unchecked_cast")
     return overrides.getOrElse(MapKey(feature, key)) {
       overrides.getOrDefault(MapKey(feature), defaultValue)

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -14,6 +14,6 @@ class FakeFeatureFlagsModuleTest {
     })
 
     val flags = injector.getInstance(FeatureFlags::class.java)
-    assertEquals(24, flags.getInt(Feature("foo"), ""))
+    assertEquals(24, flags.getInt(Feature("foo"), "bar"))
   }
 }

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -5,6 +5,7 @@ import misk.feature.getEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
 
 internal class FakeFeatureFlagsTest {
   val FEATURE = Feature("foo")
@@ -53,6 +54,19 @@ internal class FakeFeatureFlagsTest {
     subject.reset()
     assertThat(subject.getEnum<Dinosaur>(FEATURE, TOKEN))
         .isEqualTo(Dinosaur.PTERODACTYL)
+  }
+
+  @Test
+  fun invalidKeys() {
+    assertThrows<IllegalArgumentException> {
+      subject.getString(Feature("which-dinosaur"), "bad(token)")
+    }
+    assertThrows<IllegalArgumentException> {
+      subject.getString(Feature("which-dinosaur"), "Bearer auth-token")
+    }
+    assertThrows<IllegalArgumentException> {
+      subject.getEnum<Dinosaur>(Feature("which-dinosaur"), "")
+    }
   }
 
   enum class Dinosaur {

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlagValidation.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlagValidation.kt
@@ -1,0 +1,16 @@
+package misk.feature
+
+object FeatureFlagValidation {
+
+  /**
+   * Validates the feature flags's hashing "key". Most implementation technically support arbitrary
+   * strings, but we still prefer to restrict valid input to prevent accidentally passing
+   * in the wrong value or potentially sensitive information.
+   */
+  fun checkValidKey(feature: Feature, key: String) {
+    require(key.isNotEmpty()) { "Key to flag $feature must not be empty" }
+    require(match.matches(key)) { "Key to flag $feature can only contain alphanumeric characters, -, . and +" }
+  }
+
+  private val match = Regex("[a-zA-Z0-9_.-]+")
+}

--- a/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
+++ b/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
@@ -21,6 +21,7 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import java.lang.IllegalArgumentException
 
 internal class LaunchDarklyFeatureFlagsTest {
   private val client = mock(LDClientInterface::class.java)
@@ -97,6 +98,16 @@ internal class LaunchDarklyFeatureFlagsTest {
     assertThrows<RuntimeException> {
       featureFlags.getEnum<Dinosaur>(
           Feature("which-dinosaur"), "a-token")
+    }
+  }
+
+  @Test
+  fun invalidKeys() {
+    assertThrows<IllegalArgumentException> {
+      featureFlags.getString(Feature("which-dinosaur"), "bad(token)")
+    }
+    assertThrows<IllegalArgumentException> {
+      featureFlags.getEnum<Dinosaur>(Feature("which-dinosaur"), "")
     }
   }
 


### PR DESCRIPTION
Only allow things that look like keys to be passed in to `FeatureFlags`. I'm sure this validation doesn't really belong in misk, but the effort to make this configurable is a bit high and not worthwhile.

I'm also not sure we _should_ have this level of validation. Theoretically users should be testing their code and making sure they are passing in the right key. But, evidence shows that this hasn't been happening. The risk of a bug here is high, since we could potentially launch features to the wrong customers, or worse accidentally send PII to the feature flag vendor when we don't mean to.

So I think this validation is a good bad way of preventing mistakes.