### PR TITLE
Add support for host-based http client settings

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
@@ -7,6 +7,7 @@ import okhttp3.Dispatcher
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import java.io.File
 import java.net.Proxy
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -73,11 +74,9 @@ class HttpClientFactory @Inject constructor(
       builder.proxy(Proxy.NO_PROXY)
     }
 
-    config.clientConfig.protocols?.let {
-      builder.protocols(
-          config.clientConfig.protocols.map { Protocol.get(it) }
-      )
-    }
+    config.clientConfig.protocols
+        ?.map { Protocol.get(it) }
+        ?.let { builder.protocols(it) }
 
     config.envoy?.let {
       builder.socketFactory(

--- a/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
@@ -8,11 +8,25 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import java.net.Proxy
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 import javax.net.ssl.X509TrustManager
+
+
+private object Defaults {
+  /*
+    Copied from okhttp3.ConnectionPool, as it does not provide "use default" option
+   */
+  val maxIdleConnections = 5
+
+  /*
+    Copied from okhttp3.ConnectionPool, as it does not provide "use default" option
+   */
+  val keepAliveDuration = Duration.ofMinutes(5)
+}
 
 @Singleton
 class HttpClientFactory @Inject constructor(
@@ -52,7 +66,7 @@ class HttpClientFactory @Inject constructor(
     }
 
     config.clientConfig.unixSocketFile?.let {
-      builder.socketFactory(UnixDomainSocketFactory(it))
+      builder.socketFactory(UnixDomainSocketFactory(File(it)))
       // No DNS lookup needed since we're just sending the request over a socket.
       builder.dns(NoOpDns)
       // Proxy config not supported
@@ -62,7 +76,6 @@ class HttpClientFactory @Inject constructor(
     config.clientConfig.protocols?.let {
       builder.protocols(
           config.clientConfig.protocols.map { Protocol.get(it) }
-              ?: listOf(Protocol.HTTP_1_1) //Safe default
       )
     }
 
@@ -78,13 +91,17 @@ class HttpClientFactory @Inject constructor(
     }
 
     val dispatcher = Dispatcher()
-    dispatcher.maxRequests = config.clientConfig.maxRequests
-    dispatcher.maxRequestsPerHost = config.clientConfig.maxRequestsPerHost
+    config.clientConfig.maxRequests?.let { maxRequests ->
+      dispatcher.maxRequests = maxRequests
+    }
+    config.clientConfig.maxRequestsPerHost?.let { maxRequestsPerHost ->
+      dispatcher.maxRequestsPerHost = maxRequestsPerHost
+    }
     builder.dispatcher(dispatcher)
 
     val connectionPool = ConnectionPool(
-        config.clientConfig.maxIdleConnections,
-        config.clientConfig.keepAliveDuration.toMillis(),
+        config.clientConfig.maxIdleConnections ?: Defaults.maxIdleConnections,
+        (config.clientConfig.keepAliveDuration?:Defaults.keepAliveDuration).toMillis(),
         TimeUnit.MILLISECONDS)
     builder.connectionPool(connectionPool)
 

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -6,7 +6,6 @@ import misk.config.Config
 import misk.logging.getLogger
 import misk.security.ssl.CertStoreConfig
 import misk.security.ssl.TrustStoreConfig
-import java.io.File
 import java.net.URL
 import java.time.Duration
 
@@ -19,17 +18,6 @@ data class HttpClientsConfig(
 ) : Config {
   init {
     validatePatterns()
-  }
-
-  private fun validatePatterns() = try {
-    endpoints.keys
-        .map { it.toRegex(RegexOption.IGNORE_CASE) }
-        .forEach { it.matches("") }
-  } catch (e: Exception) {
-    throw IllegalArgumentException(
-        "Failed to initialize HttpClientsConfig, failed to parse Regexp patterns!",
-        e
-    )
   }
 
   /** @return The [HttpClientEndpointConfig] for the given client, populated with defaults as needed */
@@ -52,6 +40,17 @@ data class HttpClientsConfig(
         url = endpointConfig.url,
         envoy = endpointConfig.envoy,
         clientConfig = allMatchingConfigs
+    )
+  }
+
+  private fun validatePatterns() = try {
+    endpoints.keys
+        .map { it.toRegex(RegexOption.IGNORE_CASE) }
+        .forEach { it.matches("") }
+  } catch (e: Exception) {
+    throw IllegalArgumentException(
+        "Failed to initialize HttpClientsConfig, failed to parse Regexp patterns!",
+        e
     )
   }
 

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfigBackwardsCompatibility.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfigBackwardsCompatibility.kt
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.type.TypeFactory
 import java.time.Duration
 
 data class BackwardsCompatibleEndpointConfig(
-    //Common fields
+    // Common fields
   val url: String? = null,
   val envoy: HttpClientEnvoyConfig? = null,
 
-    //Legacy fields
+    // Legacy fields
   val connectTimeout: Duration? = null,
   val writeTimeout: Duration? = null,
   val readTimeout: Duration? = null,
@@ -21,12 +21,12 @@ data class BackwardsCompatibleEndpointConfig(
   val keepAliveDuration: Duration = Duration.ofMinutes(5),
   val ssl: HttpClientSSLConfig? = null,
 
-    //New fields
+    // New fields
   val clientConfig: HttpClientConfig? = null
 )
 
 data class BackwardsCompatibleClientsConfig(
-    //Legacy fields
+    // Legacy fields
   val defaultConnectTimeout: Duration? = null,
   val defaultWriteTimeout: Duration? = null,
   val defaultReadTimeout: Duration? = null,
@@ -34,10 +34,10 @@ data class BackwardsCompatibleClientsConfig(
   val defaultPingInterval: Duration? = null,
   val defaultCallTimeout: Duration? = null,
 
-    //Shared fields
+    // Shared fields
   val endpoints: Map<String, BackwardsCompatibleEndpointConfig> = mapOf(),
 
-    //New fields
+    // New fields
   @JsonAlias("hosts")
   val hostConfigs: LinkedHashMap<String, HttpClientConfig> = linkedMapOf()
 )
@@ -88,7 +88,6 @@ class BackwardsCompatibleClientsConfigConverter : com.fasterxml.jackson.databind
   }
 
   private fun convert(value: BackwardsCompatibleEndpointConfig) =
-      //http://%s.%s.gns.square
       if (value.clientConfig == null)
         HttpClientEndpointConfig(
             url = value.url,

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfigBackwardsCompatibility.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfigBackwardsCompatibility.kt
@@ -1,0 +1,146 @@
+package misk.client
+
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.databind.type.TypeFactory
+import java.time.Duration
+
+data class BackwardsCompatibleEndpointConfig(
+    //Common fields
+  val url: String? = null,
+  val envoy: HttpClientEnvoyConfig? = null,
+
+    //Legacy fields
+  val connectTimeout: Duration? = null,
+  val writeTimeout: Duration? = null,
+  val readTimeout: Duration? = null,
+  val pingInterval: Duration? = null,
+  val callTimeout: Duration? = null,
+  val maxRequests: Int = 128,
+  val maxRequestsPerHost: Int = 32,
+  val maxIdleConnections: Int = 100,
+  val keepAliveDuration: Duration = Duration.ofMinutes(5),
+  val ssl: HttpClientSSLConfig? = null,
+
+    //New fields
+  val clientConfig: HttpClientConfig? = null
+)
+
+data class BackwardsCompatibleClientsConfig(
+    //Legacy fields
+  val defaultConnectTimeout: Duration? = null,
+  val defaultWriteTimeout: Duration? = null,
+  val defaultReadTimeout: Duration? = null,
+  val ssl: HttpClientSSLConfig? = null,
+  val defaultPingInterval: Duration? = null,
+  val defaultCallTimeout: Duration? = null,
+
+    //Shared fields
+  val endpoints: Map<String, BackwardsCompatibleEndpointConfig> = mapOf(),
+
+    //New fields
+  @JsonAlias("hosts")
+  val hostConfigs: LinkedHashMap<String, HttpClientConfig> = linkedMapOf()
+)
+
+class BackwardsCompatibleClientsConfigConverter : com.fasterxml.jackson.databind.util.Converter<BackwardsCompatibleClientsConfig, HttpClientsConfig> {
+  override fun getInputType(typeFactory: TypeFactory) =
+      typeFactory.constructType(BackwardsCompatibleClientsConfig::class.java)
+
+  override fun getOutputType(typeFactory: TypeFactory) =
+      typeFactory.constructType(HttpClientsConfig::class.java)
+
+  override fun convert(value: BackwardsCompatibleClientsConfig): HttpClientsConfig {
+    //Convert defaults into HttpClientConfig, or null
+    val defaults = listOfNotNull(
+        value.defaultConnectTimeout,
+        value.defaultWriteTimeout,
+        value.defaultReadTimeout,
+        value.ssl,
+        value.defaultPingInterval,
+        value.defaultCallTimeout
+    )
+        .takeUnless { it.isEmpty() }
+        ?.let {
+          HttpClientConfig(
+              connectTimeout = value.defaultConnectTimeout,
+              writeTimeout = value.defaultWriteTimeout,
+              readTimeout = value.defaultReadTimeout,
+              ssl = value.ssl,
+              pingInterval = value.defaultPingInterval,
+              callTimeout = value.defaultCallTimeout
+          )
+        }
+
+    //If `defaults` is specified - prepend it to the list of patterns as highest priority
+    val hostConfigs = defaults?.let { def ->
+      sequence {
+        yield(".*" to def)
+        yieldAll(value.hostConfigs.asSequence().map { it.toPair() })
+      }.toMap(LinkedHashMap())
+    } ?: value.hostConfigs
+
+    val endpoints = value.endpoints.mapValues { (_, v) -> convert(v) }
+
+    return HttpClientsConfig(
+        hostConfigs = hostConfigs,
+        endpoints = endpoints
+    )
+  }
+
+  private fun convert(value: BackwardsCompatibleEndpointConfig) =
+      //http://%s.%s.gns.square
+      if (value.clientConfig == null)
+        HttpClientEndpointConfig(
+            url = value.url,
+            envoy = value.envoy,
+            clientConfig = HttpClientConfig(
+                connectTimeout = value.connectTimeout,
+                writeTimeout = value.writeTimeout,
+                readTimeout = value.readTimeout,
+                pingInterval = value.pingInterval,
+                callTimeout = value.callTimeout,
+                maxRequests = value.maxRequests,
+                maxRequestsPerHost = value.maxRequestsPerHost,
+                maxIdleConnections = value.maxIdleConnections,
+                keepAliveDuration = value.keepAliveDuration,
+                ssl = value.ssl
+            )
+        )
+      else
+        HttpClientEndpointConfig(
+            url = value.url,
+            envoy = value.envoy,
+            clientConfig = value.clientConfig
+        )
+}
+
+@Deprecated("Use default constructor")
+fun HttpClientEndpointConfig(
+  url: String? = null,
+  envoy: HttpClientEnvoyConfig? = null,
+  connectTimeout: Duration? = null,
+  writeTimeout: Duration? = null,
+  readTimeout: Duration? = null,
+  pingInterval: Duration? = null,
+  callTimeout: Duration? = null,
+  maxRequests: Int? = null,
+  maxRequestsPerHost: Int? = null,
+  maxIdleConnections: Int? = null,
+  keepAliveDuration: Duration? = null,
+  ssl: HttpClientSSLConfig? = null
+) = HttpClientEndpointConfig(
+    url = url,
+    envoy = envoy,
+    clientConfig = HttpClientConfig(
+        connectTimeout = connectTimeout,
+        writeTimeout = writeTimeout,
+        readTimeout = readTimeout,
+        pingInterval = pingInterval,
+        callTimeout = callTimeout,
+        maxRequests = maxRequests,
+        maxRequestsPerHost = maxRequestsPerHost,
+        maxIdleConnections = maxIdleConnections,
+        keepAliveDuration = keepAliveDuration,
+        ssl = ssl
+    )
+)

--- a/misk/src/test/resources/http_clients_config_new-testing.yaml
+++ b/misk/src/test/resources/http_clients_config_new-testing.yaml
@@ -1,11 +1,18 @@
+hosts:
+  .*:
+    maxRequests: 199
+    maxRequestsPerHost: 100
+  .*\.google\.com:
+    maxRequestsPerHost: 50
+
 endpoints:
   test_client_url:
-    url: https://google.com/
+    url: https://test.google.com/
     clientConfig:
       connectTimeout: PT31S
       readTimeout: PT32S
       writeTimeout: PT33S
-      unixSocketFile: file.socket
+      unixSocketFile: "\u0000egress.sock"
       protocols:
         - http1
         - http2
@@ -16,3 +23,4 @@ endpoints:
       env: test_env
     clientConfig:
       connectTimeout: PT34S
+      maxRequests: 200

--- a/misk/src/test/resources/http_clients_config_old-testing.yaml
+++ b/misk/src/test/resources/http_clients_config_old-testing.yaml
@@ -1,3 +1,5 @@
+defaultReadTimeout: PT60S
+
 endpoints:
   test_client_url:
     url: https://google.com/


### PR DESCRIPTION
Second part of HttpClientEndpointConfig overhaul (first part [here](https://github.com/cashapp/misk/pull/1532)). This is the last piece required to start the migration off `envoy` style configs towards the host-based configs with `unixSocketFile` explicitly specified.
This change is still mostly backwards compatible with original config format. 

1. Made all of the fields in `HttpClientsConfig` nullable. This is to avoid accidentally overwriting default settings by no specifying any override (thus using constructor defaults, which would in fact count as an override).
2. Added `hostConfigs` attribute to `HttpClientsConfig`. This allows overriding settings based on host regular expressions. Uses `LinkedHashMap` as the order of definition defines the order the overrides are evaluated/applied.
3. Removed all the `default*` attributes from `HttpClientsConfig` constructor. The default settings can now be specified as `.*` host pattern. The backwards compatibility layer does exactly this, when it sees `default*` specified - it creates a synthetic "hosts" entry with `.*` in it.
4. `HttpClientFactory` uses the `hostConfigs` to build final set of settings. For `url` based endpoints it checks regular expressions for all matches. For `envoy` based endpoints, only hosts with `.*` in them are applied - this is to provide backwards compatibility for `envoy` endpoints with default configuration settings.

You can look at example of how new http client settings look like [here](https://github.com/cashapp/misk/blob/79d986aa8a1caa04c7a52199be499340bafefc69/misk/src/test/resources/http_clients_config_new-testing.yaml). The order of application priority is:
1. Hardcoded defaults.
2. Host-pattern based configuration (`hosts` section in Yaml), by order of declaration (lowest priority first).
3. Endpoint-based configuration. This would allow to have 2 differently named clients using some variation of settings.

Further planned steps (in future PRs):
1. Migrate all projects to not use `envoy` endpoints.
2. Remove support for `envoy` endpoints from Misk.
3. Remove all backwards-compatibility code.