### PR TITLE
Improves default configuration of `AwsSqsJobQueueConfig`.

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -30,5 +30,9 @@ class AwsSqsJobQueueConfig(
    */
   val message_batch_size: Int = 10,
 
-  val task_queue: RepeatedTaskQueueConfig = RepeatedTaskQueueConfig()
+  /**
+   * Task queue configuration, which should have a `num_parallel_tasks` equal or greater than the
+   * number of consumed queues. If undefined, an unbounded number of parallel tasks will be used.
+   */
+  val task_queue: RepeatedTaskQueueConfig?
 ) : Config

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -16,6 +16,7 @@ import misk.jobqueue.JobQueue
 import misk.jobqueue.QueueName
 import misk.jobqueue.TransactionalJobQueue
 import misk.tasks.RepeatedTaskQueue
+import misk.tasks.RepeatedTaskQueueConfig
 import misk.tasks.RepeatedTaskQueueFactory
 import javax.inject.Inject
 
@@ -72,8 +73,11 @@ class AwsSqsJobQueueModule(
   ): RepeatedTaskQueue {
     return queueFactory.new(
         "sqs-consumer-poller",
-        config.task_queue)
+        repeatedTaskQueueConfig(config))
   }
+
+  private fun repeatedTaskQueueConfig(config: AwsSqsJobQueueConfig) =
+      config.task_queue ?: RepeatedTaskQueueConfig(num_parallel_tasks = -1)
 
   private class AmazonSQSProvider(val region: AwsRegion) : Provider<AmazonSQS> {
     @Inject lateinit var credentials: AWSCredentialsProvider


### PR DESCRIPTION
* By default we're using one thread which is problematic as it slows down
the consumption of messages when you have more than one queue.