### PR TITLE
Allow using DbEntity directly

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/DbEntity.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/DbEntity.kt
@@ -3,12 +3,6 @@ package misk.hibernate
 /**
  * Marker interface for persistent entities. Ensures that only persistent entities can be passed
  * into [Session] methods.
- *
- * You can't implement this interface directly because you need to decide on the scaling strategy:
- *   * Use [DbSharded] subclasses [DbRoot] or [DbChild] if the entity will have unbounded growth
- *   with usage.
- *   * Use [DbUnsharded] if your entity has bounded growth like metadata, configuration, static
- *   data etc.
  */
 interface DbEntity<T : DbEntity<T>> {
   val id: Id<T>

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -432,10 +432,7 @@ internal class RealTransacter private constructor(
       check(!readOnly) { "Saving isn't permitted in a read only session." }
       return when (entity) {
         is DbChild<*, *> -> (hibernateSession.save(entity) as Gid<*, *>).id
-        is DbRoot<*> -> hibernateSession.save(entity)
-        is DbUnsharded<*> -> hibernateSession.save(entity)
-        else -> throw IllegalArgumentException(
-            "You need to sub-class one of [DbChild, DbRoot, DbUnsharded]")
+        else -> hibernateSession.save(entity)
       } as Id<T>
     }
 


### PR DESCRIPTION
Instead of requiring an app to explicitly mark a DbEntity as sharded or unsharded, allow using DbEntity directly to denote that sharding is not relevant (suitable for TiDB).