### PR TITLE
Cleanup obsolete TODO

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -30,18 +30,8 @@ internal class SqsJob(
   private val queue: ResolvedQueue = queues.getForReceiving(queueName)
   private val jobqueueMetadata: Map<String, String> by lazy {
     val metadata = message.messageAttributes[JOBQUEUE_METADATA_ATTR]
-    // NB: old/in-flight jobs enqueued prior to the introduction of _jobqueue-metadata won't have this property. In
-    // order to not change the contract later on (optional to non-optional), synthesize a reasonable replacement.
-    if (metadata == null) {
-      // TODO(bruno): drop fallback after rollout; error when metadata is not set.
-      mapOf(
-          JOBQUEUE_METADATA_ORIGIN_QUEUE to queueName.parentQueue.value,
-          // If the job had no metadata, there was no app-specified idempotence key;
-          // any sufficiently random value would work, so just use system-assigned id.
-          JOBQUEUE_METADATA_IDEMPOTENCE_KEY to id)
-    } else {
-      moshi.adapter<Map<String, String>>().fromJson(metadata.stringValue)!!
-    }
+        ?: throw IllegalStateException (JOBQUEUE_METADATA_ATTR + " not found in messageAttributes")
+    moshi.adapter<Map<String, String>>().fromJson(metadata.stringValue)!!
   }
 
   override fun acknowledge() {

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -54,20 +54,4 @@ internal class SqsJobTest {
         .containsEntry("foo", "bar")
         .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
   }
-
-  @Test
-  fun getIdempotenceKey_withNoJobqueueMetadata() {
-    val message = Message().apply {
-      messageId = "id-0"
-      body = "body-0"
-      addMessageAttributesEntry("foo", MessageAttributeValue().withDataType("String").withStringValue("bar"))
-    }
-
-    val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)
-
-    assertThat(job.idempotenceKey).isEqualTo(job.id)
-    assertThat(job.attributes)
-        .containsEntry("foo", "bar")
-        .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
-  }
 }


### PR DESCRIPTION
Remove fallback to old, exploded attributes in a job's custom
`messageAttributes`. This was a temporary workaround to support jobs enqueued
with older versions of the jobqueue library.

This change landed in March; all relevant services running in production have
since been deployed so this fallback is no longer relevant.