### PR TITLE
Add SamplingLogger that is separate of Logging

### DIFF
--- a/misk-core/src/main/kotlin/misk/logging/Logging.kt
+++ b/misk-core/src/main/kotlin/misk/logging/Logging.kt
@@ -12,54 +12,33 @@ inline fun <reified T> getLogger(): KLogger {
   return KotlinLogging.logger(T::class.qualifiedName!!)
 }
 
+fun KLogger.sampled(sampler: Sampler): KLogger {
+  return SampledLogger(this, sampler)
+}
+
 fun KLogger.info(vararg tags: Tag, message: () -> Any?) =
     log(Level.INFO, tags = *tags, message = message)
-
-fun KLogger.info(sampler: Sampler, vararg tags: Tag, message: () -> Any?) {
-    sample(sampler, Level.INFO, tags = *tags, message = message)
-}
 
 fun KLogger.warn(vararg tags: Tag, message: () -> Any?) =
     log(Level.WARN, tags = *tags, message = message)
 
-fun KLogger.warn(sampler: Sampler, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.WARN, tags = *tags, message = message)
-
 fun KLogger.error(vararg tags: Tag, message: () -> Any?) =
     log(Level.ERROR, tags = *tags, message = message)
-
-fun KLogger.error(sampler: Sampler, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.ERROR, tags = *tags, message = message)
 
 fun KLogger.debug(vararg tags: Tag, message: () -> Any?) =
     log(Level.DEBUG, tags = *tags, message = message)
 
-fun KLogger.debug(sampler: Sampler, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.DEBUG, tags = *tags, message = message)
-
 fun KLogger.info(th: Throwable, vararg tags: Tag, message: () -> Any?) =
     log(Level.INFO, th, tags = *tags, message = message)
-
-fun KLogger.info(sampler: Sampler, th: Throwable, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.INFO, th, tags = *tags, message = message)
 
 fun KLogger.warn(th: Throwable, vararg tags: Tag, message: () -> Any?) =
     log(Level.WARN, th, tags = *tags, message = message)
 
-fun KLogger.warn(sampler: Sampler, th: Throwable, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.WARN, th, tags = *tags, message = message)
-
 fun KLogger.error(th: Throwable, vararg tags: Tag, message: () -> Any?) =
     log(Level.ERROR, th, tags = *tags, message = message)
 
-fun KLogger.error(sampler: Sampler, th: Throwable, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.ERROR, th, tags = *tags, message = message)
-
 fun KLogger.debug(th: Throwable, vararg tags: Tag, message: () -> Any?) =
     log(Level.DEBUG, th, tags = *tags, message = message)
-
-fun KLogger.debug(sampler: Sampler, th: Throwable, vararg tags: Tag, message: () -> Any?) =
-    sample(sampler, Level.DEBUG, th, tags = *tags, message = message)
 
 fun KLogger.log(level: Level, vararg tags: Tag, message: () -> Any?) {
   misk.logging.withTags(*tags) {
@@ -81,34 +60,6 @@ fun KLogger.log(level: Level, th: Throwable, vararg tags: Tag, message: () -> An
       Level.WARN -> warn(th, message)
       Level.DEBUG -> debug(th, message)
       Level.TRACE -> trace(th, message)
-    }
-  }
-}
-
-fun KLogger.sample(sampler: Sampler, level: Level, vararg  tags: Tag, message: () -> Any?) {
-  if (sampler.sample()) {
-    misk.logging.withTags(*tags) {
-      when (level) {
-        Level.ERROR -> error(message)
-        Level.WARN -> warn(message)
-        Level.INFO -> info(message)
-        Level.DEBUG -> debug(message)
-        Level.TRACE -> trace(message)
-      }
-    }
-  }
-}
-
-fun KLogger.sample(sampler: Sampler, level: Level, th: Throwable, vararg tags: Tag, message: () -> Any?) {
-  if (sampler.sample()) {
-    misk.logging.withTags(*tags) {
-      when (level) {
-        Level.ERROR -> error(th, message)
-        Level.INFO -> info(th, message)
-        Level.WARN -> warn(th, message)
-        Level.DEBUG -> debug(th, message)
-        Level.TRACE -> trace(th, message)
-      }
     }
   }
 }

