### PR TITLE
Add BigDecimal Moshi Adapter

### DIFF
--- a/misk/src/main/kotlin/misk/moshi/adapters/BigDecimalAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/adapters/BigDecimalAdapter.kt
@@ -1,0 +1,13 @@
+package misk.moshi.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+object BigDecimalAdapter {
+  @FromJson
+  fun decode(decimal: String): BigDecimal = BigDecimal(decimal)
+
+  @ToJson
+  fun encode(decimal: BigDecimal): String = decimal.toString()
+}

--- a/misk/src/test/kotlin/misk/moshi/BigDecimalAdapterTest.kt
+++ b/misk/src/test/kotlin/misk/moshi/BigDecimalAdapterTest.kt
@@ -1,0 +1,37 @@
+package misk.moshi
+
+import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.moshi.adapters.BigDecimalAdapter
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import javax.inject.Inject
+
+@MiskTest(startService = false)
+internal class BigDecimalAdapterTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject
+  lateinit var moshi: Moshi
+
+  @Test
+  fun `adapter converts from and to json`() {
+    val json = "\"5.5\""
+    val value = BigDecimal("5.5")
+    val jsonAdapter = moshi.adapter<BigDecimal>()
+    assertThat(jsonAdapter.toJson(value)).isEqualTo(json)
+    assertThat(jsonAdapter.fromJson(json)).isEqualTo(value)
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+      install(MoshiAdapterModule(BigDecimalAdapter))
+    }
+  }
+}


### PR DESCRIPTION
BigDecimal Moshi Adapter is needed for multiple projects. It's time to promote it to misk.