### PR TITLE
Make MoshiModule public

### DIFF
--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -15,7 +15,11 @@ import javax.inject.Singleton
 import com.squareup.wire.WireJsonAdapterFactory as WireOnlyJsonAdapterFactory
 import misk.moshi.wire.WireMessageAdapter as MiskOnlyMessageAdapter
 
-internal class MoshiModule(
+/**
+ * For service setup, prefer to install [misk.MiskCommonServiceModule] over installing [MoshiModule]
+ * directly.
+ */
+class MoshiModule(
   private val useWireToRead: Boolean = false,
   private val useWireToWrite: Boolean = false
 ) : KAbstractModule() {


### PR DESCRIPTION
Making this available publicly, so that lightweight tests that only need moshi set up and don't rely on more misk modules can depend on it