### PR TITLE
ReflectionQueryFactory supports query hint specification

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -24,6 +24,8 @@ interface Query<T> {
 
   fun disableCheck(check: Check)
 
+  fun addQueryHint(queryHint: String)
+
   /** Asserts that there is either zero or one results. */
   fun uniqueResult(session: Session): T?
 
@@ -103,6 +105,19 @@ inline fun <T, reified Q : Query<T>> Q.allowTableScan(): Q {
 
 inline fun <T, reified Q : Query<T>> Q.allowFullScatter(): Q {
   this.disableCheck(Check.FULL_SCATTER)
+  return this
+}
+
+/**
+ * Equivalent to Query.addQueryHint, but takes the hint String and returns this. This may be easier
+ * to use with method chaining.
+ *
+ * Passes a query hint with the generated query where possible.
+ * Hints should be used sparingly; generally the optimizer is smart enough without hints.
+ * In general, hints are ignored if they are not applicable to the vendor DB type, or invalid.
+ */
+inline fun <T, reified Q : Query<T>> Q.withQueryHint(hint: String): Q {
+  addQueryHint(hint)
   return this
 }
 


### PR DESCRIPTION
This adds a pass-through for Hibernate's `Query#addQueryHint` in Misk's `ReflectionQueryFactory`-produced `ReflectionQuery`. [See: Query#addQueryHint](https://docs.jboss.org/hibernate/orm/5.0/javadocs/org/hibernate/Query.html#addQueryHint-java.lang.String-)

I'm aware that hints should be used sparingly, but I have a use case (at least with TiDB) where specifying a hint (e.g., for `INDEX_MERGE` on two same-table indices) makes the difference between a table scan (or making two sequential queries to the two independent indices that are suitable for `INDEX_MERGE`.