### PR TITLE
Load classpath resources lazily

### DIFF
--- a/misk-core/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
+++ b/misk-core/src/main/kotlin/misk/resources/ClasspathResourceLoaderBackend.kt
@@ -1,10 +1,10 @@
 package misk.resources
 
-import com.google.common.reflect.ClassPath
+import java.io.File
+import java.util.jar.JarFile
 import okio.BufferedSource
 import okio.buffer
 import okio.source
-import java.util.TreeMap
 
 /**
  * Read-only resources that are fetched from either the deployed .jar file or the local filesystem.
@@ -12,22 +12,81 @@ import java.util.TreeMap
  * This uses the scheme `classpath:`.
  */
 internal object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
-  private val resourcesByPath: Map<String, ClassPath.ResourceInfo>
+  override fun list(path: String): List<String> {
+    require(path.startsWith("/"))
+    val path = path.removePrefix("/").removeSuffix("/")
 
-  init {
     val classLoader = ClasspathResourceLoaderBackend::class.java.classLoader
-    val classPath = ClassPath.from(classLoader)
-    resourcesByPath = TreeMap(classPath.resources.filter {
-      it !is ClassPath.ClassInfo
-    }.associateBy { "/${it.resourceName}" })
+    val result = mutableSetOf<String>()
+    for (url in classLoader.getResources(path)) {
+      val urlString = url.toString()
+      when {
+        urlString.startsWith("file:") -> {
+          val file = File(url.toURI())
+          result += file.list() ?: arrayOf()
+        }
+        urlString.startsWith("jar:file:") -> {
+          val file = jarFile(urlString)
+          result += jarFileChildren(file, "$path/")
+        }
+        else -> {
+          // Silently ignore unexpected URLs.
+        }
+      }
+    }
+
+    return result
+        .filter { !it.endsWith(".class") }
+        .map { "/$path/$it" }
+        .toList()
+  }
+
+  /**
+   * Returns a string like `/tmp/foo.jar` from a URL string like
+   * `jar:file:/tmp/foo.jar!/META-INF/MANIFEST.MF`. This strips the scheme prefix `jar:file:` and an
+   * optional path suffix like `!/META-INF/MANIFEST.MF`.
+   */
+  private fun jarFile(jarFileUrl: String): File {
+    var suffixStart = jarFileUrl.lastIndexOf("!")
+    if (suffixStart == -1) suffixStart = jarFileUrl.length
+    return File(jarFileUrl.substring("jar:file:".length, suffixStart))
+  }
+
+  /**
+   * Returns the contents of a directory inside the JAR file [file].
+   *
+   * @param pathPrefix a string like `misk/resources/` that ends in a slash. This will return the
+   *     simple names of the files and directories that are direct descendants of this path.
+   */
+  private fun jarFileChildren(file: File, pathPrefix: String): Set<String> {
+    // If we're looking for the children of `misk/resources/`, there's a few cases to cover:
+    //  * Unrelated paths like `META-INF/MANIFEST.MF`. Ignore these.
+    //  * Equal paths like `misk/resources/`. Ignore these; we're only collecting children.
+    //  * Child file paths like `misk/resources/child.txt`. We collect the `child.txt` substring.
+    //  * Child directory paths like `misk/resources/nested/child.txt`. We collect the `nexted`
+    //    substring for the child directory.
+    val result = mutableSetOf<String>()
+    JarFile(file).use { jarFile ->
+      for (entry in jarFile.entries().asIterator()) {
+        if (!entry.name.startsWith(pathPrefix) || entry.name == pathPrefix) continue
+
+        var endIndex = entry.name.indexOf("/", pathPrefix.length)
+        if (endIndex == -1) endIndex = entry.name.length
+
+        result += entry.name.substring(pathPrefix.length, endIndex)
+      }
+    }
+    return result
   }
 
   override fun open(path: String): BufferedSource? {
-    val resource = resourcesByPath[path] ?: return null
-    return resource.asByteSource().openStream().source().buffer()
+    val classLoader = ClasspathResourceLoaderBackend::class.java.classLoader
+    val resourceAsStream = classLoader.getResourceAsStream(path.removePrefix("/")) ?: return null
+    return resourceAsStream.source().buffer()
   }
 
-  override fun exists(path: String) = resourcesByPath[path] != null
-
-  override fun all() = resourcesByPath.keys
+  override fun exists(path: String): Boolean {
+    val classLoader = ClasspathResourceLoaderBackend::class.java.classLoader
+    return classLoader.getResource(path.removePrefix("/")) != null
+  }
 }

--- a/misk-core/src/main/kotlin/misk/resources/ResourceLoader.kt
+++ b/misk-core/src/main/kotlin/misk/resources/ResourceLoader.kt
@@ -2,16 +2,16 @@ package misk.resources
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.inject.Inject
+import javax.inject.Singleton
 import misk.resources.ResourceLoader.Backend
 import okio.BufferedSource
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.buffer
 import okio.sink
-import java.nio.file.Files
-import java.nio.file.Path
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * ResourceLoader is a testable API for loading resources from the classpath, from the filesystem,
@@ -141,12 +141,10 @@ class ResourceLoader @Inject constructor(
    * Copies all resources with [root] as a prefix to the directory [dir].
    */
   fun copyTo(root: String, dir: Path) {
-    val (scheme, path) = parseAddress(root)
-    val prefix = if (path.endsWith("/")) path else "$path/"
-    for (resource in backends[scheme].all()) {
-      if (resource.startsWith(prefix)) {
-        copyResource("$scheme$resource", dir.resolve(resource.substring(prefix.length)))
-      }
+    val prefix = if (root.endsWith("/")) root else "$root/"
+    for (resource in walk(root)) {
+      val destination = dir.resolve(resource.substring(prefix.length))
+      copyResource(resource, destination)
     }
   }
 

--- a/misk-core/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
+++ b/misk-core/src/test/kotlin/misk/resources/ResourceLoaderTest.kt
@@ -1,6 +1,9 @@
 package misk.resources
 
 import com.google.inject.util.Modules
+import java.io.File
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.testing.TemporaryFolder
@@ -9,9 +12,6 @@ import okio.buffer
 import okio.sink
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
-import javax.inject.Inject
-import kotlin.test.assertFailsWith
 
 @MiskTest
 class ResourceLoaderTest {
@@ -42,6 +42,12 @@ class ResourceLoaderTest {
   fun listDoesNotContainChildOfChild() {
     assertThat(resourceLoader.list("classpath:/misk/"))
         .doesNotContain("classpath:/misk/resources/ResourceLoaderTest.txt")
+  }
+
+  @Test
+  fun listContainsResourcesFromJar() {
+    assertThat(resourceLoader.list("classpath:/META-INF/"))
+        .contains("classpath:/META-INF/MANIFEST.MF")
   }
 
   @Test


### PR DESCRIPTION
Previously we used Guava's classpath scanner to load all resources
eagerly. This was easy but it also required us to load a lot of
resources that we might not need, potentially slowing app launch.

Also this should make it possible to make further improvements to
load resources in more complex classloader situations.