### PR TITLE
Don't retry on HTTP connection failures

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientFactory.kt
@@ -44,6 +44,7 @@ class HttpClientFactory @Inject constructor(
   fun create(config: HttpClientEndpointConfig): OkHttpClient {
     // TODO(mmihic): Cache, proxy, etc
     val builder = unconfiguredClient.newBuilder()
+    builder.retryOnConnectionFailure(false)
     config.clientConfig.connectTimeout?.let { builder.connectTimeout(it.toMillis(), TimeUnit.MILLISECONDS) }
     config.clientConfig.readTimeout?.let { builder.readTimeout(it.toMillis(), TimeUnit.MILLISECONDS) }
     config.clientConfig.writeTimeout?.let { builder.writeTimeout(it.toMillis(), TimeUnit.MILLISECONDS) }

--- a/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
+++ b/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
@@ -59,6 +59,7 @@ abstract class AbstractRebalancingTest(
     }
 
     val httpClient = okHttpClient.newBuilder()
+        .retryOnConnectionFailure(true)
         .protocols(protocolsList)
         .addNetworkInterceptor {
           connections += it.connection()!!


### PR DESCRIPTION
This is not that useful in server apps where there are already
facilities to retry on connectivity failures.