### PR TITLE
Upgrade tidb version to use experimental autorandom feature in testing

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/database/StartDatabaseService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/StartDatabaseService.kt
@@ -124,6 +124,7 @@ class StartDatabaseService(
           DataSourceType.TIDB -> {
             DockerTidbCluster(
                 moshi = moshi,
+                resourceLoader = ResourceLoader.SYSTEM,
                 config = config.config,
                 docker = docker)
           }

--- a/misk-hibernate/src/main/resources/misk/tidb/tidb.toml
+++ b/misk-hibernate/src/main/resources/misk/tidb/tidb.toml
@@ -1,0 +1,2 @@
+[experimental]
+allow-auto-random = true

--- a/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v1__movies.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v1__movies.sql
@@ -1,5 +1,5 @@
 CREATE TABLE movies(
-    id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    id bigint NOT NULL PRIMARY KEY AUTO_RANDOM,
     created_at timestamp(3) NOT NULL DEFAULT NOW(3),
     updated_at timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
     name varchar(191) NOT NULL,

--- a/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v2__actors.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v2__actors.sql
@@ -1,5 +1,5 @@
 CREATE TABLE actors(
-    id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    id bigint NOT NULL PRIMARY KEY AUTO_RANDOM,
     created_at timestamp(3) NOT NULL DEFAULT NOW(3),
     updated_at timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
     name varchar(255) NOT NULL,

--- a/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v3__characters.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/moviestestmodule-tidb/v3__characters.sql
@@ -1,5 +1,5 @@
 CREATE TABLE characters(
-    id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    id bigint NOT NULL PRIMARY KEY AUTO_RANDOM,
     created_at timestamp(3) NOT NULL DEFAULT NOW(3),
     updated_at timestamp(3) NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
     name varchar(200) NOT NULL,


### PR DESCRIPTION
Upgrading to TiDB 3.1.0-rc to use experimental (will graduate in GA) auto_random primary keys