### PR TITLE
Close vschema.json source file after reading

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/database/DockerVitessCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/DockerVitessCluster.kt
@@ -91,7 +91,10 @@ class VitessCluster(
         .toList().filter { Files.isDirectory(it) }
     return keyspaceDirs.associateBy(
         { it.fileName.toString() },
-        { keyspaceAdapter.fromJson(it.resolve("vschema.json").source().buffer())!! })
+        {
+          val source = it.resolve("vschema.json").source()
+          source.use { keyspaceAdapter.fromJson(source.buffer())!! }
+        })
   }
 
   /**


### PR DESCRIPTION
I noticed in cash-token that there were lots of "Too many files open" exception pointing at the vschema file. This was puzzling but after some investigation it pointed at the code reading the vschema file but couldn't see any resource cleanup.