### PR TITLE
Introduce Deployment type to eventually replace Environment enum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,17 @@ subprojects { subProject ->
   compileKotlin {
     kotlinOptions {
       jvmTarget = "1.8"
-      allWarningsAsErrors = true
+
+      // TODO(alec): Enable again once Environment enum is deleted
+       allWarningsAsErrors = false
     }
   }
   compileTestKotlin {
     kotlinOptions {
       jvmTarget = "1.8"
-      allWarningsAsErrors = true
+
+      // TODO(alec): Enable again once Environment enum is deleted
+       allWarningsAsErrors = false
     }
   }
   sourceSets {

--- a/misk/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk/src/main/kotlin/misk/config/MiskConfig.kt
@@ -24,12 +24,13 @@ import org.apache.commons.lang3.StringUtils
 import java.io.File
 import java.io.FilenameFilter
 import java.net.URL
+import java.util.Locale
 
 object MiskConfig {
   @JvmStatic
   inline fun <reified T : Config> load(
     appName: String,
-    environment: Environment,
+    environment: String,
     overrideFiles: List<File> = listOf(),
     resourceLoader: ResourceLoader = ResourceLoader.SYSTEM
   ): T {
@@ -37,10 +38,21 @@ object MiskConfig {
   }
 
   @JvmStatic
+  @Deprecated("the Environment enum is deprecated")
+  inline fun <reified T : Config> load(
+    appName: String,
+    environment: Environment,
+    overrideFiles: List<File> = listOf(),
+    resourceLoader: ResourceLoader = ResourceLoader.SYSTEM
+  ): T {
+    return load(T::class.java, appName, environment.name, overrideFiles, resourceLoader)
+  }
+
+  @JvmStatic
   fun <T : Config> load(
     configClass: Class<out Config>,
     appName: String,
-    environment: Environment,
+    environment: String,
     overrideFiles: List<File> = listOf(),
     resourceLoader: ResourceLoader = ResourceLoader.SYSTEM
   ): T {
@@ -57,7 +69,7 @@ object MiskConfig {
 
     val jsonNode = flattenYamlMap(configYamls)
 
-    val configFile = "$appName-${environment.name.toLowerCase()}.yaml"
+    val configFile = "$appName-${environment.toLowerCase(Locale.US)}.yaml"
     try {
       @Suppress("UNCHECKED_CAST")
       return mapper.readValue(jsonNode.toString(), configClass) as T
@@ -134,7 +146,7 @@ object MiskConfig {
    */
   fun loadConfigYamlMap(
     appName: String,
-    environment: Environment,
+    environment: String,
     overrideFiles: List<File>
   ): Map<String, String?> {
     // Load from jar files first, starting with the common config and then env specific config
@@ -157,8 +169,8 @@ object MiskConfig {
   }
 
   /** @return the list of config file names in the order they should be read */
-  private fun embeddedConfigFileNames(appName: String, environment: Environment) =
-      listOf("common", environment.name.toLowerCase()).map { "$appName-$it.yaml" }
+  private fun embeddedConfigFileNames(appName: String, environment: String) =
+      listOf("common", environment.toLowerCase(Locale.US)).map { "$appName-$it.yaml" }
 
   class SecretJacksonModule(val resourceLoader: ResourceLoader, val mapper: ObjectMapper) :
       SimpleModule() {

--- a/misk/src/main/kotlin/misk/environment/Deployment.kt
+++ b/misk/src/main/kotlin/misk/environment/Deployment.kt
@@ -1,0 +1,49 @@
+package misk.environment
+
+/**
+ * The raw environment name. The set of possibilities is unbounded so this should rarely be used.
+ * Instead, use the Deployment type for behavior based on characteristics of an environment.
+ */
+data class Env(val name: String)
+
+/** Deployment describes the context in which the application is running */
+data class Deployment(
+  /**
+   * The name of this deployment. This is used for debugging and should not be parsed.
+   *
+   * All pods in the same deployment will have this same name.
+   */
+  val name: String,
+
+  /**
+   * Whether the service is running in a production environment, having an SLA or handling customer data.
+   */
+  val isProduction: Boolean = false,
+
+  /**
+   * Whether the service is running in a test environment, either locally or in a CI.
+   */
+  val isTest: Boolean = false,
+
+  /**
+   * Whether the service is running on a local developer machine, including as a Docker image.
+   */
+  val isLocalDevelopment: Boolean = false
+) {
+  init {
+    if (isProduction) check(!isTest && !isLocalDevelopment)
+    if (isTest) check(!isLocalDevelopment)
+  }
+
+  /**
+   * Returns true if running in a managed cluster, such as a staging or production cluster. Mutually exclusive with isFake.
+   */
+  val isReal: Boolean
+    get() = !isFake
+
+  /**
+   * Returns true if running outside of a cluster (CI or local development). Mutually exclusive with isReal.
+   */
+  val isFake: Boolean
+    get() = isTest || isLocalDevelopment
+}

--- a/misk/src/main/kotlin/misk/environment/DeploymentModule.kt
+++ b/misk/src/main/kotlin/misk/environment/DeploymentModule.kt
@@ -1,0 +1,14 @@
+package misk.environment
+
+import misk.inject.KAbstractModule
+
+/** Binds [Deployment] and [Env] to make them available to services and actions */
+class DeploymentModule(
+  private val deployment: Deployment,
+  private val env: Env
+) : KAbstractModule() {
+  override fun configure() {
+    bind<Deployment>().toInstance(deployment)
+    bind<Env>().toInstance(env)
+  }
+}

--- a/misk/src/main/kotlin/misk/environment/Environment.kt
+++ b/misk/src/main/kotlin/misk/environment/Environment.kt
@@ -4,39 +4,56 @@ import com.google.common.base.Preconditions
 import misk.logging.getLogger
 
 /** The environment in which the application is running */
+@Deprecated("use Deployment instead")
 enum class Environment {
   TESTING,
   DEVELOPMENT,
   STAGING,
   PRODUCTION;
 
+  fun isFake(): Boolean = this == TESTING || this == DEVELOPMENT
+
+  fun isReal(): Boolean = !isFake()
+
   companion object {
     internal val logger = getLogger<Environment>()
     private const val ENV_ENVIRONMENT = "ENVIRONMENT"
-    private lateinit var env: Environment
+
+    private lateinit var rawEnv: String
 
     fun setTesting() {
-      if (::env.isInitialized) {
-        Preconditions.checkState(env == TESTING, "Environment already set to ${env.name}")
+      if (::rawEnv.isInitialized) {
+        Preconditions.checkState(rawEnv == TESTING.name, "Environment already set to $rawEnv")
       }
-      env = TESTING
+      rawEnv = TESTING.name
     }
 
     @JvmStatic
     fun fromEnvironmentVariable(): Environment {
+      val rawEnvName = when (val rawEnv = rawEnvironment()) {
+        "PLATFORM-STAGING" -> STAGING.name // Special case during deprecation of Environment
+        else -> rawEnv
+      }
+      return valueOf(rawEnvName)
+    }
+
+    fun rawEnvironment(): String {
       // The system variable should always take precedence
       val environmentName = System.getenv(ENV_ENVIRONMENT)
-      val environment = environmentName?.let { Environment.valueOf(it) } ?: {
-        if (::env.isInitialized) {
-          env
-        } else {
-          // TODO(dhanji): We should remove this default, eventually
-          logger.warn { "No environment variable with key $ENV_ENVIRONMENT found, running in DEVELOPMENT" }
-          Environment.DEVELOPMENT
+      val environment = when (environmentName) {
+        null -> {
+          if (::rawEnv.isInitialized) {
+            rawEnv
+          } else {
+            // TODO(dhanji): We should remove this default, eventually
+            logger.warn { "No environment variable with key $ENV_ENVIRONMENT found, running in DEVELOPMENT" }
+            DEVELOPMENT.toString()
+          }
         }
-      }()
+        else -> environmentName
+      }
 
-      logger.info { "Running with environment ${environment.name}" }
+      logger.info { "Running with environment $environment" }
       return environment
     }
   }

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -22,7 +22,11 @@ import javax.inject.Qualifier
  *   Dashboard Annotation [AdminDashboard]. Tabs are then included in the admin dashboard menu
  *   grouping according to the [DashboardTab].category field and sorting by [DashboardTab].name
  */
-class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
+class AdminDashboardModule(private val isDevelopment: Boolean) : KAbstractModule() {
+
+  @Deprecated("Environment is deprecated")
+  constructor(env: Environment) : this(env == Environment.TESTING || env == Environment.DEVELOPMENT)
+
   override fun configure() {
     // Install base dashboard support
     install(DashboardModule())
@@ -32,71 +36,71 @@ class AdminDashboardModule(val environment: Environment) : KAbstractModule() {
 
     // Admin Dashboard Tab
     multibind<DashboardHomeUrl>().toInstance(
-      DashboardHomeUrl<AdminDashboard>("/_admin/")
+        DashboardHomeUrl<AdminDashboard>("/_admin/")
     )
     install(WebTabResourceModule(
-      environment = environment,
-      slug = "admin-dashboard",
-      web_proxy_url = "http://localhost:3100/"
+        isDevelopment = isDevelopment,
+        slug = "admin-dashboard",
+        web_proxy_url = "http://localhost:3100/"
     ))
     install(WebTabResourceModule(
-      environment = environment,
-      slug = "admin-dashboard",
-      web_proxy_url = "http://localhost:3100/",
-      url_path_prefix = "/_admin/",
-      resourcePath = "classpath:/web/_tab/admin-dashboard/"
+        isDevelopment = isDevelopment,
+        slug = "admin-dashboard",
+        web_proxy_url = "http://localhost:3100/",
+        url_path_prefix = "/_admin/",
+        resourcePath = "classpath:/web/_tab/admin-dashboard/"
     ))
 
     // @misk packages
     install(WebTabResourceModule(
-      environment = environment,
-      slug = "@misk",
-      web_proxy_url = "http://localhost:3100/",
-      url_path_prefix = "/@misk/",
-      resourcePath = "classpath:/web/_tab/admin-dashboard/@misk/"
+        isDevelopment = isDevelopment,
+        slug = "@misk",
+        web_proxy_url = "http://localhost:3100/",
+        url_path_prefix = "/@misk/",
+        resourcePath = "classpath:/web/_tab/admin-dashboard/@misk/"
     ))
 
     // Config
     install(WebActionModule.create<ConfigMetadataAction>())
     multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "config",
-        url_path_prefix = "/_admin/config/",
-        name = "Config",
-        category = "Container Admin"
-      ))
+        DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
+            slug = "config",
+            url_path_prefix = "/_admin/config/",
+            name = "Config",
+            category = "Container Admin"
+        ))
     install(WebTabResourceModule(
-      environment = environment,
-      slug = "config",
-      web_proxy_url = "http://localhost:3200/"
+        isDevelopment = isDevelopment,
+        slug = "config",
+        web_proxy_url = "http://localhost:3200/"
     ))
 
     // Web Actions
     install(WebActionModule.create<WebActionMetadataAction>())
     multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "web-actions",
-        url_path_prefix = "/_admin/web-actions/",
-        name = "Web Actions",
-        category = "Container Admin"
-      ))
+        DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
+            slug = "web-actions",
+            url_path_prefix = "/_admin/web-actions/",
+            name = "Web Actions",
+            category = "Container Admin"
+        ))
     install(WebTabResourceModule(
-      environment = environment,
-      slug = "web-actions",
-      web_proxy_url = "http://localhost:3201/"
+        isDevelopment = isDevelopment,
+        slug = "web-actions",
+        web_proxy_url = "http://localhost:3201/"
     ))
   }
 }
 
 // Module that allows testing/development environments to bind up the admin dashboard
-class AdminDashboardTestingModule(val environment: Environment) : KAbstractModule() {
+class AdminDashboardTestingModule() : KAbstractModule() {
+
   override fun configure() {
     // Set dummy values for access, these shouldn't matter,
     // as test environments should prefer to use the FakeCallerAuthenticator.
-    multibind<AccessAnnotationEntry>()
-      .toInstance(
+    multibind<AccessAnnotationEntry>().toInstance(
         AccessAnnotationEntry<AdminDashboardAccess>(capabilities = listOf("admin_access")))
-    install(AdminDashboardModule(environment))
+    install(AdminDashboardModule(true))
   }
 }
 

--- a/misk/src/main/kotlin/misk/web/metadata/ConfigMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/ConfigMetadataAction.kt
@@ -55,7 +55,7 @@ class ConfigMetadataAction @Inject constructor(
       environment: Environment,
       config: Config
     ): Map<String, String?> {
-      val rawYamlFiles = MiskConfig.loadConfigYamlMap(appName, environment, listOf())
+      val rawYamlFiles = MiskConfig.loadConfigYamlMap(appName, environment.name, listOf())
       val yamlFiles = linkedMapOf<String, String?>("Effective Config" to MiskConfig.toYaml(
         config, ResourceLoader.SYSTEM))
       rawYamlFiles.map { yamlFiles.put("classpath:/${it.key}", it.value) }

--- a/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
@@ -37,10 +37,10 @@ class ServiceMetadataAction @Inject constructor(
 class OptionalBinder @Inject constructor(@AppName val appName: String) {
   @com.google.inject.Inject(optional = true)
   var serviceMetadata: ServiceMetadata =
-    ServiceMetadata(appName, Environment.fromEnvironmentVariable())
+    ServiceMetadata(appName, Environment.fromEnvironmentVariable().name)
 }
 
 data class ServiceMetadata(
   val app_name: String,
-  val environment: Environment
+  val environment: String
 )

--- a/misk/src/test/kotlin/misk/web/metadata/MetadataTestingModule.kt
+++ b/misk/src/test/kotlin/misk/web/metadata/MetadataTestingModule.kt
@@ -2,7 +2,6 @@ package misk.web.metadata
 
 import misk.config.AppName
 import misk.config.Config
-import misk.environment.Environment
 import misk.inject.KAbstractModule
 import misk.web.actions.TestWebActionModule
 import misk.web.dashboard.AdminDashboardTestingModule
@@ -17,7 +16,7 @@ import javax.inject.Qualifier
 class MetadataTestingModule : KAbstractModule() {
   override fun configure() {
     install(TestWebActionModule())
-    install(AdminDashboardTestingModule(Environment.TESTING))
+    install(AdminDashboardTestingModule())
     bind<Config>().toInstance(TestAdminDashboardConfig())
     // TODO(wesley): Remove requirement for AppName to bind AdminDashboard APIs
     bind<String>().annotatedWith<AppName>().toInstance("testApp")

--- a/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -14,7 +14,7 @@ public class ExemplarJavaApp {
   public static void main(String[] args) {
     Environment environment = Environment.fromEnvironmentVariable();
     ExemplarJavaConfig config = MiskConfig.load(ExemplarJavaConfig.class, "exemplar",
-        environment, ImmutableList.of(), ResourceLoader.Companion.getSYSTEM());
+        environment.name(), ImmutableList.of(), ResourceLoader.Companion.getSYSTEM());
 
     new MiskApplication(
         new MiskRealServiceModule(),

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -4,6 +4,7 @@ import misk.MiskApplication
 import misk.MiskRealServiceModule
 import misk.config.ConfigModule
 import misk.config.MiskConfig
+import misk.environment.DeploymentModule
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.metrics.backends.prometheus.PrometheusMetricsModule
@@ -11,7 +12,7 @@ import misk.web.MiskWebModule
 
 fun main(args: Array<String>) {
   val environment = Environment.fromEnvironmentVariable()
-  val config = MiskConfig.load<ExemplarConfig>("exemplar", environment)
+  val config = MiskConfig.load<ExemplarConfig>("exemplar", environment.name)
   MiskApplication(
       MiskRealServiceModule(),
       MiskWebModule(config.web),

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -32,3 +32,10 @@ shadowJar {
 artifacts {
   archives shadowJar
 }
+
+compileKotlin {
+  kotlinOptions {
+    // TODO(alec): Enable again once Environment enum is deleted
+    allWarningsAsErrors = false
+  }
+}

--- a/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatService.kt
+++ b/samples/exemplarchat/src/main/kotlin/com/squareup/chat/ChatService.kt
@@ -12,7 +12,7 @@ import misk.web.MiskWebModule
 
 fun main(args: Array<String>) {
   val environment = Environment.fromEnvironmentVariable()
-  val config = MiskConfig.load<ChatConfig>("chat", environment)
+  val config = MiskConfig.load<ChatConfig>("chat", environment.name)
 
   MiskApplication(
       MiskRealServiceModule(),


### PR DESCRIPTION
Not meant to be fully complete, but shows the Misk changes for starting to remove the `Environment` enum in favor of a `Deployment` type.

The environment (in plain string form) is still used for things like parsing config, at least for now.