### PR TITLE
Allow an unbounded RepeatedTaskQueue

### DIFF
--- a/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueue.kt
+++ b/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueue.kt
@@ -202,11 +202,17 @@ class RepeatedTaskQueueFactory @Inject constructor(
    */
   fun new(name: String, config: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig()):
       RepeatedTaskQueue {
+    val threadFactory = ThreadFactoryBuilder()
+        .setNameFormat("$name-%d")
+        .build()
+    val executor = if (config.num_parallel_tasks == -1) {
+      Executors.newCachedThreadPool(threadFactory)
+    } else {
+      Executors.newFixedThreadPool(config.num_parallel_tasks, threadFactory)
+    }
     return RepeatedTaskQueue(name,
         clock,
-        Executors.newFixedThreadPool(config.num_parallel_tasks, ThreadFactoryBuilder()
-            .setNameFormat("$name-%d")
-            .build()),
+        executor,
         null,
         DelayQueue<DelayedTask>(),
         metrics,

--- a/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueueConfig.kt
+++ b/misk/src/main/kotlin/misk/tasks/RepeatedTaskQueueConfig.kt
@@ -20,7 +20,11 @@ data class RepeatedTaskQueueConfig(
   val default_max_delay_sec: Long = 60,
 
   /**
-   * The number of parallel tasks to run.
+   * The fixed number of parallel tasks to run.
+   *
+   * If -1 then an unbounded number of parallel tasks are allowed. An unbounded number of tasks can
+   * be useful for an App that needs to dynamically compute the number of tasks at runtime. However,
+   * the App is then responsible for ensuring an upper bound for the number of tasks submitted.
    */
   val num_parallel_tasks: Int = 1
 


### PR DESCRIPTION
An unbounded queue can be nice if an App doesn't know the number of
tasks statically. For example an Event consumer might dynamically
subscribe to topics.