### PR TITLE
Delete obsolete @ConcurrencyLimitsOptOut annotations

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/Http.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Http.kt
@@ -56,31 +56,3 @@ annotation class ResponseContentType(val value: String)
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class AvailableWhenDegraded
-
-/**
- * Opt-in to concurrency limits. If the service is overloaded permit Misk to shed calls to this
- * endpoint by returning "HTTP 503 Service Unavailable".
- */
-@Deprecated(message = "this annotation is not necessary; concurrency limits are on by default")
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class ConcurrencyLimitsOptIn
-
-/**
- * Opt-out of concurrency limits. Misk will not shed calls to this endpoint even if the service is
- * overloaded.
- *
- * In a future release this annotation will be deprecated. Developers will need to decide how this
- * action responds when the service is degraded:
- *
- *  * The action is eligible for concurrency limits. In this case the annotation can safely be
- *    removed. Most services should do this.
- *
- *  * The action is not eligible for concurrency limits. In this case the [AvailableWhenDegraded]
- *    annotation should be used instead. Most services should not do this.
- *
- * TODO(jwilson): deprecate this when make concurrency limits on by default.
- */
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class ConcurrencyLimitsOptOut

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -6,7 +6,6 @@ import misk.Action
 import misk.exceptions.StatusCode
 import misk.logging.getLogger
 import misk.web.AvailableWhenDegraded
-import misk.web.ConcurrencyLimitsOptOut
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import java.time.Clock
@@ -63,7 +62,6 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
   class Factory @Inject constructor(val clock: Clock) : NetworkInterceptor.Factory {
     override fun create(action: Action): NetworkInterceptor? {
       if (action.function.findAnnotation<AvailableWhenDegraded>() != null) return null
-      if (action.function.findAnnotation<ConcurrencyLimitsOptOut>() != null) return null
 
       val limiter = SimpleLimiter.Builder()
           .clock { clock.millis() }

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -9,7 +9,7 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import misk.time.FakeClockModule
-import misk.web.ConcurrencyLimitsOptOut
+import misk.web.AvailableWhenDegraded
 import misk.web.DispatchMechanism
 import misk.web.FakeHttpCall
 import misk.web.Get
@@ -135,7 +135,7 @@ class ConcurrencyLimitsInterceptorTest {
 
   internal class OptOutAction : WebAction {
     @Get("/important")
-    @ConcurrencyLimitsOptOut
+    @AvailableWhenDegraded
     fun call(): String = "important"
   }
 }


### PR DESCRIPTION
They're on by default.

Opt out in very rare cases with @AvailableWhenDegraded.