### PR TITLE
Implement repeated tasks in FakeScheduledExecutorService

### DIFF
--- a/misk-testing/src/main/kotlin/misk/concurrent/FakeScheduledExecutorService.kt
+++ b/misk-testing/src/main/kotlin/misk/concurrent/FakeScheduledExecutorService.kt
@@ -1,13 +1,12 @@
 package misk.concurrent
 
-import com.google.common.collect.MultimapBuilder
 import com.google.common.util.concurrent.MoreExecutors
 import java.time.Clock
 import java.util.concurrent.Callable
 import java.util.concurrent.Delayed
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.FutureTask
-import java.util.concurrent.RunnableFuture
+import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -17,20 +16,42 @@ import javax.inject.Singleton
 /**
  * ScheduledExecutorService for testing that runs in the current thread and is triggered using the
  * `tick()` method. An injected [Clock] is used to decide whether to execute a scheduled task.
+ *
+ * This service must always "catch up" to the clock, so fixed rate and fixed delay jobs are not different.
  */
 @Singleton
 class FakeScheduledExecutorService @Inject constructor(private val clock: Clock) :
     ScheduledExecutorService, ExecutorService by MoreExecutors.newDirectExecutorService() {
 
-  private val futures =
-      MultimapBuilder.treeKeys().arrayListValues().build<Long, RunnableFuture<*>>()
+  internal val futures = PriorityBlockingQueue<ScheduledFutureTask<*>>()
+
+  private var shutdown = false
 
   /** Check the current time on the clock and run any scheduled tasks that are due. */
   fun tick() {
-    futures.entries().stream()
-        .filter { entry -> entry.key <= clock.millis() }
-        .forEach { entry -> entry.value.run() }
+    var future = futures.poll()
+    while (future != null) {
+      if (clock.millis() < future.executeAt) {
+        // We went too far. Requeue this future, it's not yet ready to run.
+        futures.add(future)
+        return
+      }
+
+      if (!future.isRepeated) {
+        future.run()
+      } else {
+        future.runAndReset()
+        future.reschedule()
+      }
+      future = futures.poll()
+    }
   }
+
+  override fun shutdown() {
+    shutdown = true
+  }
+
+  override fun isShutdown(): Boolean = shutdown
 
   override fun schedule(
     command: Runnable,
@@ -46,39 +67,69 @@ class FakeScheduledExecutorService @Inject constructor(private val clock: Clock)
 
   private fun <V> scheduleTask(delay: Long, unit: TimeUnit, task: () -> V): ScheduledFuture<V> {
     val executeAt = clock.millis() + unit.toMillis(delay)
-    val future =
-        ScheduledFutureTask(executeAt, clock, task)
-    futures.put(executeAt, future)
+    val future = ScheduledFutureTask(executeAt, clock, task)
+    futures.add(future)
     return future
   }
 
   override fun scheduleAtFixedRate(
-    command: Runnable?,
+    command: Runnable,
     initialDelay: Long,
     period: Long,
-    unit: TimeUnit?
+    unit: TimeUnit
   ): ScheduledFuture<*> {
-    TODO("not implemented")
+    check(period > 0) { "Period ($period) must be greater than 0" }
+    return scheduleWithFixedDelay(command, initialDelay, period, unit)
   }
 
   override fun scheduleWithFixedDelay(
-    command: Runnable?,
+    command: Runnable,
     initialDelay: Long,
     delay: Long,
-    unit: TimeUnit?
+    unit: TimeUnit
   ): ScheduledFuture<*> {
-    TODO("not implemented")
+    check(delay > 0) { "Delay ($delay) must be greater than 0" }
+
+    val executeAt = clock.millis() + unit.toMillis(initialDelay)
+    val everyMillis = unit.toMillis(delay)
+
+    val future = ScheduledFutureTask(executeAt, everyMillis, clock) { command.run() }
+    futures.add(future)
+    return future
   }
 
-  class ScheduledFutureTask<V>(
-    val executeAt: Long,
+  inner class ScheduledFutureTask<V>(
+    var executeAt: Long,
+    private val fixedDelay: Long,
     val clock: Clock,
-    task: () -> V
+    val task: () -> V
   ) : FutureTask<V>(task), ScheduledFuture<V> {
+    constructor(
+      executeAt: Long,
+      clock: Clock,
+      task: () -> V
+    ) : this(executeAt, 0L, clock, task)
+
     override fun compareTo(other: Delayed): Int =
         getDelay(TimeUnit.MILLISECONDS).compareTo(other.getDelay(TimeUnit.MILLISECONDS))
 
     override fun getDelay(unit: TimeUnit) =
         unit.convert(clock.millis() - executeAt, TimeUnit.MILLISECONDS)
+
+    val isRepeated: Boolean get() = fixedDelay > 0
+
+    public override fun runAndReset(): Boolean {
+      return super.runAndReset()
+    }
+
+    internal fun reschedule() {
+      check(isRepeated) { "Cannot reschedule a non-repeated FutureTask" }
+      futures.add(ScheduledFutureTask(
+          executeAt = executeAt + fixedDelay,
+          fixedDelay = fixedDelay,
+          clock = clock,
+          task = task
+      ))
+    }
   }
 }

--- a/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
+++ b/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class FakeScheduledExecutorServiceTest {
   @Test
@@ -25,5 +26,21 @@ class FakeScheduledExecutorServiceTest {
 
     assertThat(done.await(1L, TimeUnit.SECONDS)).isTrue()
     assertThat(task.get()).isEqualTo(result)
+  }
+
+  @Test
+  fun testScheduleTaskWithFixedDelay() {
+    val clock = FakeClock()
+    val executor = FakeScheduledExecutorService(clock)
+    val done = AtomicInteger(0)
+
+    executor.scheduleWithFixedDelay({
+      done.getAndAdd(1)
+    }, 10, 10, TimeUnit.MILLISECONDS)
+
+    clock.add(Duration.ofMillis(30))
+    executor.tick()
+
+    assertThat(done.get()).isEqualTo(3)
   }
 }


### PR DESCRIPTION
Implemented the  `scheduleWithFixedDelay` and `scheduleWithFixedRate` functions for the _FakeScheduledExecutorService_.

Since this is a single-threaded executor,  and the service always has to catch up to the clock, fixed delay is no different from fixed rate to my understanding.