### PR TITLE
Use service instead of principal in MetricsInterceptor

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -22,7 +22,7 @@ internal class MetricsInterceptor internal constructor(
     val elapsedTimeMillis = elapsedTime.toMillis().toDouble()
     val callingPrincipal = when {
       caller.get()?.service != null -> caller.get()?.service!!
-      caller.get()?.user != null -> "user"
+      caller.get()?.user != null -> "<user>"
       else -> "unknown"
     }
 

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -20,10 +20,14 @@ internal class MetricsInterceptor internal constructor(
     val (elapsedTime, result) = timed { chain.proceed(chain.httpCall) }
 
     val elapsedTimeMillis = elapsedTime.toMillis().toDouble()
-    val callingService = caller.get()?.service ?: "unknown"
+    val callingPrincipal = when {
+      caller.get()?.service != null -> caller.get()?.service!!
+      caller.get()?.user != null -> "user"
+      else -> "unknown"
+    }
 
     val statusCode = chain.httpCall.statusCode
-    requestDuration.record(elapsedTimeMillis, actionName, callingService, statusCode.toString())
+    requestDuration.record(elapsedTimeMillis, actionName, callingPrincipal, statusCode.toString())
     return result
   }
 

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -20,10 +20,10 @@ internal class MetricsInterceptor internal constructor(
     val (elapsedTime, result) = timed { chain.proceed(chain.httpCall) }
 
     val elapsedTimeMillis = elapsedTime.toMillis().toDouble()
-    val callingPrincipal = caller.get()?.principal ?: "unknown"
+    val callingService = caller.get()?.service ?: "unknown"
 
     val statusCode = chain.httpCall.statusCode
-    requestDuration.record(elapsedTimeMillis, actionName, callingPrincipal, statusCode.toString())
+    requestDuration.record(elapsedTimeMillis, actionName, callingService, statusCode.toString())
     return result
   }
 

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -4,6 +4,7 @@ import misk.inject.KAbstractModule
 import misk.security.authz.AccessControlModule
 import misk.security.authz.FakeCallerAuthenticator
 import misk.security.authz.FakeCallerAuthenticator.Companion.SERVICE_HEADER
+import misk.security.authz.FakeCallerAuthenticator.Companion.USER_HEADER
 import misk.security.authz.MiskCallerAuthenticator
 import misk.security.authz.Unauthenticated
 import misk.testing.MiskTest
@@ -42,6 +43,7 @@ class MetricsInterceptorTest {
     assertThat(invoke(200, "my-peer").code).isEqualTo(200)
     assertThat(invoke(200, "my-peer").code).isEqualTo(200)
     assertThat(invoke(200, "my-peer").code).isEqualTo(200)
+    assertThat(invoke(200, user = "some-user").code).isEqualTo(200)
   }
 
   @Test
@@ -58,9 +60,16 @@ class MetricsInterceptorTest {
 
     requestDuration.record(1.0, "TestAction", "my-peer", "200")
     assertThat(requestDuration.count("TestAction", "my-peer", "200")).isEqualTo(5)
+
+    requestDuration.record(1.0, "TestAction", "user", "200")
+    assertThat(requestDuration.count("TestAction", "user", "200")).isEqualTo(2)
   }
 
-  fun invoke(desiredStatusCode: Int, service: String? = null): okhttp3.Response {
+  fun invoke(
+    desiredStatusCode: Int,
+    service: String? = null,
+    user: String? = null
+  ): okhttp3.Response {
     val url = jettyService.httpServerUrl.newBuilder()
         .encodedPath("/call/$desiredStatusCode")
         .build()
@@ -69,6 +78,7 @@ class MetricsInterceptorTest {
         .url(url)
         .get()
     service?.let { request.addHeader(SERVICE_HEADER, it) }
+    user?.let { request.addHeader(USER_HEADER, it) }
     return httpClient.newCall(request.build()).execute()
   }
 

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -61,8 +61,8 @@ class MetricsInterceptorTest {
     requestDuration.record(1.0, "TestAction", "my-peer", "200")
     assertThat(requestDuration.count("TestAction", "my-peer", "200")).isEqualTo(5)
 
-    requestDuration.record(1.0, "TestAction", "user", "200")
-    assertThat(requestDuration.count("TestAction", "user", "200")).isEqualTo(2)
+    requestDuration.record(1.0, "TestAction", "<user>", "200")
+    assertThat(requestDuration.count("TestAction", "<user>", "200")).isEqualTo(2)
   }
 
   fun invoke(


### PR DESCRIPTION
When recording the caller for http_request_latency_ms, we should only be
recording the calling service name, if it exists, not a username. Since
`caller.get()?.principal` will return service or username, instead use
just `.service`. Having the username tagged on these metrics causes
cardinality explosion.