### PR TITLE
Avoid storing references to .class files in ClasspathResourceLoaderBackend #1191

### DIFF
--- a/misk/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
+++ b/misk/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
@@ -17,7 +17,9 @@ internal object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
   init {
     val classLoader = ClasspathResourceLoaderBackend::class.java.classLoader
     val classPath = ClassPath.from(classLoader)
-    resourcesByPath = TreeMap(classPath.resources.associateBy { "/${it.resourceName}" })
+    resourcesByPath = TreeMap(classPath.resources.filter {
+      it !is ClassPath.ClassInfo
+    }.associateBy { "/${it.resourceName}" })
   }
 
   override fun open(path: String): BufferedSource? {


### PR DESCRIPTION
`ClasspathResourceLoaderBackend` promises to load `resources` not class files so this seems OK.
Should help with #1191

For reference, without this change running `ResourceLoaderTest#loadResource`
![image](https://user-images.githubusercontent.com/5392881/71233332-4a601780-22c3-11ea-8c47-a7085cd6e757.png)

With this change
![image](https://user-images.githubusercontent.com/5392881/71233364-62d03200-22c3-11ea-9ba0-bfa251cf59d5.png)
