### PR TITLE
Add LogRateLimiter

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
@@ -10,7 +10,22 @@ package misk.web.interceptors
  *
  * If arguments and responses may include sensitive information, it is expected that the toString()
  * methods of these objects will redact it.
+ *
+ * Rate limiting is used to sample the number of requests logged. The value specified is the
+ * log events per sec allotted per caller per action.
+ *
+ * By default we set rate limiting for both successes and errors to 1 log event per sec,
+ * enough to show things are happening without sending too many logs.
+ *
+ * If you would like to turn off rate limiting and emit all logs, set rateLimiting and/or
+ * errorRateLimiting to 0.
  */
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class LogRequestResponse(val sampling: Double, val includeBody: Boolean)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+annotation class LogRequestResponse(
+  // TODO(isabel): Remove sampling and includeBody. Will be replaced with rate limiting
+  val sampling: Double,
+  val includeBody: Boolean,
+  // Currently unused
+  val rateLimiting: Long = 1,
+  val errorRateLimiting: Long = 1)

--- a/misk/src/main/kotlin/misk/ratelimit/RateLimiter.kt
+++ b/misk/src/main/kotlin/misk/ratelimit/RateLimiter.kt
@@ -1,0 +1,121 @@
+package misk.ratelimit
+
+import com.google.common.base.Ticker
+import misk.concurrent.Sleeper
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+
+/**
+ * A deterministic testable rate limiter that uses two variables:
+ *
+ * * Permits per second. This is the application's configured rate. We express as a per-second rate
+ *   but use it as a time-between-permits. For example, 250 permits per second is a permit every
+ *   4 milliseconds. This may be zero, in which case all acquire attempts will return false.
+ *
+ * * Window size. If the application specified 250 permits per second, that doesn't specify how many
+ *   permits can be returned at once. An implementation could strictly return 1 permit every 4
+ *   milliseconds, or batches of 1000 permits every 4 seconds. This class hard codes the window size
+ *   to 1 second. Small windows shrink batch sizes which is inefficient; large windows grow batch
+ *   sizes which is bursty. This class uses 1 second to balance latency and throughput.
+ *
+ * The implementation tracks a future timestamp that permits are consumed until.
+ *
+ * This class is similar to Guava's rate limiter. Unlike Guava's rate limiter this class is testable
+ * by application code using the rate limiter. It also has very predictable behavior because its
+ * internal mechanisms are simpler than Guava's.
+ */
+class RateLimiter private constructor(
+  private val ticker: Ticker,
+  private val sleeper: Sleeper
+) {
+  @Volatile var permitsPerSecond: Long = 0L
+
+  /**
+   * The nanoTime that we've consumed all permits through. This is at most [windowSizeNs] + current
+   * nanoTime.
+   */
+  private val atomicAllocatedUntil = AtomicLong(ticker.read())
+
+  /** The size of our window where we can borrow bytes from the future. */
+  private var windowSizeNs = TimeUnit.SECONDS.toNanos(1L)
+
+  /**
+   * Attempt to acquire [permitCount] permits, sleeping up to [timeout] if necessary for them to
+   * become available.
+   *
+   * Returns true if permits were acquired.
+   *
+   * This always returns false if you request more than [1 window size][windowSizeNs] worth of
+   * permits. If you need many permits, shrink your batch size. This is intended to smooth out
+   * consumption of the resources guarded by this rate limiter.
+   */
+  fun tryAcquire(permitCount: Long, timeout: Long, unit: TimeUnit): Boolean {
+    require(permitCount > 0) { "unexpected permitCount: $permitCount" }
+    require(timeout >= 0L) { "unexpected timeout: $timeout" }
+
+    val sleepTime = timeToAcquire(unit, timeout, permitCount)
+      ?: return false
+
+    if (sleepTime.toNanos() > 0L) {
+      sleeper.sleep(sleepTime)
+    }
+
+    return true
+  }
+
+  /**
+   * Returns the duration to sleep to acquire [permitCount], or null if the permits cannot be
+   * acquired within the given timeout.
+   *
+   * This implementation is lock-free.
+   *
+   * @return the time to wait, never greater than [timeout]. Null to not wait because permits were
+   *     not issued.
+   */
+  private fun timeToAcquire(
+    unit: TimeUnit,
+    timeout: Long,
+    permitCount: Long
+  ): Duration? {
+    while (true) {
+      val allocatedUntil = atomicAllocatedUntil.get()
+      val permitsPerSecond = this.permitsPerSecond // Sample this volatile only once.
+
+      val maxRequestSize = windowSizeNs.nanosToPermits(permitsPerSecond)
+      if (permitCount > maxRequestSize) return null
+
+      val now = ticker.read()
+      val timeoutNs = unit.toNanos(timeout)
+
+      // If this acquire succeeds, this is the time we're consuming permits through.
+      val newAllocatedUntil = maxOf(allocatedUntil, now) +
+        permitCount.permitsToNanos(permitsPerSecond)
+
+      // We only sleep for permits until the beginning of our window.
+      val sleepNs = newAllocatedUntil - now - windowSizeNs
+
+      // We'd have to sleep too long for this number of permits. Fail fast.
+      if (sleepNs > timeoutNs) return null
+
+      // Try to consume permits! If atomicAllocatedUntil changed, we lost a race; loop to try again.
+      if (!atomicAllocatedUntil.compareAndSet(allocatedUntil, newAllocatedUntil)) continue
+
+      // Permits were consumed. Return how long to wait before these permits can be used.
+      return if (sleepNs < 0) Duration.ZERO else Duration.ofNanos(sleepNs)
+    }
+  }
+
+  private fun Long.nanosToPermits(permitsPerSecond: Long) = this * permitsPerSecond / 1_000_000_000L
+
+  private fun Long.permitsToNanos(permitsPerSecond: Long) = this * 1_000_000_000L / permitsPerSecond
+
+  class Factory @Inject constructor(
+    private val ticker: Ticker,
+    private val sleeper: Sleeper
+  ) {
+    fun create(rate: Long) = RateLimiter(ticker, sleeper)
+      .apply { permitsPerSecond = rate }
+  }
+}

