### PR TITLE
bump launchdarkly

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,7 +52,7 @@ ext.dep = [
   "kotlinTest": "org.jetbrains.kotlin:kotlin-test:1.3.21",
   "kotlinxCoroutines": "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1",
   "kubernetesClient": "io.kubernetes:client-java:1.0.0",
-  "launchDarkly": "com.launchdarkly:launchdarkly-java-server-sdk:4.9.0",
+  "launchDarkly": "com.launchdarkly:launchdarkly-java-server-sdk:4.10.0",
   "logbackClassic": "ch.qos.logback:logback-classic:1.2.3",
   "logbackJsonCore": "ch.qos.logback.contrib:logback-json-core:0.1.5",
   "loggingApi": "io.github.microutils:kotlin-logging:1.4.9",


### PR DESCRIPTION
Includes a bugfix for `MALFORMED_FLAG` exceptions we've been seeing
https://github.com/launchdarkly/java-server-sdk/releases/tag/4.10.0