### PR TITLE
Make is possible to install PrometheusMetricsClientModule multiple times

### DIFF
--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -6,6 +6,7 @@ import misk.environment.RealEnvVarModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
 import misk.metrics.MetricsModule
+import misk.metrics.backends.prometheus.PrometheusMetricsClientModule
 import misk.moshi.MoshiModule
 import misk.resources.ResourceLoaderModule
 import misk.time.ClockModule
@@ -40,7 +41,7 @@ class MiskCommonServiceModule : KAbstractModule() {
     binder().requireExactBindingAnnotations()
     install(ExecutorsModule())
     install(ServiceManagerModule())
-    install(MetricsModule())
+    install(PrometheusMetricsClientModule())
     install(MoshiModule())
 
     // Initialize empty sets for our multibindings.


### PR DESCRIPTION
Use a provider to make the module bindings equal in PrometheusMetricsClientModule allowing multiple installs of PrometheusMetricsClientModule