### PR TITLE
Plaintext HTTP listener support for h2c

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -77,5 +77,7 @@ data class WebSslConfig(
 
 data class WebUnixDomainSocketConfig(
   /** The Unix Domain Socket to listen on. */
-  val path: String
+  val path: String,
+  /** If true, the listener will support H2C. */
+  val h2c: Boolean? = true
 )


### PR DESCRIPTION
If the config specifies http2 support, adds h2c listeners to non-TLS listeners.