### PR TITLE
Try to use failOnUnknown when parsing JSON FeatureFlags

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -8,6 +8,8 @@ import misk.feature.Feature
 import misk.feature.FeatureFlagValidation
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
+import misk.feature.fromSafeJson
+import misk.feature.toSafeJson
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Provider
@@ -61,7 +63,7 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
   ): T {
     val json = get(feature, key) as? String ?: throw IllegalArgumentException(
         "JSON flag $feature must be overridden with override() before use")
-    return moshi.get().adapter(clazz).fromJson(json)
+    return moshi.get().adapter(clazz).fromSafeJson(json)
         ?: throw IllegalArgumentException("null value deserialized from $feature")
   }
 
@@ -103,7 +105,7 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
   }
 
   fun <T> override(feature: Feature, value: T, clazz: Class<T>) {
-    overrides[MapKey(feature)] = moshi.get().adapter(clazz).toJson(value)
+    overrides[MapKey(feature)] = moshi.get().adapter(clazz).toSafeJson(value)
   }
 
   inline fun <reified T> overrideJson(feature: Feature, value: T) {
@@ -127,7 +129,7 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
   }
 
   fun <T> overrideKey(feature: Feature, key: String, value: T, clazz : Class<T>) {
-    overrides[MapKey(feature, key)] = moshi.get().adapter(clazz).toJson(value)
+    overrides[MapKey(feature, key)] = moshi.get().adapter(clazz).toSafeJson(value)
   }
 
   inline fun <reified T> overrideKeyJson(feature: Feature, key: String, value: T) {

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -2,6 +2,7 @@ package misk.feature.testing
 
 import com.google.inject.Guice
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import misk.feature.Feature
 import misk.feature.FeatureFlags
 import misk.inject.KAbstractModule
@@ -18,7 +19,9 @@ class FakeFeatureFlagsModuleTest {
       override fun configure() {
         // Misk services automatically get this binding, but no need to depend on all of misk to
         // test this.
-        bind<Moshi>().toInstance(Moshi.Builder().build())
+        bind<Moshi>().toInstance(Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build())
       }
     })
 

--- a/misk-feature/build.gradle
+++ b/misk-feature/build.gradle
@@ -7,6 +7,8 @@ buildscript {
 dependencies {
   compile dep.kotlinStdLib
   compile dep.guava
+  compile dep.moshiKotlin
+  compile project(':misk-core')
 
   testCompile project(':misk-testing')
 }

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
@@ -52,7 +52,7 @@ interface FeatureFlags {
   /**
    * Calculates the value of a JSON feature flag for the given key and attributes.
    *
-   * @param clazz the type to convert the JSON string into. It is expected the a Moshi type adapter
+   * @param clazz the type to convert the JSON string into. It is expected that a Moshi type adapter
    * is registered with the impl.
    * @see [getEnum] for param details
    */

--- a/misk-feature/src/main/kotlin/misk/feature/MoshiExt.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/MoshiExt.kt
@@ -1,0 +1,37 @@
+package misk.feature
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import misk.logging.getLogger
+
+private val logger = getLogger<FeatureFlags>()
+
+/**
+ * Attempts to use [JsonAdapter.failOnUnknown] and logs any issues before falling back to ignoring
+ * the unknown fields.
+ */
+fun <T> JsonAdapter<T>.toSafeJson(value: T): String {
+  return try {
+    failOnUnknown().toJson(value)
+  } catch (e: JsonDataException) {
+    logger.error(e) {
+      "failed to serialize JSON due to unknown fields. ignoring those fields and trying again"
+    }
+    return toJson(value)
+  }
+}
+
+/**
+ * Attempts to use [JsonAdapter.failOnUnknown] and logs any issues before falling back to ignoring
+ * the unknown fields.
+ */
+fun <T> JsonAdapter<T>.fromSafeJson(json: String): T? {
+  return try {
+    failOnUnknown().fromJson(json)
+  } catch (e: JsonDataException) {
+    logger.error(e) {
+      "failed to parse JSON due to unknown fields. ignoring those fields and trying again"
+    }
+    return fromJson(json)
+  }
+}

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -13,6 +13,7 @@ import misk.feature.Feature
 import misk.feature.FeatureFlagValidation
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
+import misk.feature.fromSafeJson
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -90,7 +91,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
         buildUser(feature, key, attributes),
         LDValue.ofNull())
     checkDefaultNotUsed(feature, result)
-    return moshi.adapter(clazz).fromJson(result.value.toJsonString())
+    return moshi.adapter(clazz).fromSafeJson(result.value.toJsonString())
         ?: throw IllegalArgumentException("null value deserialized from $feature")
   }
 


### PR DESCRIPTION
This will notify the application owner they have an incorrect json field
in LaunchDarkly, without failing the request.

In addition, addressed a few additional followups from https://github.com/cashapp/misk/pull/1350