### PR TITLE
Added information about a HTTP request's source socket.

### DIFF
--- a/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
+++ b/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
@@ -12,6 +12,7 @@ import okio.BufferedSource
 
 data class FakeHttpCall(
   override val url: HttpUrl = "https://example.com/".toHttpUrl(),
+  override val linkLayerAddress: SocketAddress = SocketAddress.Network("1.2.3.4", 56789),
   override val dispatchMechanism: DispatchMechanism = DispatchMechanism.GET,
   override val requestHeaders: Headers = headersOf(),
   override var statusCode: Int = 200,

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -33,9 +33,6 @@ class WebTestingModule(
                 format = SslLoader.FORMAT_PEM
             ),
             mutual_auth = WebSslConfig.MutualAuth.NONE
-        ),
-        unix_domain_socket = WebUnixDomainSocketConfig(
-            path = "@test"
         )
     )
   }

--- a/misk/src/main/kotlin/misk/web/HttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/HttpCall.kt
@@ -12,12 +12,21 @@ import okio.BufferedSink
 import okio.BufferedSource
 
 /**
+ * Information about the socket on which a HTTP call arrived.
+ */
+sealed class SocketAddress {
+  class Network(val ipAddress: String, val port: Int) : SocketAddress()
+  class Unix(val path: String) : SocketAddress()
+}
+
+/**
  * A live HTTP call from a client for use by a chain of network interceptors.
  */
 interface HttpCall {
 
   /** Immutable information about the incoming HTTP request. */
   val url: HttpUrl
+  val linkLayerAddress: SocketAddress?
   val dispatchMechanism: DispatchMechanism
   val requestHeaders: Headers
 

--- a/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest
 
 internal data class ServletHttpCall(
   override val url: HttpUrl,
+  override val linkLayerAddress: SocketAddress? = null,
   override val dispatchMechanism: DispatchMechanism,
   override val requestHeaders: Headers,
   var requestBody: BufferedSource? = null,
@@ -98,6 +99,7 @@ internal data class ServletHttpCall(
       request: HttpServletRequest,
       dispatchMechanism: DispatchMechanism,
       upstreamResponse: UpstreamResponse,
+      linkLayerAddress: SocketAddress? = null,
       webSocket: WebSocket? = null,
       requestBody: BufferedSource? = null,
       responseBody: BufferedSink? = null
@@ -108,6 +110,7 @@ internal data class ServletHttpCall(
 
       return ServletHttpCall(
           url = request.httpUrl(),
+          linkLayerAddress = linkLayerAddress,
           dispatchMechanism = dispatchMechanism,
           requestHeaders = request.headers(),
           upstreamResponse = upstreamResponse,

--- a/misk/src/main/kotlin/misk/web/jetty/JettyWebSocket.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyWebSocket.kt
@@ -3,6 +3,7 @@ package misk.web.jetty
 import misk.web.BoundAction
 import misk.web.DispatchMechanism
 import misk.web.ServletHttpCall
+import misk.web.SocketAddress
 import misk.web.actions.WebAction
 import misk.web.actions.WebSocket
 import misk.web.actions.WebSocketListener
@@ -10,6 +11,8 @@ import okhttp3.Headers
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.utf8Size
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.unixsocket.UnixSocketConnector
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.api.WebSocketAdapter
 import org.eclipse.jetty.websocket.api.WriteCallback

--- a/misk/src/test/kotlin/misk/web/jetty/WebActionsServletTest.kt
+++ b/misk/src/test/kotlin/misk/web/jetty/WebActionsServletTest.kt
@@ -1,0 +1,138 @@
+package misk.web.jetty
+
+import com.netflix.concurrency.limits.limit.SettableLimit
+import com.netflix.concurrency.limits.limiter.SimpleLimiter
+import misk.Action
+import misk.ApplicationInterceptor
+import misk.asAction
+import misk.client.UnixDomainSocketFactory
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.FakeClock
+import misk.time.FakeClockModule
+import misk.web.Get
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import misk.web.ResponseContentType
+import misk.web.SocketAddress
+import misk.web.WebActionModule
+import misk.web.WebTestingModule
+import misk.web.WebUnixDomainSocketConfig
+import misk.web.actions.LivenessCheckAction
+import misk.web.actions.ReadinessCheckAction
+import misk.web.actions.StatusAction
+import misk.web.actions.WebAction
+import misk.web.interceptors.UserInterceptorTest
+import misk.web.mediatype.MediaTypes
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.Duration
+import java.util.UUID
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class WebActionsServletTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject
+  internal lateinit var jettyService: JettyService
+
+  private var socketName: String = "@udstest" + UUID.randomUUID().toString()
+
+  @Test
+  fun networkSocketSuccess() {
+    val response = get("/potato", false)
+    assertThat(response.header("ActualSocketName")).isEqualTo(
+      with (jettyService.httpServerUrl) { "${host}:${port}" }
+    )
+  }
+
+  @Test
+  fun udsSocketSuccess() {
+    val response = get("/potato", true)
+    assertThat(response.header("ActualSocketName")).isEqualTo(socketName)
+  }
+
+  internal class WebActionsServletNetworkInterceptor : NetworkInterceptor {
+    override fun intercept(chain: NetworkChain) {
+      chain.httpCall.addResponseHeaders(
+        Headers.Builder()
+          .set(
+            "ActualSocketName",
+            with (chain.httpCall.linkLayerAddress) {
+              when {
+                this is SocketAddress.Network -> "${this.ipAddress}:${this.port}"
+                this is SocketAddress.Unix -> this.path
+                else -> "null"
+              }
+            }
+          )
+          .build())
+    }
+
+    class Factory : NetworkInterceptor.Factory {
+      override fun create(action: Action): NetworkInterceptor? = WebActionsServletNetworkInterceptor()
+    }
+  }
+
+  internal class TestAction @Inject constructor() : WebAction {
+    @Get("/potato")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun call(): TestActionResponse {
+      return TestActionResponse("foo")
+    }
+  }
+
+  internal data class TestActionResponse(val text: String)
+
+  private fun get(path: String, viaUDS: Boolean): okhttp3.Response =
+    with (Request.Builder().url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())) {
+      when {
+        viaUDS -> {udsCall(get())}
+        else -> {call(get())}
+      }
+    }
+
+  private fun call(request: Request.Builder): okhttp3.Response {
+    return OkHttpClient().newCall(request.build()).execute()
+  }
+
+  private fun udsCall(request: Request.Builder): okhttp3.Response {
+    return OkHttpClient().newBuilder()
+        .socketFactory(UnixDomainSocketFactory(File(socketName)))
+        .build()
+        .newCall(request.build())
+        .execute()
+  }
+
+  inner class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(
+        WebTestingModule(
+          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+            unix_domain_socket = WebUnixDomainSocketConfig(path = socketName)
+          )
+        )
+      )
+
+      multibind<NetworkInterceptor.Factory>().toInstance(
+          WebActionsServletTest.WebActionsServletNetworkInterceptor.Factory())
+
+      install(WebActionModule.create<TestAction>())
+    }
+  }
+
+  companion object {
+    internal val TEXT_HEADERS: Headers = Headers.Builder()
+        .set("Content-Type", MediaTypes.TEXT_PLAIN_UTF8)
+        .build()
+  }
+}


### PR DESCRIPTION
The SourceSocket data class provides some identifying information about the socket on which a request arrives. Authentication interceptors will sometimes make assumptions based on the source socket (for example: accept a header value as an identity if the request arrives on a Unix domain socket).