### PR TITLE
Move ClusterResourceMapper out of cluster snapshot

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
@@ -1,5 +1,6 @@
 package misk.clustering.zookeeper
 
+import misk.clustering.ClusterResourceMapper
 import misk.clustering.NoMembersAvailableException
 import misk.clustering.lease.Lease
 import misk.clustering.weights.ClusterWeightProvider
@@ -39,6 +40,7 @@ internal class ZkLease(
   private val manager: ZkLeaseManager,
   private val leaseResourceName: String,
   private val clusterWeight: ClusterWeightProvider,
+  private val clusterResourceMapper: ClusterResourceMapper.Provider,
   override val name: String
 ) : Lease {
 
@@ -199,7 +201,7 @@ internal class ZkLease(
   private fun shouldHoldLease(): Boolean {
     val clusterSnapshot = manager.cluster.snapshot
     val desiredLeaseOwner = try {
-      clusterSnapshot.resourceMapper[leaseResourceName]
+      clusterResourceMapper.get()[leaseResourceName]
     } catch (e: NoMembersAvailableException) {
       log.warn { e.message }
       null

--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
@@ -3,6 +3,7 @@ package misk.clustering.zookeeper
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import misk.clustering.Cluster
+import misk.clustering.ClusterResourceMapper
 import misk.clustering.lease.LeaseManager
 import misk.clustering.weights.ClusterWeightProvider
 import misk.config.AppName
@@ -32,7 +33,8 @@ internal class ZkLeaseManager @Inject internal constructor(
   @ForZkLease private val taskQueue: RepeatedTaskQueue,
   internal val cluster: Cluster,
   @ForZkLease curator: CuratorFramework,
-  private val clusterWeight: ClusterWeightProvider
+  private val clusterWeight: ClusterWeightProvider,
+  private val clusterResourceMapper: ClusterResourceMapper.Provider
 ) : AbstractExecutionThreadService(), LeaseManager {
   internal val leaseNamespace = "$SERVICES_NODE/${appName.asZkNamespace}/leases"
   internal val client = lazy { curator.usingNamespace(leaseNamespace) }
@@ -106,7 +108,7 @@ internal class ZkLeaseManager @Inject internal constructor(
 
   override fun requestLease(name: String): ZkLease {
     return leases.computeIfAbsent(name) {
-      ZkLease(ownerName, this, "$leaseNamespace/$name", clusterWeight, name)
+      ZkLease(ownerName, this, "$leaseNamespace/$name", clusterWeight, clusterResourceMapper, name)
     }
   }
 

--- a/misk/src/main/kotlin/misk/clustering/Cluster.kt
+++ b/misk/src/main/kotlin/misk/clustering/Cluster.kt
@@ -27,10 +27,7 @@ interface Cluster {
     val readyMembers: Set<Cluster.Member>,
 
     /** true if the current service instance is ready as perceived by the cluster manager */
-    val selfReady: Boolean = readyMembers.any { it.name == self.name },
-
-    /** A [ClusterResourceMapper] built from the ready members of this cluster */
-    val resourceMapper: ClusterResourceMapper
+    val selfReady: Boolean = readyMembers.any { it.name == self.name }
   ) {
     /** The of the ready peers; basically all of the ready cluster members except sel */
     val readyPeers: Set<Member> = readyMembers - self
@@ -42,7 +39,4 @@ interface Cluster {
   /** Registers interest in cluster changes */
   fun watch(watch: ClusterWatch)
 
-  /** @return A new [ClusterResourceMapper] for the given set of ready members */
-  fun newResourceMapper(readyMembers: Set<Cluster.Member>): ClusterResourceMapper =
-      ClusterHashRing(readyMembers)
 }

--- a/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterHashRing.kt
@@ -4,6 +4,8 @@ import com.google.common.hash.HashFunction
 import com.google.common.hash.Hashing
 import java.util.Arrays
 import java.util.Objects
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /** A [ClusterHashRing] maps resources to cluster members based on a consistent hash */
 class ClusterHashRing(
@@ -54,5 +56,15 @@ class ClusterHashRing(
 
   override fun hashCode(): Int {
     return Objects.hash(vnodesCount, vnodesToMembers, Arrays.hashCode(vnodes))
+  }
+
+  @Singleton
+  class Provider @Inject constructor(
+    private val cluster: Cluster
+  ): ClusterResourceMapper.Provider {
+
+    override fun get(): ClusterResourceMapper {
+      return ClusterHashRing(cluster.snapshot.readyMembers)
+    }
   }
 }

--- a/misk/src/main/kotlin/misk/clustering/ClusterResourceMapper.kt
+++ b/misk/src/main/kotlin/misk/clustering/ClusterResourceMapper.kt
@@ -12,4 +12,8 @@ interface ClusterResourceMapper {
    * @return The [Cluster.Member] that should own the given resource id
    */
   operator fun get(resourceId: String): Cluster.Member
+
+  interface Provider {
+    fun get(): ClusterResourceMapper
+  }
 }

--- a/misk/src/main/kotlin/misk/clustering/fake/ExplicitClusterResourceMapper.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/ExplicitClusterResourceMapper.kt
@@ -5,6 +5,8 @@ import misk.clustering.ClusterResourceMapper
 import misk.clustering.NoMembersAvailableException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * An [ExplicitClusterResourceMapper] is a [ClusterResourceMapper] where the mapping
@@ -36,5 +38,14 @@ class ExplicitClusterResourceMapper : ClusterResourceMapper {
     }
     return mappings[resourceId] ?: defaultMapping.get() ?: throw IllegalStateException(
         "no mapping for $resourceId")
+  }
+
+  @Singleton
+  class Provider @Inject constructor(): ClusterResourceMapper.Provider {
+    private val mapper = ExplicitClusterResourceMapper()
+
+    override fun get(): ExplicitClusterResourceMapper {
+      return mapper
+    }
   }
 }

--- a/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/FakeCluster.kt
@@ -23,12 +23,10 @@ class FakeCluster internal constructor(
   val resourceMapper: ExplicitClusterResourceMapper,
   private val delegate: DefaultCluster
 ) : ClusterService by delegate, Cluster by delegate {
-  constructor(resourceMapper: ExplicitClusterResourceMapper) :
-      this(resourceMapper, DefaultCluster(self) { resourceMapper })
-
-  @Inject constructor() : this(ExplicitClusterResourceMapper().apply {
-    setDefaultMapping(self)
-  })
+  @Inject constructor(resourceMapper: ExplicitClusterResourceMapper.Provider) :
+      this(resourceMapper.get(), DefaultCluster(self)) {
+    resourceMapper.get().setDefaultMapping(self)
+  }
 
   override fun watch(watch: ClusterWatch) {
     waitFor {

--- a/misk/src/main/kotlin/misk/clustering/fake/FakeClusterModule.kt
+++ b/misk/src/main/kotlin/misk/clustering/fake/FakeClusterModule.kt
@@ -2,6 +2,7 @@ package misk.clustering.fake
 
 import misk.ServiceModule
 import misk.clustering.Cluster
+import misk.clustering.ClusterResourceMapper
 import misk.clustering.ClusterService
 import misk.inject.KAbstractModule
 
@@ -10,6 +11,7 @@ class FakeClusterModule : KAbstractModule() {
   override fun configure() {
     bind<Cluster>().to<FakeCluster>()
     bind<ClusterService>().to<FakeCluster>()
+    bind<ClusterResourceMapper.Provider>().to<ExplicitClusterResourceMapper.Provider>()
     install(ServiceModule<ClusterService>())
   }
 }

--- a/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
+++ b/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
@@ -2,6 +2,8 @@ package misk.clustering.kubernetes
 
 import misk.ServiceModule
 import misk.clustering.Cluster
+import misk.clustering.ClusterHashRing
+import misk.clustering.ClusterResourceMapper
 import misk.clustering.ClusterService
 import misk.clustering.DefaultCluster
 import misk.inject.KAbstractModule
@@ -14,6 +16,7 @@ class KubernetesClusterModule(private val config: KubernetesConfig) : KAbstractM
     bind<Cluster>().to<DefaultCluster>()
     bind<ClusterService>().to<DefaultCluster>()
     bind<DefaultCluster>().toProvider(KubernetesClusterProvider::class.java).asSingleton()
+    bind<ClusterResourceMapper.Provider>().to<ClusterHashRing.Provider>()
     install(ServiceModule<KubernetesClusterWatcher>()
         .dependsOn<ClusterService>())
     install(ServiceModule<ClusterService>())

--- a/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
@@ -9,7 +9,6 @@ import helpers.protos.Dinosaur
 import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
 import misk.clustering.ClusterWatch
-import misk.clustering.fake.ExplicitClusterResourceMapper
 import misk.config.AppName
 import misk.inject.KAbstractModule
 import misk.security.ssl.CertStoreConfig
@@ -87,15 +86,10 @@ internal class TypedPeerHttpClientTest {
 
     init {
       val self = Cluster.Member(name = "self-name", ipAddress = memberIp)
-      val resourceMapper = ExplicitClusterResourceMapper()
-
-      resourceMapper.setDefaultMapping(self)
-
       snapshot = Cluster.Snapshot(
           self = self,
           readyMembers = setOf(),
-          selfReady = true,
-          resourceMapper = resourceMapper
+          selfReady = true
       )
     }
 

--- a/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/fake/FakeClusterTest.kt
@@ -33,15 +33,15 @@ internal class FakeClusterTest {
     cluster.resourceMapper.setDefaultMapping(Cluster.Member("zork", "192.168.12.0"))
     cluster.resourceMapper.addMapping("my-object", Cluster.Member("bork", "192.168.12.1"))
 
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("bork")
-    assertThat(cluster.snapshot.resourceMapper["other-object"].name).isEqualTo("zork")
+    assertThat(cluster.resourceMapper["my-object"].name).isEqualTo("bork")
+    assertThat(cluster.resourceMapper["other-object"].name).isEqualTo("zork")
 
     // Ensure resource mapper remains the same even through cluster changes
     cluster.clusterChanged(membersBecomingReady = setOf(Cluster.Member("blerp", "192.168.12.3")))
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("bork")
-    assertThat(cluster.snapshot.resourceMapper["other-object"].name).isEqualTo("zork")
+    assertThat(cluster.resourceMapper["my-object"].name).isEqualTo("bork")
+    assertThat(cluster.resourceMapper["other-object"].name).isEqualTo("zork")
 
     cluster.resourceMapper.removeMapping("my-object")
-    assertThat(cluster.snapshot.resourceMapper["my-object"].name).isEqualTo("zork")
+    assertThat(cluster.resourceMapper["my-object"].name).isEqualTo("zork")
   }
 }

--- a/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
+++ b/misk/src/test/kotlin/misk/clustering/kubernetes/KubernetesClusterTest.kt
@@ -9,7 +9,6 @@ import io.kubernetes.client.models.V1PodStatus
 import io.kubernetes.client.util.Watches
 import misk.MiskTestingServiceModule
 import misk.clustering.Cluster
-import misk.clustering.ClusterHashRing
 import misk.clustering.DefaultCluster
 import misk.clustering.kubernetes.KubernetesClusterWatcher.Companion.CHANGE_TYPE_ADDED
 import misk.clustering.kubernetes.KubernetesClusterWatcher.Companion.CHANGE_TYPE_DELETED
@@ -65,20 +64,17 @@ internal class KubernetesClusterTest {
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            readyMembers = setOf()
         )),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = true,
-            readyMembers = setOf(expectedSelf),
-            resourceMapper = ClusterHashRing(setOf(expectedSelf))
+            readyMembers = setOf(expectedSelf)
         ), added = setOf(expectedSelf)),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            readyMembers = setOf()
         ), removed = setOf(expectedSelf))
     )
   }
@@ -97,25 +93,19 @@ internal class KubernetesClusterTest {
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            readyMembers = setOf()
         )),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(Cluster.Member("larry-blerp", "10.0.0.3")),
-            resourceMapper = ClusterHashRing(setOf(Cluster.Member("larry-blerp", "10.0.0.3")))
+            readyMembers = setOf(Cluster.Member("larry-blerp", "10.0.0.3"))
         ), added = setOf(Cluster.Member("larry-blerp", "10.0.0.3"))),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp", "10.0.0.3"),
                 Cluster.Member("larry-blerp2", "10.0.0.4"))
