### PR TITLE
Bind ClientNetworkInterceptor.Factory for standalone use

### DIFF
--- a/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
@@ -36,6 +36,9 @@ class GrpcClientModule<T : Service, G : T>(
     bind(key)
         .toProvider(GrpcClientProvider(kclass, grpcClientClass, name, httpClientProvider))
         .`in`(Singleton::class.java)
+
+    // Initialize empty sets for our multibindings.
+    newMultibinder<ClientNetworkInterceptor.Factory>()
   }
 
   companion object {


### PR DESCRIPTION
Applications that install GrpcClientModule in tests might not get this
binding, and that'll cause dependency problems.