### PR TITLE
Change directory Static Resource handling

### DIFF
--- a/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
@@ -12,6 +12,10 @@ import misk.testing.MiskTestModule
 import misk.web.WebActionModule
 import misk.web.WebTestingModule
 import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes.APPLICATION_JAVASCRIPT
+import misk.web.mediatype.MediaTypes.TEXT_CSS
+import misk.web.mediatype.MediaTypes.TEXT_HTML
+import misk.web.mediatype.MediaTypes.TEXT_PLAIN_UTF8
 import misk.web.resources.StaticResourceAction
 import misk.web.resources.StaticResourceEntry
 import okhttp3.OkHttpClient
@@ -77,42 +81,42 @@ class StaticResourceActionTest {
     val response = request("/hi/")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("<p>Hello world</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun hiHtml() {
     val response = request("/hi/index.html")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("<p>Hello world</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun hiCss() {
     val response = request("/hi/main.css")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("hello > world")
-    assertThat(response.header("Content-Type")).isEqualTo("text/css")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_CSS)
   }
 
   @Test fun hiJs() {
     val response = request("/hi/app.js")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("alert(\"hello world\")")
-    assertThat(response.header("Content-Type")).isEqualTo("application/javascript")
+    assertThat(response.header("Content-Type")).isEqualTo(APPLICATION_JAVASCRIPT)
   }
 
   @Test fun rootUrl() {
     val response = request("/")
     assertThat(response.code).isEqualTo(404)
     assertThat(response.body!!.string()).contains("Nothing found at /")
-    assertThat(response.header("Content-Type")).isEqualTo("text/plain;charset=utf-8")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_PLAIN_UTF8)
   }
 
   @Test fun noPathMatch() {
     val response = request("/not/found")
     assertThat(response.code).isEqualTo(404)
     assertThat(response.body!!.string()).contains("Nothing found at /")
-    assertThat(response.header("Content-Type")).isEqualTo("text/plain;charset=utf-8")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_PLAIN_UTF8)
   }
 
   @Test fun nasaCommandRoot() {
@@ -120,7 +124,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Welcome to NASA Space Command Dashboard</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaCommandHtml() {
@@ -128,7 +132,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Welcome to NASA Space Command Dashboard</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelRoot() {
@@ -136,7 +140,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelHtml() {
@@ -144,21 +148,21 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaCss() {
     val response = request("/nasa/tabs/o2fuel/tab_o2fuel.css")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("nasa > world")
-    assertThat(response.header("Content-Type")).isEqualTo("text/css")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_CSS)
   }
 
   @Test fun nasaJs() {
     val response = request("/nasa/tabs/o2fuel/tab_o2fuel.js")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains("alert(\"nasa world\")")
-    assertThat(response.header("Content-Type")).isEqualTo("application/javascript")
+    assertThat(response.header("Content-Type")).isEqualTo(APPLICATION_JAVASCRIPT)
   }
 
   @Test fun nasaCommandBadPathRedirectsToPrefixIndex() {
@@ -166,7 +170,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Welcome to NASA Space Command Dashboard</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelBadPathRedirectsToPrefixIndex() {
@@ -174,7 +178,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelSlashesOnSlashesRedirectsToPrefixIndex() {
@@ -182,7 +186,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelSlashesOnSlashesQueryRedirectsToPrefixIndex() {
@@ -190,7 +194,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun nasaFuelDotDirectoryRedirectsToPrefixIndex() {
@@ -198,7 +202,7 @@ class StaticResourceActionTest {
     assertThat(response.code).isEqualTo(200)
     assertThat(response.body!!.string()).contains(
         "<p>Your o2fuel gauge reads: this</p>")
-    assertThat(response.header("Content-Type")).isEqualTo("text/html")
+    assertThat(response.header("Content-Type")).isEqualTo(TEXT_HTML)
   }
 
   @Test fun blockedPrefixEntryFails() {


### PR DESCRIPTION
This should fix the recently spotted Admin Dashboard load failures where
`/_admin/` was not correctly returning
`/_tab/admin-dashboard/index.html` as the response and instead was a
blank response of type `APPLICATION_OCTETSTREAM_MEDIA_TYPE` from falling
through the `MediaTypes.fromFileExtension` resolver function.
