### PR TITLE
Pass HttpCalls down via the Chain.

### DIFF
--- a/misk/src/main/kotlin/misk/Chain.kt
+++ b/misk/src/main/kotlin/misk/Chain.kt
@@ -1,5 +1,6 @@
 package misk
 
+import misk.web.HttpCall
 import misk.web.actions.WebAction
 import kotlin.reflect.KFunction
 
@@ -7,5 +8,6 @@ interface Chain {
   val action: WebAction
   val args: List<Any?>
   val function: KFunction<*>
+  val httpCall: HttpCall
   fun proceed(args: List<Any?>): Any
 }

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -219,7 +219,7 @@ private class RequestBridgeInterceptor(
     val arguments = webActionBinding.beforeCall(chain.webAction, httpCall, pathMatcher)
 
     val applicationChain = chain.webAction.asChain(
-        chain.action.function, arguments, applicationInterceptors)
+        chain.action.function, arguments, applicationInterceptors, httpCall)
 
     var returnValue = applicationChain.proceed(applicationChain.args)
 

--- a/misk/src/main/kotlin/misk/web/RealChain.kt
+++ b/misk/src/main/kotlin/misk/web/RealChain.kt
@@ -10,11 +10,12 @@ internal class RealChain(
   override val args: List<Any?>,
   private val interceptors: List<ApplicationInterceptor>,
   override val function: KFunction<*>,
+  override val httpCall: HttpCall,
   private val index: Int = 0
 ) : Chain {
   override fun proceed(args: List<Any?>): Any {
     check(index < interceptors.size) { "final interceptor must be terminal" }
-    val next = RealChain(action, args, interceptors, function, index + 1)
+    val next = RealChain(action, args, interceptors, function, httpCall, index + 1)
     return interceptors[index].intercept(next)
   }
 }

--- a/misk/src/main/kotlin/misk/web/actions/WebActions.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActions.kt
@@ -2,6 +2,7 @@ package misk.web.actions
 
 import misk.ApplicationInterceptor
 import misk.Chain
+import misk.web.HttpCall
 import misk.web.RealChain
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -9,7 +10,8 @@ import kotlin.reflect.KParameter
 fun WebAction.asChain(
   function: KFunction<*>,
   args: List<Any?>,
-  interceptors: List<ApplicationInterceptor>
+  interceptors: List<ApplicationInterceptor>,
+  httpCall: HttpCall
 ): Chain {
   val callFunctionInterceptor = object : ApplicationInterceptor {
     override fun intercept(chain: Chain): Any {
@@ -28,5 +30,5 @@ fun WebAction.asChain(
     }
   }
   val realChainInterceptors = interceptors + callFunctionInterceptor
-  return RealChain(this, args, realChainInterceptors, function, 0)
+  return RealChain(this, args, realChainInterceptors, function, httpCall,0)
 }


### PR DESCRIPTION
This will allow interceptors to affect headers before the body is sent.

Adapted from https://github.com/cashapp/misk/compare/jwilson.1125.fastpath