### PR TITLE
Explicitly override default attibutes in Launchdarkly

### DIFF
--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -75,6 +75,27 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     return java.lang.Enum.valueOf(clazz, result.value.toUpperCase())
   }
 
+  override fun getBoolean(
+    feature: Feature,
+    key: String
+  ) = getBoolean(feature, key, Attributes())
+
+  override fun getInt(
+    feature: Feature,
+    key: String
+  ) = getInt(feature, key, Attributes())
+
+  override fun getString(
+    feature: Feature,
+    key: String
+  ) = getString(feature, key, Attributes())
+
+  override fun <T : Enum<T>> getEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>
+  ) = getEnum(feature, key, clazz, Attributes())
+
   private fun checkInitialized() {
     checkState(ldClient.initialized(),
         "LaunchDarkly feature flags not initialized. Did you forget to make your service depend on [FeatureFlags]?")


### PR DESCRIPTION
Seeing this in deployed java app using launchdarkly. 
```
java.lang.AbstractMethodError: Receiver class misk.feature.launchdarkly.LaunchDarklyFeatureFlags 
does not define or inherit an implementation of the resolved method abstract 
getEnum(Lmisk/feature/Feature;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Enum; of interface 
misk.feature.FeatureFlags.

```
Not sure how to confirm if this fixes it, but I assume explicitly overriding it will help. One thing to note, this was not showing up in tests.
