### PR TITLE
Removes AwsSqsJobQueueConfig.clustered_consumers config

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -27,14 +27,6 @@ class AwsSqsJobQueueConfig(
   val task_queue: RepeatedTaskQueueConfig? = null,
 
   /**
-   * The number of receivers will be distributed among the app cluster If [clustered_consumers] is
-   * true. Otherwise, each app in the cluster will run the number of receivers.
-   *
-   * The number of receivers is configured by [Feature("jobqueue-consumers")].
-   */
-  val clustered_consumers: Boolean = true,
-
-  /**
    * Frequency used to import Queue Attributes in milliseconds.
    */
   val queue_attribute_importer_frequency_ms: Long = 1000,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -112,7 +112,7 @@ internal class SqsJobConsumer @Inject internal constructor(
       return (1..receiversForQueue())
           .filter { num ->
             val lease = leaseManager.requestLease("sqs-job-consumer-${queue.name.value}-$num")
-            !config.clustered_consumers || lease.checkHeld()
+            lease.checkHeld()
           }
     }
 


### PR DESCRIPTION
This feature is replaced by the feature flag `Feature("pod-jobqueue-consumers")`
which was introduced in [here](https://github.com/cashapp/misk/pull/1620).