### PR TITLE
Expose all gRPC endpoints as JSON POST endpoints

### DIFF
--- a/misk-grpc-tests/build.gradle
+++ b/misk-grpc-tests/build.gradle
@@ -32,6 +32,7 @@ protobuf {
 wire {
   kotlin {
     rpcRole = 'client'
+    javaInterop = true
   }
 
   // Generate service interfaces also.

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -155,6 +155,8 @@ internal class BoundAction<A : WebAction>(
     }
     return setOf()
   }
+
+  override fun toString() = "BoundAction[$action]"
 }
 
 /** Matches a request. Can be sorted to pick the most specific match amongst a set of candidates. */

--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -74,7 +74,7 @@ class NotFoundAction @Inject constructor(
       val alternative = alternativeActions[i]
       val metadata = alternative.action.metadata
       append("Alternative:\n")
-      append("${metadata.dispatchMechanism.method} ${metadata.pathPattern}\n")
+      append("${metadata.httpMethod} ${metadata.pathPattern}\n")
       append("Accept: ${metadata.responseMediaType}\n")
       for (requestContentType in metadata.requestMediaTypes) {
         append("Content-Type: $requestContentType\n")

--- a/misk/src/main/kotlin/misk/web/metadata/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/WebActionMetadataAction.kt
@@ -15,6 +15,7 @@ import misk.web.jetty.WebActionsServlet
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
 import okhttp3.MediaType
+import org.eclipse.jetty.http.HttpMethod
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -49,7 +50,7 @@ data class WebActionMetadata(
   val pathPattern: String,
   val applicationInterceptors: List<String>,
   val networkInterceptors: List<String>,
-  val dispatchMechanism: DispatchMechanism,
+  val httpMethod: HttpMethod,
   val allowedServices: Set<String>,
   val allowedCapabilities: Set<String>
 )
@@ -86,7 +87,7 @@ internal fun WebActionMetadata(
     pathPattern = pathPattern.toString(),
     applicationInterceptors = applicationInterceptors.map { ClassNameFormatter.format(it::class) },
     networkInterceptors = networkInterceptors.map { ClassNameFormatter.format(it::class) },
-    dispatchMechanism = dispatchMechanism,
+    httpMethod = dispatchMechanism.method,
     allowedServices = allowedServices,
     allowedCapabilities = allowedCapabilities
   )

--- a/misk/src/test/kotlin/misk/grpc/Http2ClientTestingModule.kt
+++ b/misk/src/test/kotlin/misk/grpc/Http2ClientTestingModule.kt
@@ -1,0 +1,45 @@
+package misk.grpc
+
+import com.google.inject.Provides
+import misk.MiskTestingServiceModule
+import misk.client.HttpClientEndpointConfig
+import misk.client.HttpClientModule
+import misk.client.HttpClientSSLConfig
+import misk.client.HttpClientsConfig
+import misk.inject.KAbstractModule
+import misk.security.ssl.SslLoader
+import misk.security.ssl.TrustStoreConfig
+import misk.web.jetty.JettyService
+import javax.inject.Singleton
+
+/**
+ * Configures an OkHttp client with HTTPS and HTTP/2.
+ *
+ * Create a client-specific injector for this. This is necessary because the server doesn't get a
+ * port until after it starts.
+ */
+class Http2ClientTestingModule(val jetty: JettyService) : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(HttpClientModule("default"))
+  }
+
+  @Provides
+  @Singleton
+  fun provideHttpClientsConfig(): HttpClientsConfig {
+    return HttpClientsConfig(
+        endpoints = mapOf(
+            "default" to HttpClientEndpointConfig(
+                "http://example.com/",
+                ssl = HttpClientSSLConfig(
+                    cert_store = null,
+                    trust_store = TrustStoreConfig(
+                        resource = "classpath:/ssl/server_cert.pem",
+                        format = SslLoader.FORMAT_PEM
+                    )
+                )
+            )
+        )
+    )
+  }
+}

--- a/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
@@ -1,9 +1,16 @@
 package misk.web
 
