### PR TITLE
Monitor external SQS Queue attributes and record them as metrics

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.
 ext.dep = [
   "assertj": "org.assertj:assertj-core:3.13.2",
+  "awaitility": "org.awaitility:awaitility-kotlin:4.0.2",
   "awsApi": "com.amazonaws:aws-java-sdk:1.11.144",
   "awsSqs": "com.amazonaws:aws-java-sdk-sqs:1.11.144",
   "bouncycastle": "org.bouncycastle:bcprov-jdk15on:1.55",

--- a/misk-aws/build.gradle
+++ b/misk-aws/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   testCompile dep.junitEngine
   testCompile dep.junitParams
   testCompile dep.docker
+  testCompile dep.awaitility
   testCompile project(':misk-testing')
   testCompile project(':misk-feature-testing')
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -47,13 +47,14 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 
 @Singleton
 internal class AwsSqsJobHandlerSubscriptionService @Inject constructor(
+  private val attributeImporter: AwsSqsQueueAttributeImporter,
   private val consumer: SqsJobConsumer,
   private val consumerMapping: Map<QueueName, JobHandler>,
   private val externalQueues: Map<QueueName, AwsSqsQueueConfig>
 ) : AbstractIdleService() {
   override fun startUp() {
     consumerMapping.forEach { consumer.subscribe(it.key, it.value) }
-    externalQueues.forEach { consumer.subscribeToMetrics(it.key) }
+    externalQueues.forEach { attributeImporter.import(it.key) }
   }
 
   override fun shutDown() {}

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -48,10 +48,12 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 @Singleton
 internal class AwsSqsJobHandlerSubscriptionService @Inject constructor(
   private val consumer: SqsJobConsumer,
-  private val consumerMapping: Map<QueueName, JobHandler>
+  private val consumerMapping: Map<QueueName, JobHandler>,
+  private val externalQueues: Map<QueueName, AwsSqsQueueConfig>
 ) : AbstractIdleService() {
   override fun startUp() {
     consumerMapping.forEach { consumer.subscribe(it.key, it.value) }
+    externalQueues.forEach { consumer.subscribeToMetrics(it.key) }
   }
 
   override fun shutDown() {}

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -31,5 +31,10 @@ class AwsSqsJobQueueConfig(
    *
    * The number of receivers is configured by [Feature("jobqueue-consumers")].
    */
-  val clustered_consumers: Boolean = true
+  val clustered_consumers: Boolean = true,
+
+  /**
+   * Frequency used to import Queue Attributes in milliseconds.
+   */
+  val queue_attribute_importer_frequency_ms: Long = 1000
 ) : Config

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
@@ -1,0 +1,64 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import misk.clustering.lease.LeaseManager
+import misk.jobqueue.QueueName
+import misk.logging.getLogger
+import misk.tasks.RepeatedTaskQueue
+import misk.tasks.Status
+import java.time.Duration
+import javax.inject.Inject
+
+internal class AwsSqsQueueAttributeImporter @Inject constructor(
+  private val config: AwsSqsJobQueueConfig,
+  private val leaseManager: LeaseManager,
+  private val metrics: SqsMetrics,
+  private val queues: QueueResolver,
+  @ForSqsHandling private val taskQueue: RepeatedTaskQueue
+){
+
+  /**
+   * Spawn a new thread that will consume the [queueName] SQS attributes and record them as metrics
+   *
+   * The metric recorded are:
+   * - jobs_sqs_aproximate_number_of_messages
+   * - jobs_sqs_aproximate_number_of_messages_not_visible
+   */
+  fun import(queueName: QueueName) {
+    val frequency = Duration.ofMillis(config.queue_attribute_importer_frequency_ms)
+
+    taskQueue.scheduleWithBackoff(frequency) {
+      val queue = queues[queueName]
+      val lease = leaseManager.requestLease("sqs-queue-attributes-${queue.queueName}")
+      if (lease.checkHeld()) {
+        log.info {
+          "recording metrics for queue ${queueName.value}"
+        }
+        val attributes = queue.call { client ->
+          val request = GetQueueAttributesRequest()
+              .withQueueUrl(queue.url)
+              .withAttributeNames(
+                  QueueAttributeName.ApproximateNumberOfMessages,
+                  QueueAttributeName.ApproximateNumberOfMessagesNotVisible)
+          val response = client.getQueueAttributes(request)
+          response.attributes
+        }
+
+        attributes[QueueAttributeName.ApproximateNumberOfMessages.toString()]?.let {
+          metrics.sqsApproxNumberOfMessages.labels(queue.queueName, queue.queueName)
+              .set(it.toDouble())
+        }
+        attributes[QueueAttributeName.ApproximateNumberOfMessagesNotVisible.toString()]?.let {
+          metrics.sqsApproxNumberOfMessagesNotVisible.labels(queue.queueName, queue.queueName)
+              .set(it.toDouble())
+        }
+      }
+      Status.OK
+    }
+  }
+
+  companion object {
+    private val log = getLogger<AwsSqsQueueAttributeImporter>()
+  }
+}

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -66,50 +66,6 @@ internal class SqsJobConsumer @Inject internal constructor(
     }
   }
 
-  /**
-   * Spawn a new thread that will consume the [queueName] SQS attributes and record them as metrics
-   *
-   * The metric recorded are:
-   * - jobs_sqs_aproximate_number_of_messages
-   * - jobs_sqs_aproximate_number_of_messages_not_visible
-   */
-  fun subscribeToMetrics(queueName: QueueName) {
-    log.info {
-      "recording metrics for queue ${queueName.value}"
-    }
-
-    taskQueue.scheduleWithBackoff(Duration.ZERO) {
-      val queue = queues[queueName]
-      val lease = leaseManager.requestLease("sqs-queue-attributes-${queue.queueName}")
-      if (lease.checkHeld()) {
-        val attributes = try {
-          queue.call { client ->
-            val request = GetQueueAttributesRequest()
-                .withQueueUrl(queue.url)
-                .withAttributeNames(
-                    QueueAttributeName.ApproximateNumberOfMessages,
-                    QueueAttributeName.ApproximateNumberOfMessagesNotVisible)
-            val response = client.getQueueAttributes(request)
-            response.attributes
-          }
-        } catch (e: ClientExecutionTimeoutException) {
-          log.info("timed out long polling for queue attributes: ${queue.queueName}")
-          return@scheduleWithBackoff Status.FAILED
-        }
-
-        attributes[QueueAttributeName.ApproximateNumberOfMessages.toString()]?.let {
-          metrics.sqsApproxNumberOfMessages.labels(queue.queueName, queue.queueName)
-              .set(it.toDouble())
-        }
-        attributes[QueueAttributeName.ApproximateNumberOfMessagesNotVisible.toString()]?.let {
-          metrics.sqsApproxNumberOfMessagesNotVisible.labels(queue.queueName, queue.queueName)
-              .set(it.toDouble())
-        }
-      }
-      Status.OK
-    }
-  }
-
   internal fun getReceiver(queueName: QueueName): QueueReceiver {
     return subscriptions[queueName]!!
   }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -1,9 +1,7 @@
 package misk.jobqueue.sqs
 
 import com.amazonaws.http.timers.client.ClientExecutionTimeoutException
-import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
 import com.amazonaws.services.sqs.model.Message
-import com.amazonaws.services.sqs.model.QueueAttributeName
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.google.common.util.concurrent.ServiceManager
 import io.opentracing.Tracer

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
@@ -75,13 +75,13 @@ internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
   )
 
   val sqsApproxNumberOfMessages = metrics.gauge(
-      "jobs_sqs_aproximate_number_of_messages",
+      "ApproximateNumberOfMessagesVisible",
       "the approximate number of messages available for retrieval from SQS",
       listOf("queueName", "QueueName")
   )
 
   val sqsApproxNumberOfMessagesNotVisible = metrics.gauge(
-      "jobs_sqs_aproximate_number_of_messages_not_visible",
+          "ApproximateNumberOfMessagesNotVisible",
       "the  approximate number of messages that are in flight. Messages are considered to " +
           "be in flight if they have been sent to a client but have not yet been deleted or have " +
           "not yet reached the end of their visibility window.",

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
@@ -69,8 +69,22 @@ internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
   )
 
   val sqsDeleteTime = metrics.histogram(
-    "jobs_sqs_delete_latency",
-    "the round trip time to delete messages from SQS",
-    listOf("queueName", "QueueName")
+      "jobs_sqs_delete_latency",
+      "the round trip time to delete messages from SQS",
+      listOf("queueName", "QueueName")
+  )
+
+  val sqsApproxNumberOfMessages = metrics.gauge(
+      "jobs_sqs_aproximate_number_of_messages",
+      "the approximate number of messages available for retrieval from SQS",
+      listOf("queueName", "QueueName")
+  )
+
+  val sqsApproxNumberOfMessagesNotVisible = metrics.gauge(
+      "jobs_sqs_aproximate_number_of_messages_not_visible",
+      "the  approximate number of messages that are in flight. Messages are considered to " +
+          "be in flight if they have been sent to a client but have not yet been deleted or have " +
+          "not yet reached the end of their visibility window.",
+      listOf("queueName", "QueueName")
   )
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
@@ -77,7 +77,8 @@ internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
   val sqsApproxNumberOfMessages = metrics.gauge(
       "ApproximateNumberOfMessagesVisible",
       "the approximate number of messages available for retrieval from SQS",
-      listOf("queueName", "QueueName")
+      // `namespace` and `stat` is to emulate the CloudWatch metrics.
+      listOf("namespace", "stat", "queueName", "QueueName")
   )
 
   val sqsApproxNumberOfMessagesNotVisible = metrics.gauge(
@@ -85,6 +86,7 @@ internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
       "the  approximate number of messages that are in flight. Messages are considered to " +
           "be in flight if they have been sent to a client but have not yet been deleted or have " +
           "not yet reached the end of their visibility window.",
-      listOf("queueName", "QueueName")
+      // `namespace` and `stat` is to emulate the CloudWatch metrics.
+      listOf("namespace", "stat", "queueName", "QueueName")
   )
 }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporterTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporterTest.kt
