### PR TITLE
Revert "Add with*Timeout methods to ClientNetworkChain (#1519)"

### DIFF
--- a/misk/src/main/kotlin/misk/client/ClientNetworkChain.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkChain.kt
@@ -2,25 +2,9 @@ package misk.client
 
 import okhttp3.Request
 import okhttp3.Response
-import java.util.concurrent.TimeUnit
 
 interface ClientNetworkChain {
   val action: ClientAction
   val request: Request
   fun proceed(request: Request): Response
-
-  /**
-   * Override the connect timeout.
-   */
-  fun withConnectTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain
-
-  /**
-   * Override the read timeout.
-   */
-  fun withReadTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain
-
-  /**
-   * Override the write timeout.
-   */
-  fun withWriteTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain
 }

--- a/misk/src/main/kotlin/misk/client/RealClientNetworkChain.kt
+++ b/misk/src/main/kotlin/misk/client/RealClientNetworkChain.kt
@@ -2,24 +2,11 @@ package misk.client
 
 import okhttp3.Request
 import okhttp3.Response
-import java.util.concurrent.TimeUnit
 
 internal class RealClientNetworkChain(
   private val okhttpChain: okhttp3.Interceptor.Chain,
   override val action: ClientAction
 ) : ClientNetworkChain {
-  override val request: Request = okhttpChain.request()
+  override val request: okhttp3.Request = okhttpChain.request()
   override fun proceed(request: Request): Response = okhttpChain.proceed(request)
-
-  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain {
-    return RealClientNetworkChain(okhttpChain.withConnectTimeout(timeout, unit), action)
-  }
-
-  override fun withReadTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain {
-    return RealClientNetworkChain(okhttpChain.withReadTimeout(timeout, unit), action)
-  }
-
-  override fun withWriteTimeout(timeout: Int, unit: TimeUnit): ClientNetworkChain {
-    return RealClientNetworkChain(okhttpChain.withWriteTimeout(timeout, unit), action)
-  }
 }


### PR DESCRIPTION
This reverts commit ade5a2088a98664acc32a651bbf4d0e696d7b8e7.

This did not work as expected due to https://github.com/square/okhttp/issues/6100