### PR TITLE
Improve vitess scale safety checks.

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
@@ -23,7 +23,7 @@ object ScaleSafetyChecks {
   }
 
   fun checkQueryForTableScan(connection: Connection, query: String) {
-    if (isDml(query)) return
+    if (isDml(query) || query.startsWith("EXPLAIN", true)) return
 
     val explanations = connection.createStatement().use { statement ->
       try {


### PR DESCRIPTION
These PR addresses two issues:
- don't explain explain queries
- match tables by word boundaries. This avoid exceptions analyzing queries for sequence tables where ```select next, val from customer_token_lookup_seq``` will match ```customer_token_lookup``` in the ```service_lookup``` keyspace, for instancr