### PR TITLE
Enable gzip compression by default

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -55,7 +55,7 @@ data class WebConfig(
    * If true responses which are larger than the minGzipSize will be compressed. Gzip compression
    * always enabled for requests and cannot be turned off.
    */
-  val gzip: Boolean = false,
+  val gzip: Boolean = true,
 
   /** The minimum size in bytes before the response body will be compressed. */
   val minGzipSize: Int = 1024

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -8,6 +8,7 @@ import misk.security.ssl.SslLoader
 import misk.security.ssl.TlsProtocols
 import misk.web.WebConfig
 import misk.web.WebSslConfig
+import misk.web.mediatype.MediaTypes
 import okhttp3.HttpUrl
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory
@@ -185,6 +186,7 @@ class JettyService @Inject internal constructor(
     if (webConfig.gzip) {
       gzipHandler.minGzipSize = webConfig.minGzipSize
       gzipHandler.addIncludedMethods("POST")
+      gzipHandler.addExcludedMimeTypes(MediaTypes.APPLICATION_GRPC)
     } else {
       // GET is enabled by default for gzipHandler.
       gzipHandler.addExcludedMethods("GET")

--- a/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
@@ -48,7 +48,7 @@ internal class JettyServiceMetricsTest {
     assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(130.0)
-    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(153.0)
     assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
 
@@ -69,7 +69,7 @@ internal class JettyServiceMetricsTest {
     assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(0.0)
     assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(130.0)
-    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(153.0)
     assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
 
@@ -78,7 +78,7 @@ internal class JettyServiceMetricsTest {
     assertThat(connectionMetrics.acceptedConnections.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.activeConnections.labels(*labels).get()).isEqualTo(0.0)
     assertThat(connectionMetrics.bytesReceived.labels(*labels).get()).isEqualTo(130.0)
-    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(118.0)
+    assertThat(connectionMetrics.bytesSent.labels(*labels).get()).isEqualTo(153.0)
     assertThat(connectionMetrics.messagesReceived.labels(*labels).get()).isEqualTo(1.0)
     assertThat(connectionMetrics.messagesSent.labels(*labels).get()).isEqualTo(1.0)
   }


### PR DESCRIPTION
Let's enable gzip compression for responses by default. This dramatically reduces page load times for misk apps using misk-web UIs.

Enabling this option for my service allowed me to serve javascript which was 2-3.5x smaller, and CSS which was about 9x smaller, which is such a huge win on slow home networks.