### PR TITLE
Publish snapshots to Github Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to Github Packages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Publish packages
+        if: github.repository == 'cashapp/misk'
+        run: ./gradlew -x samples:exemplar:publish -x samples:exemplarchat:publish -Dorg.gradle.internal.publish.checksums.insecure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,25 @@ subprojects { subProject ->
   if (!name.startsWith("samples")) {
     apply plugin: 'com.vanniktech.maven.publish'
   }
+  apply plugin: 'maven-publish'
+
+  publishing {
+    repositories {
+      maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/cashapp/misk")
+        credentials {
+          username = 'cashapp'
+          password = System.getenv('GITHUB_TOKEN')
+        }
+      }
+    }
+    publications {
+      gpr(MavenPublication) {
+        from(components.java)
+      }
+    }
+  }
 
   // Workaround the Gradle bug resolving multiplatform dependencies.
   // https://github.com/square/okio/issues/647


### PR DESCRIPTION
Fixes #1489 

I tested this on my fork and it worked like a charm. I did end up using the maven-publish plugin which was easier to get working, I wasn't sure on the benefit of the existing plugin. Happy to discuss that though.

This should publish snapshots to Github Packages on pushes to master (merging PR's counts), and it'll only run on the cashapp/misk project, not any forks.

If this is merged, I'll update the broken link in the README in a followup.