### PR TITLE
Pager does not generate many duplicate where conditions and order by …

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/jdbc/ScaleSafetyChecks.kt
@@ -94,7 +94,7 @@ object ScaleSafetyChecks {
   /**
    * Turn on MySQL general_log so that we can inspect it in the detectors.
    */
-  internal fun turnOnSqlGeneralLogging(connection: Connection) {
+  fun turnOnSqlGeneralLogging(connection: Connection) {
     connection.createStatement().use { statement ->
       statement.execute("SET GLOBAL log_output = 'TABLE'")
       statement.execute("SET GLOBAL general_log = 1")

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -59,6 +59,8 @@ interface Query<T> {
 
   fun <T : Query<*>> newOrBuilder(): OrBuilder<T>
 
+  fun <Q : Query<*>> clone(): Q
+
   /** Creates instances of queries. */
   interface Factory {
     fun <Q : Query<*>> newQuery(queryClass: KClass<Q>): Q

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -68,6 +68,28 @@ internal class ReflectionQuery<T : DbEntity<T>>(
     disabledChecks += check
   }
 
+  override fun <Q: Query<*>> clone(): Q {
+    val copy = ReflectionQuery(
+        this.queryClass,
+        this.rootEntityType,
+        this.queryMethodHandlers,
+        this.tracer,
+        this.queryLimitsConfig
+    )
+    if (copy.maxRows != -1) {
+      copy.maxRows = this.maxRows
+    }
+    if (copy.firstResult != 0) {
+      copy.firstResult = this.firstResult
+    }
+    copy.constraints.addAll(this.constraints)
+    copy.orderFactories.addAll(this.orderFactories)
+    copy.disabledChecks.addAll(this.disabledChecks)
+
+    @Suppress("UNCHECKED_CAST")
+    return copy.toProxy() as Q
+  }
+
   override fun dynamicAddConstraint(path: String, operator: Operator, value: Any?) {
     val pathList = path.split('.')
     addConstraint(pathList, operator, value)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/RealPager.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/RealPager.kt
@@ -2,6 +2,7 @@ package misk.hibernate.pagination
 
 import misk.hibernate.DbEntity
 import misk.hibernate.Query
+import misk.hibernate.ReflectionQuery
 import misk.hibernate.Session
 
 internal class RealPager<T : DbEntity<T>, Q: Query<T>>(
@@ -19,6 +20,8 @@ internal class RealPager<T : DbEntity<T>, Q: Query<T>>(
   }
 
   override fun nextPage(session: Session): Page<T>? {
+    @Suppress("UNCHECKED_CAST")
+    val query = query.clone<Q>()
     paginator.applyOffset(query, nextOffset)
     val (contents, hasNext) = query.listWithHasNext(session, pageSize)
     nextOffset = if (hasNext) {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
@@ -10,11 +10,15 @@ import misk.hibernate.Query
 import misk.hibernate.Transacter
 import misk.hibernate.load
 import misk.hibernate.or
+import misk.jdbc.DataSourceType
+import misk.jdbc.ScaleSafetyChecks
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.SessionFactory
 import org.junit.jupiter.api.Test
+import java.sql.Timestamp
+import java.time.Instant
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -22,7 +26,7 @@ import javax.inject.Inject
 class RealPagerTest {
 
   @MiskTestModule
-  val module = MoviesTestModule()
+  val module = MoviesTestModule(DataSourceType.MYSQL)
 
   @Inject @Movies private lateinit var transacter: Transacter
   @Inject @Movies lateinit var sessionFactory: SessionFactory
@@ -77,10 +81,10 @@ class RealPagerTest {
           .list(session)
           .map { it.name }
     }
-      val actualCharacterNames = queryFactory.newQuery(CharacterQuery::class)
-          .movieId(movieId)
-          .newPager(CharacterNameDescIdAscPaginator, pageSize = 5)
-          .listAll(transacter) { it.name }
+    val actualCharacterNames = queryFactory.newQuery(CharacterQuery::class)
+        .movieId(movieId)
+        .newPager(CharacterNameDescIdAscPaginator, pageSize = 5)
+        .listAll(transacter) { it.name }
     assertThat(actualCharacterNames).containsExactlyElementsOf(expectedCharacterNames)
   }
 
@@ -119,6 +123,62 @@ class RealPagerTest {
     // 1 page left
     assertThat(pager.hasNext()).isTrue()
   }
+
+  @Test fun `paging does not generate duplicate constraints and order by`() {
+    val pageSize = 4
+    val pageCount = 3
+    val movieId = givenStarWarsMovie()
+    givenStormtrooperCharacters(movieId, count = pageCount * pageSize)
+
+    val pager = queryFactory.newQuery(CharacterQuery::class)
+        .movieId(movieId)
+        .newPager(idDescPaginator(), pageSize = pageSize)
+
+    sessionFactory.openSession().use { session ->
+      session.doWork { connection ->
+        ScaleSafetyChecks.turnOnSqlGeneralLogging(connection)
+      }
+    }
+
+    val start = Timestamp.from(Instant.now())
+
+    transacter.transaction { session ->
+      pager.nextPage(session)
+      pager.nextPage(session)
+      pager.nextPage(session)
+    }
+
+    val queries = sessionFactory.openSession().use { session ->
+      session.doReturningWork { connection ->
+        ScaleSafetyChecks.extractQueriesSince(connection, start)
+      }
+    }
+
+    val pageQueries = queries.reversed().filter { it.contains("select") }.map {
+      Regex("""/\* (.*) \*/""").find(it)!!.groups[1]!!.value
+    }
+    assertThat(pageQueries).hasSize(3)
+    // The first page doesn't have an (id > ?) condition
+    assertThat(countClauses(pageQueries[0])).isEqualTo(Clauses(1, 1))
+    // The second page each have exactly one (id > ?) condition and one ORDER BY column
+    assertThat(countClauses(pageQueries[1])).isEqualTo(Clauses(2, 1))
+    assertThat(countClauses(pageQueries[2])).isEqualTo(Clauses(2, 1))
+  }
+
+  private fun countClauses(query: String): Clauses {
+    val whereMatches = Regex("where (.*) order by").find(query)
+    val whereCount = if (whereMatches != null) {
+      whereMatches.groups[1]!!.value.split(" and ").size
+    } else 0
+    val orderByMatches = Regex("order by (.*)").find(query)
+    val orderByCount = if (orderByMatches != null) {
+      orderByMatches.groups[1]!!.value.split(",").size
+    } else 0
+
+    return Clauses(whereCount, orderByCount)
+  }
+
+  private data class Clauses(val where: Int, val orderBy: Int)
 
   @Test fun `hasNext is false where there are no pages left`() {
     val pageSize = 4


### PR DESCRIPTION
…columns

Adds a `clone()` method to the Query so that the Pager can modify a copy
of the query instead of the original.

Fixes https://github.com/cashapp/misk/issues/1613