--- a/misk/src/main/kotlin/misk/web/interceptors/LogRateLimiter.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/LogRateLimiter.kt
@@ -1,0 +1,46 @@
+package misk.web.interceptors
+
+import misk.ratelimit.RateLimiter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+
+/**
+ * Holds rate limiters for logging success and error responses. There is a rate limiter for every
+ * action and service that calls it, for both success and error. The rate limiters are created
+ * according to the value set in [LogRequestResponse] annotation.
+ */
+@Singleton
+class LogRateLimiter @Inject constructor(
+  private val rateLimiterFactory: RateLimiter.Factory
+) {
+  private val rateLimiters = ConcurrentHashMap<LogBucketId, RateLimiter>()
+
+  fun tryAcquire(bucketId: LogBucketId): Boolean {
+    val logRequestResponse = bucketId.actionClass.java.getAnnotation(LogRequestResponse::class.java)
+    val bucketQps =
+      if (bucketId.isError) logRequestResponse.errorRateLimiting else logRequestResponse.rateLimiting
+    if (bucketQps == 0L) {
+      // If bucketQps is zero, it was specified by the service owner in the [LogRequestResponse]
+      // annotation meaning rate limiting on logs should be off
+      return true
+    }
+    val rateLimiter = rateLimiters.getOrPut(bucketId) { rateLimiterFactory.create(bucketQps) }
+    return rateLimiter.tryAcquire(1, 0L, TimeUnit.MILLISECONDS)
+  }
+
+  data class LogBucketId(
+    /** Calling service, this comes from misk headers. */
+    val caller: String,
+    /** ActionClass from which we can grab the [LogRequestResponse] **/
+    val actionClass: KClass<*>,
+    /** If the response code is error, we look up the errorRateLimiter **/
+    val isError: Boolean
+  ) : Comparable<LogBucketId> {
+    override fun toString() = "$caller/${actionClass.simpleName}/${isError}"
+
+    override fun compareTo(other: LogBucketId) = toString().compareTo(other.toString())
+  }
+}

--- a/misk/src/test/kotlin/misk/ratelimit/FakeTicker.kt
+++ b/misk/src/test/kotlin/misk/ratelimit/FakeTicker.kt
@@ -1,0 +1,26 @@
+package misk.ratelimit
+
+import com.google.common.base.Ticker
+import misk.concurrent.Sleeper
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FakeTicker @Inject constructor() : Ticker(), Sleeper {
+  private var nowNs = 0L
+
+  val nowMs: Long
+    get() = TimeUnit.NANOSECONDS.toMillis(nowNs)
+
+  override fun read() = nowNs
+
+  override fun sleep(duration: Duration) {
+    nowNs += duration.toNanos()
+  }
+
+  fun sleepMs(durationMs: Long) {
+    nowNs += TimeUnit.MILLISECONDS.toNanos(durationMs)
+  }
+}

