### PR TITLE
sqs: each job handler gets its own trace

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -18,6 +18,7 @@ import misk.logging.getLogger
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.Status
 import misk.time.timed
+import misk.tracing.traceWithNewRootSpan
 import misk.tracing.traceWithSpan
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
@@ -150,7 +151,7 @@ internal class SqsJobConsumer @Inject internal constructor(
         CompletableFuture.supplyAsync(Supplier {
           metrics.jobsReceived.labels(queue.queueName, queue.queueName).inc()
 
-          tracer.traceWithSpan("handle-job-${queue.queueName}") { span ->
+          tracer.traceWithNewRootSpan("handle-job-${queue.queueName}") { span ->
             // If the incoming job has an original trace id, set that as a tag on the new span.
             // We don't turn that into the parent of the current span because that would
             // incorrectly include the execution time of the job in the execution time of the


### PR DESCRIPTION
We want each sqs job handled to have its own trace. This previously
worked properly while we used jaeger, assuming that by submitting tasks
to the handler thread pool does not propagate any existing trace.

However, now that we switched to datadog, it actually automagically uses
code generation to propagate traces across asynchronous execution
boundaries. So now the receiver scheduling thread becomes one giant long
trace that includes every job.

See https://github.com/DataDog/dd-trace-java/tree/master/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent

This change forces a new root span for each job.