### PR TITLE
Add basic CompressionCodec abstraction and a few impls

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -95,6 +95,7 @@ ext.dep = [
   "servletApi": "javax.servlet:javax.servlet-api:3.1.0",
   "shadowJarPlugin": "com.github.jengelman.gradle.plugins:shadow:5.1.0",
   "slf4jApi": "org.slf4j:slf4j-api:1.7.28",
+  "snappy": "org.xerial.snappy:snappy-java:1.1.7.1",
   "tink": "com.google.crypto.tink:tink:1.2.0",
   "tracingDatadog": "com.datadoghq:dd-trace-api:0.49.0",
   "vitess": "io.vitess:vitess-jdbc:3.0.0",

--- a/misk-core/build.gradle
+++ b/misk-core/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile dep.okio
   compile dep.okHttp
   compile dep.slf4jApi
+  compile dep.snappy
 
   compile project(':misk-inject')
   compile project(':misk-service')

--- a/misk-core/src/main/kotlin/misk/compress/CompressionCodec.kt
+++ b/misk-core/src/main/kotlin/misk/compress/CompressionCodec.kt
@@ -1,0 +1,6 @@
+package com.squareup.misk.compress
+
+interface CompressionCodec {
+  fun encode(input: ByteArray): ByteArray
+  fun decode(input: ByteArray): ByteArray
+}

--- a/misk-core/src/main/kotlin/misk/compress/DeflateCompressionCodec.kt
+++ b/misk-core/src/main/kotlin/misk/compress/DeflateCompressionCodec.kt
@@ -1,0 +1,52 @@
+package com.squareup.misk.compress
+
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.zip.Deflater
+import java.util.zip.Deflater.DEFAULT_COMPRESSION
+import java.util.zip.DeflaterOutputStream
+import java.util.zip.InflaterOutputStream
+
+/**
+ * A {@link CompressionCodec} implementation for the deflate compression format. It uses the
+ * implementation provided in the standard {@code java.util.zip} package.
+ *
+ * Cribbed from SQ/repos/java/browse/compression.
+ */
+class DeflateCompressionCodec(private val compressionLevel: Int = DEFAULT_COMPRESSION) :
+    CompressionCodec {
+  init {
+    check(-1 <= compressionLevel && compressionLevel <= 9) {
+      "Invalid compression level $compressionLevel"
+    }
+  }
+
+  override fun encode(input: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream()
+    val deflater = Deflater(compressionLevel)
+    try {
+      DeflaterOutputStream(out, deflater).use { compressed -> compressed.write(input) }
+    } catch (e: IOException) {
+      throw RuntimeException(e)
+    } finally {
+      deflater.end()
+    }
+    return out.toByteArray()
+  }
+
+  /**
+   * Decompresses `input` bytes using a [InflaterOutputStream].
+   *
+   * @param input bytes to be decoded
+   * @return decoded bytes
+   */
+  override fun decode(input: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream()
+    try {
+      InflaterOutputStream(out).use { inflate -> inflate.write(input) }
+    } catch (e: IOException) {
+      throw RuntimeException(e)
+    }
+    return out.toByteArray()
+  }
+}

--- a/misk-core/src/main/kotlin/misk/compress/NoopCompressionCodec.kt
+++ b/misk-core/src/main/kotlin/misk/compress/NoopCompressionCodec.kt
@@ -1,0 +1,6 @@
+package com.squareup.misk.compress
+
+class NoopCompressionCodec : CompressionCodec {
+  override fun encode(input: ByteArray): ByteArray = input
+  override fun decode(input: ByteArray): ByteArray = input
+}

--- a/misk-core/src/main/kotlin/misk/compress/SnappyCompressionCodec.kt
+++ b/misk-core/src/main/kotlin/misk/compress/SnappyCompressionCodec.kt
@@ -1,0 +1,27 @@
+package com.squareup.misk.compress
+
+import org.xerial.snappy.Snappy
+import java.io.IOException
+
+/**
+ * A {@link CompressionCodec} implementation for the snappy compression format.
+ *
+ * Cribbed from SQ/repos/java/browse/compression, but basically delegates to Snappy instance.
+ */
+class SnappyCompressionCodec : CompressionCodec {
+  override fun encode(input: ByteArray): ByteArray {
+    return try {
+      Snappy.compress(input)
+    } catch (e: IOException) {
+      throw RuntimeException(e)
+    }
+  }
+
+  override fun decode(input: ByteArray): ByteArray {
+    return try {
+      Snappy.uncompress(input)
+    } catch (e: IOException) {
+      throw RuntimeException(e)
+    }
+  }
+}

--- a/misk-core/src/test/kotlin/misk/compress/CompressionCodecTest.kt
+++ b/misk-core/src/test/kotlin/misk/compress/CompressionCodecTest.kt
@@ -1,0 +1,28 @@
+package com.squareup.misk.compress
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+abstract class CompressionCodecTest {
+  abstract val codecUnderTest: CompressionCodec
+
+  private val fixtureValues = listOf(
+      "perfectly splendid",
+      "346af795eba789033dd4696b18eff03d",
+      "0f6a64771ec115039851676c6541d24b8758684a803ae9aff45a0bd6cf5f7039",
+      "9eee9f73ae587affa120bcc89a998a0e10d29581762177b5ac93f560ae829a48efc9fdb01a2f60a956ce6f2ec64a66d1db79abd38d85c39b07652c9f5e9459b3",
+      "repetition repetition repetition repetition",
+      "mostly distinct letters"
+  ).map { it.toByteArray() }
+
+  @TestFactory
+  fun `test reversibility of small input`(): List<DynamicTest> {
+    return fixtureValues.mapIndexed { index, testFixture ->
+      DynamicTest.dynamicTest("test fixture $index") {
+        val encoded = codecUnderTest.encode(testFixture)
+        assertThat(codecUnderTest.decode(encoded)).isEqualTo(testFixture)
+      }
+    }
+  }
+}

--- a/misk-core/src/test/kotlin/misk/compress/DeflateCompressionCodecTest.kt
+++ b/misk-core/src/test/kotlin/misk/compress/DeflateCompressionCodecTest.kt
@@ -1,0 +1,5 @@
+package com.squareup.misk.compress
+
+class DeflateCompressionCodecTest : CompressionCodecTest() {
+  override val codecUnderTest = DeflateCompressionCodec()
+}

--- a/misk-core/src/test/kotlin/misk/compress/NoopCompressionCodecTest.kt
+++ b/misk-core/src/test/kotlin/misk/compress/NoopCompressionCodecTest.kt
@@ -1,0 +1,5 @@
+package com.squareup.misk.compress
+
+class NoopCompressionCodecTest : CompressionCodecTest() {
+  override val codecUnderTest: CompressionCodec = NoopCompressionCodec()
+}

--- a/misk-core/src/test/kotlin/misk/compress/SnappyCompressionCodecTest.kt
+++ b/misk-core/src/test/kotlin/misk/compress/SnappyCompressionCodecTest.kt
@@ -1,0 +1,5 @@
+package com.squareup.misk.compress
+
+class SnappyCompressionCodecTest : CompressionCodecTest() {
+  override val codecUnderTest: CompressionCodec = SnappyCompressionCodec()
+}


### PR DESCRIPTION
When I have some downtime, I want to write something something to support compression on our Hibernate (and other persistence integrations) field definitions... Something like:

```
@Column(nullable = false)
@ProtoColumn
@Compressed(codec = SnappyCompressionCodec::class)
var some_cool_data: LargeCoolDataType
```

But also something like this, where the compression is applied to the plaintext (and not counterproductively to the ciphertext):
```
@Column(nullable = false)
@Compressed(codec = SnappyCompressionCodec::class)
@SecretColumn(key_name = "super-secure-key")
var large_sensitive_data: ByteArray // Nice-to-have: proto-aware SecretColumn
```

Here's the first step of just cribbing some existing compression codec wrappers we have that should play nice with our Hibernate user types.