### PR TITLE
Allow apps to configure a global dead-letter queue

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -36,5 +36,19 @@ class AwsSqsJobQueueConfig(
   /**
    * Frequency used to import Queue Attributes in milliseconds.
    */
-  val queue_attribute_importer_frequency_ms: Long = 1000
+  val queue_attribute_importer_frequency_ms: Long = 1000,
+
+  /**
+   * Name of the global dead-letter queue. Optional; when set, explicitly dead-lettered jobs are
+   * sent to the specified queue, regardless of which queue they were originally submitted to/read
+   * from. When undefined, explicitly dead-lettered jobs are sent to a dead-letter queue named after
+   * the parent queue, with a "_dlq" suffix (e.g. "barb-queue" -> "barb-queue_dlq").
+   *
+   * All jobs contain a `_jobqueue-metadata` custom attribute. Any jobs sent to the global
+   * dead-letter queue can be traced to their original main queue by inspecting this property.
+   *
+   * Make sure this property is set or unset according to the AWS redrive policy for queues used
+   * by your app.
+   */
+  val global_dead_letter_queue_name: String? = null
 ) : Config

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -50,9 +50,7 @@ internal class SqsJob(
   }
 
   override fun deadLetter() {
-    if (queueName.isDeadLetterQueue) return
-
-    val dlq = queues.getForReceiving(queueName.deadLetterQueue)
+    val dlq = queues.getDeadLetter(queueName)
     dlq.call { client ->
       client.sendMessage(SendMessageRequest()
           .withQueueUrl(dlq.url)

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/QueueResolverTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/QueueResolverTest.kt
@@ -1,0 +1,51 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import misk.cloud.aws.AwsAccountId
+import misk.cloud.aws.AwsRegion
+import misk.jobqueue.QueueName
+import misk.mockito.Mockito.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.`when`
+
+internal class QueueResolverTest {
+
+  @Test
+  fun `getDeadLetter returns global DLQ when one is configured`() {
+    val queue = QueueName("barb-queue")
+    val resolved = resolver(globalDlqName = "global_dlq").getDeadLetter(queue)
+
+    assertThat(resolved.queueName).isEqualTo("global_dlq")
+  }
+
+  @Test
+  fun `getDeadLetter returns DLQ named after main queue when global DLQ is not configured`() {
+    val queue = QueueName("barb-queue")
+    val resolved = resolver(globalDlqName = null).getDeadLetter(queue)
+
+    assertThat(resolved.sqsQueueName).isEqualTo(queue.deadLetterQueue)
+  }
+
+  /** Create a test subject, optionally configured to use a global DLQ. */
+  private fun resolver(globalDlqName: String?): QueueResolver {
+    val currentRegion = AwsRegion("region")
+    val sqs = mock<AmazonSQS>()
+    `when`(sqs.getQueueUrl(any(GetQueueUrlRequest::class.java)))
+        // Any bogus value works since tests check resolved queue name, not URL.
+        .thenReturn(GetQueueUrlResult().withQueueUrl("http://bogus.info"))
+
+    return QueueResolver(
+        currentRegion = currentRegion,
+        currentAccount = AwsAccountId("account_id"),
+        defaultSQS = sqs,
+        crossRegionSQS = mapOf(currentRegion to sqs),
+        defaultForReceivingSQS = sqs,
+        crossRegionForReceivingSQS = mapOf(currentRegion to sqs),
+        externalQueues = mapOf(),
+        config = AwsSqsJobQueueConfig(global_dead_letter_queue_name = globalDlqName))
+  }
+}


### PR DESCRIPTION
Rather than forcing every queue to have its own DLQ, this change introduces the
possibility to configure a global DLQ, where all explicitly dead-lettered jobs
get sent to.

All jobs have a `_jobqueue-metadata` attribute that contains the original main
queue name. Jobs that end up in the global DLQ can be traced back to their main
queue by inspecting this property.

Unless this new property is overridden, apps will preserve existing behavior.