### PR TITLE
Do not update all connection metrics when a connection is removed

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
@@ -4,7 +4,6 @@ import org.eclipse.jetty.io.Connection
 import org.eclipse.jetty.util.component.AbstractLifeCycle
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 
 internal class ConnectionListener(
@@ -19,28 +18,24 @@ internal class ConnectionListener(
   private val totalMessagesSent = AtomicLong()
 
   private val connections = Collections.newSetFromMap(ConcurrentHashMap<ConnectionKey, Boolean>())
-  private val openedConnections = ConcurrentLinkedQueue<ConnectionKey>()
-  private val closedConnections = ConcurrentLinkedQueue<ConnectionKey>()
   private val labels = ConnectionMetrics.forPort(protocol, port)
 
-  // Updating prometheus metrics requires monitor locks and its best to avoid acquiring those
-  // with the high number of jetty threads. Instead we queue up changes to the connection and
-  // process the changes when metrics are refreshed by a single background thread.
   override fun onOpened(connection: Connection) {
-    openedConnections.add(ConnectionKey(connection))
+    connections.add(ConnectionKey(connection))
+    metrics.activeConnections.labels(*labels).inc()
+    metrics.acceptedConnections.labels(*labels).inc()
   }
 
   override fun onClosed(connection: Connection) {
-    closedConnections.add(ConnectionKey(connection))
+    // Force a refresh so that we gather the final stats on the connection
+    refreshMetrics()
+
+    if (connections.remove(ConnectionKey(connection))) {
+      metrics.activeConnections.labels(*labels).dec()
+    }
   }
 
   fun refreshMetrics() {
-    while (openedConnections.isNotEmpty()) {
-      connections.add(openedConnections.remove())
-      metrics.activeConnections.labels(*labels).inc()
-      metrics.acceptedConnections.labels(*labels).inc()
-    }
-
     var bytesReceivedSnapshot = 0L
     var bytesSentSnapshot = 0L
     var messagesReceivedSnapshot = 0L
@@ -88,11 +83,6 @@ internal class ConnectionListener(
 
     if (messagesReceivedDiff > 0) {
       metrics.messagesReceived.labels(*labels).inc(messagesReceivedDiff.toDouble())
-    }
-
-    while (closedConnections.isNotEmpty()) {
-      connections.remove(closedConnections.remove())
-      metrics.activeConnections.labels(*labels).dec()
     }
   }
 

--- a/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/ConnectionListener.kt
@@ -12,78 +12,65 @@ internal class ConnectionListener(
   private val metrics: ConnectionMetrics
 ) : AbstractLifeCycle(), Connection.Listener {
 
-  private val totalBytesReceived = AtomicLong()
-  private val totalBytesSent = AtomicLong()
-  private val totalMessagesReceived = AtomicLong()
-  private val totalMessagesSent = AtomicLong()
-
-  private val connections = Collections.newSetFromMap(ConcurrentHashMap<ConnectionKey, Boolean>())
+  // not thread safe since it's only used by refreshMetrics
+  private var previousSnapshot = Snapshot.empty()
+  // see the Accumulator doc for thread safety
+  private val removedTotals = Accumulator()
+  private val activeConnections =
+      Collections.newSetFromMap(ConcurrentHashMap<ConnectionKey, Boolean>())
   private val labels = ConnectionMetrics.forPort(protocol, port)
 
   override fun onOpened(connection: Connection) {
-    connections.add(ConnectionKey(connection))
+    activeConnections.add(ConnectionKey(connection))
     metrics.activeConnections.labels(*labels).inc()
     metrics.acceptedConnections.labels(*labels).inc()
   }
 
   override fun onClosed(connection: Connection) {
-    // Force a refresh so that we gather the final stats on the connection
-    refreshMetrics()
-
-    if (connections.remove(ConnectionKey(connection))) {
+    if (activeConnections.remove(ConnectionKey(connection))) {
+      // save the stats for the removed connection so they are included in the next call to
+      // refreshMetrics.
+      removedTotals.addConnection(connection)
+      recordDuration(connection)
       metrics.activeConnections.labels(*labels).dec()
     }
   }
 
   fun refreshMetrics() {
-    var bytesReceivedSnapshot = 0L
-    var bytesSentSnapshot = 0L
-    var messagesReceivedSnapshot = 0L
-    var messagesSentSnapshot = 0L
-
-    connections.forEach {
-      val bytesIn = it.connection.bytesIn
-      if (bytesIn > 0) bytesReceivedSnapshot += bytesIn
-
-      val bytesOut = it.connection.bytesOut
-      if (bytesOut > 0) bytesSentSnapshot += bytesOut
-
-      val messagesIn = it.connection.messagesIn
-      if (messagesIn > 0) messagesReceivedSnapshot += messagesIn
-
-      val messagesOut = it.connection.messagesOut
-      if (messagesOut > 0) messagesSentSnapshot += messagesOut
-
-      val connectionDuration = System.currentTimeMillis() - it.connection.createdTimeStamp
-      metrics.connectionDurations.record(connectionDuration.toDouble(), *labels)
+    val newTotals = Accumulator()
+    activeConnections.forEach {
+      newTotals.addConnection(it.connection)
+      recordDuration(it.connection)
     }
+    // add any connections that were removed since the previous refresh
+    newTotals.addSnapshot(removedTotals.snapshotAndReset())
 
     // Compute any diffs with the last time we took a snapshot, and apply those diffs
     // to the counter
-    val bytesReceivedDiff =
-        bytesReceivedSnapshot - totalBytesReceived.getAndSet(bytesReceivedSnapshot)
-    val bytesSentDiff =
-        bytesSentSnapshot - totalBytesSent.getAndSet(bytesSentSnapshot)
-    val messagesReceivedDiff =
-        messagesReceivedSnapshot - totalMessagesReceived.getAndSet(messagesReceivedSnapshot)
-    val messagesSentDiff =
-        messagesSentSnapshot - totalMessagesSent.getAndSet(messagesSentSnapshot)
+    val newSnapshot = newTotals.snapshotAndReset()
+    val diff = newSnapshot - previousSnapshot
+    previousSnapshot = newSnapshot
 
-    if (bytesSentDiff > 0) {
-      metrics.bytesSent.labels(*labels).inc(bytesSentDiff.toDouble())
+    if (diff.bytesSent > 0) {
+      metrics.bytesSent.labels(*labels).inc(diff.bytesSent.toDouble())
     }
 
-    if (bytesReceivedDiff > 0) {
-      metrics.bytesReceived.labels(*labels).inc(bytesReceivedDiff.toDouble())
+    if (diff.bytesReceived > 0) {
+      metrics.bytesReceived.labels(*labels).inc(diff.bytesReceived.toDouble())
     }
 
-    if (messagesSentDiff > 0) {
-      metrics.messagesSent.labels(*labels).inc(messagesSentDiff.toDouble())
+    if (diff.messagesSent > 0) {
+      metrics.messagesSent.labels(*labels).inc(diff.messagesSent.toDouble())
     }
 
-    if (messagesReceivedDiff > 0) {
-      metrics.messagesReceived.labels(*labels).inc(messagesReceivedDiff.toDouble())
+    if (diff.messagesReceived > 0) {
+      metrics.messagesReceived.labels(*labels).inc(diff.messagesReceived.toDouble())
     }
+  }
+
+  private fun recordDuration(connection : Connection) {
+    val connectionDuration = System.currentTimeMillis() - connection.createdTimeStamp
+    metrics.connectionDurations.record(connectionDuration.toDouble(), *labels)
   }
 
   private class ConnectionKey(val connection: Connection) {
@@ -92,5 +79,73 @@ internal class ConnectionListener(
     }
 
     override fun hashCode() = System.identityHashCode(connection)
+  }
+
+  /**
+   * An immutable snapshot from an [Accumulator]
+   */
+  private data class Snapshot(
+    val bytesReceived: Long,
+    val bytesSent: Long,
+    val messagesReceived: Long,
+    val messagesSent: Long
+  ) {
+
+    operator fun minus(other: Snapshot): Snapshot {
+      return Snapshot(
+          bytesReceived - other.bytesReceived,
+          bytesSent - other.bytesSent,
+          messagesReceived - other.messagesReceived,
+          messagesSent - other.messagesSent)
+    }
+
+    companion object {
+      fun empty() = Snapshot(0, 0, 0, 0)
+    }
+  }
+
+  /**
+   * A mutable accumulator of metric data.
+   *
+   * This Accumulator is not entirely thread safe as an intentional trade off to avoid locking. The
+   * individual accumulated metrics are thread safe (use AtomicLongs), but the group of metrics is
+   * not updated atomically. When a snapshot is generated it might include a partial set of metrics
+   * from an in-flight addition. Since metrics are inherently lossy and compressed this is a reasonable
+   * trade off to avoid locking every jetty thread.
+   */
+  private data class Accumulator(
+    private val bytesReceived: AtomicLong = AtomicLong(),
+    private val bytesSent: AtomicLong = AtomicLong(),
+    private val messagesReceived: AtomicLong = AtomicLong(),
+    private val messagesSent: AtomicLong = AtomicLong()
+  ) {
+
+    /**
+     * Update the accumulator with metrics from the [Connection].
+     */
+    fun addConnection(connection: Connection) {
+      bytesReceived.addAndGet(connection.bytesIn)
+      bytesSent.addAndGet(connection.bytesOut)
+      messagesReceived.addAndGet(connection.messagesIn)
+      messagesSent.addAndGet(connection.messagesOut)
+    }
+
+    /**
+     * Update the accumulator with metrics from a [Snapshot].
+     */
+    fun addSnapshot(snapshot: Snapshot) {
+      bytesReceived.addAndGet(snapshot.bytesReceived)
+      bytesSent.addAndGet(snapshot.bytesSent)
+      messagesReceived.addAndGet(snapshot.messagesReceived)
+      messagesSent.addAndGet(snapshot.messagesSent)
+    }
+
+    fun snapshotAndReset(): Snapshot {
+      return Snapshot(
+          bytesReceived.getAndSet(0),
+          bytesSent.getAndSet(0),
+          messagesReceived.getAndSet(0),
+          messagesSent.getAndSet(0))
+    }
   }
 }


### PR DESCRIPTION
If there are a lot of active connections this can cause a lot of
contention on the metrics, since you might have many closing connections
all trying to update the same metrics.

There is no need to refresh the metrics when closing a connection. We
can just save the stats of the closed connections so they are included
in the next call to refereshMetrics.