### PR TITLE
Configure Kotlin support in Moshi

### DIFF
--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -1,6 +1,7 @@
 package misk.feature.testing
 
 import com.google.inject.util.Providers
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import misk.feature.Feature
 import misk.feature.getEnum
@@ -94,12 +95,14 @@ internal class FakeFeatureFlagsTest {
   }
 
   @Test
-  fun `sets null for missing fields`() {
-    subject.overrideJsonString(FEATURE, "{}")
-    val feature = subject.getJson<JsonFeature>(FEATURE, TOKEN)
-    assertThat(feature.value).isNull()
-    assertThat(feature.optional).isNull()
-    assertThrows<NullPointerException> { feature.value.length }
+  fun `fails for missing required fields`() {
+    subject.overrideJsonString(FEATURE, """
+      {
+        "optional" : "value"
+      }
+    """.trimIndent())
+
+    assertThrows<JsonDataException> { subject.getJson<JsonFeature>(FEATURE, TOKEN) }
   }
 
   @Test

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -8,13 +8,16 @@ import misk.feature.getJson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 internal class FakeFeatureFlagsTest {
   val FEATURE = Feature("foo")
   val OTHER_FEATURE = Feature("bar")
   val TOKEN = "cust_abcdef123"
 
-  val subject = FakeFeatureFlags(Providers.of(Moshi.Builder().build()))
+  val subject = FakeFeatureFlags(Providers.of(Moshi.Builder()
+      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+      .build()))
 
   @Test
   fun getInt() {

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpcTest.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpcTest.kt
@@ -6,6 +6,7 @@ import misk.testing.MiskTestModule
 import misk.testing.TemporaryFolder
 import misk.testing.TemporaryFolderModule
 import javax.inject.Inject
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 @MiskTest(startService = false)
 internal class LocalStorageRpcTest : CustomStorageRpcTestCases<LocalStorageRpc>() {
@@ -15,5 +16,7 @@ internal class LocalStorageRpcTest : CustomStorageRpcTestCases<LocalStorageRpc>(
   @Inject
   private lateinit var tempFolder: TemporaryFolder
 
-  override fun newStorageRpc() = LocalStorageRpc(tempFolder.newFolder(), Moshi.Builder().build())
+  override fun newStorageRpc() = LocalStorageRpc(tempFolder.newFolder(), Moshi.Builder()
+      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+      .build())
 }

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/storage/LocalStorageRpc.kt
@@ -34,6 +34,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 import kotlin.streams.asSequence
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 /**
  * Implementation of [StorageRpc] that is backed by local disk storage. Useful for running
@@ -92,7 +93,12 @@ import kotlin.streams.asSequence
  * as the etag value.
  *
  */
-class LocalStorageRpc(root: Path, moshi: Moshi = Moshi.Builder().build()) : BaseCustomStorageRpc() {
+class LocalStorageRpc(
+  root: Path,
+  moshi: Moshi = Moshi.Builder()
+      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+      .build()
+) : BaseCustomStorageRpc() {
   // Handles in-process synchronization; cross-process synchronization is handled by file locks
   private val internalLock = ReentrantReadWriteLock()
   private val locksRoot = root.resolve("locks")

--- a/misk-hibernate/src/main/kotlin/misk/vitess/DockerVitessCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/DockerVitessCluster.kt
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.reflect.KClass
 import kotlin.streams.toList
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 class Table
 class Keyspace(val sharded: Boolean, val tables: Map<String, Table>) {
@@ -44,7 +46,9 @@ class VitessCluster(
   val name: String,
   resourceLoader: ResourceLoader,
   val config: DataSourceConfig,
-  val moshi: Moshi = Moshi.Builder().build()
+  val moshi: Moshi = Moshi.Builder()
+      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+      .build()
 ) {
   val schemaDir: Path
   val configDir: Path
@@ -219,7 +223,9 @@ class DockerVitessCluster(
       val docker: DockerClient = DockerClientBuilder.getInstance()
           .withDockerCmdExecFactory(NettyDockerCmdExecFactory())
           .build()
-      val moshi = Moshi.Builder().build()
+      val moshi = Moshi.Builder()
+          .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+          .build()
       val dockerCluster =
           DockerVitessCluster(
               name = qualifier.simpleName!!,

--- a/misk-hibernate/src/main/kotlin/misk/vitess/DockerVitessCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/vitess/DockerVitessCluster.kt
@@ -10,6 +10,7 @@ import com.github.dockerjava.core.DockerClientBuilder
 import com.github.dockerjava.core.async.ResultCallbackTemplate
 import com.github.dockerjava.netty.NettyDockerCmdExecFactory
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.zaxxer.hikari.util.DriverDataSource
 import misk.backoff.DontRetryException
 import misk.backoff.ExponentialBackoff
@@ -32,8 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.reflect.KClass
 import kotlin.streams.toList
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 class Table
 class Keyspace(val sharded: Boolean, val tables: Map<String, Table>) {

--- a/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
+++ b/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
@@ -24,10 +24,13 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 internal class LaunchDarklyFeatureFlagsTest {
   private val client = mock(LDClientInterface::class.java)
-  private val moshi = Moshi.Builder().build()
+  private val moshi = Moshi.Builder()
+      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+      .build()
   private val featureFlags: FeatureFlags = LaunchDarklyFeatureFlags(client, moshi)
 
   @BeforeEach


### PR DESCRIPTION
Without this Moshi will incorrectly decode null into non-nullable
fields which causes all kinds of problems.