### PR TITLE
fix gradle.properties for misk-jdbc

### DIFF
--- a/misk-jdbc/gradle.properties
+++ b/misk-jdbc/gradle.properties
@@ -1,4 +1,4 @@
-POM_ARTIFACT_ID=misk-hibernate
-POM_NAME=misk-hibernate
-POM_DESCRIPTION=A Misk module for the Hibernate ORM
+POM_ARTIFACT_ID=misk-jdbc
+POM_NAME=misk-jdbc
+POM_DESCRIPTION=A Misk module for JDBC
 POM_PACKAGING=jar


### PR DESCRIPTION
Maybe this will fix errors like the below?

```
Cannot access class 'misk.jdbc.DatabasePool'. Check your module classpath for missing or conflicting dependencies
```