### PR TITLE
Adding an KInstallOnceModule class.

### DIFF
--- a/misk-inject/src/main/kotlin/misk/inject/KInstallOnceModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KInstallOnceModule.kt
@@ -1,0 +1,15 @@
+package misk.inject
+
+/**
+ * It's safe to call [KAbstractModule.install] on multiple instances of this module.
+ * Guice will only install it once.
+ */
+abstract class KInstallOnceModule : KAbstractModule() {
+  override fun hashCode(): Int {
+    return javaClass.hashCode()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return other != null && javaClass == other.javaClass
+  }
+}

--- a/misk-inject/src/test/kotlin/misk/inject/InstallOnceTest.kt
+++ b/misk-inject/src/test/kotlin/misk/inject/InstallOnceTest.kt
@@ -1,0 +1,40 @@
+package misk.inject
+
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest
+class InstallOnceTest {
+  @MiskTestModule
+  val module = TestInstallModule()
+
+  @Inject @TestAnnotation private lateinit var installedOnce: String
+
+  @Test
+  fun testInstallOnce() {
+    Assertions.assertThat(installedOnce).startsWith("only one of me with identity")
+  }
+}
+
+class TestInstallModule : KAbstractModule() {
+  override fun configure() {
+    // Install many. It should still resolve.
+    install(OnceModule())
+    install(OnceModule())
+    install(OnceModule())
+    install(OnceModule())
+    install(OnceModule())
+    install(OnceModule())
+    install(OnceModule())
+  }
+}
+
+class OnceModule : KInstallOnceModule() {
+  override fun configure() {
+    bind(String::class.java).annotatedWith(TestAnnotation::class.java)
+        .toInstance("only one of me with identity ${System.identityHashCode(this)}")
+  }
+}

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -2,6 +2,7 @@ package misk.web.dashboard
 
 import misk.environment.Environment
 import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 import misk.security.authz.AccessAnnotationEntry
 import misk.web.NetworkInterceptor
 import misk.web.WebActionModule
@@ -22,7 +23,7 @@ import javax.inject.Qualifier
  *   Dashboard Annotation [AdminDashboard]. Tabs are then included in the admin dashboard menu
  *   grouping according to the [DashboardTab].category field and sorting by [DashboardTab].name
  */
-class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
+class AdminDashboardModule(val environment: Environment) : KInstallOnceModule() {
   override fun configure() {
     // Install base dashboard support
     install(DashboardModule())


### PR DESCRIPTION
For situations where you want the flexiblity of ensuring a dependent module exists.