### PR TITLE
document and simplify SampledLogger construction

### DIFF
--- a/misk-core/src/main/kotlin/misk/logging/Logging.kt
+++ b/misk-core/src/main/kotlin/misk/logging/Logging.kt
@@ -12,6 +12,18 @@ inline fun <reified T> getLogger(): KLogger {
   return KotlinLogging.logger(T::class.qualifiedName!!)
 }
 
+/**
+ * Returns a logger that samples logs. This logger MUST be instantiated statically,
+ * in a companion object or as a Singleton.
+ *
+ * To get a rate limited logger:
+ *
+ *   val logger = getLogger<MyClass>().sampled(RateLimitingSampler(RATE_PER_SECOND))
+ *
+ * To get a probabilistic sampler
+ *
+ *   val logger = getLogger<MyClass>().sampled(PercentSampler(PERCENTAGE_TO_ALLOW))
+ */
 fun KLogger.sampled(sampler: Sampler): KLogger {
   return SampledLogger(this, sampler)
 }

--- a/misk-core/src/main/kotlin/misk/sampling/Sampler.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/Sampler.kt
@@ -1,5 +1,7 @@
 package misk.sampling
 
+import com.google.common.base.Ticker
+import misk.concurrent.Sleeper
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -29,21 +31,14 @@ class PercentSampler(
 }
 
 class RateLimitingSampler(
-  val rateLimiter: RateLimiter
+  private val rateLimiter: RateLimiter
 ) : Sampler {
+  constructor(ratePerSecond: Long) : this(RateLimiter.Factory(Ticker.systemTicker(), Sleeper.DEFAULT).create(1))
+
   override fun sample(): Boolean {
     return rateLimiter.tryAcquire(1L, 0, TimeUnit.SECONDS)
   }
-
-  class Factory @Inject constructor(
-    private val rateLimiterFactory: RateLimiter.Factory
-  ) {
-    fun createSampler(ratePerSecond: Long): RateLimitingSampler {
-      return RateLimitingSampler(rateLimiterFactory.create(ratePerSecond))
-    }
-  }
 }
-
 
 /** Sampler that always invokes an action */
 @Singleton


### PR DESCRIPTION
The existing API requires something like this, which is a bit verbose

```kotlin
val logger = getLogger<MyClass>().sampled(RateLimitingSampler(RateLimiter.Factory(Ticker.systemTicker(), Sleeper.DEFAULT).create(1)))
```

The new API looks like
```kotlin
val logger = getLogger<MyClass>().sampled(RateLimitingSampler(1))
```