### PR TITLE
Fix memory leak in SessionFactoryService

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -127,6 +127,10 @@ internal class SessionFactoryService(
       }
     }
 
+    // Hibernate's TypeConfigurations are heavyweight objects that need to be released when we're
+    // done using them. We found this out the hard way!
+    metadataDraft.typeConfiguration.sessionFactoryClosed(null)
+
     val metadataBuilder = metadataSources.metadataBuilder
 
     // Register custom type adapters so we can have columns for ByteString, Id, etc. This needs to


### PR DESCRIPTION
SessionFactoryService builds up new hibernate Metadata (type information on columns, converters etc.) when hibernate initializes. Under the hood, TypeConfigurationRegistry maintains a HashMap of uuids to registered types. Unfortunately this mapping is only cleared on an explicit deregister call, which hibernate assumes happens when a session closes. misk-hibernate has a need to build up "draft" Metadata (for UserType resolution). Unfortunately these Metadata objects never have their session close invoked and thus never free up the underlying HashMap entries. 

Without this fix, as the number of tests using the database layer increases, the JVM instance processing the tests will eventually run out of memory.

This is a hacky fix to force a sessionFactoryClosed call when we are done with the intermediate MetadataBuilder.