### PR TITLE
Introduce DynamicTypedClientFactory

### DIFF
--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -61,7 +61,7 @@ class TypedHttpClientModule<T : Any>(
     private val name: String,
     private val httpClientProvider: Provider<OkHttpClient>,
     retrofitBuilderProvider: Provider<Retrofit.Builder>?
-  ) : TypedClientFactory<T>(kclass, name, retrofitBuilderProvider), Provider<T> {
+  ) : TypedClientFactoryProvider<T>(kclass, name, retrofitBuilderProvider), Provider<T> {
 
     @Inject private lateinit var httpClientsConfig: HttpClientsConfig
     @Inject private lateinit var httpClientConfigUrlProvider: HttpClientConfigUrlProvider
@@ -121,7 +121,7 @@ class TypedPeerHttpClientModule<T : Any>(
     kclass: KClass<T>,
     name: String,
     retrofitBuilderProvider: Provider<Retrofit.Builder>?
-  ) : TypedClientFactory<T>(kclass, name, retrofitBuilderProvider),
+  ) : TypedClientFactoryProvider<T>(kclass, name, retrofitBuilderProvider),
       Provider<TypedPeerClientFactory<T>> {
 
     @Inject private lateinit var peerClientFactory: PeerClientFactory
@@ -136,15 +136,7 @@ class TypedPeerHttpClientModule<T : Any>(
   }
 }
 
-private abstract class TypedClientFactory<T : Any>(
-  private val kclass: KClass<T>,
-  private val name: String,
-  private val retrofitBuilderProvider: Provider<Retrofit.Builder>?
-) {
-
-  @Inject
-  private lateinit var httpClientsConfig: HttpClientsConfig
-
+class TypedClientFactory @Inject constructor() {
   // Use Providers for the interceptors so Guice can properly detect cycles when apps inject
   // an HTTP Client in an Interceptor.
   // https://gist.github.com/ryanhall07/e3eac6d2d47b72a4c37bce87219d7ced
@@ -163,7 +155,49 @@ private abstract class TypedClientFactory<T : Any>(
   @Inject(optional = true)
   private val eventListenerFactory: EventListener.Factory? = null
 
-  fun typedClient(client: OkHttpClient, baseUrl: String): T {
+  @Inject private lateinit var httpClientConfigUrlProvider: HttpClientConfigUrlProvider
+
+  @Inject private lateinit var httpClientFactory: HttpClientFactory
+
+  /**
+   * Build up a typed client dynamically in runtime. This is useful for platform-type services
+   * that cannot statically define all of the services they talk to.
+   *
+   * Services should cache the resulting clients to avoid incurring the construction on every call.
+   *
+   * @param endpointConfig HTTP configuration to use to connect to the service
+   * @param kclass The class of the typed client that will be built
+   * @param name A name to reference the client by for observability purposes
+   * @param retrofitBuilderProvider Optional retrofit builder override.
+   *        If not provided, an empty builder is used
+   */
+  fun <T : Any> build(
+    endpointConfig: HttpClientEndpointConfig,
+    kclass: KClass<T>,
+    name: String,
+    retrofitBuilderProvider: Provider<Retrofit.Builder>?
+  ): T {
+    val baseUrl = httpClientConfigUrlProvider.getUrl(endpointConfig)
+    val client = httpClientFactory.create(endpointConfig)
+
+    return typedClient(client, baseUrl, kclass, name, retrofitBuilderProvider)
+  }
+
+  /** Reified flavor of build */
+  inline fun <reified T : Any> build(
+    endpointConfig: HttpClientEndpointConfig,
+    name: String,
+    retrofitBuilderProvider: Provider<Retrofit.Builder>? = null
+  ): T {
+    return build(endpointConfig, T::class, name, retrofitBuilderProvider)
+  }
+
+  internal fun <T : Any> typedClient(
+    client: OkHttpClient,
+    baseUrl: String,
+    kclass: KClass<T>,
+    name: String,
+    retrofitBuilderProvider: Provider<Retrofit.Builder>?): T {
     val retrofit = (retrofitBuilderProvider?.get() ?: Retrofit.Builder())
         .baseUrl(baseUrl)
         .build()
@@ -185,5 +219,18 @@ private abstract class TypedClientFactory<T : Any>(
         arrayOf(kclass.java),
         invocationHandler
     ) as T
+  }
+}
+
+private abstract class TypedClientFactoryProvider<T : Any>(
+  private val kclass: KClass<T>,
+  private val name: String,
+  private val retrofitBuilderProvider: Provider<Retrofit.Builder>?
+) {
+
+  @Inject private lateinit var typedClientFactory: TypedClientFactory
+
+  fun typedClient(client: OkHttpClient, baseUrl: String): T {
+    return typedClientFactory.typedClient(client, baseUrl, kclass, name, retrofitBuilderProvider)
   }
 }

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -27,6 +27,7 @@ import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @MiskTest(startService = true)
@@ -34,8 +35,7 @@ internal class TypedHttpClientTest {
   @MiskTestModule
   val module = TestModule()
 
-  @Inject
-  private lateinit var jetty: JettyService
+  @Inject private lateinit var jetty: JettyService
 
   private lateinit var clientInjector: Injector
 
@@ -60,6 +60,31 @@ internal class TypedHttpClientTest {
     assertThat(response.code()).isEqualTo(200)
     assertThat(response.body()).isNotNull()
     assertThat(response.body()?.name!!).isEqualTo("supertrex")
+  }
+
+  @Test
+  fun buildDynamicClients() {
+    val typedClientFactory = clientInjector.getInstance(TypedClientFactory::class.java)
+
+    val dinoClient = typedClientFactory.build<ReturnADinosaur>(
+        HttpClientEndpointConfig(jetty.httpServerUrl.toString()),
+        "dynamicDino"
+    )
+    val response = dinoClient.getDinosaur(Dinosaur.Builder().name("trex").build()).execute()
+    assertThat(response.code()).isEqualTo(200)
+    assertThat(response.body()).isNotNull()
+    assertThat(response.body()?.name!!).isEqualTo("supertrex")
+
+    val protoDinoClient = typedClientFactory.build<ReturnAProtoDinosaur>(
+        HttpClientEndpointConfig(jetty.httpServerUrl.toString()),
+        "dynamicProtoDino"
+    )
+    val protoResponse = protoDinoClient.getDinosaur(
+        Dinosaur.Builder().name("trex").build()
+    ).execute()
+    assertThat(protoResponse.code()).isEqualTo(200)
+    assertThat(protoResponse.body()).isNotNull()
+    assertThat(protoResponse.body()?.name!!).isEqualTo("supertrex")
   }
 
   interface ReturnADinosaur {


### PR DESCRIPTION
Enables services to dynamically build up typed clients
with the same interceptors / listeners that you would
get with TypedHttpClientModule.

Useful for platform services such as backfila that may
not know all the services they talk to upfront.