### PR TITLE
Remove misk.hash package since it's unused #1330

### DIFF
--- a/misk/src/main/kotlin/misk/hash/HashExtensions.kt
+++ b/misk/src/main/kotlin/misk/hash/HashExtensions.kt
@@ -1,7 +1,0 @@
-package misk.hash
-
-import com.google.common.hash.HashCode
-import okio.ByteString
-
-/** @return the [HashCode] as a [ByteString] */
-fun HashCode.asByteString(): ByteString = ByteString.of(*asBytes())


### PR DESCRIPTION
Part of #1330 for breaking up misk module. One less thing to move out since it's deleted.

This is unused internally too