### PR TITLE
jdbc: support sslMode

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -70,6 +70,7 @@ data class DataSourceConfig(
   // going forward
   val trust_certificate_key_store_path: String? = null,
   val client_certificate_key_store_path: String? = null,
+  val verify_server_identity: Boolean = false,
   val show_sql: String? = "false",
   // Consider using this if you want Hibernate to automagically batch inserts/updates when it can.
   val jdbc_statement_batch_size: Int? = null
@@ -181,7 +182,6 @@ data class DataSourceConfig(
           }
           queryParams += "&trustCertificateKeyStoreUrl=$trustStoreUrl"
           queryParams += "&trustCertificateKeyStorePassword=${config.trust_certificate_key_store_password}"
-          queryParams += "&verifyServerCertificate=true"
           useSSL = true
         }
         if (!certStoreUrl.isNullOrBlank()) {
@@ -194,10 +194,14 @@ data class DataSourceConfig(
           useSSL = true
         }
 
-        if (useSSL) {
-          queryParams += "&useSSL=true"
-          queryParams += "&requireSSL=true"
+        val sslMode = if (useSSL && verify_server_identity) {
+          "VERIFY_IDENTITY"
+        } else if (useSSL) {
+          "VERIFY_CA"
+        } else {
+          "PREFERRED"
         }
+        queryParams += "&sslMode=$sslMode"
 
         "jdbc:tracing:mysql://${config.host}:${config.port}/${config.database}$queryParams"
       }
@@ -293,6 +297,7 @@ data class DataSourceConfig(
               this.client_certificate_key_store_password,
               this.trust_certificate_key_store_path,
               this.client_certificate_key_store_path,
+              this.verify_server_identity,
               this.show_sql
       )
   }

--- a/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -76,8 +76,8 @@ class DataSourceConfigTest {
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
-        "trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true&" +
-        "useSSL=true&requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
@@ -88,15 +88,33 @@ class DataSourceConfigTest {
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
-        "trustCertificateKeyStorePassword=changeit&verifyServerCertificate=true&useSSL=true&" +
-        "requireSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
+        config.buildJdbcUrl(Environment.TESTING))
+  }
+
+  @Test
+  fun buildMysqlJDBCUrlWithKeystoreAndTruststoreUrlsAndVerifyIdentity() {
+    val config = DataSourceConfig(DataSourceType.MYSQL,
+        trust_certificate_key_store_url = "file://path/to/truststore",
+        trust_certificate_key_store_password = "changeit",
+        client_certificate_key_store_url = "file://path/to/keystore",
+        client_certificate_key_store_password = "changeit",
+        verify_server_identity = true)
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&" +
+        "clientCertificateKeyStoreUrl=file://path/to/keystore&" +
+        "clientCertificateKeyStorePassword=changeit&" +
+        "sslMode=VERIFY_IDENTITY",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildMysqlJDBCUrlWithNoTls() {
     val config = DataSourceConfig(DataSourceType.MYSQL)
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
-        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000",
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&sslMode=PREFERRED",
         config.buildJdbcUrl(Environment.TESTING))
   }
 }


### PR DESCRIPTION
`useSSL`, `requireSSL`, and `verifyServerCertificate` are all deprecated
and superceded by `sslMode` as of `mysql:mysql-connector-java:8.0.13`.

This PR removes the deprecated options and uses `sslMode`, and also
enables the use of the `VERIFY_IDENTITY` option to verify the server's
hostname against its certificate.

Apparently validating the hostname has never been supported in the
jdbc connector before.

https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html