### PR TITLE
Add transaction token to sessions

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -22,6 +22,7 @@ import misk.jdbc.RealDatabasePool
 import misk.jdbc.SpanInjector
 import misk.metrics.Metrics
 import misk.resources.ResourceLoader
+import misk.tokens.TokenGenerator
 import misk.vitess.StartDatabaseService
 import misk.web.exceptions.ExceptionMapperModule
 import org.hibernate.SessionFactory
@@ -139,12 +140,14 @@ class HibernateModule(
     bind(transacterKey).toProvider(object : Provider<Transacter> {
       @com.google.inject.Inject(optional = true) val tracer: Tracer? = null
       @Inject lateinit var queryTracingListener: QueryTracingListener
+      @Inject lateinit var tokenGenerator: TokenGenerator
       override fun get(): RealTransacter = RealTransacter(
           qualifier = qualifier,
           sessionFactoryProvider = sessionFactoryProvider,
           readerSessionFactoryProvider = readerSessionFactoryProvider,
           config = config,
           queryTracingListener = queryTracingListener,
+          tokenGenerator = tokenGenerator,
           tracer = tracer
       )
     }).asSingleton()

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -5,6 +5,9 @@ import kotlin.reflect.KClass
 
 interface Session {
   val hibernateSession: org.hibernate.Session
+  // Token to identify a session. Tokens stay the same across transaction retries.
+  val transactionToken: String
+
   /**
    * @throws IllegalStateException when save is called on a read only session.
    */

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -19,6 +19,7 @@ import misk.jdbc.RealDatabasePool
 import misk.resources.ResourceLoader
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.tokens.TokenGenerator
 import misk.vitess.StartDatabaseService
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
@@ -71,12 +72,14 @@ internal class SchemaValidatorTest {
       bind(keyOf<Transacter>(qualifier)).toProvider(object : Provider<Transacter> {
         @Inject lateinit var queryTracingListener: QueryTracingListener
         @com.google.inject.Inject(optional = true) val tracer: Tracer? = null
+        @Inject lateinit var tokenGenerator: TokenGenerator
         override fun get(): RealTransacter = RealTransacter(
             qualifier = qualifier,
             sessionFactoryProvider = sessionFactoryProvider,
             readerSessionFactoryProvider = null,
             config = config.data_source,
             queryTracingListener = queryTracingListener,
+            tokenGenerator = tokenGenerator,
             tracer = tracer
         )
       }).asSingleton()


### PR DESCRIPTION
Adds an identifier to a hibernate session which stays the same across retries. Can be used to determine whether something happened in the same transaction.