### PR TITLE
Remove deprecated Environment from DataSourceConfig.kt

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlScaleSafetyChecks.kt
@@ -1,6 +1,8 @@
 package misk.jdbc
 
 import com.zaxxer.hikari.util.DriverDataSource
+import misk.environment.Deployment
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import misk.hibernate.Check
 import misk.hibernate.Transacter
@@ -35,7 +37,7 @@ class MySqlScaleSafetyChecks(
   fun connect(): Connection {
     return try {
       DriverDataSource(
-        config.buildJdbcUrl(Environment.TESTING),
+        config.buildJdbcUrl(TEST_DEPLOYMENT),
         config.type.driverClassName,
         Properties(),
         config.username,

--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
@@ -1,6 +1,8 @@
 package misk.jdbc
 
 import com.zaxxer.hikari.util.DriverDataSource
+import misk.environment.Deployment
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import java.sql.Connection
 import java.sql.SQLException
@@ -19,7 +21,7 @@ internal class MySqlTestDatabasePoolBackend @Inject constructor(
   internal val connection: Connection by lazy {
     try {
       DriverDataSource(
-          config.buildJdbcUrl(Environment.TESTING),
+          config.buildJdbcUrl(TEST_DEPLOYMENT),
           config.type.driverClassName,
           Properties(),
           config.username,

--- a/misk-hibernate/src/main/kotlin/misk/database/DockerCockroachCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/DockerCockroachCluster.kt
@@ -10,6 +10,8 @@ import com.zaxxer.hikari.util.DriverDataSource
 import misk.backoff.DontRetryException
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
+import misk.environment.Deployment
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceType
@@ -31,8 +33,7 @@ class CockroachCluster(
   fun openConnection(): Connection = dataSource().connection
 
   private fun dataSource(): DriverDataSource {
-    val jdbcUrl = config.withDefaults().buildJdbcUrl(
-        Environment.TESTING)
+    val jdbcUrl = config.withDefaults().buildJdbcUrl(TEST_DEPLOYMENT)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(),
         config.username, config.password)

--- a/misk-hibernate/src/main/kotlin/misk/database/DockerPostgresServer.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/DockerPostgresServer.kt
@@ -9,6 +9,7 @@ import com.zaxxer.hikari.util.DriverDataSource
 import misk.backoff.DontRetryException
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.uniqueInt
@@ -185,7 +186,7 @@ class DockerPostgresServer(
     fun openConnection(): Connection = dataSource().connection
 
     private fun dataSource(): DriverDataSource {
-      val jdbcUrl = config.withDefaults().copy(database = "postgres").buildJdbcUrl(Environment.TESTING)
+      val jdbcUrl = config.withDefaults().copy(database = "postgres").buildJdbcUrl(TEST_DEPLOYMENT)
       return DriverDataSource(
           jdbcUrl,
           config.type.driverClassName,

--- a/misk-hibernate/src/main/kotlin/misk/database/DockerTidbCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/DockerTidbCluster.kt
@@ -15,6 +15,7 @@ import com.zaxxer.hikari.util.DriverDataSource
 import misk.backoff.DontRetryException
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceType
@@ -55,8 +56,7 @@ class TidbCluster(
   fun openConnection(): Connection = dataSource().connection
 
   private fun dataSource(): DriverDataSource {
-    val jdbcUrl = config.withDefaults().buildJdbcUrl(
-        Environment.TESTING)
+    val jdbcUrl = config.withDefaults().buildJdbcUrl(TEST_DEPLOYMENT)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(),
         config.username, config.password)

--- a/misk-hibernate/src/main/kotlin/misk/database/DockerVitessCluster.kt
+++ b/misk-hibernate/src/main/kotlin/misk/database/DockerVitessCluster.kt
@@ -16,6 +16,7 @@ import com.zaxxer.hikari.util.DriverDataSource
 import misk.backoff.DontRetryException
 import misk.backoff.ExponentialBackoff
 import misk.backoff.retry
+import misk.environment.DeploymentModule.Companion.TEST_DEPLOYMENT
 import misk.environment.Environment
 import misk.jdbc.DataSourceConfig
 import misk.jdbc.DataSourceType
@@ -108,8 +109,7 @@ class VitessCluster(
   fun openMysqlConnection() = mysqlDataSource().connection
 
   private fun dataSource(): DriverDataSource {
-    val jdbcUrl = config.withDefaults().buildJdbcUrl(
-        Environment.TESTING)
+    val jdbcUrl = config.withDefaults().buildJdbcUrl(TEST_DEPLOYMENT)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(),
         config.username, config.password)
@@ -125,7 +125,7 @@ class VitessCluster(
 
   private fun mysqlDataSource(): DriverDataSource {
     val config = mysqlConfig()
-    val jdbcUrl = config.buildJdbcUrl(Environment.TESTING)
+    val jdbcUrl = config.buildJdbcUrl(TEST_DEPLOYMENT)
     return DriverDataSource(
         jdbcUrl, config.type.driverClassName, Properties(),
         config.username, config.password)

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -1,7 +1,7 @@
 package misk.jdbc
 
 import misk.config.Config
-import misk.environment.Environment
+import misk.environment.Deployment
 import java.time.Duration
 
 /** Defines a type of datasource */
@@ -131,7 +131,7 @@ data class DataSourceConfig(
     }
   }
 
-  fun buildJdbcUrl(env: Environment): String {
+  fun buildJdbcUrl(deployment: Deployment): String {
     val config = withDefaults()
 
     require(config.client_certificate_key_store_path.isNullOrBlank() || config.client_certificate_key_store_url.isNullOrBlank()) {
@@ -146,7 +146,7 @@ data class DataSourceConfig(
       DataSourceType.MYSQL, DataSourceType.VITESS_MYSQL, DataSourceType.TIDB -> {
         var queryParams = "?useLegacyDatetimeCode=false"
 
-        if (env == Environment.TESTING || env == Environment.DEVELOPMENT) {
+        if (deployment.isFake) {
           queryParams += "&createDatabaseIfNotExist=true"
         }
 
@@ -259,7 +259,7 @@ data class DataSourceConfig(
       }
       DataSourceType.COCKROACHDB, DataSourceType.POSTGRESQL -> {
         var params = "ssl=false&user=${config.username}"
-        if (env == Environment.TESTING || env == Environment.DEVELOPMENT) {
+        if (deployment.isFake) {
           params += "&createDatabaseIfNotExist=true"
         }
         "jdbc:postgresql://${config.host}:${config.port}/${config.database}?$params"

--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.AbstractIdleService
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
+import misk.environment.Deployment
 import misk.environment.Environment
 import misk.logging.getLogger
 import misk.metrics.Metrics
@@ -23,7 +24,7 @@ import kotlin.reflect.KClass
 class DataSourceService(
   private val qualifier: KClass<out Annotation>,
   private val baseConfig: DataSourceConfig,
-  private val environment: Environment,
+  private val deployment: Deployment,
   private val dataSourceDecorators: Set<DataSourceDecorator>,
   private val databasePool: DatabasePool,
   private val metrics: Metrics? = null
@@ -54,7 +55,7 @@ class DataSourceService(
 
     val hikariConfig = HikariConfig()
     hikariConfig.driverClassName = config.type.driverClassName
-    hikariConfig.jdbcUrl = config.buildJdbcUrl(environment)
+    hikariConfig.jdbcUrl = config.buildJdbcUrl(deployment)
     if (config.username != null) {
       hikariConfig.username = config.username
     }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/SchemaValidatorTest.kt
@@ -21,6 +21,8 @@ import misk.resources.ResourceLoader
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.database.StartDatabaseService
+import misk.environment.Deployment
+import misk.environment.DeploymentModule
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.SessionFactory
@@ -54,7 +56,7 @@ internal class SchemaValidatorTest {
       val dataSourceService = DataSourceService(
           qualifier = qualifier,
           baseConfig = config.data_source,
-          environment = Environment.TESTING,
+          deployment = DeploymentModule.TEST_DEPLOYMENT,
           dataSourceDecorators = emptySet(),
           databasePool = RealDatabasePool
       )
@@ -114,7 +116,7 @@ internal class SchemaValidatorTest {
       install(ServiceModule<PingDatabaseService>(qualifier)
           .dependsOn<StartDatabaseService>(qualifier))
       bind(keyOf<PingDatabaseService>(qualifier))
-          .toInstance(PingDatabaseService(config.data_source, Environment.TESTING))
+          .toInstance(PingDatabaseService(config.data_source, DeploymentModule.TEST_DEPLOYMENT))
 
       install(ServiceModule<DataSourceService>(qualifier)
           .dependsOn<PingDatabaseService>(qualifier))

--- a/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -1,5 +1,6 @@
 package misk.jdbc
 
+import misk.environment.DeploymentModule
 import misk.environment.Environment
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -8,7 +9,7 @@ class DataSourceConfigTest {
   @Test
   fun buildVitessJDBCUrlNoSSL() {
     val config = DataSourceConfig(DataSourceType.VITESS)
-    assertEquals("jdbc:vitess://127.0.0.1:27001/", config.buildJdbcUrl(Environment.TESTING))
+    assertEquals("jdbc:vitess://127.0.0.1:27001/", config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -18,7 +19,7 @@ class DataSourceConfigTest {
         trust_certificate_key_store_password = "changeit")
     assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
         "trustStorePassword=changeit&useSSL=true",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -28,7 +29,7 @@ class DataSourceConfigTest {
         client_certificate_key_store_password = "changeit")
     assertEquals("jdbc:vitess://127.0.0.1:27001/?keyStore=path/to/keystore&" +
         "keyStorePassword=changeit&useSSL=true",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -41,7 +42,7 @@ class DataSourceConfigTest {
     assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
         "trustStorePassword=changeit&keyStore=path/to/keystore&" +
         "keyStorePassword=changeit&useSSL=true",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -53,7 +54,7 @@ class DataSourceConfigTest {
         client_certificate_key_store_password = "changeit")
     assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
         "trustStorePassword=changeit&keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -65,7 +66,7 @@ class DataSourceConfigTest {
         client_certificate_key_store_password = "changeit")
     assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
         "trustStorePassword=changeit&keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -77,7 +78,7 @@ class DataSourceConfigTest {
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
         "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -89,7 +90,7 @@ class DataSourceConfigTest {
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
         "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -107,7 +108,7 @@ class DataSourceConfigTest {
         "clientCertificateKeyStoreUrl=file://path/to/keystore&" +
         "clientCertificateKeyStorePassword=changeit&" +
         "sslMode=VERIFY_IDENTITY",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 
   @Test
@@ -115,6 +116,6 @@ class DataSourceConfigTest {
     val config = DataSourceConfig(DataSourceType.MYSQL)
     assertEquals("jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&sslMode=PREFERRED",
-        config.buildJdbcUrl(Environment.TESTING))
+        config.buildJdbcUrl(DeploymentModule.TEST_DEPLOYMENT))
   }
 }

--- a/misk/src/main/kotlin/misk/environment/Environment.kt
+++ b/misk/src/main/kotlin/misk/environment/Environment.kt
@@ -15,6 +15,15 @@ enum class Environment {
 
   fun isReal(): Boolean = !isFake()
 
+  fun toDeployment(): Deployment {
+    return Deployment(
+        name = name,
+        isProduction = this == Environment.PRODUCTION || this == Environment.STAGING,
+        isTest =  this == Environment.TESTING,
+        isLocalDevelopment = this == Environment.DEVELOPMENT
+    )
+  }
+
   companion object {
     internal val logger = getLogger<Environment>()
     private const val ENV_ENVIRONMENT = "ENVIRONMENT"


### PR DESCRIPTION
This would be a breaking change, since injection would fail if `Deployment` is not provided. That said, it would be a fairly easy change for users to accommodate. 