### PR TITLE
Fix queue processing to keep threads busy

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -125,10 +125,11 @@ internal class SqsJobConsumer @Inject internal constructor(
               // Run the handler and record timing
               try {
                 val (duration, _) = timed { handler.handleJob(message) }
-                metrics.handlerDispatchTime.record(duration.toMillis().toDouble(), queueName.value)
+                metrics.handlerDispatchTime.record(duration.toMillis().toDouble(), queueName.value,
+                    queueName.value)
               } catch (th: Throwable) {
                 log.error(th) { "error handling job from ${queueName.value}" }
-                metrics.handlerFailures.labels(queueName.value).inc()
+                metrics.handlerFailures.labels(queueName.value, queueName.value).inc()
                 Tags.ERROR.set(span, true)
                 throw th
               }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
@@ -21,7 +21,7 @@ import misk.testing.ExternalDependency
 internal object DockerSqs : ExternalDependency {
 
   private val log = getLogger<DockerSqs>()
-  private const val clientPort = 4100
+  private const val clientPort = 9324
 
   override fun beforeEach() {
     // noop
@@ -39,9 +39,8 @@ internal object DockerSqs : ExternalDependency {
     // NB(mmihic): Because the client port is embedded directly into the queue URLs, we have to use
     // the same external port as we do for the internal port
     val exposedClientPort = ExposedPort.tcp(clientPort)
-    withImage("pafortin/goaws")
-        .withName("sqs")
-        .withCmd(listOf("goaws"))
+    withImage("roribio16/alpine-sqs")
+        .withName("alpine-sqs")
         .withExposedPorts(exposedClientPort)
         .withPortBindings(
             Ports().apply { bind(exposedClientPort, Ports.Binding.bindPort(clientPort)) })

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -348,7 +348,7 @@ internal class SqsJobQueueTest {
     }
     queue.enqueue(queueName, "fail away")
     val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
-    assertThat(receiver.runOnce()).isEqualTo(Status.FAILED)
+    assertThat(receiver.runOnce()).isTrue()
   }
 
   @Test fun noWork() {
@@ -357,7 +357,7 @@ internal class SqsJobQueueTest {
       throw IllegalStateException("boom!")
     }
     val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
-    assertThat(receiver.runOnce()).isEqualTo(Status.NO_WORK)
+    assertThat(receiver.runOnce()).isFalse()
   }
 
   private fun turnOffTaskQueue() {


### PR DESCRIPTION
The current queue processing implementation will block waiting for the last
message in the batch to be processed. We want to make sure that we keep all
threads busy while there are still messages on the queue.