@@ -7,9 +7,10 @@ import misk.jobqueue.QueueName
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import org.assertj.core.api.Assertions
+import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @MiskTest(startService = true)
@@ -42,8 +43,14 @@ internal class AwsSqsQueueAttributeImporterTest {
     queue.enqueue(queueName, "ok")
     queue.enqueue(queueName, "ok")
 
-    Thread.sleep(100)
-    Assertions.assertThat(sqsMetrics.sqsApproxNumberOfMessages.labels(queueName.value,
-        queueName.value).get()).isEqualTo(4.0)
+    await()
+        .atMost(1, TimeUnit.SECONDS)
+        .until {
+          sqsMetrics.sqsApproxNumberOfMessages.labels(
+              AwsSqsQueueAttributeImporter.metricNamespace,
+              AwsSqsQueueAttributeImporter.metricStat,
+              queueName.value,
+              queueName.value).get() == 4.0
+        }
   }
 }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporterTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporterTest.kt
@@ -1,0 +1,49 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import misk.jobqueue.JobQueue
+import misk.jobqueue.QueueName
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class AwsSqsQueueAttributeImporterTest {
+  @MiskExternalDependency private val dockerSqs = DockerSqs
+  @MiskTestModule private val module = SqsJobQueueTestModule(dockerSqs.credentials, dockerSqs.client)
+
+  @Inject private lateinit var sqs: AmazonSQS
+  @Inject private lateinit var queue: JobQueue
+  @Inject private lateinit var importer: AwsSqsQueueAttributeImporter
+  @Inject private lateinit var sqsMetrics: SqsMetrics
+
+  private lateinit var queueName: QueueName
+
+  @BeforeEach fun createQueues() {
+    // Ensure that each test case runs on a unique queue
+    queueName = QueueName("sqs_job_queue_test")
+    sqs.createQueue(CreateQueueRequest()
+        .withQueueName(queueName.value)
+        .withAttributes(mapOf(
+            // 1 second visibility timeout
+            "VisibilityTimeout" to 1.toString())
+        ))
+  }
+
+  @Test fun importQueueAttributes() {
+    importer.import(queueName)
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+
+    Thread.sleep(100)
+    Assertions.assertThat(sqsMetrics.sqsApproxNumberOfMessages.labels(queueName.value,
+        queueName.value).get()).isEqualTo(4.0)
+  }
+}

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -29,7 +29,7 @@ internal class SqsJobQueueTest {
 
   @Inject private lateinit var sqs: AmazonSQS
   @Inject private lateinit var queue: JobQueue
-  @Inject private lateinit var consumer: JobConsumer
+  @Inject private lateinit var consumer: SqsJobConsumer
   @Inject private lateinit var sqsMetrics: SqsMetrics
   @Inject @ForSqsHandling lateinit var taskQueue: RepeatedTaskQueue
   @Inject private lateinit var fakeLeaseManager: FakeLeaseManager
@@ -269,7 +269,7 @@ internal class SqsJobQueueTest {
       throw IllegalStateException("boom!")
     }
     queue.enqueue(queueName, "fail away")
-    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    val receiver = consumer.getReceiver(queueName)
     assertThat(receiver.run()).isEqualTo(Status.FAILED)
   }
 
