### PR TITLE
New annotation @ConcurrencyLimitsOptOut to help migration

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/Http.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Http.kt
@@ -58,11 +58,33 @@ annotation class ResponseContentType(val value: String)
 annotation class AvailableWhenDegraded
 
 /**
- * Opt-in to concurrency limits.
+ * Opt-in to concurrency limits. If the service is overloaded permit Misk to shed calls to this
+ * endpoint by returning "HTTP 503 Service Unavailable".
  *
- * TODO(jwilson): make this the default once we're comfortable with the behavior and remove this
- *     annotation.
+ * In a future release of Misk this will be unnecessary because concurrency limits will be on by
+ * default.
+ *
+ * TODO(jwilson): deprecate this when it becomes unnecessary.
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class ConcurrencyLimitsOptIn
+
+/**
+ * Opt-out of concurrency limits. Misk will not shed calls to this endpoint even if the service is
+ * overloaded.
+ *
+ * In a future release this annotation will be deprecated. Developers will need to decide how this
+ * action responds when the service is degraded:
+ *
+ *  * The action is eligible for concurrency limits. In this case the annotation can safely be
+ *    removed. Most services should do this.
+ *
+ *  * The action is not eligible for concurrency limits. In this case the [AvailableWhenDegraded]
+ *    annotation should be used instead. Most services should not do this.
+ *
+ * TODO(jwilson): deprecate this when make concurrency limits on by default.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ConcurrencyLimitsOptOut

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -7,6 +7,7 @@ import misk.exceptions.StatusCode
 import misk.logging.getLogger
 import misk.web.AvailableWhenDegraded
 import misk.web.ConcurrencyLimitsOptIn
+import misk.web.ConcurrencyLimitsOptOut
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import java.time.Clock
@@ -62,6 +63,7 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
   class Factory @Inject constructor(val clock: Clock) : NetworkInterceptor.Factory {
     override fun create(action: Action): NetworkInterceptor? {
       if (action.function.findAnnotation<AvailableWhenDegraded>() != null) return null
+      if (action.function.findAnnotation<ConcurrencyLimitsOptOut>() != null) return null
 
       // TODO(jwilson): make this the default behavior and remove this annotation.
       if (action.function.findAnnotation<ConcurrencyLimitsOptIn>() == null) return null

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -10,6 +10,7 @@ import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
 import misk.web.ConcurrencyLimitsOptIn
+import misk.web.ConcurrencyLimitsOptOut
 import misk.web.DispatchMechanism
 import misk.web.FakeHttpCall
 import misk.web.Get
@@ -65,6 +66,18 @@ class ConcurrencyLimitsInterceptorTest {
     assertThat(factory.create(getStatus)).isNull()
   }
 
+  @Test
+  fun limitsOnOptInEndpoints() {
+    val optInAction = OptInAction::call.asAction(DispatchMechanism.GET)
+    assertThat(factory.create(optInAction)).isNotNull()
+  }
+
+  @Test
+  fun noLimitsOnOptOutEndpoints() {
+    val optOutAction = OptOutAction::call.asAction(DispatchMechanism.GET)
+    assertThat(factory.create(optOutAction)).isNull()
+  }
+
   private fun call(
     action: Action,
     interceptor: NetworkInterceptor,
@@ -115,5 +128,17 @@ class ConcurrencyLimitsInterceptorTest {
     @Get("/hello")
     @ConcurrencyLimitsOptIn
     fun call(): String = "hello"
+  }
+
+  internal class OptInAction : WebAction {
+    @Get("/chill")
+    @ConcurrencyLimitsOptIn
+    fun call(): String = "chill"
+  }
+
+  internal class OptOutAction : WebAction {
+    @Get("/important")
+    @ConcurrencyLimitsOptOut
+    fun call(): String = "important"
   }
 }


### PR DESCRIPTION
I'll remove this once we flip the defaults.