### PR TITLE
tell hibernate autocommit is always disabled

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -68,6 +68,12 @@ class DataSourceService(
     hikariConfig.validationTimeout = config.validation_timeout.toMillis()
     hikariConfig.maxLifetime = config.connection_max_lifetime.toMillis()
 
+    if (config.type != DataSourceType.VITESS && config.type != DataSourceType.VITESS_MYSQL) {
+      // Our Hibernate settings expect autocommit to be disabled, see
+      // CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT in SessionFactoryService
+      hikariConfig.isAutoCommit = false
+    }
+
     if (config.type == DataSourceType.MYSQL || config.type == DataSourceType.VITESS || config.type == DataSourceType.VITESS_MYSQL || config.type == DataSourceType.TIDB) {
       hikariConfig.minimumIdle = 5
       if (config.type == DataSourceType.MYSQL) {


### PR DESCRIPTION
Hopefully fixes https://github.com/cashapp/misk/issues/1288
Idea comes from https://vladmihalcea.com/why-you-should-always-use-hibernate-connection-provider_disables_autocommit-for-resource-local-jpa-transactions/