--- a/misk/src/test/kotlin/misk/ratelimit/RateLimiterTest.kt
+++ b/misk/src/test/kotlin/misk/ratelimit/RateLimiterTest.kt
@@ -1,0 +1,124 @@
+package misk.ratelimit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
+
+class RateLimiterTest {
+  private val ticker = FakeTicker()
+  private val rateLimiter = RateLimiter.Factory(ticker, ticker).create(1L)
+
+  @Test
+  fun `rate zero`() {
+    rateLimiter.permitsPerSecond = 0L
+    assertThat(rateLimiter.tryAcquire(1L, 0, TimeUnit.MILLISECONDS)).isFalse()
+  }
+
+  @Test
+  fun `cannot acquire zero permits`() {
+    val exception = assertFailsWith<IllegalArgumentException> {
+      rateLimiter.tryAcquire(0L, 0, TimeUnit.MILLISECONDS)
+    }
+    assertThat(exception).hasMessage("unexpected permitCount: 0")
+  }
+
+  @Test
+  fun `cannot use negative timeout`() {
+    val exception = assertFailsWith<IllegalArgumentException> {
+      rateLimiter.tryAcquire(1L, -1L, TimeUnit.MILLISECONDS)
+    }
+    assertThat(exception).hasMessage("unexpected timeout: -1")
+  }
+
+  @Test
+  fun `consume slower than target rate`() {
+    rateLimiter.permitsPerSecond = 2L
+    assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(500L)
+    assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(1_000L)
+    assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(1_500L)
+  }
+
+  @Test
+  fun `consume at target rate`() {
+    rateLimiter.permitsPerSecond = 2L
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(500L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(1_000L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(1_500L)
+  }
+
+  @Test
+  fun `consumer faster than target rate`() {
+    rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.tryAcquire(1L, 499, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    assertThat(rateLimiter.tryAcquire(1L, 499, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    assertThat(rateLimiter.tryAcquire(1L, 499, TimeUnit.MILLISECONDS)).isFalse()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+  }
+
+  @Test
+  fun `rate limit increases`() {
+    rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    // Exhausted.
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isFalse()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    rateLimiter.permitsPerSecond = 10L
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(100L)
+  }
+
+  @Test
+  fun `rate limit decreases`() {
+    rateLimiter.permitsPerSecond = 10L
+
+    assertThat(rateLimiter.tryAcquire(10L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(100L)
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(200L)
+
+    rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isFalse()
+    assertThat(ticker.nowMs).isEqualTo(200L)
+  }
+
+  @Test
+  fun `permit count exceeds window size`() {
+    rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.tryAcquire(3L, 2_000, TimeUnit.MILLISECONDS)).isFalse()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+  }
+}

--- a/misk/src/test/kotlin/misk/web/interceptors/LogRateLimiterTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/LogRateLimiterTest.kt
@@ -1,0 +1,59 @@
+package misk.web.interceptors
+
+import com.google.common.base.Ticker
+import misk.ServiceManagerModule
+import misk.concurrent.Sleeper
+import misk.inject.KAbstractModule
+import misk.ratelimit.FakeTicker
+import misk.web.interceptors.LogRateLimiter.LogBucketId
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class LogRateLimiterTest {
+  @MiskTestModule val module =
+    TestModule()
+
+  @Inject lateinit var logRateLimiter: LogRateLimiter
+  @Inject lateinit var fakeTicker: FakeTicker
+
+  @Test
+  fun tryAcquire() {
+    val bucketId = LogBucketId("caller", TestAction::class, false)
+    assertThat(
+      logRateLimiter.tryAcquire(bucketId)).isTrue()
+    assertThat(
+      logRateLimiter.tryAcquire(bucketId)).isTrue()
+    assertThat(
+      logRateLimiter.tryAcquire(bucketId)).isFalse()
+
+    // Wait 1 second
+    fakeTicker.sleepMs(1000L)
+    assertThat(logRateLimiter.tryAcquire(bucketId)).isTrue()
+  }
+
+  @Test
+  fun noRateLimiting() {
+    assertThat(
+      logRateLimiter.tryAcquire(LogBucketId("caller", NoLogRateLimitingTestAction::class, false))
+    ).isTrue()
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(ServiceManagerModule())
+      bind<Ticker>().to<FakeTicker>()
+      bind<Sleeper>().to<FakeTicker>()
+    }
+  }
+
+  @LogRequestResponse(rateLimiting = 2L, errorRateLimiting = 2L, sampling = 1.0, includeBody = false)
+  class TestAction: WebAction
+
+  @LogRequestResponse(sampling = 1.0, includeBody = false)
+  class NoLogRateLimitingTestAction: WebAction
+}


### PR DESCRIPTION
Added a LogRateLimiter but it is not being used yet. It will be added to the RequestLoggingInterceptor to rate limit on log emission for WebActions.