### PR TITLE
Add github action to create date+sha releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: install misk-web
+        run: |
+          mkdir ~/.npm-global
+          npm config set prefix '~/.npm-global'
+          PATH=~/.npm-global/bin:$PATH
+          npm install -g @misk/cli
+          miskweb ci-build -e
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Set gradle version
+        run: echo "version=String.valueOf(project.version).replace(\"-SNAPSHOT\", \"\") + '-$(date +%Y%m%d)-$(git rev-parse --short HEAD)-SNAPSHOT'" > hooks.gradle
+      - name: Publish packages
+        run: ./gradlew clean uploadArchives
+        env:
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
           java-version: 11
       - name: run misk-web
         run: |
-          echo ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           mkdir ~/.npm-global
           npm config set prefix '~/.npm-global'
           PATH=~/.npm-global/bin:$PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           java-version: 11
       - name: run misk-web
         run: |
+          echo ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           mkdir ~/.npm-global
           npm config set prefix '~/.npm-global'
           PATH=~/.npm-global/bin:$PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Publish packages
         run: ./gradlew clean uploadArchives
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
       - name: Close and Promote packages
         run: ./gradlew closeAndReleaseRepository
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Set gradle version
-        run: echo "version=String.valueOf(project.version).replace(\"-SNAPSHOT\", \"\") + '-$(date +%Y%m%d.%H%M)-$(git rev-parse --short HEAD)-SNAPSHOT'" > hooks.gradle
+        run: echo "version=String.valueOf(project.version).replace(\"-SNAPSHOT\", \"\") + '-$(date +%Y%m%d.%H%M)-$(git rev-parse --short HEAD)'" > hooks.gradle
       - name: Publish packages
         run: ./gradlew clean uploadArchives
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build
+name: release
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: install misk-web
+      - name: run misk-web
         run: |
           mkdir ~/.npm-global
           npm config set prefix '~/.npm-global'
@@ -29,9 +29,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Set gradle version
-        run: echo "version=String.valueOf(project.version).replace(\"-SNAPSHOT\", \"\") + '-$(date +%Y%m%d)-$(git rev-parse --short HEAD)-SNAPSHOT'" > hooks.gradle
+        run: echo "version=String.valueOf(project.version).replace(\"-SNAPSHOT\", \"\") + '-$(date +%Y%m%d.%H%M)-$(git rev-parse --short HEAD)-SNAPSHOT'" > hooks.gradle
       - name: Publish packages
         run: ./gradlew clean uploadArchives
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+      - name: Close and Promote packages
+        run: ./gradlew closeAndReleaseRepository
+        env:
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: release
 
 on:
-  push:
-    branches:
-      - master
+  push
+  #push:
+   # branches:
+    #  - master
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,13 @@ subprojects { subProject ->
 
   if (!path.startsWith(":samples") && !path.startsWith(":misk-embedded-sample")) {
     apply plugin: 'com.vanniktech.maven.publish'
+
+    // Override signing plugin details that maven-publish will use.
+    signing {
+      def signingKey = findProperty("signingKey")
+      def signingPassword = ""
+      useInMemoryPgpKeys(signingKey, signingPassword)
+    }
   }
 
   if (rootProject.file("hooks.gradle").exists()) {

--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,6 @@ subprojects { subProject ->
       showStandardStreams = false
     }
   }
-  if (rootProject.file("hooks.gradle").exists()) {
-    apply from: rootProject.file("hooks.gradle")
-  }
 
   if (["misk-aws","misk-events","misk-jobqueue","misk-jobqueue-testing","misk-hibernate","misk-hibernate-testing"].contains(name)) {
     rootProject.getTasksByName("testShardHibernate", false).first().dependsOn.add(test)
@@ -108,6 +105,10 @@ subprojects { subProject ->
 
   if (!path.startsWith(":samples") && !path.startsWith(":misk-embedded-sample")) {
     apply plugin: 'com.vanniktech.maven.publish'
+  }
+
+  if (rootProject.file("hooks.gradle").exists()) {
+    apply from: rootProject.file("hooks.gradle")
   }
 
   // Workaround the Gradle bug resolving multiplatform dependencies.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,7 +63,7 @@ ext.dep = [
   "logbackClassic": "ch.qos.logback:logback-classic:1.2.3",
   "logbackJsonCore": "ch.qos.logback.contrib:logback-json-core:0.1.5",
   "loggingApi": "io.github.microutils:kotlin-logging:1.7.9",
-  "mavenPublishGradlePlugin": "com.vanniktech:gradle-maven-publish-plugin:0.9.0",
+  "mavenPublishGradlePlugin": "com.vanniktech:gradle-maven-publish-plugin:0.12.0",
   "mockitoCore": "org.mockito:mockito-core:3.2.4",
   "moshiAdapters": "com.squareup.moshi:moshi-adapters:1.9.2",
   "moshiCore": "com.squareup.moshi:moshi:1.9.2",


### PR DESCRIPTION
Publishes snapshots to maven with date/sha added so snapshots aren't overwritten. I want to pull these in in backfila.
Already added this in backfila, check it out:
![image](https://user-images.githubusercontent.com/1468196/89847524-4171ce00-db52-11ea-9eb2-8b50932966aa.png)
