### PR TITLE
Lazily provide the JSON overrides in FakeFeatureFlags

### DIFF
--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -5,6 +5,8 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import misk.feature.Feature
 import misk.feature.FeatureFlags
+import misk.feature.getJson
+import misk.feature.testing.FakeFeatureFlagsTest.JsonFeature
 import misk.inject.KAbstractModule
 import misk.moshi.MoshiAdapterModule
 import org.junit.jupiter.api.Test
@@ -15,17 +17,11 @@ class FakeFeatureFlagsModuleTest {
   fun testModule() {
     val injector = Guice.createInjector(FakeFeatureFlagsModule().withOverrides {
       override(Feature("foo"), 24)
-    }, object : KAbstractModule() {
-      override fun configure() {
-        // Misk services automatically get this binding, but no need to depend on all of misk to
-        // test this.
-        bind<Moshi>().toInstance(Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build())
-      }
-    })
+      overrideJson(Feature("jsonFeature"), JsonFeature("testValue"))
+    }, MoshiTestingModule())
 
     val flags = injector.getInstance(FeatureFlags::class.java)
     assertEquals(24, flags.getInt(Feature("foo"), "bar"))
+    assertEquals("testValue", flags.getJson<JsonFeature>(Feature("jsonFeature"), "key").value)
   }
 }

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -1,24 +1,33 @@
 package misk.feature.testing
 
-import com.google.inject.util.Providers
 import com.squareup.moshi.JsonDataException
-import com.squareup.moshi.Moshi
 import misk.feature.Feature
 import misk.feature.getEnum
 import misk.feature.getJson
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import javax.inject.Inject
 
+@MiskTest
 internal class FakeFeatureFlagsTest {
   val FEATURE = Feature("foo")
   val OTHER_FEATURE = Feature("bar")
   val TOKEN = "cust_abcdef123"
 
-  val subject = FakeFeatureFlags(Providers.of(Moshi.Builder()
-      .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
-      .build()))
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(FakeFeatureFlagsModule())
+      install(MoshiTestingModule())
+    }
+  }
+
+  @MiskTestModule val module = TestModule()
+
+  @Inject lateinit var subject: FakeFeatureFlags
 
   @Test
   fun getInt() {

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/MoshiTestingModule.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/MoshiTestingModule.kt
@@ -1,0 +1,18 @@
+package misk.feature.testing
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import misk.inject.KAbstractModule
+
+/**
+ * Binds a [Moshi] instance for testing.
+ *
+ * Misk services automatically get this binding, but no need to depend on all of misk to test this.
+ */
+internal class MoshiTestingModule : KAbstractModule() {
+  override fun configure() {
+    bind<Moshi>().toInstance(Moshi.Builder()
+        .add(KotlinJsonAdapterFactory()) // Added last for lowest precedence.
+        .build())
+  }
+}


### PR DESCRIPTION
This handles the case where the override is set in the
FakeFeatureFlagsModule. When called from the module, the Moshi instance
cannot be accessed yet, so we need to lazily serialize into JSON
when fetching.