### PR TITLE
Don't set gRPC response headers until the action completes

### DIFF
--- a/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
@@ -5,6 +5,7 @@ import com.squareup.protos.test.grpc.HelloReply
 import com.squareup.protos.test.grpc.HelloRequest
 import com.squareup.wire.Service
 import com.squareup.wire.WireRpc
+import misk.exceptions.BadRequestException
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -13,14 +14,18 @@ import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
+import okhttp3.Headers.Companion.headersOf
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okio.BufferedSink
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * This test gets Misk running as a GRPC server and then acts as a basic GRPC client to send a
@@ -35,8 +40,8 @@ class GrpcConnectivityTest {
   @MiskTestModule
   val module = TestModule()
 
-  @Inject
-  private lateinit var jetty: JettyService
+  @Inject private lateinit var jetty: JettyService
+  @Inject private lateinit var helloRpcAction: HelloRpcAction
 
   private lateinit var client: OkHttpClient
 
@@ -67,21 +72,62 @@ class GrpcConnectivityTest {
 
     val call = client.newCall(request)
     val response = call.execute()
+    response.use {
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.headers["grpc-status"]).isNull() // Sent in the trailers!
+      assertThat(response.headers["grpc-encoding"]).isEqualTo("identity")
+      assertThat(response.body!!.contentType()).isEqualTo("application/grpc".toMediaType())
 
-    for (i in 0 until response.headers.size) {
-      println("${response.headers.name(i)}: ${response.headers.value(i)}")
-    }
-
-    val reader = GrpcMessageSource(response.body!!.source(), HelloReply.ADAPTER,
-        response.header("grpc-encoding"))
-    while (true) {
-      val message = reader.read() ?: break
-      println(message)
+      val reader = GrpcMessageSource(
+          response.body!!.source(), HelloReply.ADAPTER,
+          response.header("grpc-encoding")
+      )
+      assertThat(reader.read()).isEqualTo(HelloReply("howdy, jesse!"))
+      assertThat(reader.read()).isNull()
+      assertThat(response.trailers()).isEqualTo(headersOf("grpc-status", "0"))
     }
   }
 
+  @Test
+  fun serviceThrowsException() {
+    helloRpcAction.failNextRequest = true
+
+    val request = Request.Builder()
+        .url(jetty.httpsServerUrl!!.resolve("/helloworld.Greeter/SayHello")!!)
+        .addHeader("grpc-trace-bin", "")
+        .addHeader("grpc-accept-encoding", "gzip")
+        .addHeader("grpc-encoding", "gzip")
+        .post(object : RequestBody() {
+          override fun contentType(): MediaType? {
+            return MediaTypes.APPLICATION_GRPC_MEDIA_TYPE
+          }
+
+          override fun writeTo(sink: BufferedSink) {
+            val writer = GrpcMessageSink(sink, HelloRequest.ADAPTER, "gzip")
+            writer.write(HelloRequest("jesse!"))
+          }
+        })
+        .build()
+
+    val call = client.newCall(request)
+    val response = call.execute()
+    response.use {
+      assertThat(response.code).isEqualTo(400)
+      assertThat(response.body!!.string()).isEqualTo("bad request!")
+      assertThat(response.headers["grpc-status"]).isNull()
+      assertThat(response.headers["grpc-encoding"]).isNull()
+      assertThat(response.trailers().size).isEqualTo(0)
+      assertThat(response.body?.contentType()).isEqualTo("text/plain;charset=utf-8".toMediaType())
+    }
+  }
+
+  @Singleton
   class HelloRpcAction @Inject constructor() : WebAction, GreeterSayHello {
+    var failNextRequest = false
+
     override fun sayHello(request: HelloRequest): HelloReply {
+      if (failNextRequest) throw BadRequestException("bad request!")
+
       return HelloReply.Builder()
           .message("howdy, ${request.name}")
           .build()


### PR DESCRIPTION
That way if the action throws an exception we don't send any gRPC
response headers.