### PR TITLE
Specify utf8 on mysql data source config

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -94,6 +94,7 @@ class DataSourceService(
       hikariConfig.dataSourceProperties["cacheServerConfiguration"] = "true"
       hikariConfig.dataSourceProperties["elideSetAutoCommits"] = "true"
       hikariConfig.dataSourceProperties["maintainTimeStats"] = "false"
+      hikariConfig.dataSourceProperties["characterEncoding"] = "UTF-8"
     }
 
     metrics?.let {


### PR DESCRIPTION
explicitly set to utf8 for the connection even if server is not configured to default to it. Was required to get emojis working