### PR TITLE
Do not randomly close Unix domain socket connections

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/RebalancingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RebalancingInterceptor.kt
@@ -5,6 +5,7 @@ import misk.logging.getLogger
 import misk.random.ThreadLocalRandom
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
+import misk.web.SocketAddress
 import misk.web.WebConfig
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,12 +16,22 @@ private val logger = getLogger<RebalancingInterceptor>()
  * When we're deploying and redeploying our pods, we want to make sure that clients rebalance onto
  * the new pods. This randomly closes connections so they will be recreated, naturally balancing
  * connections across pods.
+ *
+ * This does not close Unix domain socket connections. This interceptor is intended to mitigate
+ * imbalanced load from long-lived client connections maintained from client apps.
+ * Connections over UDS are oriented towards service mesh sidecars that employ sufficient
+ * client-side load balancing.
  */
 class RebalancingInterceptor @Inject constructor(
   private val random: ThreadLocalRandom,
   private val probability: Double
 ) : NetworkInterceptor {
   override fun intercept(chain: NetworkChain) {
+    if (chain.httpCall.linkLayerLocalAddress is SocketAddress.Unix) {
+      chain.proceed(chain.httpCall)
+      return
+    }
+
     if (random.current().nextDouble() < probability) {
       chain.httpCall.setResponseHeader("Connection", "close")
     }


### PR DESCRIPTION
Connections over a Unix domain do not need to be randomly closed. The proxy in front of it should handle this if it's needed, although in our case Istio will load balance properly for us.