### PR TITLE
Allow opting out of scale safety checks

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
@@ -34,7 +34,9 @@ class HibernateTestingModule(
   private val qualifier: KClass<out Annotation>,
   private val config: DataSourceConfig? = null,
   private val startUpStatements: List<String> = listOf(),
-  private val shutDownStatements: List<String> = listOf()
+  private val shutDownStatements: List<String> = listOf(),
+  // TODO: default to opt-out once these are ready for prime time.
+  private val scaleSafetyChecks: Boolean = false
 ) : KAbstractModule() {
   override fun configure() {
     install(ServiceModule<ForceUtcTimeZoneService>())
@@ -44,7 +46,7 @@ class HibernateTestingModule(
     val transacterKey = Transacter::class.toKey(qualifier)
     val transacterProvider = getProvider(transacterKey)
 
-    bindScaleSafetyChecks(transacterProvider)
+    if (scaleSafetyChecks) bindScaleSafetyChecks(transacterProvider)
 
     val dataSourceConnector = getProvider(keyOf<DataSourceConnector>(qualifier))
     install(ServiceModule(truncateTablesServiceKey)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -16,7 +16,8 @@ import misk.time.FakeClockModule
 
 /** This module creates movies, actors, and characters tables for several Hibernate tests. */
 class MoviesTestModule(
-  private val type: DataSourceType = DataSourceType.VITESS_MYSQL
+  private val type: DataSourceType = DataSourceType.VITESS_MYSQL,
+  private val scaleSafetyChecks: Boolean = false
 ) : KAbstractModule() {
   override fun configure() {
     install(LogCollectorModule())
@@ -27,7 +28,7 @@ class MoviesTestModule(
 
     val config = MiskConfig.load<MoviesConfig>("moviestestmodule", Environment.TESTING)
     val dataSourceConfig = selectDataSourceConfig(config)
-    install(HibernateTestingModule(Movies::class, dataSourceConfig))
+    install(HibernateTestingModule(Movies::class, dataSourceConfig, scaleSafetyChecks = scaleSafetyChecks))
     install(HibernateModule(Movies::class, MoviesReader::class,
         DataSourceClusterConfig(writer = dataSourceConfig, reader = dataSourceConfig)))
     install(object : HibernateEntityModule(Movies::class) {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/VitessScaleSafetyTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/VitessScaleSafetyTest.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 @MiskTest(startService = true)
 class VitessScaleSafetyTest {
   @MiskTestModule
-  val module = MoviesTestModule()
+  val module = MoviesTestModule(scaleSafetyChecks = true)
 
   @Inject @Movies lateinit var sessionFactory: SessionFactory
   @Inject @Movies lateinit var transacter: Transacter


### PR DESCRIPTION
This option severely impacts test suite performance.

A misk app I was updating went from 20s to run the full test suite to 12m,
while causing a test to systematically fail.

Comparison used the exact same code as `HibernateTestModule` but without
`bindScaleSafetyCheck`.

---

In understand the value of having this (hence the change to make this opt-out, rather than opt-in) but the impact to tests shouldn't have to be this high.