### PR TITLE
give launchdarkly more time to start

### DIFF
--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -27,7 +27,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
   private val moshi: Moshi
 ) : AbstractIdleService(), FeatureFlags, FeatureService {
   override fun startUp() {
-    var attempts = 50
+    var attempts = 300
     val intervalMillis = 100L
 
     // LaunchDarkly has its own threads for initialization. We just need to keep checking until
@@ -38,7 +38,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     }
 
     if (attempts == 0 && !ldClient.initialized()) {
-      throw Exception("LaunchDarkly did not initialize in 5 seconds")
+      throw Exception("LaunchDarkly did not initialize in 30 seconds")
     }
   }
 


### PR DESCRIPTION
CPU contention in staging on startup can cause this, which should usually take ~100ms, to take more than 5 seconds. Raise the threshold to 30 seconds.