### PR TITLE
WebActions: add a synthetic json binding for proto web actions

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebActionBinding.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionBinding.kt
@@ -180,7 +180,9 @@ internal class WebActionBinding @Inject constructor(
 
       val nonNullParameters = mutableListOf<FeatureBinding>()
       for (i in 0 until parameters.size) {
-        nonNullParameters += checkNotNull(parameters[i]) { "$action parameter $i not claimed" }
+        nonNullParameters += checkNotNull(parameters[i]) {
+          "$action parameter $i not claimed (did you forget @RequestBody ?)"
+        }
       }
 
       if (action.dispatchMechanism != DispatchMechanism.WEBSOCKET) {

--- a/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
@@ -1,0 +1,102 @@
+package misk.web
+
+import com.squareup.moshi.Moshi
+import com.squareup.protos.test.parsing.Shipment
+import com.squareup.protos.test.parsing.Warehouse
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.ByteString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class JsonForProtoEndpointsTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject
+  lateinit var moshi: Moshi
+
+  @Inject
+  lateinit var jettyService: JettyService
+
+  @Test
+  fun json() {
+    val httpClient = OkHttpClient()
+    val requestBody = Shipment.Builder()
+        .shipment_token("abc")
+        .build()
+    val expectedResponseBody = Warehouse.Builder()
+        .warehouse_token("abc")
+        .build()
+
+    val request = Request.Builder()
+        .post(moshi.adapter(Shipment::class.java).toJson(requestBody)
+            .toRequestBody(MediaTypes.APPLICATION_JSON_MEDIA_TYPE))
+        .url(serverUrlBuilder().encodedPath("/get_destination_warehouse").build())
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    response.use {
+      val responseBody = moshi.adapter(Warehouse::class.java).fromJson(response.body!!.source())
+      assertThat(responseBody).isEqualTo(expectedResponseBody)
+      assertThat(response.body!!.contentType().toString())
+          .isEqualTo("application/json;charset=utf-8")
+    }
+  }
+
+  @Test
+  fun protobuf() {
+    val requestBody = Shipment.Builder()
+        .shipment_token("abc")
+        .build()
+    val expectedResponseBody = Warehouse.Builder()
+        .warehouse_token("abc")
+        .build()
+
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .post(ByteString.of(*requestBody.encode()).toRequestBody(
+            MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE))
+        .url(serverUrlBuilder().encodedPath("/get_destination_warehouse").build())
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    response.use {
+      val responseBody = Warehouse.ADAPTER.decode(response.body!!.source())
+      assertThat(responseBody).isEqualTo(expectedResponseBody)
+      assertThat(response.body!!.contentType())
+          .isEqualTo(MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE)
+    }
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebTestingModule())
+      install(WebActionModule.create<EchoShipmentToken>())
+    }
+  }
+
+  class EchoShipmentToken @Inject constructor() : WebAction {
+    @Post("/get_destination_warehouse")
+    @RequestContentType(MediaTypes.APPLICATION_PROTOBUF)
+    @ResponseContentType(MediaTypes.APPLICATION_PROTOBUF)
+    fun getDestinationWarehouse(@RequestBody shipment: Shipment) =
+        Warehouse.Builder()
+            .warehouse_token(shipment.shipment_token)
+            .build()
+  }
+
+  private fun serverUrlBuilder(): HttpUrl.Builder {
+    return jettyService.httpServerUrl.newBuilder()
+  }
+}

--- a/misk/src/test/kotlin/misk/web/WebActionBindingTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebActionBindingTest.kt
@@ -54,8 +54,8 @@ internal class WebActionBindingTest {
       webActionBindingFactory.create(TestAction::fakeApiCall.asAction(DispatchMechanism.POST),
           pathPattern)
     }
-    assertThat(e).hasMessage(
-        "${TestAction::fakeApiCall.asAction(DispatchMechanism.POST)} parameter 1 not claimed")
+    assertThat(e).hasMessage("${TestAction::fakeApiCall.asAction(
+        DispatchMechanism.POST)} parameter 1 not claimed (did you forget @RequestBody ?)")
   }
 
   @Test


### PR DESCRIPTION
For web actions that receive and/or respond with proto, add a second binding over json.