### PR TITLE
Include encryption context in ciphertext

### DIFF
--- a/misk-crypto/FORMAT.md
+++ b/misk-crypto/FORMAT.md
@@ -1,0 +1,62 @@
+# Misk encryption packet format
+## Overview
+Misk uses Tink to encrypt data, which uses Additional Authentication Data (AAD) 
+to authenticate ciphertext.
+
+Instead of using Tink's byte array AAD, 
+Misk introduces a new, higher level abstraction, that’ll be used instead of the encryption 
+interfaces Tink exposes to users.
+
+The main reasons to do this are:
+1. Preventing the misuse of AAD
+2. Preventing undecipherable ciphertext from being created
+3. Exposing a user friendlier interface
+## Details
+The use of AAD can be confusing to users. 
+In Tink, AAD is represented by an array of bytes, which is hard to deal with when debugging
+and can be easily corrupted and misused.
+
+On top of that, different languages and environments may parse byte arrays in different ways.
+
+Instead of letting misk-crypto users supply their own byte array as AAD, 
+we decided to expose a more convenient data structure - a map of strings where 
+each key-value pair in the map represents a context variable and its value.
+
+When encrypting/decrypting with misk-crypto
+the encryption context map will be serialized to a byte array and used instead.
+## Encryption Context Specification
+- `Map<String, String>`
+- `null` values are *not* allowed
+- Empty maps are *not* allowed
+- Empty keys or values are *not* allowed
+- Map keys and value lengths are limited to `Short.MAX_VALUE`
+- The entire serialized encryption context is also limited to `Short.MAX_VALUE`
+- EC is optional, and can be completely omitted from the encryption operation
+
+The encryption context will be serialized using the following format:
+```
+[ [ varint: pair count ] 
+  [ pairs: 
+    (
+      [ varint: key length ] [ bytearray: key ]
+      [ varint: value length ] [ bytearray: value ]
+    )*
+] ]
+```
+All lengths are encoded is `varint` using [Google's Protocol Buffers](https://developers.google.com/protocol-buffers/docs/encoding#varints) encoding
+## Misk Ciphertext Format
+The serialized EC used when creating the ciphertext and the ciphertext are put together in the following format.
+```
+[ 0xEE: magic byte + version ]
+[ varint: AAD length ] 
+[ AAD ]
+[ tink ciphertext ]
+```
+| Size | Description | Type |
+|------|-------------|------|
+| 1 | Schema version, encoded as a single byte. Currently set to 0xEE | Byte |
+| varint | Serialized AAD length | Integer |
+| AAD array length | Serialized AAD | ByteArray |
+| Ciphertext length | Ciphertext | ByteArray |
+
+__Note__: If the ciphertext doesn't have an encryption context associated with it, the AAD length field is set to 0.

--- a/misk-crypto/src/main/kotlin/misk/crypto/CiphertextFormat.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CiphertextFormat.kt
@@ -1,0 +1,304 @@
+package misk.crypto
+
+import com.google.common.annotations.VisibleForTesting
+import com.google.common.io.ByteStreams
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.security.GeneralSecurityException
+
+/**
+ * Wraps a ciphertext and the encryption context associated with it in a [ByteArray].
+ *
+ * Misk uses Tink to encrypt data, which uses Encryption Context (EC),
+ * or Additional Authentication Data (AAD) to authenticate ciphertext.
+ * This class introduces a new, higher level abstraction, that’ll be used instead of the
+ * AAD byte array interfaces Tink exposes to users.
+ * The main reasons to do this are:
+ * - Preventing the misuse of AAD
+ * - Preventing undecipherable ciphertext from being created
+ * - Exposing a friendlier user interface
+ *
+ * ## Encryption Context Specification
+ * - `Map<String, String>`
+ * - The map must contain at least 1 entry
+ * - No blank/empty/null strings in either the map's keys or values
+ * - The map is optional, and can be completely omitted from the encryption operation
+ * The encryption context will be serialized using the following format:
+ * ```
+ * [ AAD:
+ * [ varint: pair count ]
+ *   [ pairs:
+ *     ( [ varint: key length ] [ ByteArray: key ]
+ *       [ varint: value length ] [ ByteArray: value ]
+ *     )*
+ *   ]
+ * ]
+ * ```
+ *
+ * The final output will be serialized using the following format:
+ * ```
+ * [ 0xEE: magic+version ]
+ * [ varint: AAD length ]
+ * [ AAD ]
+ * [ tink ciphertext ]
+ * ```
+ *
+ * For the full documentation of the [CiphertextFormat] serialization, read FORMAT.md
+ */
+class CiphertextFormat private constructor() {
+
+  companion object {
+    /**
+     * Current version of the encryption packet schema
+     */
+    const val CURRENT_VERSION = 0xEE
+
+    /**
+     * Serializes the given [ciphertext] and associated encryption context to a [ByteArray]
+     */
+    fun serialize(ciphertext: ByteArray, aad: ByteArray?): ByteArray {
+      val outputStream = ByteStreams.newDataOutput()
+      outputStream.writeByte(CURRENT_VERSION)
+      if (aad == null) {
+        outputStream.write(byteArrayOf(0))
+      } else {
+        outputStream.write(encodeVarInt(aad.size))
+        outputStream.write(aad)
+      }
+      outputStream.write(ciphertext)
+      return outputStream.toByteArray()
+    }
+
+    /**
+     * Extracts the ciphertext and associated authentication data from the [serialized] ByteArray.
+     *
+     * This method also compares the given [context] to the serialized AAD
+     * and will throw an exception if they do not match.
+     */
+    fun deserialize(serialized: ByteArray, context: Map<String, String>?): Pair<ByteArray, ByteArray?> {
+      val src = DataInputStream(ByteArrayInputStream(serialized))
+      val version = src.readByte()
+      if (version != CURRENT_VERSION.toByte()) {
+        throw InvalidCiphertextFormatException("invalid version: $version")
+      }
+      val ecSize = decodeVarInt(src)
+      val aad = if (ecSize > 0) {
+        ByteArray(ecSize)
+      } else {
+        null
+      }?.also { src.readFully(it) }
+
+      val serializedEncryptionContext = serializeEncryptionContext(context)
+      if (aad == null && serializedEncryptionContext != null) {
+        throw UnexpectedEncryptionContextException()
+      } else if (aad != null && serializedEncryptionContext == null) {
+        throw MissingEncryptionContextException()
+      }
+      if (aad != null && !serializedEncryptionContext!!.contentEquals(aad)) {
+        throw EncryptionContextMismatchException("encryption context doesn't match")
+      }
+      val ciphertext = readCiphertext(src)
+      return Pair(ciphertext, aad)
+    }
+
+    /**
+     * Serializes the encryption context to a [ByteArray] so it could be passed to Tink's
+     * encryption/decryption methods.
+     */
+    fun serializeEncryptionContext(context: Map<String, String>?): ByteArray? {
+      if (context == null || context.isEmpty()) {
+        return null
+      }
+
+      val buffer = ByteBuffer.allocate(Short.MAX_VALUE.toInt())
+      try {
+        buffer.put(encodeVarInt(context.size))
+        context.toSortedMap(compareBy { it }).forEach { (k, v) ->
+          if (k.isEmpty() || v.isEmpty()) {
+            throw InvalidEncryptionContextException("empty key or value")
+          }
+          val key = k.toByteArray(Charsets.UTF_8)
+          val value = v.toByteArray(Charsets.UTF_8)
+          if (key.size >= Short.MAX_VALUE) {
+            throw InvalidEncryptionContextException("key is too long")
+          }
+          if (value.size >= Short.MAX_VALUE) {
+            throw InvalidEncryptionContextException("value is too long")
+          }
+          buffer.put(encodeVarInt(key.size))
+          buffer.put(key)
+          buffer.put(encodeVarInt(value.size))
+          buffer.put(value)
+        }
+      } catch (e: BufferOverflowException) {
+        throw InvalidEncryptionContextException("encryption context is too long")
+      }
+      val aad = ByteArray(buffer.position())
+      buffer.flip()
+      buffer.get(aad)
+      return aad
+    }
+
+    @VisibleForTesting
+    internal fun deserializeEncryptionContext(aad: ByteArray?): Map<String, String>? {
+      if (aad == null) {
+        return null
+      }
+      val src = DataInputStream(ByteArrayInputStream(aad))
+      val entries = decodeVarInt(src)
+      if (entries == 0) {
+        return null
+      }
+      return (1..entries).map {
+        val keySize = decodeVarInt(src)
+        val keyBytes = ByteArray(keySize)
+        src.readFully(keyBytes)
+        val valueSize = decodeVarInt(src)
+        val valueBytes = ByteArray(valueSize)
+        src.readFully(valueBytes)
+        keyBytes.toString(Charsets.UTF_8) to valueBytes.toString(Charsets.UTF_8)
+      }.toMap()
+    }
+
+    private fun readCiphertext(src: DataInputStream) : ByteArray {
+      val ciphertextStream = ByteArrayOutputStream()
+      var readByte = src.read()
+      while(readByte >= 0) {
+        ciphertextStream.write(readByte)
+        readByte = src.read()
+      }
+      return ciphertextStream.toByteArray()
+    }
+
+    private const val SEPTET = (1 shl 7) -1
+    private const val HAS_MORE_BIT = 1 shl 7
+
+    private fun encodeVarInt(integer: Int): ByteArray {
+      val list = mutableListOf<Byte>()
+      var int = integer
+      var byte = int and SEPTET
+      while(int shr 7 > 0) {
+        list.add((byte or HAS_MORE_BIT).toByte())
+        int = int shr 7
+        byte = int and SEPTET
+      }
+      list.add(int.toByte())
+
+      return list.toByteArray()
+    }
+
+    private fun decodeVarInt(src: DataInputStream): Int {
+      var byte = src.readByte().toInt()
+      var integer = byte and SEPTET
+      while (byte and HAS_MORE_BIT > 0) {
+        byte = src.readByte().toInt()
+        integer += ((byte and SEPTET) shl 7)
+      }
+      return integer
+    }
+
+    /**
+     * Extracts the ciphertext and encryption context from the [serialized] ByteArray.
+     *
+     * This method is meant to be used with field-level-encryption in Hibernate only.
+     */
+    fun deserializeFleFormat(serialized: ByteArray): Pair<ByteArray, Map<String, String?>> {
+      val src = DataInputStream(ByteArrayInputStream(serialized))
+      val version = src.readByte().toInt()
+      if (version != 1) {
+        throw InvalidCiphertextFormatException("invalid version")
+      }
+      val bitmask = src.readInt()
+      if (bitmask > Short.MAX_VALUE) {
+        throw InvalidCiphertextFormatException("invalid bitmask")
+      }
+      var context = mutableMapOf<String, String?>()
+      var ciphertext : ByteArray? = null
+      if (bitmask != 0) {
+        context.putAll(ContextKey.values()
+            .filter { it.index and bitmask != 0 }
+            .map { it.name.toLowerCase() to null }
+            .toMap())
+      }
+
+      when(src.read()) {
+        EntryType.EXPANDED_CONTEXT_DESCRIPTION.type -> {
+          val size = src.readUnsignedShort()
+          val serializedExpandedContextDescription = ByteArray(size)
+          src.readFully(serializedExpandedContextDescription)
+          val expanded = deserializeEncryptionContext(
+              serializedExpandedContextDescription.toString(Charsets.UTF_8))
+          context.putAll(expanded!!)
+        }
+        EntryType.ENCRYPTION_CONTEXT.type -> {
+          val size = src.readUnsignedShort()
+          val serializedContext = ByteArray(size)
+          src.readFully(serializedContext)
+          context = deserializeEncryptionContext(
+              serializedContext.toString(Charsets.UTF_8))!!.toMutableMap()
+        }
+        EntryType.CIPHERTEXT.type -> {
+          ciphertext = readCiphertext(src)
+        }
+      }
+      if (ciphertext == null && src.read() == EntryType.CIPHERTEXT.type) {
+        ciphertext = readCiphertext(src)
+      }
+      if (ciphertext == null) {
+        throw InvalidCiphertextFormatException("no ciphertext found")
+      }
+
+      return Pair(ciphertext, context)
+    }
+
+    private fun deserializeEncryptionContext(serialized: String) : Map<String, String?>? {
+      if (serialized.isEmpty()) {
+        return mapOf()
+      }
+
+      return serialized.split("|")
+          .map { pair ->
+            val components = pair.split("=")
+            components.first() to components.getOrNull(1)
+          }
+          .toMap()
+    }
+  }
+
+  private enum class EntryType(val type: Int) {
+    UNDEFINED(0),
+    EXPANDED_CONTEXT_DESCRIPTION(1),
+    ENCRYPTION_CONTEXT(2),
+    SIZED_CIPHERTEXT(3),
+    CIPHERTEXT(4)
+  }
+
+  /**
+   * Some common context keys are typically taken from the environment
+   * and can be compactly encoded via a bitmask; keys and their bit offsets are defined below.
+   *
+   * Maximum value types supported is 15.
+   */
+  private enum class ContextKey constructor(val index: Int) {
+    UNDEFINED(1 shl 0),
+    TABLE_NAME(1 shl 1),
+    DATABASE_NAME(1 shl 2),
+    COLUMN_NAME(1 shl 3),
+    SHARD_NAME(1 shl 4),
+    PRIMARY_ID(1 shl 5),
+    EVENT_TOPIC(1 shl 6),
+    SERVICE_NAME(1 shl 7),
+    CUSTOMER_TOKEN(1 shl 8),
+  }
+
+  class InvalidCiphertextFormatException(message: String) : GeneralSecurityException(message)
+  class EncryptionContextMismatchException(message: String) : GeneralSecurityException(message)
+  class MissingEncryptionContextException
+    : GeneralSecurityException("expected a non empty map of strings")
+  class UnexpectedEncryptionContextException
+    : GeneralSecurityException("expected null as encryption context")
+  class InvalidEncryptionContextException(message: String) : GeneralSecurityException(message)
+}

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -27,7 +27,7 @@ import java.util.Base64
 
 /**
  * Configures and registers the keys listed in the configuration file.
- * Each key is read, decrypted, and then bound via Google Guice and added to the [KeyManager].
+ * Each key is read, decrypted, and then bound via Google Guice and added to a [MappedKeyManager].
  */
 class CryptoModule(
   private val config: CryptoConfig

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -125,14 +125,6 @@ fun Aead.encrypt(plaintext: ByteString, aad: ByteArray? = null): ByteString {
   return encrypted.toByteString()
 }
 
-fun Aead.encrypt(plaintext : ByteString, encryptionContext : Map<String, String>?) : ByteString {
-  val plaintextBytes = plaintext.toByteArray()
-  val aad = CiphertextFormat.serializeEncryptionContext(encryptionContext)
-  val encrypted = this.encrypt(plaintextBytes, aad)
-  plaintextBytes.fill(0)
-  return CiphertextFormat.serialize(encrypted, aad).toByteString()
-}
-
 /**
  * Extension function for convenient decryption of [ByteString]s.
  * This function also makes sure that no extra copies of the plaintext data are kept in memory.
@@ -146,18 +138,6 @@ fun Aead.encrypt(plaintext : ByteString, encryptionContext : Map<String, String>
 )
 fun Aead.decrypt(ciphertext: ByteString, aad: ByteArray? = null): ByteString {
   val decryptedBytes = this.decrypt(ciphertext.toByteArray(), aad)
-  val decrypted = decryptedBytes.toByteString()
-  decryptedBytes.fill(0)
-  return decrypted
-}
-
-fun Aead.decrypt(ciphertext : ByteString, encryptionContext: Map<String, String>?) : ByteString {
-  val (payload, aad) = try {
-    CiphertextFormat.deserialize(ciphertext.toByteArray(), encryptionContext)
-  } catch (e: InvalidCiphertextFormatException) {
-    Pair(ciphertext.toByteArray(), CiphertextFormat.serializeEncryptionContext(encryptionContext))
-  }
-  val decryptedBytes = this.decrypt(payload, aad)
   val decrypted = decryptedBytes.toByteString()
   decryptedBytes.fill(0)
   return decrypted
@@ -184,17 +164,6 @@ fun DeterministicAead.encryptDeterministically(
   return encrypted.toByteString()
 }
 
-fun DeterministicAead.encryptDeterministically(
-  plaintext: ByteString,
-  encryptionContext: Map<String, String>?
-): ByteString {
-  val plaintextBytes = plaintext.toByteArray()
-  val aad = CiphertextFormat.serializeEncryptionContext(encryptionContext)
-  val encrypted = this.encryptDeterministically(plaintextBytes, aad ?: byteArrayOf())
-  plaintextBytes.fill(0)
-  return CiphertextFormat.serialize(encrypted, aad).toByteString()
-}
-
 /**
  * Extension function for convenient decryption of [ByteString]s.
  * This function also makes sure that no extra copies of the plaintext data are kept in memory.
@@ -211,22 +180,6 @@ fun DeterministicAead.decryptDeterministically(
   aad: ByteArray? = null
 ) : ByteString {
   val decryptedBytes = this.decryptDeterministically(ciphertext.toByteArray(), aad)
-  val decrypted = decryptedBytes.toByteString()
-  decryptedBytes.fill(0)
-  return decrypted
-}
-
-fun DeterministicAead.decryptDeterministically(
-  ciphertext: ByteString,
-  encryptionContext: Map<String, String>?
-): ByteString {
-  val bytes = ciphertext.toByteArray()
-  val (payload, aad) = try {
-    CiphertextFormat.deserialize(bytes, encryptionContext)
-  } catch(e: InvalidCiphertextFormatException) {
-    Pair(bytes, CiphertextFormat.serializeEncryptionContext(encryptionContext))
-  }
-  val decryptedBytes = this.decryptDeterministically(payload, aad ?: byteArrayOf())
   val decrypted = decryptedBytes.toByteString()
   decryptedBytes.fill(0)
   return decrypted
@@ -250,30 +203,4 @@ fun Mac.verifyMac(tag: String, data: String) {
     throw GeneralSecurityException(String.format("invalid tag: %s", tag), e)
   }
   this.verifyMac(decodedTag, data.toByteArray())
-}
-
-fun HybridEncrypt.encrypt(
-  plaintext: ByteString,
-  encryptionContext: Map<String, String>?
-): ByteString {
-  val plaintextBytes = plaintext.toByteArray()
-  val aad = CiphertextFormat.serializeEncryptionContext(encryptionContext)
-  val ciphertext = this.encrypt(plaintextBytes, aad)
-  plaintextBytes.fill(0)
-  return CiphertextFormat.serialize(ciphertext, aad).toByteString()
-}
-
-fun HybridDecrypt.decrypt(
-  ciphertext: ByteString,
-  encryptionContext: Map<String, String>?
-): ByteString {
-  val (ciphertextBytes, aad) = try {
-    CiphertextFormat.deserialize(ciphertext.toByteArray(), encryptionContext)
-  } catch (e: InvalidCiphertextFormatException) {
-    Pair(ciphertext.toByteArray(), CiphertextFormat.serializeEncryptionContext(encryptionContext))
-  }
-  val plaintextBytes = this.decrypt(ciphertextBytes, aad)
-  val plaintext = plaintextBytes.toByteString()
-  plaintextBytes.fill(0)
-  return plaintext
 }

--- a/misk-crypto/src/test/kotlin/misk/crypto/CiphertextFormatTest.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CiphertextFormatTest.kt
@@ -1,0 +1,301 @@
+package misk.crypto
+
+import misk.testing.MiskTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.util.UUID
+
+@MiskTest
+class CiphertextFormatTest {
+
+  companion object {
+    private const val VERSION_INDEX = 0
+    private const val EC_LENGTH_INDEX = 1
+    private val fauxCiphertext = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
+  }
+
+  @Test
+  fun testBasicEncryptionContextSerialization() {
+    val context = mapOf(
+        "table_name" to "unimportant",
+        "database_name" to "unimportant",
+        "key" to "value")
+    val serialized = CiphertextFormat.serializeEncryptionContext(context)
+    assertThat(CiphertextFormat.deserializeEncryptionContext(serialized))
+        .isNotNull
+        .isEqualTo(context)
+  }
+
+  @Test
+  fun testEncryptionContextSerializationSortsKeys() {
+    val context = mapOf(
+        "table_name" to "unimportant",
+        "database_name" to "unimportant",
+        "key" to "value")
+    val context2 = linkedMapOf(
+        "key" to "value",
+        "database_name" to "unimportant",
+        "table_name" to "unimportant")
+
+    assertThat(CiphertextFormat.serializeEncryptionContext(context))
+        .isEqualTo(CiphertextFormat.serializeEncryptionContext(context2))
+  }
+
+  @Test
+  fun testEncryptionContextSerializationWithVarInts() {
+    val context = mutableMapOf<String, String>()
+    (0..300).forEach { context["$it"] = UUID.randomUUID().toString() }
+    val serialized = CiphertextFormat.serializeEncryptionContext(context)
+    assertThat(CiphertextFormat.deserializeEncryptionContext(serialized))
+        .isNotNull
+        .isEqualTo(context)
+  }
+
+  @Test
+  fun testEmptyEncryptionContext() {
+    assertThat(CiphertextFormat.serializeEncryptionContext(mapOf())).isNull()
+  }
+
+  @Test
+  fun testNullEncryptionContext() {
+    assertThat(CiphertextFormat.serializeEncryptionContext(null)).isNull()
+  }
+
+  @Test
+  fun testEncryptionContextValueTooLong() {
+    val value = (0..Short.MAX_VALUE).joinToString("") { "a" }
+    val context = mapOf("key" to value)
+    assertThatThrownBy { CiphertextFormat.serializeEncryptionContext(context) }
+        .hasMessage("value is too long")
+  }
+
+  @Test
+  fun testEncryptionContextKeyTooLong() {
+    val key = (0..Short.MAX_VALUE).joinToString("") { "a" }
+    val context = mapOf(key to "value")
+    assertThatThrownBy { CiphertextFormat.serializeEncryptionContext(context) }
+        .hasMessage("key is too long")
+  }
+
+  @Test
+  fun testEncryptionContextTooLong() {
+    val key = (100..Short.MAX_VALUE).joinToString("") { "a" }
+    val value = (100..Short.MAX_VALUE).joinToString("") { "a" }
+    assertThatThrownBy { CiphertextFormat.serializeEncryptionContext(mapOf(key to value)) }
+        .hasMessage("encryption context is too long")
+  }
+
+  @Test
+  fun testEncryptionContextWithForbiddenCharacters() {
+    var context = mapOf("" to "value")
+    assertThatThrownBy { CiphertextFormat.serializeEncryptionContext(context) }
+        .hasMessage("empty key or value")
+    context = mapOf("key" to "")
+    assertThatThrownBy { CiphertextFormat.serializeEncryptionContext(context) }
+        .hasMessage("empty key or value")
+  }
+
+  @Test
+  fun testFromByteArrayWithNoContext() {
+    val aad = CiphertextFormat.serializeEncryptionContext(null)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    assertThatCode { CiphertextFormat.deserialize(serialized, null) }
+        .doesNotThrowAnyException()
+    assertThatCode { CiphertextFormat.deserialize(serialized, mapOf()) }
+        .doesNotThrowAnyException()
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, mapOf("key" to "value")) }
+        .isInstanceOf(CiphertextFormat.UnexpectedEncryptionContextException::class.java)
+  }
+
+  @Test
+  fun testFromByteArrayWithContext() {
+    val context = mapOf("key" to "value")
+    val aad = CiphertextFormat.serializeEncryptionContext(context)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    assertThatCode { CiphertextFormat.deserialize(serialized, context) }
+        .doesNotThrowAnyException()
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, mapOf("wrong_key" to "wrong_value")) }
+        .isInstanceOf(CiphertextFormat.EncryptionContextMismatchException::class.java)
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, null) }
+        .isInstanceOf(CiphertextFormat.MissingEncryptionContextException::class.java)
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, emptyMap()) }
+        .isInstanceOf(CiphertextFormat.MissingEncryptionContextException::class.java)
+  }
+
+  @Test
+  fun testFromByteArrayWithLongContext() {
+    val context = mutableMapOf<String, String>()
+    (0..300).forEach { context["$it"] = UUID.randomUUID().toString() }
+    val aad = CiphertextFormat.serializeEncryptionContext(context)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    val (ciphertext, ciphertextAad) = CiphertextFormat.deserialize(serialized, context)
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(ciphertextAad).isEqualTo(aad)
+  }
+
+  @Test
+  fun testFromByteArrayWithEmptyContext() {
+    val context = mapOf<String, String>()
+    val aad = CiphertextFormat.serializeEncryptionContext(context)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    assertThatCode { CiphertextFormat.deserialize(serialized, context) }
+        .doesNotThrowAnyException()
+    assertThatCode { CiphertextFormat.deserialize(serialized, null) }
+        .doesNotThrowAnyException()
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, mapOf("key" to "value")) }
+        .isInstanceOf(CiphertextFormat.UnexpectedEncryptionContextException::class.java)
+  }
+
+  @Test
+  fun testUnsupportedSchemaVersion() {
+    val context = mapOf("key" to "value")
+    val aad = CiphertextFormat.serializeEncryptionContext(context)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    serialized[VERSION_INDEX] = 3
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, context) }
+        .hasMessage("invalid version: 3")
+  }
+
+  @Test
+  fun testWrongEncryptionContextSize() {
+    val context = mapOf("key" to "value", "key2" to "value2")
+    val aad = CiphertextFormat.serializeEncryptionContext(context)
+    val serialized = CiphertextFormat.serialize(fauxCiphertext, aad)
+    serialized[EC_LENGTH_INDEX + 1] = 1
+    assertThatThrownBy { CiphertextFormat.deserialize(serialized, context) }
+        .hasMessage("encryption context doesn't match")
+  }
+
+  @Test
+  fun testFromByteArrayV1() {
+    val context = mapOf("key" to "value")
+    val aad = "key=value".toByteArray(Charsets.UTF_8)
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    output.writeBytes(byteArrayOf(0, 0, 0, 0))  // BITMASK
+    output.write(2) // ENCRYPTION_CONTEXT
+    val ecLength = ByteBuffer.allocate(2)
+        .putShort(aad.size.toShort())
+        .array()
+    output.writeBytes(ecLength) // EXPANDED_CONTEXT length
+    output.writeBytes(aad)
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).containsExactly(context.entries.first())
+  }
+
+  @Test
+  fun testFromByteArrayV1WithBitmask() {
+    val aad = "key=value".toByteArray(Charsets.UTF_8)
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    val bitmask = 1 shl 1 // TABLE_NAME
+    val bitmaskBytes = ByteBuffer.allocate(4)
+        .putInt(bitmask)
+        .array()
+    output.writeBytes(bitmaskBytes)  // BITMASK
+    output.write(1) // EXPANDED_CONTEXT_DESCRIPTION
+    val ecLength = ByteBuffer.allocate(2)
+        .putShort(aad.size.toShort())
+        .array()
+    output.writeBytes(ecLength) // EXPANDED_CONTEXT length
+    output.writeBytes(aad)
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).containsKey("table_name")
+  }
+
+  @Test
+  fun testFromByteArrayV1WithBitmaskAndFullContext() {
+    val context = mapOf("key" to "value")
+    val aad = "key=value".toByteArray(Charsets.UTF_8)
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    val bitmask = 1 shl 1 // TABLE_NAME
+    val bitmaskBytes = ByteBuffer.allocate(4)
+        .putInt(bitmask)
+        .array()
+    output.writeBytes(bitmaskBytes)  // BITMASK
+    output.write(2) // ENCRYPTION_CONTEXT
+    val ecLength = ByteBuffer.allocate(2)
+        .putShort(aad.size.toShort())
+        .array()
+    output.writeBytes(ecLength) // EXPANDED_CONTEXT length
+    output.writeBytes(aad)
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).containsExactly(context.entries.first())
+  }
+
+  @Test
+  fun testFromByteArrayV1NoContext() {
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    output.writeBytes(byteArrayOf(0, 0, 0, 0))  // BITMASK
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).isEmpty()
+  }
+
+  @Test
+  fun testFromByteArrayV1EmptyContext() {
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    output.writeBytes(byteArrayOf(0, 0, 0, 0))  // BITMASK
+    output.write(2) // ENCRYPTION_CONTEXT
+    output.writeBytes(byteArrayOf(0, 0))
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).isEmpty()
+  }
+
+  @Test
+  fun testFromByteArrayV1BitmaskOnly() {
+    val output = ByteArrayOutputStream()
+    output.write(1) // VERSION
+    val bitmask = 1 shl 1 // TABLE_NAME
+    val bitmaskBytes = ByteBuffer.allocate(4)
+        .putInt(bitmask)
+        .array()
+    output.writeBytes(bitmaskBytes)  // BITMASK
+    output.write(4) // CIPHERTEXT
+    output.writeBytes(fauxCiphertext)
+
+    val (ciphertext, map) = CiphertextFormat.deserializeFleFormat(output.toByteArray())
+    assertThat(ciphertext).isEqualTo(fauxCiphertext)
+    assertThat(map).containsKey("table_name")
+  }
+
+  @Test
+  fun testInvalidPacketWithNoCiphertext() {
+    val output = byteArrayOf(1, 0, 0, 0, 0, 5) // represents a V1 encryption packet with an invalid type
+    assertThatThrownBy { CiphertextFormat.deserializeFleFormat(output) }
+        .hasMessage("no ciphertext found")
+  }
+
+  @Test
+  fun testInvalidPacketWithInvalidBitmask() {
+    val output = byteArrayOf(1, 0, 1, 0, 0) // represents a V1 packet with a bitmask > Short.MAX_VALUE
+    assertThatThrownBy { CiphertextFormat.deserializeFleFormat(output) }
+        .hasMessage("invalid bitmask")
+  }
+}


### PR DESCRIPTION
This PR introduces a new object that wraps the ciphertext and includes the encryption context associated with it.
Encryption Context is a higher abstraction we're introducing here as well.
Instead of providing a byte array when performing AEAD or DAEAD encryption, commonly referred t as AAD in Tink's lingo, we use a map of strings which will be then serialized to a byte array.