### PR TITLE
Support OkHttp interceptors

### DIFF
--- a/misk-slack/src/main/kotlin/misk/slack/SlackModule.kt
+++ b/misk-slack/src/main/kotlin/misk/slack/SlackModule.kt
@@ -5,7 +5,9 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientFactory
+import misk.client.HttpClientModule
 import misk.inject.KAbstractModule
+import okhttp3.Interceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Named

--- a/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
@@ -4,12 +4,13 @@ import misk.security.ssl.SslContextFactory
 import misk.security.ssl.SslLoader
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
-import java.io.File
 import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import javax.net.ssl.X509TrustManager
 
@@ -20,6 +21,9 @@ class HttpClientFactory @Inject constructor(
 ) {
   @com.google.inject.Inject(optional = true)
   lateinit var envoyClientEndpointProvider: EnvoyClientEndpointProvider
+
+  @com.google.inject.Inject(optional = true)
+  var okhttpInterceptors: Provider<List<Interceptor>>? = null
 
   /** Returns a client initialized based on `config`. */
   fun create(config: HttpClientEndpointConfig): OkHttpClient {
@@ -83,6 +87,10 @@ class HttpClientFactory @Inject constructor(
         config.clientConfig.keepAliveDuration.toMillis(),
         TimeUnit.MILLISECONDS)
     builder.connectionPool(connectionPool)
+
+    okhttpInterceptors?.let {
+      builder.interceptors().addAll(it.get())
+    }
 
     return builder.build()
   }

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -112,6 +112,9 @@ data class HttpClientsConfig(
         )
     )
   }
+
+  /** Names of configured endpoints, all of which can be fetched using [get] */
+  fun endpointNames(): Set<String> = endpoints.keys
 }
 
 data class HttpClientSSLConfig(

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -10,6 +10,7 @@ import io.opentracing.Tracer
 import misk.clustering.Cluster
 import misk.inject.KAbstractModule
 import okhttp3.EventListener
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import java.lang.reflect.Proxy

--- a/misk/src/test/kotlin/misk/client/HttpClientProviderTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientProviderTest.kt
@@ -1,0 +1,75 @@
+package misk.client
+
+import com.google.inject.Provides
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest
+class HttpClientProviderTest {
+
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject private lateinit var mockWebServer: MockWebServer
+  @Inject private lateinit var client: OkHttpClient
+
+  @Test
+  fun `provides a valid client`() {
+    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("hello"))
+
+    val response = client.newCall(Request.Builder()
+        .url(mockWebServer.url("/foo"))
+        .build())
+        .execute()
+
+    assertThat(response.code).isEqualTo(200)
+    response.body?.use { body -> assertThat(body.string()).isEqualTo("hello") }
+
+    assertThat(response.headers["interceptor-header"]).isEqualTo("added by interceptor")
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+      bind<MockWebServer>().toInstance(MockWebServer())
+      install(HttpClientModule("pinger"))
+
+      // Add an interceptor that adds an HTTP header to the response
+      multibind<Interceptor>().toInstance(object : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+          val response = chain.proceed(chain.request())
+
+          return response.newBuilder()
+              .addHeader("interceptor-header", "added by interceptor")
+              .build()
+        }
+      })
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClientConfig(server: MockWebServer): HttpClientsConfig {
+      val url = server.url("/")
+      return HttpClientsConfig(
+          endpoints = mapOf("pinger" to HttpClientEndpointConfig(
+              url = url.toString(),
+              clientConfig = HttpClientConfig(
+                  readTimeout = Duration.ofMillis(100)
+              )
+          )))
+    }
+  }
+}


### PR DESCRIPTION
Misk `NetworkInterceptor`s end up mapping to OkHttp `NetworkInterceptor` but there is currently no way to add an OkHttp `Interceptor`. This adds support for that for typed HTTP clients. GRPC and untyped clients aren't supported in this PR but I'll draft a possibility in a comment.