### PR TITLE
Query timeout

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -89,6 +89,10 @@ internal class SessionFactoryService(
       applySetting(AvailableSettings.USE_GET_GENERATED_KEYS, "true")
       applySetting(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "false")
       applySetting(AvailableSettings.JDBC_TIME_ZONE, "UTC")
+      if (config.query_timeout != null) {
+        applySetting("javax.persistence.query.timeout", Integer.valueOf(
+            config.query_timeout.toMillis().toInt()))
+      }
       if (config.jdbc_statement_batch_size != null) {
         require(config.jdbc_statement_batch_size > 0) {
           "Invalid jdbc_statement_batch_size: must be > 0."

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -49,6 +49,7 @@ data class DataSourceConfig(
   val connection_timeout: Duration = Duration.ofSeconds(10),
   val validation_timeout: Duration = Duration.ofSeconds(3),
   val connection_max_lifetime: Duration = Duration.ofMinutes(1),
+  val query_timeout: Duration? = Duration.ofMinutes(1),
   val migrations_resource: String? = null,
   val migrations_resources: List<String>? = null,
   val vitess_schema_dir: String? = null,
@@ -123,6 +124,13 @@ data class DataSourceConfig(
 
         if (env == Environment.TESTING || env == Environment.DEVELOPMENT) {
           queryParams += "&createDatabaseIfNotExist=true"
+        }
+
+
+        queryParams += "&connectTimeout=${config.connection_timeout.toMillis()}"
+
+        if (config.query_timeout != null) {
+          queryParams += "&socketTimeout=${config.query_timeout.toMillis()}"
         }
 
         if (type == DataSourceType.VITESS_MYSQL) {
@@ -255,6 +263,7 @@ data class DataSourceConfig(
               this.connection_timeout,
               this.validation_timeout,
               this.connection_max_lifetime,
+              this.query_timeout,
               this.migrations_resource,
               this.migrations_resources,
               this.vitess_schema_dir,

--- a/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -74,9 +74,10 @@ class DataSourceConfigTest {
         trust_certificate_key_store_url = "file://path/to/truststore",
         trust_certificate_key_store_password = "changeit")
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
-        "createDatabaseIfNotExist=true&trustCertificateKeyStoreUrl=" +
-        "file://path/to/truststore&trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true" +
-        "&useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true&" +
+        "useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
@@ -85,15 +86,17 @@ class DataSourceConfigTest {
         trust_certificate_key_store_path = "path/to/truststore",
         trust_certificate_key_store_password = "changeit")
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
-        "createDatabaseIfNotExist=true&trustCertificateKeyStoreUrl=" +
-        "file://path/to/truststore&trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true" +
-        "&useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true&useSSL=true&" +
+        "requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildMysqlJDBCUrlWithNoTls() {
     val config = DataSourceConfig(DataSourceType.MYSQL)
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
-        "createDatabaseIfNotExist=true", config.buildJdbcUrl(Environment.TESTING))
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 }


### PR DESCRIPTION
We need a client side query timeout to handle Aurora instances or
vttablets that are hard killed.

For Aurora if an instance is hard killed it won't ever respond to the
query which will hold up threads in the http thread pool causing an
extended outage.

For Vitess the query sniper runs in the vttablet so it will handle an
Aurora instance being hard killed but if the vttablet itself is hard
killed the query sniper won't run again holding up threads and causing
extended outages.

1 minutes is quite a long timeout. If you want shorter timeouts they
can be overrided at the query level using the JPA query hint
javax.persistence.query.timeout.

This timeout is only applied to Hibernate queries. For raw JDBC queries
we will need something else.