### PR TITLE
Widen acceptable characters in feature flag keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ lib
 dist
 .hash
 hooks.gradle
-repositories.gradle
 
 **/site/
 docs/0.x/*

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -5,7 +5,6 @@ import misk.feature.getEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.lang.IllegalArgumentException
 
 internal class FakeFeatureFlagsTest {
   val FEATURE = Feature("foo")
@@ -58,15 +57,27 @@ internal class FakeFeatureFlagsTest {
 
   @Test
   fun invalidKeys() {
+    subject.override(FEATURE, 3)
     assertThrows<IllegalArgumentException> {
-      subject.getString(Feature("which-dinosaur"), "bad(token)")
+      subject.getInt(FEATURE, "bad(token)")
     }
     assertThrows<IllegalArgumentException> {
-      subject.getString(Feature("which-dinosaur"), "Bearer auth-token")
+      subject.getInt(FEATURE, "Bearer auth-token")
     }
     assertThrows<IllegalArgumentException> {
-      subject.getEnum<Dinosaur>(Feature("which-dinosaur"), "")
+      subject.getInt(FEATURE, "")
     }
+  }
+
+  @Test
+  fun validKeys() {
+    subject.override(FEATURE, 3)
+    subject.getInt(FEATURE, "hello")
+    subject.getInt(FEATURE, "09afAF") // hex.
+    subject.getInt(FEATURE, "AZ27=") // base32.
+    subject.getInt(FEATURE, "azAZ09+/=") // base64.
+    subject.getInt(FEATURE, "azAZ09-_=") // base64url.
+    subject.getInt(FEATURE, "azAZ09-_.~") // unreserved URL characters.
   }
 
   enum class Dinosaur {

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlagValidation.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlagValidation.kt
@@ -9,8 +9,8 @@ object FeatureFlagValidation {
    */
   fun checkValidKey(feature: Feature, key: String) {
     require(key.isNotEmpty()) { "Key to flag $feature must not be empty" }
-    require(match.matches(key)) { "Key to flag $feature can only contain alphanumeric characters, -, . and +" }
+    require(match.matches(key)) { "Key to flag $feature can only contain alphanumeric characters and [._~+/=-]" }
   }
 
-  private val match = Regex("[a-zA-Z0-9_.-]+")
+  private val match = Regex("[a-zA-Z0-9._~+/=-]+")
 }


### PR DESCRIPTION
I've added everything in token68 for the same reasons it's used in HTTP
authentication challenges:

   The token68 syntax allows the 66 unreserved URI characters
   ([RFC3986]), plus a few others, so that it can hold a base64,
   base64url (URL and filename safe alphabet), base32, or base16 (hex)
   encoding, with or without padding, but excluding whitespace
   ([RFC4648]).

https://tools.ietf.org/html/rfc7235#section-2.1