### PR TITLE
Remove includeBody and sampling from LogRequestResponse

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
@@ -28,9 +28,5 @@ annotation class LogRequestResponse(
   val errorRatePerSecond: Long = 0,
   /** By default do not log request and response bodies **/
   val bodySampling: Double = 0.0,
-  val errorBodySampling: Double = 0.0,
-  // TODO(isabel): Remove sampling and includeBody once
-  // all services move over to using above parameters
-  val sampling: Double = 0.0,
-  val includeBody: Boolean = false
+  val errorBodySampling: Double = 0.0
 )

--- a/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/GetFeatureGrpcAction.kt
+++ b/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/GetFeatureGrpcAction.kt
@@ -8,7 +8,7 @@ import routeguide.RouteGuideGetFeatureBlockingServer
 import javax.inject.Inject
 
 class GetFeatureGrpcAction @Inject constructor() : WebAction, RouteGuideGetFeatureBlockingServer {
-  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = true)
+  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0)
   override fun GetFeature(request: Point): Feature {
     return Feature(name = "maple tree", location = request)
   }

--- a/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteChatGrpcAction.kt
+++ b/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteChatGrpcAction.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 class RouteChatGrpcAction @Inject constructor() : WebAction, RouteGuideRouteChatBlockingServer {
   var welcomeMessage: String? = null
 
-  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = true)
+  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0)
   override fun RouteChat(
     request: MessageSource<RouteNote>,
     response: MessageSink<RouteNote>

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
@@ -32,10 +32,10 @@ class RequestBodyLoggingInterceptor @Inject internal constructor(
     override fun create(action: Action): ApplicationInterceptor? {
       val logRequestResponse = action.function.findAnnotation<LogRequestResponse>() ?: return null
       require(0.0 <= logRequestResponse.bodySampling && logRequestResponse.bodySampling <= 1.0) {
-        "${action.name} @LogRequestResponse sampling must be in the range (0.0, 1.0]"
+        "${action.name} @LogRequestResponse bodySampling must be in the range (0.0, 1.0]"
       }
       require(0.0 <= logRequestResponse.errorBodySampling && logRequestResponse.errorBodySampling <= 1.0) {
-        "${action.name} @LogRequestResponse sampling must be in the range (0.0, 1.0]"
+        "${action.name} @LogRequestResponse errorBodySampling must be in the range (0.0, 1.0]"
       }
       if (logRequestResponse.bodySampling == 0.0 && logRequestResponse.errorBodySampling == 0.0) {
         return null

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -46,16 +46,16 @@ class RequestLoggingInterceptor internal constructor(
     override fun create(action: Action): NetworkInterceptor? {
       val logRequestResponse = action.function.findAnnotation<LogRequestResponse>() ?: return null
       require(logRequestResponse.ratePerSecond >= 0L) {
-        "${action.name} @LogRequestResponse rateLimiting must be >= 0"
+        "${action.name} @LogRequestResponse ratePerSecond must be >= 0"
       }
       require(logRequestResponse.errorRatePerSecond >= 0L) {
-        "${action.name} @LogRequestResponse errorRateLimiting must be >= 0"
+        "${action.name} @LogRequestResponse errorRatePerSecond must be >= 0"
       }
       require(logRequestResponse.bodySampling in 0.0..1.0) {
-        "${action.name} @LogRequestResponse sampling must be in the range (0.0, 1.0]"
+        "${action.name} @LogRequestResponse bodySampling must be in the range (0.0, 1.0]"
       }
       require(logRequestResponse.errorBodySampling in 0.0..1.0) {
-        "${action.name} @LogRequestResponse sampling must be in the range (0.0, 1.0]"
+        "${action.name} @LogRequestResponse errorBodySampling must be in the range (0.0, 1.0]"
       }
 
       return RequestLoggingInterceptor(

--- a/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
@@ -51,7 +51,7 @@ internal class WebSocketsTest {
   @Singleton
   class EchoWebSocket @Inject constructor() : WebAction {
     @ConnectWebSocket("/echo")
-    @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = true)
+    @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0)
     fun echo(@Suppress("UNUSED_PARAMETER") webSocket: WebSocket): WebSocketListener {
       return object : WebSocketListener() {
         override fun onMessage(webSocket: WebSocket, text: String) {

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -137,7 +137,7 @@ internal class RequestLoggingInterceptorTest {
     @Get("/call/rateLimitingRequestLogging/{message}")
     @Unauthenticated
     @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = false)
+    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L)
     fun call(@PathParam message: String) = "echo: $message"
   }
 
@@ -145,7 +145,7 @@ internal class RequestLoggingInterceptorTest {
     @Get("/call/rateLimitingIncludesBodyRequestLogging/{message}")
     @Unauthenticated
     @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L, bodySampling = 0.5, errorBodySampling = 1.0, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = false)
+    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L, bodySampling = 0.5, errorBodySampling = 1.0)
     fun call(@PathParam message: String) = "echo: $message"
   }
 
@@ -153,7 +153,7 @@ internal class RequestLoggingInterceptorTest {
     @Get("/call/noRateLimitingRequestLogging/{message}")
     @Unauthenticated
     @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    @LogRequestResponse(ratePerSecond = 0L, errorRatePerSecond = 0L, bodySampling = 0.5, errorBodySampling = 0.5, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = false)
+    @LogRequestResponse(ratePerSecond = 0L, errorRatePerSecond = 0L, bodySampling = 0.5, errorBodySampling = 0.5)
     fun call(@PathParam message: String) = "echo: $message"
   }
 
@@ -161,7 +161,7 @@ internal class RequestLoggingInterceptorTest {
     @Get("/call/exceptionThrowingRequestLogging/{message}")
     @Unauthenticated
     @ResponseContentType(MediaTypes.APPLICATION_JSON)
-    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L, bodySampling = 0.1, errorBodySampling = 1.0, /** unused in code path **/ sampling = 1.0, /** unused in code path **/ includeBody = false)
+    @LogRequestResponse(ratePerSecond = 1L, errorRatePerSecond = 2L, bodySampling = 0.1, errorBodySampling = 1.0)
     fun call(@PathParam message: String): String = throw IllegalStateException(message)
   }
 


### PR DESCRIPTION
The parameters `includeBody` and `sampling` have been removed from all Actions that use `LogRequestResponse`. Removing them so we can fully migrate to using rate limiting sampling + percent body sampling for Actions