@@ -278,7 +278,7 @@ internal class SqsJobQueueTest {
     consumer.subscribe(queueName) {
       throw IllegalStateException("boom!")
     }
-    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    val receiver = consumer.getReceiver(queueName)
     assertThat(receiver.run()).isEqualTo(Status.NO_WORK)
   }
 
@@ -289,7 +289,7 @@ internal class SqsJobQueueTest {
       it.acknowledge()
     }
     queue.enqueue(queueName, "ok")
-    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    val receiver = consumer.getReceiver(queueName)
     assertThat(receiver.run()).isEqualTo(Status.OK)
   }
 
@@ -305,8 +305,20 @@ internal class SqsJobQueueTest {
       it.acknowledge()
     }
     queue.enqueue(queueName, "ok")
-    val receiver = (consumer as SqsJobConsumer).getReceiver(queueName)
+    val receiver = consumer.getReceiver(queueName)
     assertThat(receiver.run()).isEqualTo(Status.NO_WORK)
+  }
+
+  @Test fun subscribeToMetrics() {
+    consumer.subscribeToMetrics(queueName)
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+    queue.enqueue(queueName, "ok")
+
+    Thread.sleep(100)
+    assertThat(sqsMetrics.sqsApproxNumberOfMessages.labels(queueName.value,
+        queueName.value).get()).isEqualTo(4.0)
   }
 
 

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -309,19 +309,6 @@ internal class SqsJobQueueTest {
     assertThat(receiver.run()).isEqualTo(Status.NO_WORK)
   }
 
