### PR TITLE
Make RealTokenGenerator public

### DIFF
--- a/misk-core/src/main/kotlin/misk/tokens/RealTokenGenerator.kt
+++ b/misk-core/src/main/kotlin/misk/tokens/RealTokenGenerator.kt
@@ -7,7 +7,7 @@ import javax.inject.Singleton
 import kotlin.experimental.and
 
 @Singleton
-internal class RealTokenGenerator @Inject constructor() : TokenGenerator {
+class RealTokenGenerator @Inject constructor() : TokenGenerator {
   private val random = SecureRandom()
 
   override fun generate(label: String?, length: Int): String {


### PR DESCRIPTION
Make it easier for non-Guice usage of a RealTokenGenerator (currently
only accesible from the TokenGeneratorModule while FakeTokenGenerator
is public).
