### PR TITLE
Force use of Python 3 for mkdocs CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,20 +115,10 @@ jobs:
     parallelism: 1
     steps:
       - checkout # check out source code to working directory
-      - run: |
-          sudo mkdir -p /usr/local/bin
-          sudo chown -R circleci:circleci /usr/local/bin
-      - run: |
-          sudo mkdir -p /usr/local/lib/python3.6/site-packages
-          sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
-      - restore_cache:
-          key: pipdeps-{{ .Branch }}
-      - run: sudo pip install mkdocs mkdocs-material
-      - save_cache:
-          key: pipdeps-{{ .Branch }}
-          paths:
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.6/site-packages"
+      - run: | # mkdocs wants to be run with Python 3, force the path to prioritize pyenv 3.5.2
+          pyenv global 3.5.2
+          export PATH="/opt/circleci/.pyenv/versions/3.5.2/lib/:$PATH"
+          pip install mkdocs mkdocs-material
       - run: |
           ./gradlew dokka
       - run: |


### PR DESCRIPTION
mkdocs is fatally complaining about being run with Python 2. We can fix this by forcing CI to run mkdocs against Python 3.