### PR TITLE
Change concurrency model for job consumers.

### DIFF
--- a/misk-aws/build.gradle
+++ b/misk-aws/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compile dep.tracingJaeger
   compile project(':misk')
   compile project(':misk-jobqueue')
+  compile project(':misk-feature')
 
   testCompile dep.assertj
   testCompile dep.junitApi
@@ -11,6 +12,7 @@ dependencies {
   testCompile dep.junitParams
   testCompile dep.docker
   testCompile project(':misk-testing')
+  testCompile project(':misk-feature-testing')
 }
 
 afterEvaluate { project ->

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -9,21 +9,10 @@ import misk.tasks.RepeatedTaskQueueConfig
  */
 class AwsSqsJobQueueConfig(
   /**
-   * Number of receiver threads to run per queue. Each receiver thread can pull up to 10 messages
-   * at a time, so this parameter controls how many fetches of 10 are outstanding at any one time.
-   */
-  val concurrent_receivers_per_queue: Int = 1,
-
-  /**
    * External queues is a set of externally owned SQS queues accessed by this service, mapping
    * an internal queue name to the (account ID, region, name) of the queue in the external account
    */
   val external_queues: Map<String, AwsSqsQueueConfig> = mapOf(),
-
-  /**
-   * Number of jobs that can be processed concurrently.
-   */
-  val consumer_thread_pool_size: Int = 4,
 
   /**
    * Max number of messages to pull from SQS with each request.
@@ -34,5 +23,13 @@ class AwsSqsJobQueueConfig(
    * Task queue configuration, which should have a `num_parallel_tasks` equal or greater than the
    * number of consumed queues. If undefined, an unbounded number of parallel tasks will be used.
    */
-  val task_queue: RepeatedTaskQueueConfig? = null
+  val task_queue: RepeatedTaskQueueConfig? = null,
+
+  /**
+   * The number of receivers will be distributed among the app cluster If [clustered_consumers] is
+   * true. Otherwise, each app in the cluster will run the number of receivers.
+   *
+   * The number of receivers is configured by [Feature("jobqueue-consumers")].
+   */
+  val clustered_consumers: Boolean = true
 ) : Config

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsHandling.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsHandling.kt
@@ -4,4 +4,5 @@ import javax.inject.Qualifier
 
 @Qualifier
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
-internal annotation class ForSqsConsumer
+internal annotation class ForSqsHandling
+

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsReceiving.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ForSqsReceiving.kt
@@ -1,0 +1,6 @@
+package misk.jobqueue.sqs
+
+import javax.inject.Qualifier
+
+@Qualifier
+internal annotation class ForSqsReceiving

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
@@ -16,6 +16,9 @@ internal class ResolvedQueue(
   val client: AmazonSQS
 ) {
 
+  val queueName: String
+    get() = name.value
+
   /**
    * Invokes the lambda with this queue's [AmazonSQS] client. Exceptions thrown by the client
    * are wrapped in a [SQSException].

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
@@ -6,6 +6,8 @@ import com.google.inject.util.Modules
 import misk.MiskTestingServiceModule
 import misk.cloud.aws.AwsEnvironmentModule
 import misk.cloud.aws.FakeAwsEnvironmentModule
+import misk.clustering.fake.lease.FakeLeaseModule
+import misk.feature.testing.FakeFeatureFlagsModule
 import misk.inject.KAbstractModule
 import misk.tasks.RepeatedTaskQueueConfig
 import misk.testing.MockTracingBackendModule
@@ -19,6 +21,10 @@ class SqsJobQueueTestModule(
     install(MockTracingBackendModule())
     install(AwsEnvironmentModule())
     install(FakeAwsEnvironmentModule())
+    install(FakeLeaseModule())
+    install(FakeFeatureFlagsModule().withOverrides {
+      override(SqsJobConsumer.CONSUMERS_PER_QUEUE, 5)
+    })
     install(
         Modules.override(
             AwsSqsJobQueueModule(

--- a/misk/src/main/kotlin/misk/concurrent/ExecutorServiceModule.kt
+++ b/misk/src/main/kotlin/misk/concurrent/ExecutorServiceModule.kt
@@ -26,5 +26,15 @@ class ExecutorServiceModule(
               nThreads,
               ThreadFactoryBuilder().setNameFormat(nameFormat).build()))
     }
+
+    fun withUnboundThreadPool(
+      annotation: KClass<out Annotation>,
+      nameFormat: String
+    ): ExecutorServiceModule {
+      return ExecutorServiceModule(
+          annotation,
+          Executors.newCachedThreadPool(
+              ThreadFactoryBuilder().setNameFormat(nameFormat).build()))
+    }
   }
 }

--- a/misk/src/main/kotlin/misk/metrics/Histogram.kt
+++ b/misk/src/main/kotlin/misk/metrics/Histogram.kt
@@ -14,4 +14,11 @@ interface Histogram {
 
   /** returns the number of buckets */
   fun count(vararg labelValues: String): Int
+
+  /** records a new set of labels and the time to execute the work lambda in milliseconds */
+  fun <T> timedMills(vararg labelValues: String, work: () -> T): T {
+    val (time, result) = misk.time.timed { work.invoke() }
+    record(time.toMillis().toDouble(), *labelValues)
+    return result
+  }
 }


### PR DESCRIPTION
Every app instance has N receivers. N is configurable on runtime by
using Feature("jobqueue-receiver"). The receivers can be load balanced using
a lease, which is configurable. Every receiver will spawn an unbounded number
of threads to process the M messages received by a receiver.