### PR TITLE
Add a `@FetchEagerly` annotation which eagerly loads a relation.

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -130,3 +130,17 @@ annotation class Order(
   val path: String,
   val asc: Boolean = true
 )
+
+/**
+ * Annotates a function on a subinterface of [Query] to indicate a relationship to fetch eagerly.
+ * Currently the only strategy to do this uses a LEFT JOIN, so the relationship will be fetched in
+ * a single query.
+ */
+annotation class FetchEagerly(
+  val property: String,
+  val strategy: EagerFetchStrategy = EagerFetchStrategy.LEFT_JOIN
+)
+
+enum class EagerFetchStrategy {
+  LEFT_JOIN,
+}

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
@@ -83,6 +83,9 @@ interface CharacterQuery : Query<DbCharacter> {
 
   @Select
   fun listAsActorAndReleaseDate(session: Session): List<ActorAndReleaseDate>
+
+  @FetchEagerly(property = "actor")
+  fun prefetchActor(): CharacterQuery
 }
 
 data class NameAndReleaseDate(


### PR DESCRIPTION
In many cases it's valuable to be explicit to hibernate, for performance
reasons, which relationships to fetch ahead of time to avoid executing
N+1 queries.

An alternative to this would be using Hibernate's `@FetchProfile` on the entity.
That would look like:
```kotlin
@Entity
@FetchProfile(name = "character_actor", fetchOverrides = [
  FetchProfile.FetchOverride(
      entity = DbCharacter::class,
      association = "actor",
      mode = FetchMode.JOIN
  )
])
```
which we could then enable on a per-session basis using:
```kotlin
session.hibernateSession.enableFetchProfile("character_actor")
```

Testing this was quite a pain, and if anyone has better ideas please let 
me know. Asserting the existence of `LEFT JOIN FETCH` isn't the greatest
approach, but is better than nothing.