### PR TITLE
Extend mockito extension with more helper functions

### DIFF
--- a/misk-testing/src/main/kotlin/misk/mockito/MockitoExtensions.kt
+++ b/misk-testing/src/main/kotlin/misk/mockito/MockitoExtensions.kt
@@ -8,7 +8,11 @@ import org.mockito.stubbing.OngoingStubbing
 object Mockito {
   inline fun <reified T : Any> mock(): T = Mockito.mock(T::class.java)
 
-  inline fun <reified T : Any> whenever(t: T): OngoingStubbing<T> = `when`(t)
+  fun <T> whenever(t: T): OngoingStubbing<T> = `when`(t)
 
   inline fun <reified T : Any> captor(): ArgumentCaptor<T> = ArgumentCaptor.forClass(T::class.java)
+
+  inline fun <reified T> any(): T = Mockito.any<T>(T::class.java)
+
+  fun <T> eq(t: T): T = Mockito.eq<T>(t)
 }


### PR DESCRIPTION
It appears there are some rough edges with using Mockito with Kotlin. For example, if you use Mockito matchers directly in Kotlin, they typically return null which will trigger an NPE. The work around is to use helper functions. The real answer seems deeper philosophically, like Kotlin having its own test libraries.

Also removing the extension of Any for the whenever helper function because otherwise you can't stub out methods that return a nullable.

See https://stackoverflow.com/questions/30305217/is-it-possible-to-use-mockito-in-kotlin