### PR TITLE
Bump aws dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,8 +2,8 @@
 ext.dep = [
   "assertj": "org.assertj:assertj-core:3.13.2",
   "awaitility": "org.awaitility:awaitility-kotlin:4.0.2",
-  "awsApi": "com.amazonaws:aws-java-sdk:1.11.144",
-  "awsSqs": "com.amazonaws:aws-java-sdk-sqs:1.11.144",
+  "awsApi": "com.amazonaws:aws-java-sdk:1.11.705",
+  "awsSqs": "com.amazonaws:aws-java-sdk-sqs:1.11.705",
   "bouncycastle": "org.bouncycastle:bcprov-jdk15on:1.55",
   "concurrencyLimitsCore": "com.netflix.concurrency-limits:concurrency-limits-core:0.3.6",
   "curatorFramework": "org.apache.curator:curator-framework:4.0.1",


### PR DESCRIPTION
To get access to the transactional write api in DynamoDBMapper 
- [DynamoDBMapper now supports Amazon DynamoDB transactional API calls
](https://aws.amazon.com/about-aws/whats-new/2019/04/dynamodbmapper-now-supports-amazon-dynamodb-transactional-api-calls/)