### PR TITLE
Expose direct access to the JPA CriteriaBuilder

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -1,6 +1,7 @@
 package misk.hibernate
 
 import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.Predicate
 import javax.persistence.criteria.Root
 import javax.persistence.criteria.Selection
 import kotlin.reflect.KClass
@@ -12,6 +13,9 @@ interface Query<T> {
 
   /** How many rows to return. Must be -1 or in range 1..10_000. */
   var maxRows: Int
+
+  /** Constrain a query by operating directly on the JPA criteria builder. */
+  fun addJpaConstraint(block: (root: Root<*>, builder: CriteriaBuilder) -> Predicate)
 
   /** Constrain a query using a path known only at runtime. */
   fun dynamicAddConstraint(path: String, operator: Operator, value: Any? = null)
@@ -32,6 +36,7 @@ interface Query<T> {
   fun dynamicUniqueResult(session: Session, projectedPaths: List<String>): List<Any?>?
 
   fun list(session: Session): List<T>
+
   /** Manual projections are returned as a list of rows containing a list of cells. */
   fun dynamicList(
     session: Session,
@@ -40,9 +45,7 @@ interface Query<T> {
 
   fun dynamicList(session: Session, projectedPaths: List<String>): List<List<Any?>>
 
-  /**
-   * the number of entities deleted
-   */
+  /** Returns the number of entities deleted. */
   fun delete(session: Session): Int
 
   /**
@@ -100,6 +103,27 @@ inline fun <T, reified Q : Query<T>> Q.allowTableScan(): Q {
 
 inline fun <T, reified Q : Query<T>> Q.allowFullScatter(): Q {
   this.disableCheck(Check.FULL_SCATTER)
+  return this
+}
+
+/**
+ * Equivalent to Query.addConstraint, but takes the [CriteriaBuilder] as a receiver and returns
+ * this. This may be easier to use with method chaining.
+ *
+ * The root parameter should be used to select which property of the target entity to match against.
+ *
+ * ```
+ * queryFactory.newQuery<OperatorsMovieQuery>()
+ *     .constraint { root -> like(root.get("name"), "Jurassic%") }
+ *     .count(session)
+ * ```
+ */
+fun <T, Q : Query<T>> Q.constraint(
+  block: CriteriaBuilder.(root: Root<*>) -> Predicate
+): Q {
+  addJpaConstraint { root, criteriaBuilder ->
+    criteriaBuilder.block(root)
+  }
   return this
 }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -758,8 +758,12 @@ internal class ReflectionQuery<T : DbEntity<T>>(
     }
   }
 
-  internal fun addConstraint(predicateFactory: PredicateFactory): ReflectionQuery<T> {
-    constraints.add(predicateFactory)
+  override fun addJpaConstraint(block: PredicateFactory) {
+    addConstraint(block)
+  }
+
+  internal fun addConstraint(block: PredicateFactory): ReflectionQuery<T> {
+    constraints.add(block)
     return this
   }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -892,6 +892,24 @@ class ReflectionQueryFactoryTest {
     }
   }
 
+  @Test
+  fun customConstraint() {
+    transacter.allowCowrites().transaction { session ->
+      session.save(DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9)))
+      session.save(DbMovie("Jurassic Park: The Lost World", LocalDate.of(1997, 5, 19)))
+      session.save(DbMovie("Star Wars", LocalDate.of(1977, 5, 25)))
+    }
+
+    val jurassicCount = transacter.transaction { session ->
+      queryFactory.newQuery<OperatorsMovieQuery>()
+          .allowFullScatter()
+          .allowTableScan()
+          .constraint { root -> like(root.get("name"), "Jurassic%") }
+          .count(session)
+    }
+    assertThat(jurassicCount).isEqualTo(2)
+  }
+
   interface OperatorsMovieQuery : Query<DbMovie> {
     @Constraint(path = "name")
     fun name(name: String): OperatorsMovieQuery


### PR DESCRIPTION
So it isn't necessary to update Misk whenever a long-tail constraint
isn't built-in.