### PR TITLE
Make FakeResourcePoolTest less flaky

### DIFF
--- a/misk/src/test/kotlin/misk/time/FakeResourcePoolTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeResourcePoolTest.kt
@@ -1,6 +1,7 @@
 package misk.time
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.io.InterruptedIOException
@@ -100,8 +101,8 @@ internal class FakeResourcePoolTest {
           failureCount++
         }
       }
-      assertThat(successCount).isEqualTo(6)
-      assertThat(failureCount).isEqualTo(3)
+      assertThat(successCount).isCloseTo(6, Offset.offset(1))
+      assertThat(failureCount).isCloseTo(3, Offset.offset(1))
     }
   }
 }

--- a/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
+++ b/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
@@ -90,9 +90,9 @@ internal class DegradedHealthStressTest {
 
     // Expect 125 successful calls, most of the rest shed, and the remainder failed.
     println("successCount=$successCount, shedCount=$shedCount, failureCount=$failureCount")
-    assertThat(successCount.get().toDouble()).isCloseTo(125.0, Offset.offset(50.0))
-    assertThat(shedCount.get().toDouble()).isCloseTo(125.0, Offset.offset(50.0))
-    assertThat(failureCount.get().toDouble()).isCloseTo(0.0, Offset.offset(50.0))
+    assertThat(successCount.get()).isCloseTo(125, Offset.offset(50))
+    assertThat(shedCount.get()).isCloseTo(125, Offset.offset(50))
+    assertThat(failureCount.get()).isCloseTo(0, Offset.offset(50))
   }
 
   class UseConstrainedResourceAction @Inject constructor(


### PR DESCRIPTION
This should still fail if the logic breaks.