### PR TITLE
tidb: stop setting pessimistic tx mode and timezone

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -70,13 +70,8 @@ class DataSourceService(
 
     if (config.type == DataSourceType.MYSQL || config.type == DataSourceType.VITESS || config.type == DataSourceType.VITESS_MYSQL || config.type == DataSourceType.TIDB) {
       hikariConfig.minimumIdle = 5
-      if (config.type == DataSourceType.MYSQL || config.type == DataSourceType.TIDB) {
+      if (config.type == DataSourceType.MYSQL) {
         hikariConfig.connectionInitSql = "SET time_zone = '+00:00'"
-        if (config.type == DataSourceType.TIDB) {
-          // This should be the default in all TiDB 3.1+ clusters but we run this just to make sure
-          // as misk application do rely on this behavior
-          hikariConfig.connectionInitSql += "; set @@tidb_txn_mode = 'pessimistic'"
-        }
       }
 
       // https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration


### PR DESCRIPTION
The tx mode and timezone can be set via a global variable, and should
not be overridden by misk on connection start. If the application
wants to override it, it should do that per session.