### PR TITLE
Accept gradle scan terms and agreements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,3 +118,10 @@ subprojects { subProject ->
     }
   }
 }
+
+gradleEnterprise {
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -119,9 +119,9 @@ subprojects { subProject ->
   }
 }
 
-gradleEnterprise {
+if (hasProperty('buildScan')) {
   buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
   }
 }


### PR DESCRIPTION
Seems that newer gradle version requires accepting terms and agreements to use build scans. Without this - our builds are failing.