### PR TITLE
Make concurrency limits on-by-default

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/Http.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Http.kt
@@ -60,12 +60,8 @@ annotation class AvailableWhenDegraded
 /**
  * Opt-in to concurrency limits. If the service is overloaded permit Misk to shed calls to this
  * endpoint by returning "HTTP 503 Service Unavailable".
- *
- * In a future release of Misk this will be unnecessary because concurrency limits will be on by
- * default.
- *
- * TODO(jwilson): deprecate this when it becomes unnecessary.
  */
+@Deprecated(message = "this annotation is not necessary; concurrency limits are on by default")
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class ConcurrencyLimitsOptIn

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -6,7 +6,6 @@ import misk.Action
 import misk.exceptions.StatusCode
 import misk.logging.getLogger
 import misk.web.AvailableWhenDegraded
-import misk.web.ConcurrencyLimitsOptIn
 import misk.web.ConcurrencyLimitsOptOut
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
@@ -17,8 +16,9 @@ import kotlin.reflect.full.findAnnotation
 
 /**
  * Detects degraded behavior and sheds requests accordingly. Internally this uses adaptive limiting
- * as implemented by Netflix's [concurrency-limits][concurrency_limits] library. See
- * [AvailableWhenDegraded] for further documentation.
+ * as implemented by Netflix's [concurrency-limits][concurrency_limits] library.
+ *
+ * This annotation is applied to all actions by default. Opt-out with [AvailableWhenDegraded].
  *
  * [concurrency_limits]: https://github.com/Netflix/concurrency-limits/
  */
@@ -64,9 +64,6 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
     override fun create(action: Action): NetworkInterceptor? {
       if (action.function.findAnnotation<AvailableWhenDegraded>() != null) return null
       if (action.function.findAnnotation<ConcurrencyLimitsOptOut>() != null) return null
-
-      // TODO(jwilson): make this the default behavior and remove this annotation.
-      if (action.function.findAnnotation<ConcurrencyLimitsOptIn>() == null) return null
 
       val limiter = SimpleLimiter.Builder()
           .clock { clock.millis() }

--- a/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
+++ b/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
@@ -99,7 +99,6 @@ internal class DegradedHealthStressTest {
     private val fakeResourcePool: FakeResourcePool
   ) : WebAction {
     @Get("/use_constrained_resource")
-    @ConcurrencyLimitsOptIn
     fun get(): String {
       fakeResourcePool.useResource(Duration.ofMillis(50), Duration.ofMillis(200))
       return "success"

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -9,7 +9,6 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
-import misk.web.ConcurrencyLimitsOptIn
 import misk.web.ConcurrencyLimitsOptOut
 import misk.web.DispatchMechanism
 import misk.web.FakeHttpCall
@@ -67,8 +66,8 @@ class ConcurrencyLimitsInterceptorTest {
   }
 
   @Test
-  fun limitsOnOptInEndpoints() {
-    val optInAction = OptInAction::call.asAction(DispatchMechanism.GET)
+  fun limitsOnForUnannotatedEndpoints() {
+    val optInAction = UnannotatedAction::call.asAction(DispatchMechanism.GET)
     assertThat(factory.create(optInAction)).isNotNull()
   }
 
@@ -126,13 +125,11 @@ class ConcurrencyLimitsInterceptorTest {
 
   internal class HelloAction : WebAction {
     @Get("/hello")
-    @ConcurrencyLimitsOptIn
     fun call(): String = "hello"
   }
 
-  internal class OptInAction : WebAction {
+  internal class UnannotatedAction : WebAction {
     @Get("/chill")
-    @ConcurrencyLimitsOptIn
     fun call(): String = "chill"
   }
 


### PR DESCRIPTION
Opt-out with `@AvailableWhenDegraded`. Most actions should not need
to do this.