### PR TITLE
Add a dedicated Connector for health checks

### DIFF
--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -25,6 +25,10 @@ class WebTestingModule(
         // 0 results in a random port
         port = 0,
         health_port = 0,
+        // use a deterministic number for selector/acceptor threads since the dynamic number can
+        // vary local vs CI. this allows writing thread exhaustion tests.
+        acceptors = 1,
+        selectors = 1,
         idle_timeout = 500000,
         host = "127.0.0.1",
         ssl = WebSslConfig(

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -6,6 +6,7 @@ import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
 import misk.security.ssl.CertStoreConfig
 import misk.security.ssl.SslLoader
+import org.eclipse.jetty.util.ProcessorUtils
 
 /**
  * A module that starts an embedded Jetty web server configured for testing. The server supports

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -22,7 +22,9 @@ class WebTestingModule(
 
   companion object {
     val TESTING_WEB_CONFIG = WebConfig(
+        // 0 results in a random port
         port = 0,
+        health_port = 0,
         idle_timeout = 500000,
         host = "127.0.0.1",
         ssl = WebSslConfig(

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -65,7 +65,20 @@ data class WebConfig(
   val gzip: Boolean = true,
 
   /** The minimum size in bytes before the response body will be compressed. */
-  val minGzipSize: Int = 1024
+  val minGzipSize: Int = 1024,
+
+  /**
+   * If >= 0, run a dedicated jetty instance on this port for health checking.
+   *
+   * A dedicated instance ensures that health checks are not queued or rejected when the service
+   * is saturated and queueing requests. If health checks are rejected and/or queued, the health
+   * checks may fail and k8s will kill the container, even though it might be perfectly healthy. This
+   * can cause cascading failures by sending more requests to other containers, resulting in longer
+   * queues and more health checks failures.
+   *
+   * TODO(rhall): make this required
+   */
+  val health_port : Int = -1
 ) : Config
 
 data class WebSslConfig(

--- a/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
@@ -1,0 +1,160 @@
+package misk.web
+
+import com.google.inject.util.Modules
+import misk.concurrent.ExecutorServiceFactory
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.eclipse.jetty.util.thread.ExecutorThreadPool
+import org.eclipse.jetty.util.thread.ThreadPool
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Future
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Qualifier
+
+@MiskTest(startService = true)
+internal class JettyHealthCheckTest {
+
+  companion object {
+    const val parallelRequests = 2
+  }
+
+  @MiskTestModule val module = TestModule()
+  @Inject lateinit var jettyService: JettyService
+  @Inject @field:Blocking lateinit var blocking: CountDownLatch
+  @Inject @field:Waiting lateinit var waiting: CountDownLatch
+  @Inject @field:HealthBlocking lateinit var healthBlocking: CountDownLatch
+  @Inject @field:HealthWaiting lateinit var healthWaiting: CountDownLatch
+  @Inject lateinit var executorFactory: ExecutorServiceFactory
+
+  @Test fun health() {
+    val executor = executorFactory.unbounded("testing")
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+        .get()
+        .url(httpUrlBuilder().encodedPath("/block").build())
+        .build()
+    val healthRequest = Request.Builder()
+        .get()
+        .url(healthUrlBuilder().encodedPath("/health").build())
+        .build()
+
+    // exhaust the thread pool
+    val responses = mutableListOf<Future<Response>>()
+    for (i in 1..parallelRequests) {
+      responses.add(executor.submit(Callable { httpClient.newCall(request).execute() }))
+    }
+    waiting.await(5, TimeUnit.SECONDS)
+
+    // all threads are busy
+    assertThatThrownBy { httpClient.newCall(request).execute() }
+        .isInstanceOf(IOException::class.java)
+
+    val healthResponses = mutableListOf<Future<Response>>()
+    // make sure we can check liveness and readiness in parallel
+    healthResponses.add(executor.submit(Callable { httpClient.newCall(healthRequest).execute() }))
+    healthResponses.add(executor.submit(Callable { httpClient.newCall(healthRequest).execute() }))
+    healthWaiting.await(5, TimeUnit.SECONDS)
+    healthBlocking.countDown()
+
+    healthResponses.forEach {
+      val r = it.get(5, TimeUnit.SECONDS)
+      assertThat(r.code).isEqualTo(200)
+      assertThat(r.body?.string()).isEqualTo("healthy")
+    }
+
+    // release the blocking threads
+    blocking.countDown()
+
+    // double check these requests were successfully processed
+    responses.forEach {
+      val r = it.get(5, TimeUnit.SECONDS)
+      assertThat(r.code).isEqualTo(200)
+      assertThat(r.body?.string()).isEqualTo("done")
+    }
+  }
+
+  internal class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(Modules.override(WebTestingModule()).with(
+          object : KAbstractModule() {
+            override fun configure() {
+              // jetty reserves 5 threads
+              val threadSize = parallelRequests + 5
+              val pool = ExecutorThreadPool(
+                  ThreadPoolExecutor(threadSize, threadSize, 0, TimeUnit.MILLISECONDS,
+                      SynchronousQueue())
+              )
+              bind<ThreadPool>().toInstance(pool)
+            }
+          }
+      ))
+      install(WebActionModule.create<BlockingAction>())
+      install(WebActionModule.create<HealthAction>())
+      bind<CountDownLatch>().annotatedWith<Blocking>().toInstance(CountDownLatch(1))
+      bind<CountDownLatch>().annotatedWith<Waiting>().toInstance(CountDownLatch(parallelRequests))
+      bind<CountDownLatch>().annotatedWith<HealthBlocking>().toInstance(CountDownLatch(1))
+      bind<CountDownLatch>().annotatedWith<HealthWaiting>().toInstance(CountDownLatch(2))
+    }
+  }
+
+  @Qualifier
+  internal annotation class Blocking
+
+  @Qualifier
+  internal annotation class Waiting
+
+  @Qualifier
+  internal annotation class HealthBlocking
+
+  @Qualifier
+  internal annotation class HealthWaiting
+
+  internal class BlockingAction @Inject constructor(
+    @Blocking private val blocking: CountDownLatch,
+    @Waiting private val waiting: CountDownLatch
+  ) : WebAction {
+    @Get("/block")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun block(): String {
+      waiting.countDown()
+      blocking.await(5, TimeUnit.SECONDS)
+      return "done"
+    }
+  }
+
+  internal class HealthAction @Inject constructor(
+    @HealthBlocking private val blocking: CountDownLatch,
+    @HealthWaiting private val waiting: CountDownLatch) : WebAction {
+    @Get("/health")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun check(): String {
+      waiting.countDown()
+      blocking.await(5, TimeUnit.SECONDS)
+      return "healthy"
+    }
+  }
+
+  private fun httpUrlBuilder(): HttpUrl.Builder {
+    return jettyService.httpServerUrl.newBuilder()
+  }
+
+  private fun healthUrlBuilder(): HttpUrl.Builder {
+    return jettyService.healthServerUrl!!.newBuilder()
+  }
+}

