### PR TITLE
Rename ResourceMapper to Partitioner

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
@@ -13,7 +13,7 @@ import kotlin.concurrent.withLock
 /**
  * Zookeeper based load balanced lease.
  *
- * <p>Multiple servers use a [misk.clustering.ClusterResourceMapper] to determine which process should
+ * <p>Multiple servers use a [misk.clustering.Partitioner] to determine which process should
  * own a lease. As long as each process has the same view of the cluster, this mapping will be
  * consistent and processes will not actively compete for the same lease.
  *
@@ -199,7 +199,7 @@ internal class ZkLease(
   private fun shouldHoldLease(): Boolean {
     val clusterSnapshot = manager.cluster.snapshot
     val desiredLeaseOwner = try {
-      clusterSnapshot.resourceMapper[leaseResourceName]
+      clusterSnapshot.partitioner[leaseResourceName]
     } catch (e: NoMembersAvailableException) {
       log.warn { e.message }
       null

--- a/misk/src/main/kotlin/misk/clustering/Cluster.kt
+++ b/misk/src/main/kotlin/misk/clustering/Cluster.kt
@@ -1,5 +1,8 @@
 package misk.clustering
 
+import misk.clustering.partition.ClusterHashRing
+import misk.clustering.partition.Partitioner
+
 /** A [ClusterWatch] is a callback function triggered when cluster membership changes */
 typealias ClusterWatch = (Cluster.Changes) -> Unit
 
