### PR TITLE
Use the right keyspace when the statement is used instead of during connection creation

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlScaleSafetyChecks.kt
@@ -61,7 +61,7 @@ class MySqlScaleSafetyChecks(
       val queries = ScaleSafetyChecks.extractQueriesSince(connection, mysqlTime)
 
       for (rawQuery in queries) {
-        ScaleSafetyChecks.checkQueryForTableScan(connection, rawQuery)
+        ScaleSafetyChecks.checkQueryForTableScan(connection, null, rawQuery)
       }
     }
   }

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
@@ -22,11 +22,12 @@ object ScaleSafetyChecks {
     }
   }
 
-  fun checkQueryForTableScan(connection: Connection, query: String) {
+  fun checkQueryForTableScan(connection: Connection, database: String?, query: String) {
     if (isDml(query) || query.startsWith("EXPLAIN", true)) return
 
     val explanations = connection.createStatement().use { statement ->
       try {
+        database?.let { statement.execute("USE `$it`") }
         retry(5, FlatBackoff(Duration.ofMillis(100))) {
           statement.executeQuery("EXPLAIN ${query.replace("\n", " ")}")
               .map { Explanation.fromResultSet(it) }

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/VitessScaleSafetyChecks.kt
@@ -137,9 +137,8 @@ class VitessScaleSafetyChecks(
             } else {
               "vt_${name}_0"
             }
-            connection!!.createStatement().use { s -> s.execute("USE `$database`") }
 
-            ScaleSafetyChecks.checkQueryForTableScan(c, rawQuery)
+            ScaleSafetyChecks.checkQueryForTableScan(c, database, rawQuery)
           }
         }
       }


### PR DESCRIPTION
I think given that connection is shared is better to use the keyspace database before the explain check