-            )
         ), added = setOf(Cluster.Member("larry-blerp2", "10.0.0.4"))))
   }
 
@@ -139,19 +129,12 @@ internal class KubernetesClusterTest {
             selfReady = false,
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4"))
-            ))
+                Cluster.Member("larry-blerp2", "10.0.0.4")))
         ),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp2", "10.0.0.4")
-            ))
+            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4"))
         ), removed = setOf(Cluster.Member("larry-blerp", ""))))
   }
 
@@ -169,8 +152,7 @@ internal class KubernetesClusterTest {
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            readyMembers = setOf()
         )))
   }
 
@@ -188,8 +170,7 @@ internal class KubernetesClusterTest {
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(),
-            resourceMapper = ClusterHashRing(setOf())
+            readyMembers = setOf()
         )))
   }
 
@@ -213,19 +194,12 @@ internal class KubernetesClusterTest {
             selfReady = false,
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4"))
-            ))
+                Cluster.Member("larry-blerp2", "10.0.0.4")))
         ),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp2", "10.0.0.4")
-            ))
+            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4"))
         ), removed = setOf(Cluster.Member("larry-blerp", "10.0.0.3"))))
   }
 
@@ -249,19 +223,12 @@ internal class KubernetesClusterTest {
             selfReady = false,
             readyMembers = setOf(
                 Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp", "10.0.0.3"),
-                Cluster.Member("larry-blerp2", "10.0.0.4"))
-            ))
+                Cluster.Member("larry-blerp2", "10.0.0.4")))
         ),
         Cluster.Changes(snapshot = Cluster.Snapshot(
             self = expectedSelf,
             selfReady = false,
-            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4")),
-            resourceMapper = ClusterHashRing(setOf(
-                Cluster.Member("larry-blerp2", "10.0.0.4")
-            ))
+            readyMembers = setOf(Cluster.Member("larry-blerp2", "10.0.0.4"))
         ), removed = setOf(Cluster.Member("larry-blerp", ""))))
   }
 


### PR DESCRIPTION
Our cluster abstraction exposes `ClusterResourceMapper` as an instance variable of `Cluster.Snapshot`. This makes sense because the mapper uses only the set of cluster members to generate a mapping from resource ids to cluster members .

However, the Range/Round Robin ResourceMapper described in #1336 requires both the set of cluster members and the set of all resource ids.

This PR separates `ClusterResourceMapper` from `Cluster.Snapshot` and adds a `ClusterResourceMapper.Provider` that provides it based on the current cluster snapshot.

This makes it easy to add a range `ClusterResourceMapper.Provider` that reads both the current cluster members and all leases.



