### PR TITLE
Make maxIdleConnections configurable

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
@@ -2,6 +2,7 @@ package misk.client
 
 import misk.security.ssl.SslContextFactory
 import misk.security.ssl.SslLoader
+import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
@@ -50,6 +51,12 @@ class HttpClientFactory @Inject constructor(
     dispatcher.maxRequests = config.maxRequests
     dispatcher.maxRequestsPerHost = config.maxRequestsPerHost
     builder.dispatcher(dispatcher)
+
+    val connectionPool = ConnectionPool(
+        config.maxIdleConnections,
+        config.keepAliveDuration.toMillis(),
+        TimeUnit.MILLISECONDS)
+    builder.connectionPool(connectionPool)
 
     return builder.build()
   }

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -45,6 +45,8 @@ data class HttpClientEndpointConfig(
   val pingInterval: Duration? = null,
   val maxRequests: Int = 128,
   val maxRequestsPerHost: Int = 32,
+  val maxIdleConnections: Int = 100,
+  val keepAliveDuration: Duration = Duration.ofMinutes(5),
   val ssl: HttpClientSSLConfig? = null
 )
 


### PR DESCRIPTION
A higher `maxIdleConnections` limit gives misk client a greater chance to reuse connections before they are closed.