### PR TITLE
Add DockerDynamoDb

### DIFF
--- a/misk-aws-dynamodb-testing/build.gradle
+++ b/misk-aws-dynamodb-testing/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation dep.tracingJaeger
   implementation project(':misk')
   implementation project(':misk-aws')
+  implementation project(':misk-testing')
 
   testImplementation dep.assertj
   testImplementation dep.junitApi

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/CreateTablesService.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/CreateTablesService.kt
@@ -1,0 +1,50 @@
+package misk.aws.dynamodb.testing
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
+import com.amazonaws.services.dynamodbv2.model.ResourceInUseException
+import com.google.common.util.concurrent.AbstractIdleService
+import misk.logging.getLogger
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+
+@Singleton
+internal class CreateTablesService @Inject constructor(
+  private val dynamoDbClient: AmazonDynamoDB,
+  private val tables: Set<DynamoDbTable>
+) : AbstractIdleService() {
+
+  override fun startUp() {
+    // Cleans up the tables before each run.
+    for (tableName in dynamoDbClient.listTables().tableNames) {
+      dynamoDbClient.deleteTable(tableName)
+    }
+
+    for (table in tables) {
+      dynamoDbClient.createTable(table.tableClass)
+    }
+  }
+
+  override fun shutDown() {
+    dynamoDbClient.shutdown()
+  }
+
+  private fun AmazonDynamoDB.createTable(
+    table: KClass<*>
+  ) {
+    val tableRequest = DynamoDBMapper(this)
+        .generateCreateTableRequest(table.java)
+        // Provisioned throughput needs to be specified when creating the table. However,
+        // DynamoDB Local ignores your provisioned throughput settings. The values that you specify
+        // when you call CreateTable and UpdateTable have no effect. In addition, DynamoDB Local
+        // does not throttle read or write activity.
+        .withProvisionedThroughput(ProvisionedThroughput(1L, 1L))
+    DynamoDB(this).createTable(tableRequest).waitForActive()
+  }
+}
+
+private val logger = getLogger<CreateTablesService>()
+

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDb.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDb.kt
@@ -1,0 +1,89 @@
+package misk.aws.dynamodb.testing
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.Ports
+import misk.containers.Composer
+import misk.containers.Container
+import misk.logging.getLogger
+import misk.testing.ExternalDependency
+import okhttp3.HttpUrl
+
+/**
+ * A test DynamoDb Local service. Tests can connect to the service at 127.0.0.1:58000.
+ */
+object DockerDynamoDb : ExternalDependency {
+  private val logger = getLogger<DockerDynamoDb>()
+
+  private val url = HttpUrl.Builder()
+      .scheme("http")
+      .host("localhost")
+      .port(58000)
+      .build()
+
+  private val composer = Composer("e-dynamodb-local", Container {
+    // DynamoDB Local listens on port 8000 by default.
+    val exposedClientPort = ExposedPort.tcp(8000)
+    val portBindings =
+        Ports().apply { bind(exposedClientPort, Ports.Binding.bindPort(url.port)) }
+    withImage("amazon/dynamodb-local")
+        .withName("dynamodb-local")
+        .withExposedPorts(exposedClientPort)
+        .withPortBindings(portBindings)
+  })
+
+  override fun beforeEach() {
+    // noop
+  }
+
+  override fun afterEach() {
+    // noop
+  }
+
+  override fun startup() {
+    composer.start()
+    val client = connect()
+    while (true) {
+      try {
+        client.deleteTable("not a table")
+      } catch (e: Exception) {
+        if (e is AmazonDynamoDBException) {
+          break
+        }
+        logger.info { "DynamoDb is not available yet" }
+        Thread.sleep(100)
+      }
+    }
+    client.shutdown()
+    logger.info { "DynamoDb is available" }
+  }
+
+  override fun shutdown() {
+    composer.stop()
+  }
+
+  fun connect(): AmazonDynamoDB {
+    return AmazonDynamoDBClientBuilder
+        .standard()
+        // The values that you supply for the AWS access key and the Region are only used to name the database file.
+        .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("key", "secret")))
+        .withEndpointConfiguration(
+            AwsClientBuilder.EndpointConfiguration(
+                url.toString(),
+                Regions.US_WEST_2.toString()
+            )
+        )
+        .build()
+  }
+
+}
+
+fun main(args: Array<String>) {
+  DockerDynamoDb.startup()
+}

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
@@ -1,71 +1,33 @@
 package misk.aws.dynamodb.testing
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
-import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
-import com.amazonaws.services.dynamodbv2.model.ResourceInUseException
 import com.google.inject.Provides