--- a/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
@@ -94,12 +94,13 @@ internal class JettyHealthCheckTest {
       install(Modules.override(WebTestingModule()).with(
           object : KAbstractModule() {
             override fun configure() {
-              // jetty reserves 5 threads
-              val threadSize = parallelRequests + 5
-              val pool = ExecutorThreadPool(
-                  ThreadPoolExecutor(threadSize, threadSize, 0, TimeUnit.MILLISECONDS,
-                      SynchronousQueue())
-              )
+              // jetty needs 4 additional threads for other things
+              val threadSize = parallelRequests + 4
+              val pool = ExecutorThreadPool(ThreadPoolExecutor(
+                  threadSize,
+                  threadSize,
+                  0, TimeUnit.MILLISECONDS,
+                  SynchronousQueue()), 0)
               bind<ThreadPool>().toInstance(pool)
             }
           }


### PR DESCRIPTION
This dedicated Connector uses a dedicated thread pool for health
checking. If the Server is currently queueing/rejecting requests, it can
still process liveness/readiness checks from k8s.

Previously a queued health check could result in k8s killing the
server, even if it was perfectly healthy and serving traffic. This could
result in cascading failures since the traffic would shift to another
node, creating a queue and killing that container.

To use the experimental feature, apps set the health_port to 8080 and
the port to something else, like 8081 for local development.