### PR TITLE
RealDynamoDbModule supports specification of ClientConfiguration

### DIFF
--- a/misk-aws/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -1,10 +1,9 @@
 package misk.dynamodb
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig
 import com.google.inject.Provides
 import misk.cloud.aws.AwsRegion
 import misk.inject.KAbstractModule
@@ -14,7 +13,8 @@ import javax.inject.Singleton
  * Install this module to have access to an AmazonDynamoDB client. This can be
  * used to create a DynamoDbMapper for querying of a DynamoDb table.
  */
-class RealDynamoDbModule : KAbstractModule() {
+class RealDynamoDbModule constructor(private val clientConfig: ClientConfiguration = ClientConfiguration()) :
+    KAbstractModule() {
   override fun configure() {
     requireBinding<AWSCredentialsProvider>()
     requireBinding<AwsRegion>()
@@ -29,6 +29,7 @@ class RealDynamoDbModule : KAbstractModule() {
         .standard()
         .withRegion(awsRegion.name)
         .withCredentials(awsCredentialsProvider)
+        .withClientConfiguration(clientConfig)
         .build()
   }
 }


### PR DESCRIPTION
Expose AWS' ClientConfiguration as optional constructor argument to enable embedding services to override configuration for their use case.