+import misk.ServiceModule
 import misk.inject.KAbstractModule
 import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 /**
- * Temporary module to allow setting up DynamoDb for testing, with a
- * DockerDynamoDb external dependency running. Support for this will be short
- * lived, as soo there will be a dn embedded DynamoDb (in memory) module available.
+ * Spins up a docker container for testing. It clears the table content before each test starts.
  */
 class DockerDynamoDbModule(
-  private val entities: List<Pair<String, KClass<*>>>
+  private val tables: List<KClass<*>>
 ) : KAbstractModule() {
   override fun configure() {
+    for (table in tables) {
+      multibind<DynamoDbTable>().toInstance(DynamoDbTable(table))
+    }
+    install(ServiceModule<CreateTablesService>())
   }
 
   @Provides @Singleton
   fun providesAmazonDynamoDB(): AmazonDynamoDB {
-    val dynamoDb = AmazonDynamoDBClientBuilder
-        .standard()
-        .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials("key", "secret")))
-        .withEndpointConfiguration(
-            AwsClientBuilder.EndpointConfiguration(
-                "http://localhost:8000", // TODO: inject from config
-                Regions.US_WEST_1.toString()
-            )
-        )
-        .build()
-
-    entities.forEach {
-      createTableForEntity(
-          dynamoDb,
-          it.second,
-          it.first
-      )
-    }
-
-    return dynamoDb
-  }
-
-  companion object {
-    private fun createTableForEntity(
-      amazonDynamoDB: AmazonDynamoDB,
-      entity: KClass<*>,
-      tableName: String
-    ) {
-      val tableRequest = DynamoDBMapper(amazonDynamoDB)
-          .generateCreateTableRequest(entity.java)
-          .withTableName(tableName)
-          .withProvisionedThroughput(ProvisionedThroughput(1L, 1L))
-
-      try {
-        DynamoDB(amazonDynamoDB).createTable(tableRequest).waitForActive()
-      } catch (e: ResourceInUseException) {
-        // nothing
-      }
-    }
+    return DockerDynamoDb.connect()
   }
 }
+
+/**
+ * [DynamoDbTable] is a wrapper class that allows for unqualified binding of dynamo table classes
+ * without collision.
+ */
+data class DynamoDbTable(val tableClass: KClass<*>)