+import com.google.inject.Guice
 import com.squareup.moshi.Moshi
 import com.squareup.protos.test.parsing.Shipment
 import com.squareup.protos.test.parsing.Warehouse
+import com.squareup.wire.GrpcCall
+import com.squareup.wire.GrpcClient
+import com.squareup.wire.Service
+import com.squareup.wire.WireRpc
+import misk.grpc.Http2ClientTestingModule
 import misk.inject.KAbstractModule
+import misk.security.authz.Unauthenticated
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.actions.WebAction
@@ -15,9 +22,13 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
+/**
+ * Test that we can send JSON to proto and gRPC endpoints.
+ */
 @MiskTest(startService = true)
 internal class JsonForProtoEndpointsTest {
   @MiskTestModule
@@ -29,9 +40,16 @@ internal class JsonForProtoEndpointsTest {
   @Inject
   lateinit var jettyService: JettyService
 
+  private lateinit var httpClient: OkHttpClient
+
+  @BeforeEach
+  fun createClient() {
+    val clientInjector = Guice.createInjector(Http2ClientTestingModule(jettyService))
+    httpClient = clientInjector.getInstance(OkHttpClient::class.java)
+  }
+
   @Test
-  fun json() {
-    val httpClient = OkHttpClient()
+  fun `json to protobuf endpoint`() {
     val requestBody = Shipment.Builder()
         .shipment_token("abc")
         .build()
@@ -55,7 +73,7 @@ internal class JsonForProtoEndpointsTest {
   }
 
   @Test
-  fun protobuf() {
+  fun `json to grpc endpoint`() {
     val requestBody = Shipment.Builder()
         .shipment_token("abc")
         .build()
@@ -63,7 +81,30 @@ internal class JsonForProtoEndpointsTest {
         .warehouse_token("abc")
         .build()
 
-    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .post(moshi.adapter(Shipment::class.java).toJson(requestBody)
+            .toRequestBody(MediaTypes.APPLICATION_JSON_MEDIA_TYPE))
+        .url(serverUrlBuilder().encodedPath("/test/GetDestinationWarehouse").build())
+        .build()
+
+    val response = httpClient.newCall(request).execute()
+    response.use {
+      val responseBody = moshi.adapter(Warehouse::class.java).fromJson(response.body!!.source())
+      assertThat(responseBody).isEqualTo(expectedResponseBody)
+      assertThat(response.body!!.contentType().toString())
+          .isEqualTo("application/json;charset=utf-8")
+    }
+  }
+
+  @Test
+  fun `protobuf to protobuf endpoint`() {
+    val requestBody = Shipment.Builder()
+        .shipment_token("abc")
+        .build()
+    val expectedResponseBody = Warehouse.Builder()
+        .warehouse_token("abc")
+        .build()
+
     val request = Request.Builder()
         .post(ByteString.of(*requestBody.encode()).toRequestBody(
             MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE))
@@ -79,14 +120,36 @@ internal class JsonForProtoEndpointsTest {
     }
   }
 
+  @Test
+  fun `grpc to grpc endpoint`() {
+    val requestBody = Shipment.Builder()
+        .shipment_token("abc")
+        .build()
+    val expectedResponseBody = Warehouse.Builder()
+        .warehouse_token("abc")
+        .build()
+
+    val grpcClient = GrpcClient.Builder()
+        .baseUrl(jettyService.httpsServerUrl!!)
+        .client(httpClient)
+        .build()
+    val shippingClient = grpcClient.create(ShippingClient::class)
+
+    val responseBody = shippingClient.GetDestinationWarehouse().executeBlocking(requestBody)
+    assertThat(responseBody).isEqualTo(expectedResponseBody)
+  }
+
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
-      install(WebActionModule.create<EchoShipmentToken>())
+      install(WebTestingModule(webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+          http2 = true
+      )))
+      install(WebActionModule.create<ProtoEchoShipmentToken>())
+      install(WebActionModule.create<GrpcEchoShipmentToken>())
     }
   }
 
-  class EchoShipmentToken @Inject constructor() : WebAction {
+  class ProtoEchoShipmentToken @Inject constructor() : WebAction {
     @Post("/get_destination_warehouse")
     @RequestContentType(MediaTypes.APPLICATION_PROTOBUF)
     @ResponseContentType(MediaTypes.APPLICATION_PROTOBUF)
@@ -96,7 +159,37 @@ internal class JsonForProtoEndpointsTest {
             .build()
   }
 
+  class GrpcEchoShipmentToken @Inject constructor() :
+      ShippingGetDestinationWarehouseBlockingServer, WebAction {
+    @Unauthenticated
+    override fun GetDestinationWarehouse(shipment: Shipment): Warehouse {
+      return Warehouse.Builder()
+          .warehouse_token(shipment.shipment_token)
+          .build()
+    }
+  }
+
+  // TODO(jwilson): get Wire to generate this interface.
+  interface ShippingGetDestinationWarehouseBlockingServer : Service {
+    @WireRpc(
+        path = "/test/GetDestinationWarehouse",
+        requestAdapter = "com.squareup.protos.test.parsing.Shipment#ADAPTER",
+        responseAdapter = "com.squareup.protos.test.parsing.Warehouse#ADAPTER"
+    )
+    fun GetDestinationWarehouse(shipment: Shipment): Warehouse
+  }
+
+  // TODO(jwilson): get Wire to generate this interface.
+  interface ShippingClient : Service {
+    @WireRpc(
+        path = "/test/GetDestinationWarehouse",
+        requestAdapter = "com.squareup.protos.test.parsing.Shipment#ADAPTER",
+        responseAdapter = "com.squareup.protos.test.parsing.Warehouse#ADAPTER"
+    )
+    fun GetDestinationWarehouse(): GrpcCall<Shipment, Warehouse>
+  }
+
   private fun serverUrlBuilder(): HttpUrl.Builder {
-    return jettyService.httpServerUrl.newBuilder()
+    return jettyService.httpsServerUrl!!.newBuilder()
   }
 }

--- a/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
@@ -90,9 +90,9 @@ class TestWebActionModule : KAbstractModule() {
   // TODO(jwilson): get Wire to generate this interface.
   interface ShippingGetDestinationWarehouseBlockingServer : Service {
     @WireRpc(
-        path = "/sample.Shipping/GetDestinationWarehouse",
-        requestAdapter = "routeguide.Point#ADAPTER",
-        responseAdapter = "routeguide.Feature#ADAPTER"
+        path = "/test/GetDestinationWarehouse",
+        requestAdapter = "com.squareup.protos.test.parsing.Shipment#ADAPTER",
+        responseAdapter = "com.squareup.protos.test.parsing.Warehouse#ADAPTER"
     )
     fun GetDestinationWarehouse(requestType: Shipment): Warehouse
   }

--- a/misk/src/test/kotlin/misk/web/metadata/WebActionMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/metadata/WebActionMetadataActionTest.kt
@@ -4,10 +4,10 @@ import com.squareup.protos.test.parsing.Shipment
 import com.squareup.protos.test.parsing.Warehouse
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.web.DispatchMechanism
 import misk.web.actions.TestWebActionModule
 import misk.web.mediatype.MediaTypes
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jetty.http.HttpMethod
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -62,7 +62,7 @@ class WebActionMetadataActionTest {
     val metadata = response.webActionMetadata.find {
       it.name == TestWebActionModule.GrpcAction::class.simpleName
     }!!
-    assertThat(metadata.dispatchMechanism).isEqualTo(DispatchMechanism.GRPC)
+    assertThat(metadata.httpMethod).isEqualTo(HttpMethod.POST)
     assertThat(metadata.requestType).isEqualTo(Shipment::class.qualifiedName)
     assertThat(metadata.returnType).isEqualTo(Warehouse::class.qualifiedName)
     assertThat(metadata.types).isNotEmpty

--- a/misk/web/tabs/web-actions/src/containers/SendRequestCollapseContainer.tsx
+++ b/misk/web/tabs/web-actions/src/containers/SendRequestCollapseContainer.tsx
@@ -87,7 +87,7 @@ const SendRequestCollapseContainer = (
   }
   const method: HTTPMethod =
     simpleSelectorGet(props.simpleRedux, [`${tag}::Method`, "data"]) ||
-    action.dispatchMechanism.reverse()[0]
+    action.httpMethod.reverse()[0]
 
   // Response with fallback to error
   const response = simpleSelectorGet(
@@ -176,7 +176,7 @@ const SendRequestCollapseContainer = (
             <HTMLSelect
               large={true}
               onChange={onChangeFnCall(props.simpleMergeData, `${tag}::Method`)}
-              options={action.dispatchMechanism.sort()}
+              options={action.httpMethod.sort()}
               value={method}
             />
             <Button

--- a/misk/web/tabs/web-actions/src/containers/WebActionCardContainer.tsx
+++ b/misk/web/tabs/web-actions/src/containers/WebActionCardContainer.tsx
@@ -32,7 +32,7 @@ const WebActionCardContainer = (
   <div>
     <Card interactive={true}>
       <div css={cssHeader}>
-        {props.action.dispatchMechanism.map(m => (
+        {props.action.httpMethod.map(m => (
           <MethodTag key={m} method={m} />
         ))}
         <span css={cssFloatLeft}>

--- a/misk/web/tabs/web-actions/tests/containers/RequestFormFieldBuilderContainer.test.tsx
+++ b/misk/web/tabs/web-actions/tests/containers/RequestFormFieldBuilderContainer.test.tsx
@@ -27,7 +27,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders single body input", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST
+      httpMethod: HTTPMethod.POST
     })
     const { asFragment } = renderWithRedux(
       <RequestFormFieldBuilderContainer
@@ -42,7 +42,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form int field", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "noRepeatedInt",
       types: testTypes
     })
@@ -59,7 +59,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form nested int field", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "nestedNoRepeatedInt",
       types: testTypes
     })
@@ -76,7 +76,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form repeated short field", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -93,7 +93,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form repeated nested int field", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedNoRepeatedInt",
       types: testTypes
     })
@@ -110,7 +110,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form repeated nested repeated short field", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })
@@ -127,7 +127,7 @@ describe("RequestFormFieldBuilderContainer", () => {
   it("Renders typed form multiple top level fields", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "multipleFlatFields",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/containers/__snapshots__/FilterWebActionsContainer.test.tsx.snap
+++ b/misk/web/tabs/web-actions/tests/containers/__snapshots__/FilterWebActionsContainer.test.tsx.snap
@@ -30,9 +30,9 @@ exports[`FilterWebActionsContainer FilterWebActionsContainer can render with red
           Application Interceptor
         </option>
         <option
-          value="Dispatch Mechanism"
+          value="HTTP Method"
         >
-          Dispatch Mechanism
+          HTTP Method
         </option>
         <option
           value="Function"

--- a/misk/web/tabs/web-actions/tests/containers/__snapshots__/WebActionsContainer.test.tsx.snap
+++ b/misk/web/tabs/web-actions/tests/containers/__snapshots__/WebActionsContainer.test.tsx.snap
@@ -68,9 +68,9 @@ exports[`WebActionsContainer WebActionsContainer can render with redux loading (
             Application Interceptor
           </option>
           <option
-            value="Dispatch Mechanism"
+            value="HTTP Method"
           >
-            Dispatch Mechanism
+            HTTP Method
           </option>
           <option
             value="Function"

--- a/misk/web/tabs/web-actions/tests/ducks/__snapshots__/processMetadata.test.ts.snap
+++ b/misk/web/tabs/web-actions/tests/ducks/__snapshots__/processMetadata.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Convert incoming IWebActionAPI to IWebActionInternal processMetadata converts IWebActionAPI[] to IWebActionInternal[] 1`] = `
 Array [
   Object {
-    "allFields": "{\\"allowedCapabilities\\":[],\\"allowedServices\\":[],\\"applicationInterceptors\\":[],\\"dispatchMechanism\\":\\"GET\\",\\"function\\":\\"fun misk.web.actions.LivenessCheckAction.livenessCheck(): misk.web.Response<kotlin.String>\\",\\"functionAnnotations\\":[\\"@misk.web.Get(pathPattern=/_liveness)\\",\\"@misk.web.ResponseContentType(value=text/plain;charset=utf-8)\\",\\"@misk.security.authz.Unauthenticated()\\"],\\"name\\":\\"LivenessCheckAction\\",\\"networkInterceptors\\":[\\"misk.web.interceptors.InternalErrorInterceptorFactory$Companion$INTERCEPTOR$1\\",\\"misk.web.interceptors.RequestLogContextInterceptor\\",\\"misk.web.interceptors.RequestLoggingInterceptor\\",\\"misk.web.interceptors.MetricsInterceptor\\",\\"misk.web.interceptors.TracingInterceptor\\",\\"misk.web.exceptions.ExceptionHandlingInterceptor\\",\\"misk.web.interceptors.MarshallerInterceptor\\",\\"misk.web.interceptors.WideOpenDevelopmentInterceptor\\"],\\"parameterTypes\\":[],\\"pathPattern\\":\\"/_liveness\\",\\"requestMediaTypes\\":[\\"*/*\\"],\\"responseMediaType\\":\\"text/plain;charset=utf-8\\",\\"returnType\\":\\"misk.web.Response<kotlin.String>\\"}",
+    "allFields": "{\\"allowedCapabilities\\":[],\\"allowedServices\\":[],\\"applicationInterceptors\\":[],\\"httpMethod\\":\\"GET\\",\\"function\\":\\"fun misk.web.actions.LivenessCheckAction.livenessCheck(): misk.web.Response<kotlin.String>\\",\\"functionAnnotations\\":[\\"@misk.web.Get(pathPattern=/_liveness)\\",\\"@misk.web.ResponseContentType(value=text/plain;charset=utf-8)\\",\\"@misk.security.authz.Unauthenticated()\\"],\\"name\\":\\"LivenessCheckAction\\",\\"networkInterceptors\\":[\\"misk.web.interceptors.InternalErrorInterceptorFactory$Companion$INTERCEPTOR$1\\",\\"misk.web.interceptors.RequestLogContextInterceptor\\",\\"misk.web.interceptors.RequestLoggingInterceptor\\",\\"misk.web.interceptors.MetricsInterceptor\\",\\"misk.web.interceptors.TracingInterceptor\\",\\"misk.web.exceptions.ExceptionHandlingInterceptor\\",\\"misk.web.interceptors.MarshallerInterceptor\\",\\"misk.web.interceptors.WideOpenDevelopmentInterceptor\\"],\\"parameterTypes\\":[],\\"pathPattern\\":\\"/_liveness\\",\\"requestMediaTypes\\":[\\"*/*\\"],\\"responseMediaType\\":\\"text/plain;charset=utf-8\\",\\"returnType\\":\\"misk.web.Response<kotlin.String>\\"}",
     "allowedCapabilities": Array [
       "All",
     ],
@@ -14,14 +14,14 @@ Array [
     "authFunctionAnnotations": Array [
       "@misk.security.authz.Unauthenticated()",
     ],
-    "dispatchMechanism": Array [
-      "GET",
-    ],
     "function": "misk.web.actions.LivenessCheckAction.livenessCheck(): misk.web.Response<kotlin.String>",
     "functionAnnotations": Array [
       "@misk.web.Get(pathPattern=/_liveness)",
       "@misk.web.ResponseContentType(value=text/plain;charset=utf-8)",
       "@misk.security.authz.Unauthenticated()",
+    ],
+    "httpMethod": Array [
+      "GET",
     ],
     "name": "LivenessCheckAction",
     "networkInterceptors": Array [

--- a/misk/web/tabs/web-actions/tests/ducks/addRepeatedField.test.ts
+++ b/misk/web/tabs/web-actions/tests/ducks/addRepeatedField.test.ts
@@ -6,7 +6,7 @@ describe("Add a repeated field", () => {
   it("addRepeated", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -21,7 +21,7 @@ describe("Add a repeated field", () => {
   it("addNestedRepeated", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/ducks/generateTypesMetadata.test.ts
+++ b/misk/web/tabs/web-actions/tests/ducks/generateTypesMetadata.test.ts
@@ -15,7 +15,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get non-typed POST", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST
+      httpMethod: HTTPMethod.POST
     })
     expect(typesMetadata.size).toBe(1)
     const tmRoot = typesMetadata.get("0")
@@ -26,7 +26,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get non-repeated int", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "noRepeatedInt",
       types: testTypes
     })
@@ -36,7 +36,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get nested int", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "nestedNoRepeatedInt",
       types: testTypes
     })
@@ -53,7 +53,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get repeated short", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -73,7 +73,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get repeated nested int", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedNoRepeatedInt",
       types: testTypes
     })
@@ -101,7 +101,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("get repeated nested repeated short", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })
@@ -133,7 +133,7 @@ describe("Build typesMetadata from a raw WebActionMetadata", () => {
   it("generate multiple top level fields", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "multipleFlatFields",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/ducks/getFieldData.test.ts
+++ b/misk/web/tabs/web-actions/tests/ducks/getFieldData.test.ts
@@ -17,7 +17,7 @@ describe("Get formatted form data", () => {
   it("get non-typed POST", () => {
     const typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST
+      httpMethod: HTTPMethod.POST
     })
     const data = "Alpha"
     const getData = getFieldData(
@@ -32,7 +32,7 @@ describe("Get formatted form data", () => {
   it("get non-repeated int", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "noRepeatedInt",
       types: testTypes
     })
@@ -57,7 +57,7 @@ describe("Get formatted form data", () => {
   it("get nested int", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "nestedNoRepeatedInt",
       types: testTypes
     })
@@ -83,7 +83,7 @@ describe("Get formatted form data", () => {
   it("get repeated short", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -125,7 +125,7 @@ describe("Get formatted form data", () => {
   it("get repeated nested int", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedNoRepeatedInt",
       types: testTypes
     })
@@ -175,7 +175,7 @@ describe("Get formatted form data", () => {
   it("get repeated nested repeated short", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })
@@ -240,7 +240,7 @@ describe("Get formatted form data", () => {
   it("get data but no field input", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/ducks/handleDirtyInputField.test.ts
+++ b/misk/web/tabs/web-actions/tests/ducks/handleDirtyInputField.test.ts
@@ -9,7 +9,7 @@ describe("Set dirty input for a field", () => {
   it("Set dirty input for a field", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -26,7 +26,7 @@ describe("Set dirty input for a field", () => {
   it("Set dirty input for a nested repeated field", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/ducks/removeRepeatedField.ts
+++ b/misk/web/tabs/web-actions/tests/ducks/removeRepeatedField.ts
@@ -10,7 +10,7 @@ describe("Remove a repeated field", () => {
   it("removeRepeated", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedShort",
       types: testTypes
     })
@@ -27,7 +27,7 @@ describe("Remove a repeated field", () => {
   it("removeNestedRepeated", () => {
     let typesMetadata = generateTypesMetadata({
       ...nonTypedActionAPI,
-      dispatchMechanism: HTTPMethod.POST,
+      httpMethod: HTTPMethod.POST,
       requestType: "repeatedNestedRepeatedShort",
       types: testTypes
     })

--- a/misk/web/tabs/web-actions/tests/testUtilities.ts
+++ b/misk/web/tabs/web-actions/tests/testUtilities.ts
@@ -97,7 +97,7 @@ export const nonTypedActionAPI: IWebActionAPI = {
   allowedCapabilities: [] as string[],
   allowedServices: [] as string[],
   applicationInterceptors: [] as string[],
-  dispatchMechanism: HTTPMethod.GET,
+  httpMethod: HTTPMethod.GET,
   function:
     "fun misk.web.actions.LivenessCheckAction.livenessCheck(): misk.web.Response<kotlin.String>",
   functionAnnotations: [


### PR DESCRIPTION
We use the same mechanism we were using to expose proto endpoints
as JSON endpoints.

This also changes misk-web to use httpMethod instead of
dispatchMechanism to describe server-side endpoints. These
two concepts are related but different and conflating them
was broken for gRPC.