--- a/misk-core/src/main/kotlin/misk/logging/SampledLogger.kt
+++ b/misk-core/src/main/kotlin/misk/logging/SampledLogger.kt
@@ -1,0 +1,249 @@
+package misk.logging
+
+import misk.sampling.Sampler
+import mu.KLogger
+import mu.Marker
+
+class SampledLogger constructor(
+  override val underlyingLogger: KLogger,
+  private val sampler: Sampler
+) : KLogger {
+
+  private inline fun sampled(f: () -> Unit) {
+    if (sampler.sample()) f()
+  }
+
+  override fun <T : Throwable> catching(throwable: T)
+    = sampled { underlyingLogger.catching(throwable) }
+
+  override fun debug(msg: () -> Any?) = sampled { underlyingLogger.debug(msg) }
+
+  override fun debug(t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.debug(t, msg) }
+
+  override fun debug(marker: Marker?, msg: () -> Any?)
+    = sampled { underlyingLogger.debug(marker, msg) }
+
+  override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.debug(marker, t, msg) }
+
+  override fun debug(msg: String?) = sampled { underlyingLogger.debug(msg) }
+
+  override fun debug(format: String?, arg: Any?)
+    = sampled { underlyingLogger.debug(format, arg) }
+
+  override fun debug(format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.debug(format, arg1, arg2) }
+
+  override fun debug(format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.debug(format, arguments) }
+
+  override fun debug(msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.debug(msg, t) }
+
+  override fun debug(marker: org.slf4j.Marker?, msg: String?)
+    = sampled { underlyingLogger.debug(marker, msg) }
+
+  override fun debug(marker: org.slf4j.Marker?, format: String?, arg: Any?)
+    = sampled { underlyingLogger.debug(marker, format, arg) }
+
+  override fun debug(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.debug(marker, format, arg1, arg2) }
+
+  override fun debug(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.debug(marker, format, arguments) }
+
+  override fun debug(marker: org.slf4j.Marker?, msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.debug(marker, msg, t) }
+
+  override fun entry(vararg argArray: Any?) = sampled { underlyingLogger.entry(
+    argArray) }
+
+  override fun error(msg: () -> Any?) = sampled { underlyingLogger.error(msg) }
+
+  override fun error(t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.error(t, msg) }
+
+  override fun error(marker: Marker?, msg: () -> Any?)
+    = sampled { underlyingLogger.error(marker, msg) }
+
+  override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.error(marker, t, msg) }
+
+  override fun error(msg: String?) = sampled { underlyingLogger.error(msg) }
+
+  override fun error(format: String?, arg: Any?)
+    = sampled { underlyingLogger.error(format, arg) }
+
+  override fun error(format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.error(format, arg1, arg2) }
+
+  override fun error(format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.error(format, arguments) }
+
+  override fun error(msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.error(msg, t) }
+
+  override fun error(marker: org.slf4j.Marker?, msg: String?)
+    = sampled { underlyingLogger.error(marker, msg) }
+
+  override fun error(marker: org.slf4j.Marker?, format: String?, arg: Any?)
+    = sampled { underlyingLogger.error(marker, format, arg) }
+
+  override fun error(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.error(marker, format, arg1, arg2) }
+
+  override fun error(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.error(marker, format, arguments) }
+
+  override fun error(marker: org.slf4j.Marker?, msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.error(marker, msg, t) }
+
+  override fun exit() = underlyingLogger.exit()
+
+  override fun <T> exit(result: T): T = underlyingLogger.exit(result)
+
+  override fun getName(): String = name
+
+  override fun info(msg: () -> Any?) = sampled { underlyingLogger.info(msg) }
+
+  override fun info(t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.info(t, msg) }
+
+  override fun info(marker: Marker?, msg: () -> Any?)
+    = sampled { underlyingLogger.info(marker, msg) }
+
+  override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.info(marker, t, msg) }
+
+  override fun info(msg: String?) = sampled { underlyingLogger.info(msg) }
+
+  override fun info(format: String?, arg: Any?)
+    = sampled { underlyingLogger.info(format, arg) }
+
+  override fun info(format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.info(format, arg1, arg2) }
+
+  override fun info(format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.info(format, arguments) }
+
+  override fun info(msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.info(msg, t) }
+
+  override fun info(marker: org.slf4j.Marker?, msg: String?)
+    = sampled { underlyingLogger.info(marker, msg) }
+
+  override fun info(marker: org.slf4j.Marker?, format: String?, arg: Any?)
+    = sampled { underlyingLogger.info(marker, format, arg) }
+
+  override fun info(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.info(marker, format, arg1, arg2) }
+
+  override fun info(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.info(marker, format, arguments) }
+
+  override fun info(marker: org.slf4j.Marker?, msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.info(marker, msg, t) }
+
+  override fun isDebugEnabled(): Boolean = isDebugEnabled
+
+  override fun isDebugEnabled(marker: org.slf4j.Marker?): Boolean = isDebugEnabled(marker)
+
+  override fun isErrorEnabled(): Boolean = isErrorEnabled
+
+  override fun isErrorEnabled(marker: org.slf4j.Marker?): Boolean = isErrorEnabled(marker)
+
+  override fun isInfoEnabled(): Boolean = isInfoEnabled
+
+  override fun isInfoEnabled(marker: org.slf4j.Marker?): Boolean = isInfoEnabled(marker)
+
+  override fun isTraceEnabled(): Boolean = isTraceEnabled
+
+  override fun isTraceEnabled(marker: org.slf4j.Marker?): Boolean = isTraceEnabled(marker)
+
+  override fun isWarnEnabled(): Boolean = isWarnEnabled
+
+  override fun isWarnEnabled(marker: org.slf4j.Marker?): Boolean = isWarnEnabled(marker)
+
+  override fun <T : Throwable> throwing(throwable: T): T = throwing(throwable)
+
+  override fun trace(msg: () -> Any?) = sampled { underlyingLogger.trace(msg) }
+
+  override fun trace(t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.trace(t, msg) }
+
+  override fun trace(marker: Marker?, msg: () -> Any?)
+    = sampled { underlyingLogger.trace(marker, msg) }
+
+  override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.trace(marker, t, msg) }
+
+  override fun trace(msg: String?) = sampled { underlyingLogger.trace(msg) }
+
+  override fun trace(format: String?, arg: Any?)
+    = sampled { underlyingLogger.trace(format, arg) }
+
+  override fun trace(format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.trace(format, arg1, arg2) }
+
+  override fun trace(format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.trace(format, arguments) }
+
+  override fun trace(msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.trace(msg, t) }
+
+  override fun trace(marker: org.slf4j.Marker?, msg: String?)
+    = sampled { underlyingLogger.trace(marker, msg) }
+
+  override fun trace(marker: org.slf4j.Marker?, format: String?, arg: Any?)
+    = sampled { underlyingLogger.trace(marker, format, arg) }
+
+  override fun trace(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.trace(marker, format, arg1, arg2) }
+
+  override fun trace(marker: org.slf4j.Marker?, format: String?, vararg argArray: Any?)
+    = sampled { underlyingLogger.trace(marker, format, argArray) }
+
+  override fun trace(marker: org.slf4j.Marker?, msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.trace(marker, msg, t) }
+
+  override fun warn(msg: () -> Any?) = sampled { underlyingLogger.warn(msg) }
+
+  override fun warn(t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.warn(t, msg) }
+
+  override fun warn(marker: Marker?, msg: () -> Any?)
+    = sampled { underlyingLogger.warn(marker, msg) }
+
+  override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?)
+    = sampled { underlyingLogger.warn(marker, t, msg) }
+
+  override fun warn(msg: String?) = sampled { underlyingLogger.warn(msg) }
+
+  override fun warn(format: String?, arg: Any?)
+    = sampled { underlyingLogger.warn(format, arg) }
+
+  override fun warn(format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.warn(format, arguments) }
+
+  override fun warn(format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.warn(format, arg1, arg2) }
+
+  override fun warn(msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.warn(msg, t) }
+
+  override fun warn(marker: org.slf4j.Marker?, msg: String?)
+    = sampled { underlyingLogger.warn(marker, msg) }
+
+  override fun warn(marker: org.slf4j.Marker?, format: String?, arg: Any?)
+    = sampled { underlyingLogger.warn(marker, format, arg) }
+
+  override fun warn(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?)
+    = sampled { underlyingLogger.warn(marker, format, arg1, arg2) }
+
+  override fun warn(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?)
+    = sampled { underlyingLogger.warn(marker, format, arguments) }
+
+  override fun warn(marker: org.slf4j.Marker?, msg: String?, t: Throwable?)
+    = sampled { underlyingLogger.warn(marker, msg, t) }
+}