-  @Test fun subscribeToMetrics() {
-    consumer.subscribeToMetrics(queueName)
-    queue.enqueue(queueName, "ok")
-    queue.enqueue(queueName, "ok")
-    queue.enqueue(queueName, "ok")
-    queue.enqueue(queueName, "ok")
-
-    Thread.sleep(100)
-    assertThat(sqsMetrics.sqsApproxNumberOfMessages.labels(queueName.value,
-        queueName.value).get()).isEqualTo(4.0)
-  }
-
-
   private fun turnOffTaskQueue() {
     taskQueue.stopAsync()
     taskQueue.awaitTerminated()

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
@@ -28,7 +28,9 @@ class SqsJobQueueTestModule(
     install(
         Modules.override(
             AwsSqsJobQueueModule(
-                AwsSqsJobQueueConfig(task_queue = RepeatedTaskQueueConfig(default_jitter_ms = 0))))
+                AwsSqsJobQueueConfig(
+                    task_queue = RepeatedTaskQueueConfig(default_jitter_ms = 0),
+                    queue_attribute_importer_frequency_ms = 0)))
             .with(SqsTestModule(credentials, client))
     )
   }


### PR DESCRIPTION
We consume the following attribtues and record them as metrics:
- ApproximateNumberOfMessages
- ApproximateNumberOfMessagesNotVisible

Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html