### PR TITLE
Allow no queueing in Jetty

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -36,7 +36,14 @@ data class WebConfig(
   /** Maximum number of threads in Jetty's thread pool. */
   val jetty_max_thread_pool_size: Int = 200,
 
-  /** Maximum number of items in the queue for Jetty's thread pool. */
+  /**
+   * Maximum number of items in the queue for Jetty's thread pool.
+   *
+   * If 0, no queueing is used and requests are directly handed off to the thread pool. If a
+   * thread is not available (i.e max threads in use) the request is rejected. Unfortunately Jetty
+   * rejects requests by closing the socket instead of returning a 429. This can lead to confusing
+   * EOFExceptions for the client.
+   */
   val jetty_max_thread_pool_queue_size: Int = 300,
 
   /** Flag to enable thread pool queue metrics */

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -30,6 +30,7 @@ import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.unixsocket.UnixSocketConnector
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.QueuedThreadPool
+import org.eclipse.jetty.util.thread.ThreadPool
 import java.net.InetAddress
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,7 +42,7 @@ class JettyService @Inject internal constructor(
   private val sslLoader: SslLoader,
   private val webActionsServlet: WebActionsServlet,
   private val webConfig: WebConfig,
-  threadPool: QueuedThreadPool,
+  threadPool: ThreadPool,
   private val connectionMetricsCollector: JettyConnectionMetricsCollector,
   private val statisticsHandler: StatisticsHandler,
   private val gzipHandler: GzipHandler

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -29,7 +29,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.unixsocket.UnixSocketConnector
 import org.eclipse.jetty.util.ssl.SslContextFactory
-import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.util.thread.ThreadPool
 import java.net.InetAddress
 import javax.inject.Inject

--- a/misk/src/main/kotlin/misk/web/jetty/MeasuredThreadPool.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/MeasuredThreadPool.kt
@@ -1,0 +1,56 @@
+package misk.web.jetty
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool
+import java.util.concurrent.ThreadPoolExecutor
+
+/**
+ * A common interface that can emit metrics about a thread pool.
+ */
+interface MeasuredThreadPool {
+
+  /**
+   * The current size of the thread pool.
+   */
+  fun poolSize(): Int
+
+  /**
+   * The number of active threads.
+   */
+  fun activeCount(): Int
+
+  /**
+   * The maximum size the pool can grow to.
+   */
+  fun maxPoolSize(): Int
+
+  /**
+   * The current number of tasks in the queue waiting to be processed by the thread pool.
+   */
+  fun queueSize(): Int
+}
+
+/**
+ * A [MeasuredThreadPool] for a [QueuedThreadPool]
+ */
+class MeasuredQueuedThreadPool(private val threadPool: QueuedThreadPool) : MeasuredThreadPool {
+  override fun poolSize(): Int = threadPool.threads
+
+  override fun activeCount(): Int = threadPool.busyThreads
+
+  override fun maxPoolSize(): Int = threadPool.maxThreads
+
+  override fun queueSize(): Int = threadPool.queueSize
+}
+
+/**
+ * A [MeasuredThreadPool] for a [ThreadPoolExecutor]
+ */
+class MeasuredThreadPoolExecutor(private val threadPool: ThreadPoolExecutor) : MeasuredThreadPool {
+  override fun poolSize(): Int = threadPool.poolSize
+
+  override fun activeCount(): Int = threadPool.activeCount
+
+  override fun maxPoolSize(): Int = threadPool.maximumPoolSize
+
+  override fun queueSize(): Int = threadPool.queue.size
+}

--- a/misk/src/main/kotlin/misk/web/jetty/ThreadPoolMetrics.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ThreadPoolMetrics.kt
@@ -1,14 +1,13 @@
 package misk.web.jetty
 
 import misk.metrics.Metrics
-import org.eclipse.jetty.util.thread.QueuedThreadPool
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class ThreadPoolMetrics @Inject internal constructor(
   metrics: Metrics,
-  private val threadPool: QueuedThreadPool
+  private val threadPool: MeasuredThreadPool
 ) {
   val utilization = metrics.gauge(
       "jetty_thread_pool_utilization",
@@ -36,11 +35,11 @@ internal class ThreadPoolMetrics @Inject internal constructor(
   )
 
   fun refresh() {
-    utilization.set(ratio(threadPool.busyThreads.toDouble(), threadPool.threads.toDouble()))
-    utilizationMax.set(ratio(threadPool.busyThreads.toDouble(), threadPool.maxThreads.toDouble()))
-    size.set(threadPool.threads.toDouble())
-    busyThreads.set(threadPool.busyThreads.toDouble())
-    queuedJobs.set(threadPool.queueSize.toDouble())
+    utilization.set(ratio(threadPool.activeCount().toDouble(), threadPool.poolSize().toDouble()))
+    utilizationMax.set(ratio(threadPool.activeCount().toDouble(), threadPool.maxPoolSize().toDouble()))
+    size.set(threadPool.poolSize().toDouble())
+    busyThreads.set(threadPool.activeCount().toDouble())
+    queuedJobs.set(threadPool.queueSize().toDouble())
   }
 
   private fun ratio(numerator: Double, denominator: Double) =

--- a/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
@@ -10,6 +10,8 @@ import misk.web.actions.WebAction
 import misk.web.jetty.ConnectionMetrics
 import misk.web.jetty.JettyConnectionMetricsCollector
 import misk.web.jetty.JettyService
+import misk.web.jetty.MeasuredQueuedThreadPool
+import misk.web.jetty.MeasuredThreadPool
 import misk.web.jetty.ThreadPoolMetrics
 import misk.web.mediatype.MediaTypes
 import okhttp3.HttpUrl
@@ -18,6 +20,7 @@ import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.eclipse.jetty.util.thread.QueuedThreadPool
+import org.eclipse.jetty.util.thread.ThreadPool
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 
@@ -138,9 +141,11 @@ internal class JettyServiceMetricsTest {
       install(Modules.override(WebTestingModule()).with(
           object : KAbstractModule() {
             override fun configure() {
-              bind<QueuedThreadPool>().toInstance(QueuedThreadPool(
+              val pool = QueuedThreadPool(
                   10, 10 // Fixed # of threads
-              ))
+              )
+              bind<ThreadPool>().toInstance(pool)
+              bind<MeasuredThreadPool>().toInstance(MeasuredQueuedThreadPool(pool))
             }
           }
       ))


### PR DESCRIPTION
The QueuedThreadPool first submits all requests to the queue and the
thread pool pulls from the queue. With this impl, there is no way to
disable queueing on the server.

If config sets queue size to 0, a different impl is used which direclty
hands the reques to the ThreadPool and rejects the request if max
threads are in use.