### PR TITLE
Added an equals function to allow two X500Names to be compared.

### DIFF
--- a/misk/src/main/kotlin/misk/security/cert/X500Name.kt
+++ b/misk/src/main/kotlin/misk/security/cert/X500Name.kt
@@ -1,16 +1,21 @@
 package misk.security.cert
 
-class X500Name(private val components: Map<String, String>) {
-  val commonName = get("CN")
-  val organization = get("O")
-  val organizationalUnit = get("OU")
-  val state = get("ST")
-  val locality = get("L")
-  val country = get("C")
-
-  operator fun get(componentName: String) = components[componentName.toUpperCase()]
-
-  fun asMap() = components
+data class X500Name(
+  val commonName: String?,
+  val organizationalUnit: String?,
+  val organization: String?,
+  val locality: String?,
+  val state: String?,
+  val country: String?
+) {
+  constructor(components: Map<String, String>) : this(
+      commonName = components.get("CN"),
+      organizationalUnit = components.get("OU"),
+      organization = components.get("O"),
+      locality = components.get("L"),
+      state = components.get("ST"),
+      country = components.get("C")
+  )
 
   companion object {
     fun parse(dnString: String): X500Name {

--- a/misk/src/test/kotlin/misk/security/cert/X500NameTest.kt
+++ b/misk/src/test/kotlin/misk/security/cert/X500NameTest.kt
@@ -8,34 +8,32 @@ internal class X500NameTest {
   @Test fun parse() {
     val name = X500Name.parse(
         "CN=Marshall T. Rose, O=Dover Beach Consulting Ltd., L=Santa Clara, ST=California, OU=Sales, C=US\n")
-    assertThat(name.asMap()).isEqualTo(mapOf(
-        "CN" to "Marshall T. Rose",
-        "OU" to "Sales",
-        "O" to "Dover Beach Consulting Ltd.",
-        "L" to "Santa Clara",
-        "ST" to "California",
-        "C" to "US"
+    assertThat(name).isEqualTo(X500Name(
+        "Marshall T. Rose",
+        "Sales",
+        "Dover Beach Consulting Ltd.",
+        "Santa Clara",
+        "California",
+        "US"
     ))
   }
 
   @Test fun parseWithEscaping() {
     val name = X500Name.parse(
         """CN=Marshall T. Rose\, Esq., O="Dover Beach Consulting, Ltd."; L = Santa Clara; OU=Sales, ST=California, C=US""")
-    assertThat(name.asMap()).isEqualTo(mapOf(
-        "CN" to "Marshall T. Rose, Esq.",
-        "OU" to "Sales",
-        "O" to "Dover Beach Consulting, Ltd.",
-        "L" to "Santa Clara",
-        "ST" to "California",
-        "C" to "US"
+    assertThat(name).isEqualTo(X500Name(
+        "Marshall T. Rose, Esq.",
+        "Sales",
+        "Dover Beach Consulting, Ltd.",
+        "Santa Clara",
+        "California",
+        "US"
     ))
   }
 
   @Test fun handlesTrailingWhitespace() {
     val name = X500Name.parse("CN=Marshall T. Rose\n  \t")
-    assertThat(name.asMap()).isEqualTo(mapOf(
-        "CN" to "Marshall T. Rose"
-    ))
+    assertThat(name).isEqualTo(X500Name(mapOf("CN" to "Marshall T. Rose")))
   }
 
   @Test fun endsInAttributeName() {


### PR DESCRIPTION
The X500Name objects cannot currently be compared in tests in a nice way. Converting `X500Name` to a data class will allow comparisons in tests like:
`assertThat(actualSubject).isEqualTo(X500Name(mapOf("O" to "Square, Inc.", "OU" to "potato"))`