### PR TITLE
DeploymentModule.forTesting() to replace uses of EnvironmentModule

### DIFF
--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -4,8 +4,8 @@ import com.google.inject.util.Modules
 import misk.MiskTestingServiceModule
 import misk.config.Config
 import misk.config.MiskConfig
+import misk.environment.DeploymentModule
 import misk.environment.Environment
-import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
 import misk.jdbc.DataSourceClusterConfig
 import misk.jdbc.DataSourceConfig
@@ -23,7 +23,7 @@ class MoviesTestModule(
     install(
         Modules.override(MiskTestingServiceModule()).with(FakeClockModule(),
             MockTracingBackendModule()))
-    install(EnvironmentModule(Environment.TESTING))
+    install(DeploymentModule.forTesting())
 
     val config = MiskConfig.load<MoviesConfig>("moviestestmodule", Environment.TESTING)
     install(HibernateTestingModule(Movies::class))

--- a/misk/src/main/kotlin/misk/environment/DeploymentModule.kt
+++ b/misk/src/main/kotlin/misk/environment/DeploymentModule.kt
@@ -1,5 +1,7 @@
 package misk.environment
 
+import com.google.inject.util.Modules
+import com.google.inject.Module
 import misk.inject.KAbstractModule
 
 /** Binds [Deployment] and [Env] to make them available to services and actions */
@@ -10,5 +12,21 @@ class DeploymentModule(
   override fun configure() {
     bind<Deployment>().toInstance(deployment)
     bind<Env>().toInstance(env)
+  }
+
+  companion object {
+    /**
+     * Return a Module that binds a [Deployment] and [Env] for a test environment.
+     *
+     * Until [Environment] is deleted, this also installs an [EnvironmentModule]
+     */
+    fun forTesting(): Module {
+      return Modules.combine(
+          DeploymentModule(
+              deployment = Deployment(name = "testing", isTest = true),
+              env = Env("TESTING")),
+          EnvironmentModule(Environment.TESTING)
+      )
+    }
   }
 }

--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -1,8 +1,8 @@
 package misk.config
 
 import com.google.inject.util.Modules
+import misk.environment.DeploymentModule
 import misk.environment.Environment
-import misk.environment.EnvironmentModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebConfig
@@ -23,7 +23,7 @@ class MiskConfigTest {
   @MiskTestModule
   val module = Modules.combine(
       ConfigModule.create("test_app", config),
-      EnvironmentModule(defaultEnv)
+      DeploymentModule.forTesting()
       // @TODO(jwilson) https://github.com/square/misk/issues/272
   )
 


### PR DESCRIPTION
Getting rid of `Environment` means also phasing out `EnvironmentModule`. It's common for tests to bind up `EnvironmentModule(Environment.TESTING)` since many Misk components depend on it.

As part of the move to `Deployment`, this introduces `DeploymentModule.forTesting()` to replace unit test cases.