### PR TITLE
Optional label selector for pods considered in app cluster

### DIFF
--- a/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterWatcher.kt
+++ b/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterWatcher.kt
@@ -67,7 +67,7 @@ internal class KubernetesClusterWatcher @Inject internal constructor(
                 null, // _continue
                 null, // fieldSelector
                 false, // includeUninitialized
-                null, // labelSelector
+                config.clustering_pod_label_selector, // labelSelector
                 null, // limit
                 null, // resourceVersion
                 null, // timeoutSeconds

--- a/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesConfig.kt
+++ b/misk/src/main/kotlin/misk/clustering/kubernetes/KubernetesConfig.kt
@@ -2,10 +2,17 @@ package misk.clustering.kubernetes
 
 import misk.config.Config
 
+/**
+ * @property clustering_pod_label_selector Optional Kubernetes label selector to filter which pods
+ *     in the namespace are considered to be in the same cluster. If omitted, all healthy pods in
+ *     the namespace are included in the cluster.
+ *     Ex: "app = helloserver".
+ */
 data class KubernetesConfig(
   val my_pod_namespace: String = System.getenv("MY_POD_NAMESPACE") ?: "<invalid-namespace>",
   val my_pod_name: String = System.getenv("MY_POD_NAME") ?: "<invalid-pod-name>",
   val my_pod_ip: String = System.getenv("MY_POD_IP") ?: "<invalid-pod-ip>",
+  val clustering_pod_label_selector: String? = null,
   val kubernetes_watch_read_timeout: Long = 60, // NB(mmihic): Needs to be long to avoid timeouts during watch
   val kubernetes_read_timeout: Long = 15,
   val kubernetes_connect_timeout: Long = 5


### PR DESCRIPTION
Not all pods in a namespace may be part of the same Misk application. This adds the ability to specify a pod label selector to specify which pods are part of the running application's cluster.