### PR TITLE
Add a network interceptor that does concurrency limiting

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ ext.dep = [
   "awsApi": "com.amazonaws:aws-java-sdk:1.11.144",
   "awsSqs": "com.amazonaws:aws-java-sdk-sqs:1.11.144",
   "bouncycastle": "org.bouncycastle:bcprov-jdk15on:1.55",
+  "concurrencyLimitsCore": "com.netflix.concurrency-limits:concurrency-limits-core:0.3.6",
   "curatorFramework": "org.apache.curator:curator-framework:4.0.1",
   "datasourceProxy": "net.ttddyy:datasource-proxy:1.4.9",
   "docker": "com.github.docker-java:docker-java:3.1.0-rc-5",

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   compile dep.prometheusClient
   compile dep.prometheusHotspot
   compile dep.jnrUnixsocket
+  compile dep.concurrencyLimitsCore
   compile project(':misk-inject')
   compile project(':misk-service')
 

--- a/misk/src/main/kotlin/misk/web/Http.kt
+++ b/misk/src/main/kotlin/misk/web/Http.kt
@@ -32,3 +32,28 @@ annotation class RequestContentType(vararg val value: String)
 
 @Target(AnnotationTarget.FUNCTION)
 annotation class ResponseContentType(val value: String)
+
+/**
+ * When the service is overloaded Misk will intervene and reject calls by returning "HTTP 503
+ * Service Unavailable". We call this load shedding and it works similarly to flow control in TCP.
+ *
+ * We must not shed calls to status endpoints like health checks as doing so may create cascading
+ * failures: overloaded instances that do not respond to health checks will be killed, and this
+ * further overloads the remaining peers.
+ *
+ * Only put this on endpoints that must never be rejected. Such endpoints must not do RPCs, database
+ * queries or other I/O because unexpected latency there can take down the entire service.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class AvailableWhenDegraded
+
+/**
+ * Opt-in to concurrency limits.
+ *
+ * TODO(jwilson): make this the default once we're comfortable with the behavior and remove this
+ *     annotation.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ConcurrencyLimitsOptIn

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -31,11 +31,12 @@ import misk.web.extractors.RequestHeadersFeatureBinding
 import misk.web.extractors.ResponseBodyFeatureBinding
 import misk.web.extractors.WebSocketFeatureBinding
 import misk.web.extractors.WebSocketListenerFeatureBinding
+import misk.web.interceptors.ConcurrencyLimitsInterceptor
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.RebalancingInterceptor
-import misk.web.interceptors.RequestLogContextInterceptor
 import misk.web.interceptors.RequestBodyLoggingInterceptor
+import misk.web.interceptors.RequestLogContextInterceptor
 import misk.web.interceptors.RequestLoggingInterceptor
 import misk.web.interceptors.TracingInterceptor
 import misk.web.jetty.JettyConnectionMetricsCollector
@@ -107,6 +108,10 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
     // Collect metrics on the status of results and response times of requests
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<MetricsInterceptor.Factory>()
+
+    // Shed calls when we're degraded.
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
+        .to<ConcurrencyLimitsInterceptor.Factory>()
 
     // Traces requests as they work their way through the system.
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)

--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.Service.State
 import com.google.common.util.concurrent.ServiceManager
 import misk.logging.getLogger
 import misk.security.authz.Unauthenticated
+import misk.web.AvailableWhenDegraded
 import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
@@ -22,6 +23,7 @@ class LivenessCheckAction @Inject internal constructor(
   @Get("/_liveness")
   @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
   @Unauthenticated
+  @AvailableWhenDegraded
   fun livenessCheck(): Response<String> {
     val serviceManager = serviceManagerProvider.get()
     val failedServices = serviceManager.servicesByState().get(State.FAILED) +

--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ServiceManager
 import misk.healthchecks.HealthCheck
 import misk.logging.getLogger
 import misk.security.authz.Unauthenticated
+import misk.web.AvailableWhenDegraded
 import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
@@ -23,6 +24,7 @@ class ReadinessCheckAction @Inject internal constructor(
   @Get("/_readiness")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
+  @AvailableWhenDegraded
   fun readinessCheck(): Response<String> {
     val servicesNotRunning = serviceManagerProvider.get().servicesByState().values().asList()
         .filterNot { it.isRunning }

--- a/misk/src/main/kotlin/misk/web/actions/StatusAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/StatusAction.kt
@@ -6,6 +6,7 @@ import misk.DelegatingService
 import misk.healthchecks.HealthCheck
 import misk.healthchecks.HealthStatus
 import misk.security.authz.Unauthenticated
+import misk.web.AvailableWhenDegraded
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
@@ -26,6 +27,7 @@ class StatusAction @Inject internal constructor(
   @Get("/_status")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
+  @AvailableWhenDegraded
   fun getStatus(): ServerStatus {
     val services = serviceManagerProvider.get().servicesByState().values().asList()
     val serviceStatus = services.map {

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -1,0 +1,80 @@
+package misk.web.interceptors
+
+import com.netflix.concurrency.limits.Limiter
+import com.netflix.concurrency.limits.limiter.SimpleLimiter
+import misk.Action
+import misk.exceptions.StatusCode
+import misk.logging.getLogger
+import misk.web.AvailableWhenDegraded
+import misk.web.ConcurrencyLimitsOptIn
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import java.time.Clock
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.full.findAnnotation
+
+/**
+ * Detects degraded behavior and sheds requests accordingly. Internally this uses adaptive limiting
+ * as implemented by Netflix's [concurrency-limits][concurrency_limits] library. See
+ * [AvailableWhenDegraded] for further documentation.
+ *
+ * [concurrency_limits]: https://github.com/Netflix/concurrency-limits/
+ */
+internal class ConcurrencyLimitsInterceptor internal constructor(
+  private val actionName: String,
+  private val limiter: Limiter<String>
+) : NetworkInterceptor {
+
+  override fun intercept(chain: NetworkChain) {
+    val listener: Limiter.Listener? = limiter.acquire(actionName).orElse(null)
+
+    if (listener == null) {
+      logger.error { "concurrency limits interceptor shedding $actionName" }
+      chain.httpCall.statusCode = StatusCode.SERVICE_UNAVAILABLE.code
+      chain.httpCall.takeResponseBody()?.use { sink ->
+        sink.writeUtf8("service unavailable")
+      }
+      return
+    }
+
+    try {
+      chain.proceed(chain.httpCall)
+    } catch (unexpected: Throwable) {
+      listener.onIgnore()
+      throw unexpected
+    }
+
+    try {
+      when (chain.httpCall.statusCode) {
+        in 400 until 500 -> listener.onIgnore()
+        in 500 until 600 -> listener.onDropped() // Count 5XX errors as drops.
+        else -> listener.onSuccess()
+      }
+    } catch (e: IllegalArgumentException) {
+      // Service container does a ignores an RTT == 0 exception here.
+      // TODO(jwilson): report this upstream and get it fixed.
+      logger.debug { "ignoring concurrency-limits exception: $e" }
+    }
+  }
+
+  @Singleton
+  class Factory @Inject constructor(val clock: Clock) : NetworkInterceptor.Factory {
+    override fun create(action: Action): NetworkInterceptor? {
+      if (action.function.findAnnotation<AvailableWhenDegraded>() != null) return null
+
+      // TODO(jwilson): make this the default behavior and remove this annotation.
+      if (action.function.findAnnotation<ConcurrencyLimitsOptIn>() == null) return null
+
+      val limiter = SimpleLimiter.Builder()
+          .clock { clock.millis() }
+          .build<String>()
+
+      return ConcurrencyLimitsInterceptor(action.name, limiter)
+    }
+  }
+
+  private companion object {
+    val logger = getLogger<ConcurrencyLimitsInterceptor>()
+  }
+}

--- a/misk/src/test/kotlin/misk/time/FakeResourcePool.kt
+++ b/misk/src/test/kotlin/misk/time/FakeResourcePool.kt
@@ -1,0 +1,43 @@
+package misk.time
+
+import okio.Timeout
+import java.io.InterruptedIOException
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+/**
+ * Simulates a pool of a limited resource like database connections or disk bandwidth. Configure the
+ * number of units that can be used concurrently. Use will wait for a maximum specified time to get
+ * exclusive access to a resource, and then hold the resource for a specified time.
+ */
+class FakeResourcePool @Inject constructor() {
+  /** Total number of resources available. */
+  var total = 0
+    @Synchronized set(value) {
+      field = value
+      notifyAll()
+    }
+
+  /** Total number of currently held. */
+  private var busy = 0
+
+  @Throws(InterruptedIOException::class)
+  @Synchronized fun useResource(maxTimeToWait: Duration, timeToHold: Duration) {
+    val timeout = Timeout()
+    val maxNanosToWait = maxTimeToWait.toNanos()
+    if (maxNanosToWait > 0) {
+      timeout.deadline(maxNanosToWait, TimeUnit.NANOSECONDS)
+    }
+
+    while (busy >= total) {
+      if (maxNanosToWait == 0L) throw InterruptedIOException("timeout")
+      timeout.waitUntilNotified(this)
+    }
+
+    busy++
+    waitNanosIgnoreNotifies(timeToHold.toNanos())
+    busy--
+    notifyAll()
+  }
+}

--- a/misk/src/test/kotlin/misk/time/FakeResourcePoolTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeResourcePoolTest.kt
@@ -1,0 +1,107 @@
+package misk.time
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.InterruptedIOException
+import java.time.Duration
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import kotlin.test.assertFailsWith
+
+internal class FakeResourcePoolTest {
+  private var executorService: ExecutorService? = null
+
+  @AfterEach
+  fun tearDown() {
+    executorService?.shutdown()
+  }
+
+  @Test
+  fun happyPath() {
+    val pool = FakeResourcePool()
+    pool.total = 1
+
+    assertElapsedTime(expected = Duration.ofMillis(750)) {
+      pool.useResource(maxTimeToWait = Duration.ZERO, timeToHold = Duration.ofMillis(250))
+      pool.useResource(maxTimeToWait = Duration.ZERO, timeToHold = Duration.ofMillis(250))
+      pool.useResource(maxTimeToWait = Duration.ZERO, timeToHold = Duration.ofMillis(250))
+    }
+  }
+
+  @Test
+  fun insufficientResources() {
+    val pool = FakeResourcePool()
+    pool.total = 0
+
+    assertFailsWith<InterruptedIOException> {
+      pool.useResource(maxTimeToWait = Duration.ZERO, timeToHold = Duration.ofMillis(250))
+    }
+  }
+
+  /** Run 15 tasks over 5 threads targeting 3 resources. */
+  @Test
+  fun successfulContention() {
+    val pool = FakeResourcePool()
+    pool.total = 3
+
+    executorService = Executors.newFixedThreadPool(5)
+
+    assertElapsedTime(expected = Duration.ofMillis(1250)) {
+      val futures = mutableListOf<Future<*>>()
+      for (i in 0 until 15) {
+        futures += executorService!!.submit {
+          pool.useResource(
+              maxTimeToWait = Duration.ofMillis(1100),
+              timeToHold = Duration.ofMillis(250)
+          )
+        }
+      }
+      for (future in futures) {
+        future.get()
+      }
+    }
+  }
+
+  /**
+   * Run 9 tasks over 9 threads targeting 3 resources:
+   *
+   *  * 3 will complete immediately
+   *  * 3 will complete after waiting
+   *  * 3 will time out.
+   */
+  @Test
+  fun contentionTimeouts() {
+    val pool = FakeResourcePool()
+    pool.total = 3
+
+    executorService = Executors.newFixedThreadPool(9)
+
+    assertElapsedTime(expected = Duration.ofMillis(500)) {
+      val futures = mutableListOf<Future<*>>()
+      for (i in 0 until 9) {
+        futures += executorService!!.submit {
+          pool.useResource(
+              maxTimeToWait = Duration.ofMillis(400),
+              timeToHold = Duration.ofMillis(250)
+          )
+        }
+      }
+
+      var successCount = 0
+      var failureCount = 0
+      for (future in futures) {
+        try {
+          future.get()
+          successCount++
+        } catch (_: ExecutionException) {
+          failureCount++
+        }
+      }
+      assertThat(successCount).isEqualTo(6)
+      assertThat(failureCount).isEqualTo(3)
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/time/time_asserts.kt
+++ b/misk/src/test/kotlin/misk/time/time_asserts.kt
@@ -1,0 +1,20 @@
+package misk.time
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import java.time.Duration
+
+/** Fails unless the block executes in the expected time. */
+fun assertElapsedTime(
+  expected: Duration,
+  tolerance: Duration = Duration.ofMillis(100),
+  block: () -> Unit
+) {
+  val startNanos = System.nanoTime()
+  block()
+  val endNanos = System.nanoTime()
+  val duration = Duration.ofNanos(endNanos - startNanos)
+
+  assertThat(duration.toMillis().toDouble())
+      .isCloseTo(expected.toMillis().toDouble(), Offset.offset(tolerance.toNanos().toDouble()))
+}

--- a/misk/src/test/kotlin/misk/time/wait_notify.kt
+++ b/misk/src/test/kotlin/misk/time/wait_notify.kt
@@ -1,0 +1,35 @@
+package misk.time
+
+/**
+ * Wait until the duration has elapsed. Unlike [java.lang.Object.wait] this interprets 0 as
+ * "don't wait" instead of "wait forever".
+ */
+fun Any.waitNanosIgnoreNotifies(nanos: Long) {
+  check(nanos >= 0)
+  var now = System.nanoTime()
+  val waitUntil = now + nanos
+  while (now < waitUntil) {
+    waitNanos(waitUntil - now)
+    now = System.nanoTime()
+  }
+}
+
+/**
+ * Wait until either a duration is elapsed or this is notified. Unlike [java.lang.Object.wait] this
+ * interprets 0 as "don't wait" instead of "wait forever".
+ */
+@Throws(InterruptedException::class)
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+fun Any.waitNanos(nanos: Long) {
+  val ms = nanos / 1_000_000L
+  val ns = nanos - (ms * 1_000_000L)
+  if (ms > 0L || ns > 0) {
+    (this as Object).wait(ms, ns.toInt())
+  }
+}
+
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
+inline fun Any.notify() = (this as Object).notify()
+
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
+inline fun Any.notifyAll() = (this as Object).notifyAll()

--- a/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
+++ b/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
@@ -1,0 +1,139 @@
+package misk.web
+
+import com.google.inject.util.Modules
+import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.ClockModule
+import misk.time.FakeResourcePool
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class DegradedHealthStressTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject lateinit var jettyService: JettyService
+  @Inject lateinit var fakeResourcePool: FakeResourcePool
+
+  private lateinit var executorService: ScheduledExecutorService
+  private lateinit var httpClient: OkHttpClient
+
+  private val successCount = AtomicInteger()
+  private val shedCount = AtomicInteger()
+  private val failureCount = AtomicInteger()
+
+  @BeforeEach
+  internal fun setUp() {
+    executorService = Executors.newScheduledThreadPool(1)
+    httpClient = OkHttpClient()
+    httpClient.dispatcher.maxRequestsPerHost = 100
+    httpClient.dispatcher.maxRequests = 100
+  }
+
+  @AfterEach
+  fun tearDown() {
+    executorService.shutdown()
+    httpClient.dispatcher.executorService.shutdown()
+  }
+
+  /**
+   * This test is non-deterministic! It attempts to confirm that concurrency load shedding is
+   * working with real requests. It should take ~15 seconds to complete.
+   *
+   * It consumes a resource-constrained endpoint, /work, that takes 200 ms per call and operates on
+   * up to 5 calls a time. In total the service can complete 25 calls per second.
+   *
+   * It's inbound load is double its capacity: it sends 50 calls per second!
+   *
+   * Once stabilized we expect ~125 calls to complete successfully and the rest to be shed. Requests
+   * that are not shed that should have been will time out, and the goal of the concurrency limiter
+   * is to minimize such failures.
+   */
+  @Test
+  fun contentionStressTest() {
+    // Support 25 calls per second (5 resources are available, and each resource is used for 200ms).
+    fakeResourcePool.total = 5
+
+    // Send 50 calls per second.
+    val recurringTask = executorService.scheduleAtFixedRate({ makeAsyncHttpCall() },
+        0, 1000L / 50, TimeUnit.MILLISECONDS)
+
+    // Make 10 seconds of calls so the concurrency limiter can stabilize.
+    Thread.sleep(10_000)
+    successCount.set(0)
+    shedCount.set(0)
+    failureCount.set(0)
+
+    // Observe 5 seconds of data.
+    Thread.sleep(5_000)
+    recurringTask.cancel(false)
+
+    // Expect 125 successful calls, most of the rest shed, and the remainder failed.
+    println("successCount=$successCount, shedCount=$shedCount, failureCount=$failureCount")
+    assertThat(successCount.get().toDouble()).isCloseTo(125.0, Offset.offset(50.0))
+    assertThat(shedCount.get().toDouble()).isCloseTo(125.0, Offset.offset(50.0))
+    assertThat(failureCount.get().toDouble()).isCloseTo(0.0, Offset.offset(50.0))
+  }
+
+  class UseConstrainedResourceAction @Inject constructor(
+    private val fakeResourcePool: FakeResourcePool
+  ) : WebAction {
+    @Get("/use_constrained_resource")
+    @ConcurrencyLimitsOptIn
+    fun get(): String {
+      fakeResourcePool.useResource(Duration.ofMillis(50), Duration.ofMillis(200))
+      return "success"
+    }
+  }
+
+  private fun makeAsyncHttpCall() {
+    val url = jettyService.httpServerUrl.resolve("/use_constrained_resource")!!
+    val request = Request.Builder()
+        .url(url)
+        .build()
+
+    httpClient.newCall(request).enqueue(object : Callback {
+      override fun onFailure(call: Call, e: IOException) {
+        failureCount.incrementAndGet()
+      }
+
+      override fun onResponse(call: Call, response: Response) {
+        response.use {
+          when (response.code) {
+            200 -> successCount.incrementAndGet()
+            503 -> shedCount.incrementAndGet()
+            else -> failureCount.incrementAndGet()
+          }
+        }
+      }
+    })
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(Modules.override(WebTestingModule()).with(ClockModule()))
+      install(WebActionModule.create<UseConstrainedResourceAction>())
+      bind<FakeResourcePool>().asSingleton()
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -1,0 +1,119 @@
+package misk.web.interceptors
+
+import com.netflix.concurrency.limits.limit.SettableLimit
+import com.netflix.concurrency.limits.limiter.SimpleLimiter
+import misk.Action
+import misk.asAction
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.FakeClock
+import misk.time.FakeClockModule
+import misk.web.ConcurrencyLimitsOptIn
+import misk.web.DispatchMechanism
+import misk.web.FakeHttpCall
+import misk.web.Get
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import misk.web.RealNetworkChain
+import misk.web.actions.LivenessCheckAction
+import misk.web.actions.ReadinessCheckAction
+import misk.web.actions.StatusAction
+import misk.web.actions.WebAction
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import javax.inject.Inject
+
+@MiskTest
+class ConcurrencyLimitsInterceptorTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject private lateinit var factory: ConcurrencyLimitsInterceptor.Factory
+  @Inject private lateinit var clock: FakeClock
+
+  @Test
+  fun happyPath() {
+    val action = HelloAction::call.asAction(DispatchMechanism.GET)
+    val interceptor = factory.create(action)!!
+    assertThat(call(action, interceptor, callDuration = Duration.ofMillis(100), statusCode = 200))
+        .isEqualTo(CallResult(callWasShed = false, statusCode = 200))
+  }
+
+  @Test
+  fun limitReached() {
+    val action = HelloAction::call.asAction(DispatchMechanism.GET)
+    val limitZero = SimpleLimiter.Builder()
+        .limit(SettableLimit(0))
+        .build<String>()
+    val interceptor = ConcurrencyLimitsInterceptor(action.name, limitZero)
+    assertThat(call(action, interceptor, callDuration = Duration.ofMillis(100), statusCode = 200))
+        .isEqualTo(CallResult(callWasShed = true, statusCode = 503))
+  }
+
+  @Test
+  fun noLimitsOnHealthCriticalEndpoints() {
+    val livenessCheck = LivenessCheckAction::livenessCheck.asAction(DispatchMechanism.GET)
+    assertThat(factory.create(livenessCheck)).isNull()
+
+    val readinessCheck = ReadinessCheckAction::readinessCheck.asAction(DispatchMechanism.GET)
+    assertThat(factory.create(readinessCheck)).isNull()
+
+    val getStatus = StatusAction::getStatus.asAction(DispatchMechanism.GET)
+    assertThat(factory.create(getStatus)).isNull()
+  }
+
+  private fun call(
+    action: Action,
+    interceptor: NetworkInterceptor,
+    callDuration: Duration = Duration.ofMillis(100),
+    statusCode: Int = 200
+  ): CallResult {
+    val terminalInterceptor = TerminalInterceptor(callDuration, statusCode)
+    val httpCall = FakeHttpCall(url = "https://example.com/hello".toHttpUrl())
+    val chain = RealNetworkChain(
+        action,
+        HelloAction(),
+        httpCall,
+        listOf(interceptor, terminalInterceptor)
+    )
+    chain.proceed(chain.httpCall)
+    return CallResult(
+        callWasShed = terminalInterceptor.callWasShed,
+        statusCode = httpCall.statusCode
+    )
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(FakeClockModule())
+    }
+  }
+
+  /** Simulate forwarding through actions that return an expected result. */
+  inner class TerminalInterceptor(
+    private val callDuration: Duration,
+    private val statusCode: Int
+  ) : NetworkInterceptor {
+    var callWasShed = true
+
+    override fun intercept(chain: NetworkChain) {
+      callWasShed = false
+      clock.add(callDuration)
+      chain.httpCall.statusCode = statusCode
+    }
+  }
+
+  data class CallResult(
+    val callWasShed: Boolean,
+    val statusCode: Int
+  )
+
+  internal class HelloAction : WebAction {
+    @Get("/hello")
+    @ConcurrencyLimitsOptIn
+    fun call(): String = "hello"
+  }
+}


### PR DESCRIPTION
This uses the Netflix concurrency-limits library that we're already using
elsewhere at Square. It works great.
https://github.com/Netflix/concurrency-limits/

This is currently opt-in. In a follow-up I'd like to make it opt-out.