--- a/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbTest.kt
+++ b/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbTest.kt
@@ -1,0 +1,79 @@
+package misk.aws.dynamodb.testing
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class DockerDynamoDbTest {
+
+  @MiskTestModule
+  val module = MoviesTestModule()
+  @MiskExternalDependency
+  val dockerDynamoDb = DockerDynamoDb
+
+  @Inject
+  lateinit var dynamoDbClient: AmazonDynamoDB
+  @Inject
+  lateinit var tables: Set<DynamoDbTable>
+
+  @Test
+  fun happyPath() {
+    val dynamoDbMapper = DynamoDBMapper(dynamoDbClient)
+    val movieMapper = dynamoDbMapper.newTableMapper<DyMovie, String, LocalDate>(DyMovie::class.java)
+    val characterMapper =
+        dynamoDbMapper.newTableMapper<DyCharacter, String, String>(DyCharacter::class.java)
+
+    val movie = DyMovie()
+    movie.name = "Jurassic Park"
+    movie.release_date = LocalDate.of(1993, 6, 9)
+    movieMapper.save(movie)
+
+    val character = DyCharacter()
+    character.movie_name = "Jurassic Park"
+    character.character_name = "Ian Malcolm"
+    characterMapper.save(character)
+
+    // Query the movies created.
+    val actualMovie = movieMapper.load("Jurassic Park", LocalDate.of(1993, 6, 9))
+    assertThat(actualMovie.name).isEqualTo(movie.name)
+    assertThat(actualMovie.release_date).isEqualTo(movie.release_date)
+
+    val actualCharacter = characterMapper.load("Jurassic Park", "Ian Malcolm")
+    assertThat(actualCharacter.movie_name).isEqualTo(character.movie_name)
+    assertThat(actualCharacter.character_name).isEqualTo(character.character_name)
+  }
+
+  @Test
+  fun truncateTables() {
+    val dynamoDbMapper = DynamoDBMapper(dynamoDbClient)
+    val movieMapper = dynamoDbMapper.newTableMapper<DyMovie, String, LocalDate>(DyMovie::class.java)
+    val characterMapper =
+        dynamoDbMapper.newTableMapper<DyCharacter, String, String>(DyCharacter::class.java)
+
+    val movie = DyMovie()
+    movie.name = "Jurassic Park"
+    movie.release_date = LocalDate.of(1993, 6, 9)
+    movieMapper.save(movie)
+
+    val character = DyCharacter()
+    character.movie_name = "Jurassic Park"
+    character.character_name = "Ian Malcolm"
+    characterMapper.save(character)
+
+    val service = CreateTablesService(dynamoDbClient, tables)
+    service.startAsync()
+    service.awaitRunning()
+    val actualMovie = movieMapper.load("Jurassic Park", LocalDate.of(1993, 6, 9))
+    assertThat(actualMovie).isNull()
+    val actualCharacter = characterMapper.load("Jurassic Park", "Ian Malcolm")
+    assertThat(actualCharacter).isNull()
+  }
+
+}

--- a/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DyCharacter.kt
+++ b/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DyCharacter.kt
@@ -1,0 +1,13 @@
+package misk.aws.dynamodb.testing
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+
+@DynamoDBTable(tableName = "characters")
+class DyCharacter {
+  @DynamoDBHashKey(attributeName = "movie_name")
+  var movie_name: String = ""
+  @DynamoDBRangeKey(attributeName = "character_name")
+  var character_name: String = ""
+}

--- a/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DyMovie.kt
+++ b/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/DyMovie.kt
@@ -1,0 +1,28 @@
+package misk.aws.dynamodb.testing
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter
+import java.nio.ByteBuffer
+import java.time.LocalDate
+
+@DynamoDBTable(tableName = "movies")
+class DyMovie {
+  @DynamoDBHashKey(attributeName = "name")
+  var name: String = ""
+  @DynamoDBTypeConverted(converter = LocalDateTypeConverter::class)
+  @DynamoDBRangeKey(attributeName = "release_date")
+  var release_date: LocalDate? = LocalDate.now()
+}
+
+internal class LocalDateTypeConverter : DynamoDBTypeConverter<String, LocalDate> {
+  override fun unconvert(string: String): LocalDate {
+    return LocalDate.parse(string)
+  }
+
+  override fun convert(localDate: LocalDate): String {
+    return localDate.toString()
+  }
+}

--- a/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/MoviesTestModule.kt
+++ b/misk-aws-dynamodb-testing/src/test/kotlin/misk/aws/dynamodb/testing/MoviesTestModule.kt
@@ -1,0 +1,16 @@
+package misk.aws.dynamodb.testing
+
+import misk.MiskTestingServiceModule
+import misk.environment.Environment
+import misk.environment.EnvironmentModule
+import misk.inject.KAbstractModule
+
+class MoviesTestModule: KAbstractModule() {
+
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(EnvironmentModule(Environment.TESTING))
+
+    install(DockerDynamoDbModule(listOf(DyMovie::class, DyCharacter::class)))
+  }
+}


### PR DESCRIPTION
A follow up of #1398 and #1414

- Adds the DockerDynamoDb external dependency, hard coded to use port 58000
- Adds tests for DockerDynamoDbModule