### PR TITLE
Add JSON FeatureFlag

### DIFF
--- a/misk-feature-testing/build.gradle
+++ b/misk-feature-testing/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile dep.guice
   compile dep.kotlinStdLib
   compile dep.kotlinReflection
+  compile dep.moshiCore
   compile project(':misk-feature')
   compile project(':misk-inject')
   compile project(':misk-service')

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -1,5 +1,8 @@
 package misk.feature.testing
 
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import com.squareup.moshi.Moshi
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
 import misk.ServiceModule
@@ -14,7 +17,7 @@ import kotlin.reflect.KClass
 class FakeFeatureFlagsModule(
   private val qualifier: KClass<out Annotation>? = null
 ) : KAbstractModule() {
-  private val testFeatureFlags = FakeFeatureFlags()
+  private val testFeatureFlags = FakeFeatureFlags(getProvider(Moshi::class.java))
 
   override fun configure() {
     val key = FakeFeatureFlags::class.toKey(qualifier)
@@ -36,7 +39,7 @@ class FakeFeatureFlagsModule(
    * })
    * ```
    */
-  fun withOverrides(lambda: (FakeFeatureFlags.() -> Unit)): FakeFeatureFlagsModule {
+  fun withOverrides(lambda: FakeFeatureFlags.() -> Unit): FakeFeatureFlagsModule {
     lambda(testFeatureFlags)
     return this
   }

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -1,8 +1,11 @@
 package misk.feature.testing
 
 import com.google.inject.Guice
+import com.squareup.moshi.Moshi
 import misk.feature.Feature
 import misk.feature.FeatureFlags
+import misk.inject.KAbstractModule
+import misk.moshi.MoshiAdapterModule
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -11,6 +14,12 @@ class FakeFeatureFlagsModuleTest {
   fun testModule() {
     val injector = Guice.createInjector(FakeFeatureFlagsModule().withOverrides {
       override(Feature("foo"), 24)
+    }, object : KAbstractModule() {
+      override fun configure() {
+        // Misk services automatically get this binding, but no need to depend on all of misk to
+        // test this.
+        bind<Moshi>().toInstance(Moshi.Builder().build())
+      }
     })
 
     val flags = injector.getInstance(FeatureFlags::class.java)

--- a/misk-feature/src/main/kotlin/misk/feature/DynamicConfig.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/DynamicConfig.kt
@@ -24,8 +24,15 @@ interface DynamicConfig {
    * Returns the value of an enumerated dynamic flag.
    */
   fun <T : Enum<T>> getEnum(feature: Feature, clazz: Class<T>): T
+
+  /**
+   * Returns the value of a JSON dynamic flag.
+   */
+  fun <T> getJson(feature: Feature, clazz: Class<T>): T
 }
 
 inline fun <reified T : Enum<T>> DynamicConfig.getEnum(
   feature: Feature
 ): T = getEnum(feature, T::class.java)
+
+inline fun <reified T> DynamicConfig.getJson(feature: Feature): T = getJson(feature, T::class.java)

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
@@ -39,11 +39,24 @@ interface FeatureFlags {
    * Calculates the value of an enumerated feature flag for the given key and attributes.
    * @param feature name of the feature flag to evaluate.
    * @param key unique primary key for the entity the flag should be evaluated against.
-   * @param default default value to return if there was an error evaluating the flag or the flag
-   *   does not exist.
+   * @param clazz the enum type
    * @param attributes additional attributes to provide to flag evaluation.
    */
   fun <T : Enum<T>> getEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    attributes: Attributes = Attributes()
+  ): T
+
+  /**
+   * Calculates the value of a JSON feature flag for the given key and attributes.
+   *
+   * @param clazz the type to convert the JSON string into. It is expected the a Moshi type adapter
+   * is registered with the impl.
+   * @see [getEnum] for param details
+   */
+  fun <T> getJson(
     feature: Feature,
     key: String,
     clazz: Class<T>,
@@ -71,6 +84,9 @@ interface FeatureFlags {
     key: String,
     clazz: Class<T>
   ) = getEnum(feature, key, clazz, Attributes())
+
+  fun <T> getJson(feature: Feature, key: String, clazz: Class<T>)
+      = getJson(feature, key, clazz, Attributes())
 }
 
 inline fun <reified T : Enum<T>> FeatureFlags.getEnum(
@@ -78,6 +94,12 @@ inline fun <reified T : Enum<T>> FeatureFlags.getEnum(
   token: String,
   attributes: Attributes = Attributes()
 ): T = getEnum(feature, token, T::class.java, attributes)
+
+inline fun <reified T> FeatureFlags.getJson(
+  feature: Feature,
+  token: String,
+  attributes: Attributes = Attributes()
+): T = getJson(feature, token, T::class.java, attributes)
 
 /**
  * Typed feature string.

--- a/misk-launchdarkly-core/build.gradle
+++ b/misk-launchdarkly-core/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile dep.guice
   compile dep.kotlinStdLib
   compile dep.launchDarkly
+  compile dep.moshiCore
   compile project(':misk-feature')
 
   testCompile project(':misk-testing')

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyDynamicConfig.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyDynamicConfig.kt
@@ -28,4 +28,8 @@ class LaunchDarklyDynamicConfig(private val featureFlags: FeatureFlags) : Dynami
   override fun <T : Enum<T>> getEnum(feature: Feature, clazz: Class<T>): T {
     return featureFlags.getEnum(feature, KEY, clazz, ATTRIBUTES)
   }
+
+  override fun <T> getJson(feature: Feature, clazz: Class<T>): T {
+    return featureFlags.getJson(feature, KEY, clazz, ATTRIBUTES)
+  }
 }


### PR DESCRIPTION
The LDFeatureFlag impl uses the guice registered Moshi instance to
deserialize the JSON into a POJO.

Most likely app developers will screw up the JSON values in LD,
resulting in Moshi deserialization Exceptions in their app.
However, it should be a rather quick change to update the value in LD.
I believe the usefulness of JSON flags for DynamicConfigs outweighs this chance
of human error.

I want to use this to dynamically configure jobqueue and event
consumers. Something like a JobqueueConsumerConfig:

{
  "enabled": Boolean
  "batch_size": Int
  "schedule": TaskSchedule
}

TaskSchedule:

{
  "more_work_ms": Int
  "no_more_work_backoff: Backoff
  "error_backoff": Backoff
}

This would be extremely difficult to manage with individual flattened
flags like "jobqueue_consumer_schedule_more_work_ms".