@@ -29,8 +32,8 @@ interface Cluster {
     /** true if the current service instance is ready as perceived by the cluster manager */
     val selfReady: Boolean = readyMembers.any { it.name == self.name },
 
-    /** A [ClusterResourceMapper] built from the ready members of this cluster */
-    val resourceMapper: ClusterResourceMapper
+    /** A [Partitioner] built from the ready members of this cluster */
+    val partitioner: Partitioner
   ) {
     /** The of the ready peers; basically all of the ready cluster members except sel */
     val readyPeers: Set<Member> = readyMembers - self
@@ -42,7 +45,7 @@ interface Cluster {
   /** Registers interest in cluster changes */
   fun watch(watch: ClusterWatch)
 
-  /** @return A new [ClusterResourceMapper] for the given set of ready members */
-  fun newResourceMapper(readyMembers: Set<Cluster.Member>): ClusterResourceMapper =
+  /** @return A new [Partitioner] for the given set of ready members */
+  fun newPartitioner(readyMembers: Set<Cluster.Member>): Partitioner =
       ClusterHashRing(readyMembers)
 }

--- a/misk/src/main/kotlin/misk/clustering/fake/ExplicitPartitioner.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/ExplicitPartitioner.kt
@@ -1,16 +1,16 @@
 package misk.clustering.fake
 
 import misk.clustering.Cluster
-import misk.clustering.ClusterResourceMapper
+import misk.clustering.partition.Partitioner
 import misk.clustering.NoMembersAvailableException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * An [ExplicitClusterResourceMapper] is a [ClusterResourceMapper] where the mapping
+ * An [ExplicitPartitioner] is a [Partitioner] where the mapping
  * is explicit managed.
  */
-class ExplicitClusterResourceMapper : ClusterResourceMapper {
+class ExplicitPartitioner : Partitioner {
   private val mappings = ConcurrentHashMap<String, Cluster.Member>()
   private val defaultMapping = AtomicReference<Cluster.Member>()
 

--- a/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
@@ -20,13 +20,13 @@ import javax.inject.Singleton
  */
 @Singleton
 class FakeCluster internal constructor(
-  val resourceMapper: ExplicitClusterResourceMapper,
+  val partitioner: ExplicitPartitioner,
   private val delegate: DefaultCluster
 ) : ClusterService by delegate, Cluster by delegate {
-  constructor(resourceMapper: ExplicitClusterResourceMapper) :
-      this(resourceMapper, DefaultCluster(self) { resourceMapper })
+  constructor(partitioner: ExplicitPartitioner) :
+      this(partitioner, DefaultCluster(self) { partitioner })
 
-  @Inject constructor() : this(ExplicitClusterResourceMapper().apply {
+  @Inject constructor() : this(ExplicitPartitioner().apply {
     setDefaultMapping(self)
   })
 

--- a/misk/src/main/kotlin/misk/clustering/partition/ClusterHashRing.kt
+++ b/misk/src/main/kotlin/misk/clustering/partition/ClusterHashRing.kt
@@ -1,7 +1,9 @@
-package misk.clustering
+package misk.clustering.partition
 
 import com.google.common.hash.HashFunction
 import com.google.common.hash.Hashing
+import misk.clustering.Cluster
+import misk.clustering.NoMembersAvailableException
 import java.util.Arrays
 import java.util.Objects
 
@@ -10,7 +12,7 @@ class ClusterHashRing(
   members: Collection<Cluster.Member>,
   private val hashFn: HashFunction = Hashing.murmur3_32(),
   private val vnodesCount: Int = 16
-) : ClusterResourceMapper {
+) : Partitioner {
   private val vnodes: IntArray
   private val vnodesToMembers: Map<Int, Cluster.Member>
 

--- a/misk/src/main/kotlin/misk/clustering/partition/Partitioner.kt
+++ b/misk/src/main/kotlin/misk/clustering/partition/Partitioner.kt
@@ -1,12 +1,14 @@
-package misk.clustering
+package misk.clustering.partition
+
+import misk.clustering.Cluster
 
 /**
- * A [ClusterResourceMapper] maps string based resource IDs onto members of a cluster for the
- * purposes of resource ownership. The default [ClusterResourceMapper] is a [ClusterHashRing]
+ * A [Partitioner] maps string based resource IDs onto members of a cluster for the
+ * purposes of resource ownership. The default [Partitioner] is a [ClusterHashRing]
  * which performs a consistent hash across the cluster member, but [Cluster]s can supply their
  * own mappings if there is a mechanism specific to that cluster (or to supply a fake)
  */
-interface ClusterResourceMapper {
+interface Partitioner {
   /**
    * @throws NoMembersAvailableException if there are no members in the cluster
    * @return The [Cluster.Member] that should own the given resource id

--- a/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
@@ -9,7 +9,7 @@ import helpers.protos.Dinosaur
 import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
 import misk.clustering.ClusterWatch
-import misk.clustering.fake.ExplicitClusterResourceMapper
+import misk.clustering.fake.ExplicitPartitioner
 import misk.config.AppName
 import misk.inject.KAbstractModule
 import misk.security.ssl.CertStoreConfig
@@ -87,15 +87,15 @@ internal class TypedPeerHttpClientTest {
 
     init {
       val self = Cluster.Member(name = "self-name", ipAddress = memberIp)
-      val resourceMapper = ExplicitClusterResourceMapper()
+      val partitioner = ExplicitPartitioner()
 
-      resourceMapper.setDefaultMapping(self)
+      partitioner.setDefaultMapping(self)
 
       snapshot = Cluster.Snapshot(
           self = self,
           readyMembers = setOf(),
           selfReady = true,
-          resourceMapper = resourceMapper
+          partitioner = partitioner
       )
     }
 

--- a/misk/src/test/kotlin/misk/clustering/ClusterHashRingTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/ClusterHashRingTest.kt
@@ -3,6 +3,7 @@ package misk.clustering
 import com.google.common.hash.HashCode
 import com.google.common.hash.HashFunction
 import com.google.common.hash.Hashing
+import misk.clustering.partition.ClusterHashRing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -11,7 +12,8 @@ internal class ClusterHashRingTest {
   @Test fun singleNode() {
     val zork = Cluster.Member("zork", "192.49.168.23")
     val hashRing =
-        ClusterHashRing(members = setOf(zork), hashFn = Hashing.murmur3_32(0))
+        ClusterHashRing(members = setOf(zork),
+            hashFn = Hashing.murmur3_32(0))
     assertThat(listOf("foo", "bar", "zed").map { hashRing[it] }).containsExactly(zork, zork, zork)
   }
 
@@ -46,7 +48,8 @@ internal class ClusterHashRingTest {
 
   @Test fun zeroNodes() {
     val hashRing =
-        ClusterHashRing(members = setOf(), hashFn = Hashing.murmur3_32(0))
+        ClusterHashRing(members = setOf(),
+            hashFn = Hashing.murmur3_32(0))
     assertThrows<NoMembersAvailableException> {
       hashRing["foo"]
     }
@@ -70,13 +73,13 @@ internal class ClusterHashRingTest {
     val hashRing = ClusterHashRing(
         members = setOf(a, b, c),
         hashFn = FakeHashFn(mapOf(
-          "a 0" to 100,
-          "b 0" to 200,
-          "c 0" to 300,
-          "foo" to 50,
-          "bar" to 150,
-          "zed" to 250,
-          "zork" to 350
+            "a 0" to 100,
+            "b 0" to 200,
+            "c 0" to 300,
+            "foo" to 50,
+            "bar" to 150,
+            "zed" to 250,
+            "zork" to 350
         )),
         vnodesCount = 1)
     assertThat(listOf("foo", "bar", "zed", "zork").map { hashRing[it] })

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
@@ -26,22 +26,22 @@ internal class FakeClusterTest {
     assertThat(cluster.snapshot.readyMembers).isEmpty()
   }
 
-  @Test fun clusterUsesExplicitResourceMapping() {
+  @Test fun clusterUsesExplicitPartitioner() {
     // By default all resources should be owned by us
-    assertThat(cluster.resourceMapper["my-object"]).isEqualTo(FakeCluster.self)
+    assertThat(cluster.partitioner["my-object"]).isEqualTo(FakeCluster.self)
 
-    cluster.resourceMapper.setDefaultMapping(Cluster.Member("zork", "192.168.12.0"))
-    cluster.resourceMapper.addMapping("my-object", Cluster.Member("bork", "192.168.12.1"))
+    cluster.partitioner.setDefaultMapping(Cluster.Member("zork", "192.168.12.0"))
+    cluster.partitioner.addMapping("my-object", Cluster.Member("bork", "192.168.12.1"))
 
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("bork")
-    assertThat(cluster.snapshot.resourceMapper["other-object"].name).isEqualTo("zork")
+    assertThat(cluster.snapshot.partitioner["my-object"].name).isEqualTo("bork")
+    assertThat(cluster.snapshot.partitioner["other-object"].name).isEqualTo("zork")
 
     // Ensure resource mapper remains the same even through cluster changes
     cluster.clusterChanged(membersBecomingReady = setOf(Cluster.Member("blerp", "192.168.12.3")))
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("bork")
-    assertThat(cluster.snapshot.resourceMapper["other-object"].name).isEqualTo("zork")
+    assertThat(cluster.snapshot.partitioner["my-object"].name).isEqualTo("bork")
+    assertThat(cluster.snapshot.partitioner["other-object"].name).isEqualTo("zork")
 
-    cluster.resourceMapper.removeMapping("my-object")
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("zork")
+    cluster.partitioner.removeMapping("my-object")
+    assertThat(cluster.snapshot.partitioner["my-object"].name).isEqualTo("zork")
   }
 }

--- a/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
@@ -9,7 +9,7 @@ import io.kubernetes.client.models.V1PodStatus
 import io.kubernetes.client.util.Watches
 import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
-import misk.clustering.ClusterHashRing
+import misk.clustering.partition.ClusterHashRing
 import misk.clustering.DefaultCluster
 import misk.clustering.kubernetes.KubernetesClusterWatcher.Companion.CHANGE_TYPE_ADDED
 import misk.clustering.kubernetes.KubernetesClusterWatcher.Companion.CHANGE_TYPE_DELETED
@@ -66,19 +66,20 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            partitioner = ClusterHashRing(setOf())
         )),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = true,
             readyMembers = setOf(expectedSelf),
-            resourceMapper = ClusterHashRing(setOf(expectedSelf))
+            partitioner = ClusterHashRing(
+                setOf(expectedSelf))
         ), added = setOf(expectedSelf)),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            partitioner = ClusterHashRing(setOf())
         ), removed = setOf(expectedSelf))
     )
   }
@@ -98,13 +99,14 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            partitioner = ClusterHashRing(setOf())
         )),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(Cluster.Member("larry-blerp", "10.0.0.3")),
-            resourceMapper = ClusterHashRing(setOf(Cluster.Member("larry-blerp", "10.0.0.3")))
+            partitioner = ClusterHashRing(
+                setOf(Cluster.Member("larry-blerp", "10.0.0.3")))
         ), added = setOf(Cluster.Member("larry-blerp", "10.0.0.3"))),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
@@ -112,7 +114,7 @@ internal class KubernetesClusterTest {
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4"))
             )
@@ -140,7 +142,7 @@ internal class KubernetesClusterTest {
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4"))
             ))
@@ -149,7 +151,7 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp2", "10.0.0.4")
             ))
         ), removed = setOf(Cluster.Member("larry-blerp", ""))))
@@ -170,7 +172,7 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            partitioner = ClusterHashRing(setOf())
         )))
   }
 
@@ -189,7 +191,7 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            partitioner = ClusterHashRing(setOf())
         )))
   }
 
@@ -214,7 +216,7 @@ internal class KubernetesClusterTest {
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4"))
             ))
@@ -223,7 +225,7 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp2", "10.0.0.4")
             ))
         ), removed = setOf(Cluster.Member("larry-blerp", "10.0.0.3"))))
@@ -250,7 +252,7 @@ internal class KubernetesClusterTest {
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4"))
             ))
@@ -259,7 +261,7 @@ internal class KubernetesClusterTest {
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
+            partitioner = ClusterHashRing(setOf(
                 Cluster.Member("larry-blerp2", "10.0.0.4")
             ))
         ), removed = setOf(Cluster.Member("larry-blerp", ""))))


### PR DESCRIPTION
Metrics and tests have shown that `ClusterHashRing` does not uniformly distribute resources to cluster members when the resource to cluster size ratio is low.

Inspired by the Kafka client, I would like to add alternative ways to assign resources to cluster members that are more suitable for event consumers.
- [AbstractPartitionAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java)
- [RoundRobinAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java)
- [RangeAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java#L68)

I was going to add a `RoundRobinResourceMapper` or  a`RangeResourceMapper`.

This made me wonder if what `ResourceMapper` essentially does is partitioning resources to cluster members, would `Partitioner` or `PartitionStrategy` be a better name?