--- a/misk-core/src/test/kotlin/misk/logging/SampledLoggerTest.kt
+++ b/misk-core/src/test/kotlin/misk/logging/SampledLoggerTest.kt
@@ -1,0 +1,105 @@
+package misk.logging
+
+import ch.qos.logback.classic.Level
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.concurrent.FakeTicker
+import misk.sampling.RateLimiter
+import misk.sampling.RateLimitingSampler
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.containsExactly
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class SampledLoggerTest {
+  @MiskTestModule
+  val testModule = Modules.combine(MiskTestingServiceModule(), LogCollectorModule())
+
+  @Inject private lateinit var logCollector: LogCollector
+  @Inject private lateinit var fakeTicker: FakeTicker
+
+  @Test
+  fun rateLimitedLogger() {
+    val rateLimiter = RateLimiter.Factory(fakeTicker, fakeTicker).create(2L)
+    val logger = getLogger<LoggingTest>()
+    val sampledLogger = logger.sampled(RateLimitingSampler(rateLimiter))
+
+    // clear existing messages
+    logCollector.takeEvents(LoggingTest::class)
+
+    // Unsampled logger is not rate-limited
+    logger.info("user-id" to "blah1") { "test 1" }
+    logger.error(IllegalStateException("failed!"), "user-id" to "blah2") { "test 2" }
+    logger.warn("user-id" to "blah3") { "test 3" }
+
+    val events = logCollector.takeEvents(LoggingTest::class)
+    assertThat(events).hasSize(3)
+    assertThat(events[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.INFO)
+      assertThat(it.message).isEqualTo("test 1")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blah1"
+      )
+    }
+    assertThat(events[1]).satisfies {
+      assertThat(it.level).isEqualTo(Level.ERROR)
+      assertThat(it.message).isEqualTo("test 2")
+      assertThat(it.throwableProxy.className).isEqualTo(IllegalStateException::class.qualifiedName)
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blah2"
+      )
+    }
+    assertThat(events[2]).satisfies {
+      assertThat(it.level).isEqualTo(Level.WARN)
+      assertThat(it.message).isEqualTo("test 3")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blah3"
+      )
+    }
+
+    // Sampled logger is rate-limited
+    sampledLogger.info("user-id" to "blerb1") { "sampled test 1" }
+    sampledLogger.error(NullPointerException("failed!"),"user-id" to "blerb2", "context-id" to "111111") { "sampled test 2" }
+    sampledLogger.warn("user-id" to "blerb3") { "sampled test 3" }
+
+    val sampledEvents = logCollector.takeEvents(LoggingTest::class)
+    assertThat(sampledEvents).hasSize(2)
+    assertThat(sampledEvents[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.INFO)
+      assertThat(it.message).isEqualTo("sampled test 1")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blerb1"
+      )
+    }
+    assertThat(sampledEvents[1]).satisfies {
+      assertThat(it.level).isEqualTo(Level.ERROR)
+      assertThat(it.message).isEqualTo("sampled test 2")
+      assertThat(it.throwableProxy.className).isEqualTo(NullPointerException::class.qualifiedName)
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blerb2",
+        "context-id" to "111111"
+      )
+    }
+
+    // Wait 1 second
+    fakeTicker.sleepMs(1000L)
+
+    sampledLogger.warn("user-id" to "blerb4") { "sampled test 4" }
+    val sampledEvents2 = logCollector.takeEvents(LoggingTest::class)
+    assertThat(sampledEvents2).hasSize(1)
+    assertThat(sampledEvents2[0]).satisfies {
+      assertThat(it.level).isEqualTo(Level.WARN)
+      assertThat(it.message).isEqualTo("sampled test 4")
+      assertThat(it.throwableProxy).isNull()
+      assertThat(it.mdcPropertyMap).containsExactly(
+        "user-id" to "blerb4"
+      )
+    }
+  }
+}


### PR DESCRIPTION
This is a follow-up from https://github.com/cashapp/misk/pull/1568. This PR adds a `SamplingLogger` that implements `KLogger`. A logger can be both sampled and unsampled. To sample, the service owner would call `getLogger<Class>().sampled(Sampler()).info` as an example