### PR TITLE
Function to dynamically generate HttpClientConfig for given URL

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -43,6 +43,21 @@ data class HttpClientsConfig(
     )
   }
 
+  /** @return The [HttpClientEndpointConfig] for the given URL, populated with defaults as needed */
+  operator fun get(url: URL): HttpClientEndpointConfig {
+    val allMatchingConfigs = sequence {
+      yield(httpClientConfigDefaults)
+      yieldAll(
+          findUrlMatchingConfigs(url.toString())
+      )
+    }.reduce { prev, cur -> cur.applyDefaults(prev) }
+
+    return HttpClientEndpointConfig(
+        url = url.toString(),
+        clientConfig = allMatchingConfigs
+    )
+  }
+
   private fun validatePatterns() = try {
     endpoints.keys
         .map { it.toRegex(RegexOption.IGNORE_CASE) }

--- a/misk/src/test/kotlin/misk/client/HttpClientsConfigTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientsConfigTest.kt
@@ -1,0 +1,147 @@
+package misk.client
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.time.Duration
+
+private fun HttpClientConfig.withGlobalDefaults() = this.applyDefaults(HttpClientsConfig.httpClientConfigDefaults)
+
+class HttpClientsConfigTest {
+  @Test
+  fun `matches host settings by pattern`() {
+    val cfg = HttpClientsConfig(
+        hostConfigs = linkedMapOf(
+            ".*" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(1)
+            ),
+            ".*\\.com" to HttpClientConfig(
+                writeTimeout = Duration.ofSeconds(2)
+            ),
+            ".*\\.org" to HttpClientConfig(
+                readTimeout = Duration.ofSeconds(3)
+            )
+        )
+    )
+
+    assertThat(cfg[URL("http://test.wikipedia.org")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://test.wikipedia.org",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(1),
+                    readTimeout = Duration.ofSeconds(3)
+                ).withGlobalDefaults()
+            )
+        )
+
+    assertThat(cfg[URL("http://someting.123.domain.com")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://someting.123.domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(1),
+                    writeTimeout = Duration.ofSeconds(2)
+                ).withGlobalDefaults()
+            )
+        )
+
+    assertThat(cfg[URL("https://some.com.domain.org")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "https://some.com.domain.org",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(1),
+                    readTimeout = Duration.ofSeconds(3)
+                ).withGlobalDefaults()
+            )
+        )
+  }
+
+  @Test
+  fun `applies host settings in order of declaration`() {
+    val cfg1 = HttpClientsConfig(
+        hostConfigs = linkedMapOf(
+            ".*" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(1)
+            ),
+            ".*\\.com" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(2)
+            )
+        )
+    )
+
+    val cfg2 = HttpClientsConfig(
+        hostConfigs = linkedMapOf(
+            ".*\\.com" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(2)
+            ),
+            ".*" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(1)
+            )
+        )
+    )
+
+    assertThat(cfg1[URL("http://domain.com")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(2)
+                ).withGlobalDefaults()
+            )
+        )
+
+    assertThat(cfg2[URL("http://domain.com")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(1)
+                ).withGlobalDefaults()
+            )
+        )
+  }
+
+  @Test
+  fun `endpoint settings are always highest priority`() {
+    val cfg = HttpClientsConfig(
+        hostConfigs = linkedMapOf(
+            ".*" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(1)
+            ),
+            "domain.com" to HttpClientConfig(
+                connectTimeout = Duration.ofSeconds(2)
+            )
+        ),
+        endpoints = mapOf(
+            "test" to HttpClientEndpointConfig(
+                url = "http://domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(3)
+                )
+            )
+        )
+    )
+
+    assertThat(cfg[URL("http://domain.com")])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(2)
+                ).withGlobalDefaults()
+            )
+        )
+
+    assertThat(cfg["test"])
+        .isEqualTo(
+            HttpClientEndpointConfig(
+                url = "http://domain.com",
+                clientConfig = HttpClientConfig(
+                    connectTimeout = Duration.ofSeconds(3)
+                ).withGlobalDefaults()
+            )
+        )
+  }
+}


### PR DESCRIPTION
With the new host-based settings we can now dynamically build HttpClientConfigs for given URL, instead of only using preconfigured endpoints. This is useful for applications that have dynamic URLs, for example for callbacks (like Backfila).