### PR TITLE
Use attributes in Fake Feature Flags

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -10,6 +10,7 @@ import misk.feature.FeatureFlags
 import misk.feature.FeatureService
 import misk.feature.fromSafeJson
 import misk.feature.toSafeJson
+import java.util.PriorityQueue
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Provider
@@ -19,26 +20,25 @@ import javax.inject.Singleton
  * In-memory test implementation of [FeatureFlags] that allows flags to be overridden.
  */
 @Singleton
-class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) : AbstractIdleService(),
-    FeatureFlags,
-    FeatureService,
-    DynamicConfig {
-
+class FakeFeatureFlags @Inject constructor(
+  val moshi : Provider<Moshi>
+) : AbstractIdleService(), FeatureFlags, FeatureService, DynamicConfig {
   companion object {
     const val KEY = "fake_dynamic_flag"
+    val defaultAttributes = Attributes()
   }
 
   override fun startUp() {}
   override fun shutDown() {}
 
-  private val overrides = ConcurrentHashMap<MapKey, Any>()
+  private val overrides = ConcurrentHashMap<MapKey, PriorityQueue<MapValue>>()
 
   override fun getBoolean(feature: Feature, key: String, attributes: Attributes): Boolean {
     return getOrDefault(feature, key, false)
   }
 
   override fun getInt(feature: Feature, key: String, attributes: Attributes): Int =
-      get(feature, key) as? Int ?: throw IllegalArgumentException(
+      get(feature, key, attributes) as? Int ?: throw IllegalArgumentException(
           "Int flag $feature must be overridden with override() before use")
 
   override fun getString(feature: Feature, key: String, attributes: Attributes): String =
@@ -52,7 +52,7 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
     attributes: Attributes
   ): T {
     @Suppress("unchecked_cast")
-    return getOrDefault(feature, key, clazz.enumConstants[0]) as T
+    return getOrDefault(feature, key, clazz.enumConstants[0], attributes) as T
   }
 
   override fun <T> getJson(
@@ -61,7 +61,7 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
     clazz: Class<T>,
     attributes: Attributes
   ): T {
-    val jsonFn = get(feature, key) as? Function0<*> ?: throw IllegalArgumentException(
+    val jsonFn = get(feature, key, attributes) as? Function0<*> ?: throw IllegalArgumentException(
         "JSON flag $feature must be overridden with override() before use: ${get(feature, key)}")
     // The JSON is lazily provided to handle the case where the override is provided by the
     // FakeFeatureFlagModule and the Moshi instance cannot be accessed inside the module.
@@ -77,76 +77,153 @@ class FakeFeatureFlags @Inject constructor(private val moshi : Provider<Moshi>) 
   override fun <T : Enum<T>> getEnum(feature: Feature, clazz: Class<T>): T = getEnum(feature, KEY, clazz)
   override fun <T> getJson(feature: Feature, clazz: Class<T>): T = getJson(feature, KEY, clazz)
 
-  private fun get(feature: Feature, key: String): Any? {
-    FeatureFlagValidation.checkValidKey(feature, key)
-    return overrides.getOrElse(MapKey(feature, key)) {
-      overrides[MapKey(feature)]
-    }
-  }
-
-  private fun <V> getOrDefault(feature: Feature, key: String, defaultValue: V): V {
+  private fun <V> getOrDefault(
+    feature: Feature,
+    key: String,
+    defaultValue: V,
+    attributes: Attributes = defaultAttributes
+  ): V {
     FeatureFlagValidation.checkValidKey(feature, key)
     @Suppress("unchecked_cast")
-    return overrides.getOrElse(MapKey(feature, key)) {
-      overrides.getOrDefault(MapKey(feature), defaultValue)
-    } as V
+    return (get(feature, key, attributes) ?: defaultValue) as V
   }
 
-  fun override(feature: Feature, value: Boolean) {
-    overrides[MapKey(feature)] = value
+  private fun get(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = defaultAttributes
+  ): Any? {
+    FeatureFlagValidation.checkValidKey(feature, key)
+    // Override value lookup is structured in 3 levels: feature, key, and attributes level. The
+    // logic to get the override value is as follows:
+    //
+    // 1. Return feature level override if there is no override at the key level.
+    // 2. if there is an override at the key level, then:
+    //   2.1 Return the override value associated with the attribute override that contains
+    //       all the attributes of the given attributes.
+    //   2.2 If there is no match, return the override value defined at the key level.
+    val overrideMapValues = overrides[MapKey(feature, key)]
+        ?: return overrides[MapKey(feature)]?.let { it.first().value }
+
+    val overrideMapValuesCopy = PriorityQueue(overrideMapValues)
+    var currentMapValue = overrideMapValuesCopy.poll()
+    while (overrideMapValuesCopy.isNotEmpty() || currentMapValue != null) {
+      if (attributes.text.entries.containsAll(currentMapValue.attributes.text.entries)) { break }
+      currentMapValue = overrideMapValuesCopy.poll()
+    }
+    return currentMapValue.value
   }
 
-  fun override(feature: Feature, value: Int) {
-    overrides[MapKey(feature)] = value
-  }
+  fun override(
+    feature: Feature,
+    value: Boolean
+  ) = override<Boolean>(feature, value)
 
-  fun override(feature: Feature, value: String) {
-    overrides[MapKey(feature)] = value
-  }
+  fun override(
+    feature: Feature,
+    value: Int
+  ) = override<Int>(feature, value)
 
-  fun override(feature: Feature, value: Enum<*>) {
-    overrides[MapKey(feature)] = value
-  }
+  fun override(
+    feature: Feature,
+    value: String
+  ) = override<String>(feature, value)
 
-  fun <T> override(feature: Feature, value: T, clazz: Class<T>) {
-    overrides[MapKey(feature)] = { moshi.get().adapter(clazz).toSafeJson(value) }
-  }
+  fun override(
+    feature: Feature,
+    value: Enum<*>
+  ) = override<Enum<*>>(feature, value)
+
+  fun <T> override(
+    feature: Feature,
+    value: T
+  ) = overrideKey(feature, KEY, value, defaultAttributes)
 
   fun overrideJsonString(feature: Feature, json : String) {
-    overrides[MapKey(feature)] = { json }
+    overrideKey(feature, KEY, { json }, defaultAttributes)
   }
 
   inline fun <reified T> overrideJson(feature: Feature, value: T) {
-    override(feature, value, T::class.java)
+    overrideKeyJson(feature, KEY, value, defaultAttributes)
   }
 
-  fun overrideKey(feature: Feature, key: String, value: Boolean) {
-    overrides[MapKey(feature, key)] = value
+  fun overrideKey(
+    feature: Feature,
+    key: String,
+    value: Boolean,
+    attributes: Attributes = defaultAttributes
+  ) = overrideKey<Boolean>(feature, key, value, attributes)
+
+
+  fun overrideKey(
+    feature: Feature,
+    key: String,
+    value: Int,
+    attributes: Attributes = defaultAttributes
+  ) = overrideKey<Int>(feature, key, value, attributes)
+
+  fun overrideKey(
+    feature: Feature,
+    key: String,
+    value: String,
+    attributes: Attributes = defaultAttributes
+  ) = overrideKey<String>(feature, key, value, attributes)
+
+  fun overrideKey(
+    feature: Feature,
+    key: String,
+    value: Enum<*>,
+    attributes: Attributes = defaultAttributes
+  ) = overrideKey<Enum<*>>(feature, key, value, attributes)
+
+  fun <T> overrideKey(
+    feature: Feature,
+    key: String,
+    value: T,
+    attributes: Attributes = Attributes()
+  ) {
+    val mapKey = MapKey(feature, key)
+    overrides[mapKey] = overrides[mapKey] ?: PriorityQueue()
+    overrides[mapKey]!!.add(MapValue(
+        order = overrides[mapKey]!!.size + 1,
+        attributes = attributes,
+        value = value as Any))
   }
 
-  fun overrideKey(feature: Feature, key: String, value: Int) {
-    overrides[MapKey(feature, key)] = value
-  }
-
-  fun overrideKey(feature: Feature, key: String, value: String) {
-    overrides[MapKey(feature, key)] = value
-  }
-
-  fun overrideKey(feature: Feature, key: String, value: Enum<*>) {
-    overrides[MapKey(feature, key)] = value
-  }
-
-  fun <T> overrideKey(feature: Feature, key: String, value: T, clazz : Class<T>) {
-    overrides[MapKey(feature, key)] = { moshi.get().adapter(clazz).toSafeJson(value) }
-  }
-
-  inline fun <reified T> overrideKeyJson(feature: Feature, key: String, value: T) {
-    overrideKey(feature, key, value, T::class.java)
+  inline fun <reified T> overrideKeyJson(
+    feature: Feature,
+    key: String,
+    value: T,
+    attributes: Attributes = defaultAttributes
+  ) {
+    val jsonValue = { moshi.get().adapter(T::class.java).toSafeJson(value) } as Any
+    overrideKey(feature, key, jsonValue, attributes)
   }
 
   fun reset() {
     overrides.clear()
   }
 
-  private data class MapKey(val feature: Feature, val key: String? = null)
+  private data class MapKey(
+    val feature: Feature,
+    val key: String = KEY
+  )
+
+  /**
+   * Data class that holds the override value provided for the given [feature, key, attributes].
+   */
+  private data class MapValue(
+    val order: Int = 1, //Order is used to pick the latest provided map value.
+    val attributes: Attributes = defaultAttributes,
+    val value: Any
+  ) : Comparable<MapValue> {
+    override fun compareTo(other: MapValue): Int {
+      val attributeSizeCompare = -attributes.text.size.compareTo(other.attributes.text.size)
+      return if (attributeSizeCompare != 0) {
+        attributeSizeCompare
+      } else {
+        -order.compareTo(other.order)
+      }
+    }
+  }
 }

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -130,6 +130,69 @@ internal class FakeFeatureFlagsTest {
     //Provides the key level override when there is no match on attributes
     assertThat(subject.getJson<JsonFeature>(FEATURE, "joker", goodJokerAttributes))
         .isEqualTo(JsonFeature("joker"))
+
+    subject.reset()
+    subject.override(FEATURE, JsonFeature("test-class"), JsonFeature::class.java)
+    subject.overrideKey(FEATURE, "joker", JsonFeature("test-key-class"), JsonFeature::class.java)
+    assertThat(subject.getJson<JsonFeature>(FEATURE))
+        .isEqualTo(JsonFeature("test-class"))
+    assertThat(subject.getJson<JsonFeature>(FEATURE, "joker"))
+        .isEqualTo(JsonFeature("test-key-class"))
+  }
+
+  @Test
+  fun getBoolean() {
+    // Default returns false and not throw as the other variants.
+    assertThat(subject.getBoolean(FEATURE, TOKEN)).isEqualTo(false)
+
+    // Can be overridden
+    subject.override(FEATURE, true)
+    subject.override(OTHER_FEATURE, false)
+    assertThat(subject.getBoolean(FEATURE, TOKEN)).isEqualTo(true)
+    assertThat(subject.getBoolean(OTHER_FEATURE, TOKEN)).isEqualTo(false)
+
+    // Can override with specific keys
+    subject.overrideKey(FEATURE, "joker", false)
+    assertThat(subject.getBoolean(FEATURE, TOKEN)).isEqualTo(true)
+    assertThat(subject.getBoolean(FEATURE, "joker")).isEqualTo(false)
+
+    // Can override with specific keys and attributes
+    val attributes = Attributes(mapOf("type" to "bad"))
+    subject.overrideKey(FEATURE, "joker", false, attributes)
+    assertThat(subject.getBoolean(FEATURE, TOKEN)).isEqualTo(true)
+    assertThat(subject.getBoolean(FEATURE, "joker")).isEqualTo(false)
+    assertThat(subject.getBoolean(FEATURE, "joker", attributes)).isEqualTo(false)
+    //Provides the key level override when there is no match on attributes
+    assertThat(subject.getBoolean(FEATURE, "joker", Attributes(mapOf("don't" to "exist"))))
+        .isEqualTo(false)
+  }
+
+  @Test
+  fun getString() {
+    // Default returns false and not throw as the other variants.
+    assertThrows<RuntimeException> { subject.getString(FEATURE, TOKEN) }
+
+    // Can be overridden
+    subject.override(FEATURE, "feature")
+    subject.override(OTHER_FEATURE, "other-feature")
+    assertThat(subject.getString(FEATURE, TOKEN)).isEqualTo("feature")
+    assertThat(subject.getString(OTHER_FEATURE, TOKEN)).isEqualTo("other-feature")
+
+    // Can override with specific keys
+    subject.overrideKey(FEATURE, "joker", "feature-joker")
+    assertThat(subject.getString(FEATURE, TOKEN)).isEqualTo("feature")
+    assertThat(subject.getString(FEATURE, "joker")).isEqualTo("feature-joker")
+
+    // Can override with specific keys and attributes
+    val attributes = Attributes(mapOf("type" to "bad"))
+    subject.overrideKey(FEATURE, "joker", "feature-joker-with-attrs", attributes)
+    assertThat(subject.getString(FEATURE, TOKEN)).isEqualTo("feature")
+    assertThat(subject.getString(FEATURE, "joker")).isEqualTo("feature-joker")
+    assertThat(subject.getString(FEATURE, "joker", attributes))
+        .isEqualTo("feature-joker-with-attrs")
+    //Provides the key level override when there is no match on attributes
+    assertThat(subject.getString(FEATURE, "joker", Attributes(mapOf("don't" to "exist"))))
+        .isEqualTo("feature-joker")
   }
 
   @Test

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -1,6 +1,7 @@
 package misk.feature.testing
 
 import com.squareup.moshi.JsonDataException
+import misk.feature.Attributes
 import misk.feature.Feature
 import misk.feature.getEnum
 import misk.feature.getJson
@@ -46,6 +47,16 @@ internal class FakeFeatureFlagsTest {
     subject.overrideKey(FEATURE, "joker", 42)
     assertThat(subject.getInt(FEATURE, TOKEN)).isEqualTo(3)
     assertThat(subject.getInt(FEATURE, "joker")).isEqualTo(42)
+
+    // Can override with specific keys and attributes
+    val attributes = Attributes(mapOf("type" to "bad"))
+    subject.overrideKey(FEATURE, "joker", 55, attributes)
+    assertThat(subject.getInt(FEATURE, TOKEN)).isEqualTo(3)
+    assertThat(subject.getInt(FEATURE, "joker")).isEqualTo(42)
+    assertThat(subject.getInt(FEATURE, "joker", attributes)).isEqualTo(55)
+    //Provides the key level override when there is no match on attributes
+    assertThat(subject.getInt(FEATURE, "joker", Attributes(mapOf("don't" to "exist"))))
+        .isEqualTo(42)
   }
 
   @Test
@@ -66,9 +77,21 @@ internal class FakeFeatureFlagsTest {
     assertThat(subject.getEnum<Dinosaur>(FEATURE, "joker"))
         .isEqualTo(Dinosaur.PTERODACTYL)
 
-    subject.reset()
+    // Can override with specific keys and attributes
+    val attributes = Attributes(mapOf("type" to "bad"))
+    subject.overrideKey(FEATURE, "joker", Dinosaur.TALARURUS, attributes)
     assertThat(subject.getEnum<Dinosaur>(FEATURE, TOKEN))
+        .isEqualTo(Dinosaur.TYRANNOSAURUS)
+    assertThat(subject.getEnum<Dinosaur>(FEATURE, "joker"))
         .isEqualTo(Dinosaur.PTERODACTYL)
+    assertThat(subject.getEnum<Dinosaur>(FEATURE, "joker", attributes))
+        .isEqualTo(Dinosaur.TALARURUS)
+    //Provides the key level override when there is no match on attributes
+    assertThat(subject.getEnum<Dinosaur>(
+        FEATURE, "joker", Attributes(mapOf("don't" to "exist")))).isEqualTo(Dinosaur.PTERODACTYL)
+
+    subject.reset()
+    assertThat(subject.getEnum<Dinosaur>(FEATURE, TOKEN)).isEqualTo(Dinosaur.PTERODACTYL)
   }
 
   data class JsonFeature(val value : String, val optional : String? = null)
@@ -89,6 +112,38 @@ internal class FakeFeatureFlagsTest {
     subject.overrideKeyJson(FEATURE, "joker", JsonFeature("joker"))
     assertThat(subject.getJson<JsonFeature>(FEATURE, TOKEN)).isEqualTo(JsonFeature("test"))
     assertThat(subject.getJson<JsonFeature>(FEATURE, "joker")).isEqualTo(JsonFeature("joker"))
+
+    // Can override with specific attributes
+    val goodJokerAttributes = Attributes(mapOf("type" to "good"))
+    val badJokerAttributes = Attributes(mapOf("type" to "bad"))
+    val sleepyBadJokerAttributes = Attributes(mapOf("type" to "bad", "state" to "sleepy"))
+    subject.overrideKeyJson(FEATURE, "joker", JsonFeature("bad-joker"), badJokerAttributes)
+
+    assertThat(subject.getJson<JsonFeature>(FEATURE, TOKEN))
+        .isEqualTo(JsonFeature("test"))
+    assertThat(subject.getJson<JsonFeature>(FEATURE, "joker"))
+        .isEqualTo(JsonFeature("joker"))
+    assertThat(subject.getJson<JsonFeature>(FEATURE, "joker", badJokerAttributes))
+        .isEqualTo(JsonFeature("bad-joker"))
+    assertThat(subject.getJson<JsonFeature>(FEATURE, "joker", sleepyBadJokerAttributes))
+        .isEqualTo(JsonFeature("bad-joker"))
+    //Provides the key level override when there is no match on attributes
+    assertThat(subject.getJson<JsonFeature>(FEATURE, "joker", goodJokerAttributes))
+        .isEqualTo(JsonFeature("joker"))
+  }
+
+  @Test
+  fun `provides the latest override in case two or more attributes are a match`() {
+    val typeAttribute = Attributes(mapOf("type" to "bad"))
+    subject.overrideKey(FEATURE, "joker", 55, typeAttribute)
+    assertThat(subject.getInt(FEATURE, "joker", typeAttribute)).isEqualTo(55)
+
+    val stateAttribute = Attributes(mapOf("state" to "sleepy"))
+    subject.overrideKey(FEATURE, "joker", 75, stateAttribute)
+    assertThat(subject.getInt(FEATURE, "joker", stateAttribute)).isEqualTo(75)
+
+    val combinedAttributes = Attributes(typeAttribute.text + stateAttribute.text)
+    assertThat(subject.getInt(FEATURE, "joker", combinedAttributes)).isEqualTo(75)
   }
 
   @Test
@@ -135,6 +190,7 @@ internal class FakeFeatureFlagsTest {
 
   enum class Dinosaur {
     PTERODACTYL,
-    TYRANNOSAURUS
+    TYRANNOSAURUS,
+    TALARURUS
   }
 }


### PR DESCRIPTION
This PR contains two commits:

1. Incorporate original logic that was reverted because it was broken.
1. Added the public methods deleted by mistake, and also add methods for all the public methods exposed by the Feature Flags module.