### PR TITLE
Add the QueueName label to jobqueue metrics

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -22,7 +22,7 @@ internal class SqsJob(
 
   override fun acknowledge() {
     deleteMessage(queue, message)
-    metrics.jobsAcknowledged.labels(queueName.value).inc()
+    metrics.jobsAcknowledged.labels(queueName.value, queueName.value).inc()
   }
 
   override fun deadLetter() {
@@ -36,14 +36,14 @@ internal class SqsJob(
           .withMessageAttributes(message.messageAttributes))
     }
     deleteMessage(queue, message)
-    metrics.jobsDeadLettered.labels(queueName.value).inc()
+    metrics.jobsDeadLettered.labels(queueName.value, queueName.value).inc()
   }
 
   private fun deleteMessage(queue: ResolvedQueue, message: Message) {
     val (deleteDuration, _) = queue.call {
       timed { it.deleteMessage(queue.url, message.receiptHandle) }
     }
-    metrics.sqsDeleteTime.record(deleteDuration.toMillis().toDouble(), queueName.value)
+    metrics.sqsDeleteTime.record(deleteDuration.toMillis().toDouble(), queueName.value, queueName.value)
   }
 
   companion object {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
@@ -25,7 +25,7 @@ internal class SqsJobQueue @Inject internal constructor(
     attributes: Map<String, String>
   ) {
     tracer.traceWithSpan("enqueue-job-${queueName.value}") { span ->
-      metrics.jobsEnqueued.labels(queueName.value).inc()
+      metrics.jobsEnqueued.labels(queueName.value, queueName.value).inc()
       try {
         val queue = queues[queueName]
 
@@ -54,10 +54,10 @@ internal class SqsJobQueue @Inject internal constructor(
           timed { client.sendMessage(sendRequest) }
         }
 
-        metrics.sqsSendTime.record(sendDuration.toMillis().toDouble(), queueName.value)
+        metrics.sqsSendTime.record(sendDuration.toMillis().toDouble(), queueName.value, queueName.value)
       } catch (th: Throwable) {
         log.error(th) { "failed to enqueue to ${queueName.value}" }
-        metrics.jobEnqueueFailures.labels(queueName.value).inc()
+        metrics.jobEnqueueFailures.labels(queueName.value, queueName.value).inc()
         throw th
       }
     }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
@@ -4,65 +4,73 @@ import misk.metrics.Metrics
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * SQS Jobqueue metrics.
+ *
+ * NB: we use the capitalized "QueueName" label to stay consistent with SQS' similarly named label. This lets us filter
+ * for queues both client-side and on SQS with the same label.
+ */
 @Singleton
 internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
   val jobsEnqueued = metrics.counter(
       "jobs_enqueued_total",
       "total # of jobs sent to a queueName",
-      listOf("queueName")
+      // Duplicate labels so we don't break existing dashboards/detectors
+      // TODO(hamdan): remove queueName once no one's using it
+      listOf("queueName", "QueueName")
   )
 
   val jobEnqueueFailures = metrics.counter(
       "job_enqueue_failures_total",
       "total # of jobs that failed to enqueue",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val jobsReceived = metrics.counter(
       "jobs_received_total",
       "total # of jobs received on a queueName",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val handlerDispatchTime = metrics.histogram(
       "job_handler_duration_ms",
       "duration of job handling runs for a given job queueName",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val jobsAcknowledged = metrics.counter(
       "jobs_acknowledged_total",
       "total # of jobs acknowledged by handlers",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val handlerFailures = metrics.counter(
       "job_handler_failures",
       "total # of jobs whose handlers threw an exception",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val jobsDeadLettered = metrics.counter(
       "jobs_dead_lettered",
       "total # of jobs explicitly moved to the dead letter queueName",
-      listOf("queueName")
+      listOf("queueName", "QueueName")
   )
 
   val sqsSendTime = metrics.histogram(
     "jobs_sqs_send_latency",
     "the round trip time to send messages to SQS",
-    listOf("queueName")
+    listOf("queueName", "QueueName")
   )
 
   val sqsReceiveTime = metrics.histogram(
     "jobs_sqs_receive_latency",
     "the round trip time to receive messages from SQS",
-    listOf("queueName")
+    listOf("queueName", "QueueName")
   )
 
   val sqsDeleteTime = metrics.histogram(
     "jobs_sqs_delete_latency",
     "the round trip time to delete messages from SQS",
-    listOf("queueName")
+    listOf("queueName", "QueueName")
   )
 }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -91,19 +91,19 @@ internal class SqsJobQueueTest {
     )
 
     // Confirm metrics
-    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value).get()).isEqualTo(10.0)
-    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsSendTime.count(queueName.value)).isEqualTo(10)
+    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value, queueName.value).get()).isEqualTo(10.0)
+    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(queueName.value, queueName.value)).isEqualTo(10)
 
-    assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(10.0)
+    assertThat(sqsMetrics.jobsReceived.labels(queueName.value, queueName.value).get()).isEqualTo(10.0)
     // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
     // messages in varying batches
-    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value)).isNotZero()
+    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value, queueName.value)).isNotZero()
 
-    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value).get()).isEqualTo(10.0)
-    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value)).isEqualTo(10)
+    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value, queueName.value).get()).isEqualTo(10.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value, queueName.value)).isEqualTo(10)
 
