### PR TITLE
Add idempotence key and jobqueue metadata

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueResolver.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueResolver.kt
@@ -94,10 +94,8 @@ val QueueName.retryQueue
   get() = if (isRetryQueue) this else QueueName(value + retryQueueSuffix)
 
 val QueueName.parentQueue
-  get() = if (isDeadLetterQueue) {
-    QueueName(value.removeSuffix(deadLetterQueueSuffix))
-  } else if (isRetryQueue) {
-    QueueName(value.removeSuffix(retryQueueSuffix))
-  } else {
-    this
+  get() = when {
+    isDeadLetterQueue -> QueueName(value.removeSuffix(deadLetterQueueSuffix))
+    isRetryQueue -> QueueName(value.removeSuffix(retryQueueSuffix))
+    else -> this
   }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -2,23 +2,47 @@ package misk.jobqueue.sqs
 
 import com.amazonaws.services.sqs.model.Message
 import com.amazonaws.services.sqs.model.SendMessageRequest
+import com.squareup.moshi.Moshi
 import misk.jobqueue.Job
 import misk.jobqueue.QueueName
+import misk.moshi.adapter
 import misk.time.timed
 
 internal class SqsJob(
   override val queueName: QueueName,
   private val queues: QueueResolver,
   private val metrics: SqsMetrics,
+  private val moshi: Moshi,
   private val message: Message
 ) : Job {
   override val body: String = message.body
   override val id: String = message.messageId
-  override val attributes: Map<String, String> = message.messageAttributes.map { (key, value) ->
-    key to value.stringValue
-  }.toMap()
+  override val idempotenceKey: String by lazy {
+    jobqueueMetadata[JOBQUEUE_METADATA_IDEMPOTENCE_KEY]
+        ?: error("$JOBQUEUE_METADATA_IDEMPOTENCE_KEY not set in $JOBQUEUE_METADATA_ATTR")
+  }
+  override val attributes: Map<String, String> by lazy {
+    message.messageAttributes
+        .filter { (key, _) -> key != JOBQUEUE_METADATA_ATTR }
+        .map { (key, value) -> key to value.stringValue }.toMap()
+  }
 
   private val queue: ResolvedQueue = queues.getForReceiving(queueName)
+  private val jobqueueMetadata: Map<String, String> by lazy {
+    val metadata = message.messageAttributes[JOBQUEUE_METADATA_ATTR]
+    // NB: old/in-flight jobs enqueued prior to the introduction of _jobqueue-metadata won't have this property. In
+    // order to not change the contract later on (optional to non-optional), synthesize a reasonable replacement.
+    if (metadata == null) {
+      // TODO(bruno): drop fallback; error out if metadata is not set.
+      mapOf(
+          JOBQUEUE_METADATA_ORIGIN_QUEUE to queueName.parentQueue.value,
+          // If the job had no metadata, there was no app-specified idempotence key;
+          // any sufficiently random value would work, so just use system-assigned id.
+          JOBQUEUE_METADATA_IDEMPOTENCE_KEY to id)
+    } else {
+      moshi.adapter<Map<String, String>>().fromJson(metadata.stringValue)!!
+    }
+  }
 
   override fun acknowledge() {
     deleteMessage(queue, message)
@@ -33,6 +57,7 @@ internal class SqsJob(
       client.sendMessage(SendMessageRequest()
           .withQueueUrl(dlq.url)
           .withMessageBody(body)
+          // Preserves original jobqueue metadata and trace id.
           .withMessageAttributes(message.messageAttributes))
     }
     deleteMessage(queue, message)
@@ -47,6 +72,16 @@ internal class SqsJob(
   }
 
   companion object {
+    /** Message attribute that captures original trace id for a job, when available. */
     const val ORIGINAL_TRACE_ID_ATTR = "x-original-trace-id"
+    /** Message attribute used to store metadata specific to jobqueue functionality. JSON-encoded. */
+    const val JOBQUEUE_METADATA_ATTR = "_jobqueue-metadata"
+    /**
+     * The name of the queue the job was originally submitted to. Used when operating with a global dead-letter queue,
+     * so that jobs can be returned to their original (or retry) queue when reprocessing.
+     */
+    const val JOBQUEUE_METADATA_ORIGIN_QUEUE = "origin_queue"
+    /** Client-assigned identifier, useful to detect duplicate messages. */
+    const val JOBQUEUE_METADATA_IDEMPOTENCE_KEY = "idempotence_key"
   }
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -33,7 +33,7 @@ internal class SqsJob(
     // NB: old/in-flight jobs enqueued prior to the introduction of _jobqueue-metadata won't have this property. In
     // order to not change the contract later on (optional to non-optional), synthesize a reasonable replacement.
     if (metadata == null) {
-      // TODO(bruno): drop fallback; error out if metadata is not set.
+      // TODO(bruno): drop fallback after rollout; error when metadata is not set.
       mapOf(
           JOBQUEUE_METADATA_ORIGIN_QUEUE to queueName.parentQueue.value,
           // If the job had no metadata, there was no app-specified idempotence key;
@@ -83,5 +83,6 @@ internal class SqsJob(
     const val JOBQUEUE_METADATA_ORIGIN_QUEUE = "origin_queue"
     /** Client-assigned identifier, useful to detect duplicate messages. */
     const val JOBQUEUE_METADATA_IDEMPOTENCE_KEY = "idempotence_key"
+    const val JOBQUEUE_METADATA_ORIGINAL_TRACE_ID = "original_trace_id"
   }
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -4,6 +4,7 @@ import com.amazonaws.http.timers.client.ClientExecutionTimeoutException
 import com.amazonaws.services.sqs.model.Message
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.google.common.util.concurrent.ServiceManager
+import com.squareup.moshi.Moshi
 import io.opentracing.Tracer
 import io.opentracing.tag.StringTag
 import io.opentracing.tag.Tags
@@ -33,6 +34,7 @@ internal class SqsJobConsumer @Inject internal constructor(
   private val queues: QueueResolver,
   @ForSqsHandling private val handlingThreads: ExecutorService,
   @ForSqsHandling private val taskQueue: RepeatedTaskQueue,
+  private val moshi: Moshi,
   private val tracer: Tracer,
   private val metrics: SqsMetrics,
   private val featureFlags: FeatureFlags,
@@ -126,7 +128,7 @@ internal class SqsJobConsumer @Inject internal constructor(
         emptyList<Message>()
       }
 
-      return messages.map { SqsJob(queue.name, queues, metrics, it) }
+      return messages.map { SqsJob(queue.name, queues, metrics, moshi, it) }
     }
 
     private fun receive(): List<Status> {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
@@ -22,12 +22,13 @@ internal class SqsTransactionalJobQueue @Inject internal constructor(
     session: Session,
     queueName: QueueName,
     body: String,
+    idempotenceKey: String,
     deliveryDelay: Duration?,
     attributes: Map<String, String>
   ) {
     session.onPostCommit {
       log.info { "forwarding to ${queueName.value}" }
-      jobQueue.enqueue(queueName, body, deliveryDelay, attributes)
+      jobQueue.enqueue(queueName, body, idempotenceKey, deliveryDelay, attributes)
     }
   }
 
@@ -36,9 +37,10 @@ internal class SqsTransactionalJobQueue @Inject internal constructor(
     gid: Gid<*, *>,
     queueName: QueueName,
     body: String,
+    idempotenceKey: String,
     deliveryDelay: Duration?,
     attributes: Map<String, String>
-  ) = enqueue(session, queueName, body, deliveryDelay, attributes)
+  ) = enqueue(session, queueName, body, idempotenceKey, deliveryDelay, attributes)
 
   companion object {
     private val log = getLogger<SqsTransactionalJobQueue>()

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -60,7 +60,7 @@ internal class SqsJobQueueTest {
     }
 
     for (i in (0 until 10)) {
-      queue.enqueue(queueName, "this is job $i", attributes = mapOf("index" to i.toString()))
+      queue.enqueue(queueName, "this is job $i", "ik-$i", attributes = mapOf("index" to i.toString()))
     }
 
     assertThat(allJobsComplete.await(10, TimeUnit.SECONDS)).isTrue()
@@ -77,6 +77,18 @@ internal class SqsJobQueueTest {
         "this is job 7",
         "this is job 8",
         "this is job 9"
+    )
+    assertThat(sortedJobs.map { it.idempotenceKey }).containsExactly(
+        "ik-0",
+        "ik-1",
+        "ik-2",
+        "ik-3",
+        "ik-4",
+        "ik-5",
+        "ik-6",
+        "ik-7",
+        "ik-8",
+        "ik-9"
     )
     assertThat(sortedJobs.map { it.attributes }).containsExactly(
         mapOf("index" to "0"),

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -43,7 +43,8 @@ internal class SqsJobTest {
       addMessageAttributesEntry(SqsJob.JOBQUEUE_METADATA_ATTR,
           MessageAttributeValue().withDataType("String").withStringValue("""{
                 |  "${SqsJob.JOBQUEUE_METADATA_ORIGIN_QUEUE}":"test",
-                |  "${SqsJob.JOBQUEUE_METADATA_IDEMPOTENCE_KEY}": "ik-0"
+                |  "${SqsJob.JOBQUEUE_METADATA_IDEMPOTENCE_KEY}": "ik-0",
+                |  "${SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID}": "oti-0"
                 |}""".trimMargin()))
     }
     val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)
@@ -59,8 +60,7 @@ internal class SqsJobTest {
     val message = Message().apply {
       messageId = "id-0"
       body = "body-0"
-      addMessageAttributesEntry("foo",
-          MessageAttributeValue().withDataType("String").withStringValue("bar"))
+      addMessageAttributesEntry("foo", MessageAttributeValue().withDataType("String").withStringValue("bar"))
     }
 
     val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -42,7 +42,7 @@ internal class SqsJobTest {
       addMessageAttributesEntry("foo", MessageAttributeValue().withDataType("String").withStringValue("bar"))
       addMessageAttributesEntry(SqsJob.JOBQUEUE_METADATA_ATTR,
           MessageAttributeValue().withDataType("String").withStringValue("""{
-                |  "${SqsJob.JOBQUEUE_METADATA_ORIGIN_QUEUE}":"test",
+                |  "${SqsJob.JOBQUEUE_METADATA_ORIGIN_QUEUE}": "test",
                 |  "${SqsJob.JOBQUEUE_METADATA_IDEMPOTENCE_KEY}": "ik-0",
                 |  "${SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID}": "oti-0"
                 |}""".trimMargin()))

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -1,0 +1,73 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.Message
+import com.amazonaws.services.sqs.model.MessageAttributeValue
+import com.squareup.moshi.Moshi
+import misk.jobqueue.QueueName
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+internal class SqsJobTest {
+  @MiskExternalDependency private val dockerSqs = DockerSqs
+  @MiskTestModule private val module = SqsJobQueueTestModule(dockerSqs.credentials, dockerSqs.client)
+
+  @Inject lateinit var sqs: AmazonSQS
+  @Inject lateinit var queueResolver: QueueResolver
+  @Inject lateinit var sqsMetrics: SqsMetrics
+  @Inject lateinit var moshi: Moshi
+
+  private val testQueue = QueueName("test")
+
+  @BeforeEach fun createQueues() {
+    sqs.createQueue(CreateQueueRequest()
+        .withQueueName(testQueue.value)
+        .withAttributes(mapOf("VisibilityTimeout" to "1")))
+  }
+
+  @Test
+  fun getIdempotenceKey_withJobqueueMetadata() {
+    val message = Message().apply {
+      messageId = "id-0"
+      body = "body-0"
+      addMessageAttributesEntry("foo", MessageAttributeValue().withDataType("String").withStringValue("bar"))
+      addMessageAttributesEntry(SqsJob.JOBQUEUE_METADATA_ATTR,
+          MessageAttributeValue().withDataType("String").withStringValue("""{
+                |  "${SqsJob.JOBQUEUE_METADATA_ORIGIN_QUEUE}":"test",
+                |  "${SqsJob.JOBQUEUE_METADATA_IDEMPOTENCE_KEY}": "ik-0"
+                |}""".trimMargin()))
+    }
+    val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)
+
+    assertThat(job.idempotenceKey).isEqualTo("ik-0")
+    assertThat(job.attributes)
+        .containsEntry("foo", "bar")
+        .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
+  }
+
+  @Test
+  fun getIdempotenceKey_withNoJobqueueMetadata() {
+    val message = Message().apply {
+      messageId = "id-0"
+      body = "body-0"
+      addMessageAttributesEntry("foo",
+          MessageAttributeValue().withDataType("String").withStringValue("bar"))
+    }
+
+    val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)
+
+    assertThat(job.idempotenceKey).isEqualTo(job.id)
+    assertThat(job.attributes)
+        .containsEntry("foo", "bar")
+        .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
+  }
+}

--- a/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -32,11 +32,12 @@ class FakeJobQueue @Inject constructor(
   override fun enqueue(
     queueName: QueueName,
     body: String,
+    idempotenceKey: String,
     deliveryDelay: Duration?,
     attributes: Map<String, String>
   ) {
     val id = tokenGenerator.generate("fakeJobQueue")
-    val job = FakeJob(queueName, id, body, attributes)
+    val job = FakeJob(queueName, id, idempotenceKey, body, attributes)
     jobQueues.getOrPut(queueName, ::ConcurrentLinkedDeque).add(job)
   }
 
@@ -62,6 +63,7 @@ class FakeJobQueue @Inject constructor(
 data class FakeJob(
   override val queueName: QueueName,
   override val id: String,
+  override val idempotenceKey: String,
   override val body: String,
   override val attributes: Map<String, String>,
   internal var acknowledged: Boolean = false

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -8,6 +8,13 @@ interface Job {
   /** system assigned globally unique id for the job */
   val id: String
 
+  /**
+   * Application assigned key for a job.
+   *
+   * @see JobQueue.enqueue
+   */
+  val idempotenceKey: String
+
   /** body of the job */
   val body: String
 
@@ -20,6 +27,6 @@ interface Job {
    */
   fun acknowledge()
 
-  /** Moves the job from the main queue onto the associated dead letter quque. May perform an RPC */
+  /** Moves the job from the main queue onto the associated dead letter queue. May perform an RPC */
   fun deadLetter()
 }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
@@ -1,6 +1,7 @@
 package misk.jobqueue
 
 import java.time.Duration
+import java.util.UUID
 
 /**
  * A [JobQueue] enqueues jobs for asynchronous execution, possibly in another process. Jobs
@@ -12,16 +13,22 @@ interface JobQueue {
   /**
    * Enqueue a job onto the given queue, along with a set of job attributes.
    *
-   * @param queueName the name of the queue on which to place the job
+   * @param queueName The name of the queue on which to place the job.
    * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
-   * consumer to agree on the format of the body
+   * consumer to agree on the format of the body.
+   * @param idempotenceKey Client-assigned unique key, useful for application code to detect duplicate work.
+   * Implementations of both [JobQueue] and [JobConsumer] are expected to _not_ perform any filtering based on this
+   * value, as it carries meaning only for application code (i.e. any logic around this property should take place in
+   * [JobHandler]s). Defaults to a randomly generated UUID when not explicitly set.
    * @param deliveryDelay If specified, the job will only become visible to the consumer after
    * the provided duration. Used for jobs that should delay processing for a period of time.
-   * @param attributes Arbitrary contextual attributes associated with the job
+   * @param attributes Arbitrary contextual attributes associated with the job. Implementations may limit the number of
+   * attributes per message.
    */
   fun enqueue(
     queueName: QueueName,
     body: String,
+    idempotenceKey: String = UUID.randomUUID().toString(),
     deliveryDelay: Duration? = null,
     attributes: Map<String, String> = mapOf()
   )

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt
@@ -10,6 +10,13 @@ import java.util.UUID
  * atomically with a local database transaction should use the [TransactionalJobQueue] interface
  */
 interface JobQueue {
+  fun enqueue(
+    queueName: QueueName,
+    body: String,
+    deliveryDelay: Duration? = null,
+    attributes: Map<String, String> = mapOf()) =
+      enqueue(queueName, body, UUID.randomUUID().toString(), deliveryDelay, attributes)
+
   /**
    * Enqueue a job onto the given queue, along with a set of job attributes.
    *
@@ -30,6 +37,5 @@ interface JobQueue {
     body: String,
     idempotenceKey: String = UUID.randomUUID().toString(),
     deliveryDelay: Duration? = null,
-    attributes: Map<String, String> = mapOf()
-  )
+    attributes: Map<String, String> = mapOf())
 }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -3,6 +3,7 @@ package misk.jobqueue
 import misk.hibernate.Gid
 import misk.hibernate.Session
 import java.time.Duration
+import java.util.UUID
 
 /**
  * A [TransactionalJobQueue] supports enqueueing messages atomically in conjunction with
@@ -23,6 +24,10 @@ interface TransactionalJobQueue {
    * @param queueName the name of the queue on which to place the job
    * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
    * consumer to agree on the format of the body
+   * @param idempotenceKey Client-assigned unique key, useful for application code to detect duplicate work.
+   * Implementations are expected to _not_ perform any filtering based on this value, as it carries meaning only for
+   * application code (i.e. any logic around this property should take place in [JobHandler]s).
+   * Defaults to a randomly generated UUID when not explicitly set.
    * @param deliveryDelay If specified, the job will only become visible to the consumer after
    * the provided duration. Used for jobs that should delay processing for a period of time.
    * @param attributes Arbitrary contextual attributes associated with the job
@@ -32,6 +37,7 @@ interface TransactionalJobQueue {
     gid: Gid<*, *>,
     queueName: QueueName,
     body: String,
+    idempotenceKey: String = UUID.randomUUID().toString(),
     deliveryDelay: Duration? = null,
     attributes: Map<String, String> = mapOf()
   )
@@ -43,6 +49,10 @@ interface TransactionalJobQueue {
    * @param queueName the name of the queue on which to place the job
    * @param body The body of the job; can be any arbitrary string - it is up to the enqueuer and
    * consumer to agree on the format of the body
+   * @param idempotenceKey Client-assigned unique key, useful for application code to detect duplicate work.
+   * Implementations are expected to _not_ perform any filtering based on this value, as it carries meaning only for
+   * application code (i.e. any logic around this property should take place in [JobHandler]s).
+   * Defaults to a randomly generated UUID when not explicitly set.
    * @param deliveryDelay If specified, the job will only become visible to the consumer after
    * the provided duration. Used for jobs that should delay processing for a period of time.
    * @param attributes Arbitrary contextual attributes associated with the job
@@ -51,6 +61,7 @@ interface TransactionalJobQueue {
     session: Session,
     queueName: QueueName,
     body: String,
+    idempotenceKey: String = UUID.randomUUID().toString(),
     deliveryDelay: Duration? = null,
     attributes: Map<String, String> = mapOf()
   )


### PR DESCRIPTION
Add idempotence key and jobqueue internal metadata attributes

This change brings internal and misk jobqueue libraries closer in
feature-parity by offering the option to specify an application assigned
`idempotence_key` (as opposed to the system assigned `id`, only available after
a job is enqueued), which can be used by `JobHandler` implementations to detect
duplicate jobs.

## Jobqueue metadata

Internal attributes required for jobqueue-related functionality are stored in a
single message attribute (JSON-encoded `Map<String, String>`), leaving a
maximum of 8 arbitrary attributes for applications (the other reserved
attribute is for trace id; while not always present, it makes sense to assume
it'll exist and just consistently limit app keys to 8).

This change does not introduce dependency on metadata or any of its attributes,
meaning new jobs will begin having these properties as services are deployed.

The two metadata attributes added with this change are:

* Idempotence key: our internal jobqueue libs have always provided idempotence
key support, which some services heavily rely on to avoid duplicate work.

* Origin queue: when a job is transferred from main or retry queue to
dead-letter queue, it does not contain any metadata about its origins.
As we prepare to roll out a(n optional) more functional solution for
dead-lettered job management, which relies on a single, global dead-letter
queue, it's necessary to record the main queue where a job came from (so that
it's known where it should be sent to, in case of reprocessing).

Support for global DLQ (vs per-queue DLQ) will be introduced in a follow-up PR.