### PR TITLE
Ignore headers that doesn't pass okhttp validation.

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -181,7 +181,7 @@ internal fun HttpServletResponse.headers(): Headers {
   val result = Headers.Builder()
   for (name in headerNames) {
     for (value in getHeaders(name)) {
-      result.add(name, value)
+      result.addUnsafeNonAscii(name, value)
     }
   }
   return result.build()


### PR DESCRIPTION
This is a temporary fix. I want to gain a better understanding why that
is there and possible replace okhttp.Header for incoming web requests