-    assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
   }
 
   @Test fun enqueueAndHandlePrioritized() {
@@ -169,19 +169,19 @@ internal class SqsJobQueueTest {
 
     // Confirm metrics
     queues.forEach { queueName ->
-      assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value).get()).isEqualTo(1.0)
-      assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value).get()).isEqualTo(0.0)
-      assertThat(sqsMetrics.sqsSendTime.count(queueName.value)).isEqualTo(1)
+      assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+      assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+      assertThat(sqsMetrics.sqsSendTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-      assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(1.0)
+      assertThat(sqsMetrics.jobsReceived.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
       // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
       // messages in varying batches
-      assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value)).isNotZero()
+      assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value, queueName.value)).isNotZero()
 
-      assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value).get()).isEqualTo(1.0)
-      assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value)).isEqualTo(1)
+      assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+      assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-      assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(0.0)
+      assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
     }
   }
 
@@ -207,19 +207,19 @@ internal class SqsJobQueueTest {
     assertThat(handledJobs).allSatisfy { assertThat(it.id).isEqualTo(messageId) }
 
     // Confirm metrics
-    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value).get()).isEqualTo(1.0)
-    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsSendTime.count(queueName.value)).isEqualTo(1)
+    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-    assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.jobsReceived.labels(queueName.value, queueName.value).get()).isEqualTo(2.0)
     // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
     // messages in varying batches
-    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value)).isNotZero()
+    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value, queueName.value)).isNotZero()
 
-    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value).get()).isEqualTo(1.0)
-    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value)).isEqualTo(1)
+    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-    assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
   }
 
   @Test fun movesToDeadLetterQueueIfRequested() {
@@ -255,33 +255,33 @@ internal class SqsJobQueueTest {
     )
 
     // Confirm metrics
-    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value).get()).isEqualTo(2.0)
-    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsSendTime.count(queueName.value)).isEqualTo(2)
+    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value, queueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(queueName.value, queueName.value)).isEqualTo(2)
 
-    assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.jobsReceived.labels(queueName.value, queueName.value).get()).isEqualTo(2.0)
     // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
     // messages in varying batches
-    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value)).isNotZero()
+    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value, queueName.value)).isNotZero()
 
-    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.jobsDeadLettered.labels(queueName.value).get()).isEqualTo(2.0)
-    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value)).isEqualTo(2)
+    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.jobsDeadLettered.labels(queueName.value, queueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value, queueName.value)).isEqualTo(2)
 
-    assertThat(sqsMetrics.jobsEnqueued.labels(deadLetterQueueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.jobEnqueueFailures.labels(deadLetterQueueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsSendTime.count(deadLetterQueueName.value)).isEqualTo(0)
+    assertThat(sqsMetrics.jobsEnqueued.labels(deadLetterQueueName.value, deadLetterQueueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.jobEnqueueFailures.labels(deadLetterQueueName.value, deadLetterQueueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(deadLetterQueueName.value, deadLetterQueueName.value)).isEqualTo(0)
 
-    assertThat(sqsMetrics.jobsReceived.labels(deadLetterQueueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.jobsReceived.labels(deadLetterQueueName.value, deadLetterQueueName.value).get()).isEqualTo(2.0)
     // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
     // messages in varying batches
-    assertThat(sqsMetrics.sqsReceiveTime.count(deadLetterQueueName.value)).isNotZero()
+    assertThat(sqsMetrics.sqsReceiveTime.count(deadLetterQueueName.value, deadLetterQueueName.value)).isNotZero()
 
-    assertThat(sqsMetrics.jobsAcknowledged.labels(deadLetterQueueName.value).get()).isEqualTo(2.0)
-    assertThat(sqsMetrics.jobsDeadLettered.labels(deadLetterQueueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsDeleteTime.count(deadLetterQueueName.value)).isEqualTo(2)
+    assertThat(sqsMetrics.jobsAcknowledged.labels(deadLetterQueueName.value, deadLetterQueueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.jobsDeadLettered.labels(deadLetterQueueName.value, deadLetterQueueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(deadLetterQueueName.value, deadLetterQueueName.value)).isEqualTo(2)
 
-    assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
   }
 
   @Test fun stopsDeliveryAfterClose() {
@@ -325,20 +325,20 @@ internal class SqsJobQueueTest {
     assertThat(deliveryAttempts.get()).isEqualTo(3)
 
     // Confirm metrics
-    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value).get()).isEqualTo(1.0)
-    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsSendTime.count(queueName.value)).isEqualTo(1)
+    assertThat(sqsMetrics.jobsEnqueued.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+    assertThat(sqsMetrics.jobEnqueueFailures.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-    assertThat(sqsMetrics.jobsReceived.labels(queueName.value).get()).isEqualTo(3.0)
+    assertThat(sqsMetrics.jobsReceived.labels(queueName.value, queueName.value).get()).isEqualTo(3.0)
     // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
     // messages in varying batches
-    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value)).isNotZero()
+    assertThat(sqsMetrics.sqsReceiveTime.count(queueName.value, queueName.value)).isNotZero()
 
-    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value).get()).isEqualTo(1.0)
-    assertThat(sqsMetrics.jobsDeadLettered.labels(queueName.value).get()).isEqualTo(0.0)
-    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value)).isEqualTo(1)
+    assertThat(sqsMetrics.jobsAcknowledged.labels(queueName.value, queueName.value).get()).isEqualTo(1.0)
+    assertThat(sqsMetrics.jobsDeadLettered.labels(queueName.value, queueName.value).get()).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(queueName.value, queueName.value)).isEqualTo(1)
 
-    assertThat(sqsMetrics.handlerFailures.labels(queueName.value).get()).isEqualTo(2.0)
+    assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(2.0)
   }
 
   @Test fun waitsForDispatchedTasksToFail() {


### PR DESCRIPTION
This matches the equivalent SQS metric which lets us filter for queues using 1 metric.

Opted to add a new label instead of replacing the existing one as to not break dashboards
and detectors.