### PR TITLE
Make kotlin-test a test-only dependency

### DIFF
--- a/misk-redis/build.gradle
+++ b/misk-redis/build.gradle
@@ -20,8 +20,8 @@ dependencies {
   compile dep.guiceMultibindings
   compile dep.jedis
   compile project(':misk')
-  compile project(':misk-testing')
 
+  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 

--- a/misk-redis/build.gradle
+++ b/misk-redis/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   compile dep.jedis
   compile project(':misk')
 
-  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -1,8 +1,7 @@
 package misk.redis
 
-import misk.time.FakeClock
 import okio.ByteString
-import okio.ByteString.Companion.encodeUtf8
+import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -10,7 +9,7 @@ import javax.inject.Inject
 
 /** Mimics a Redis instance for testing. */
 class FakeRedis : Redis {
-  @Inject lateinit var clock: FakeClock
+  @Inject lateinit var clock: Clock
 
   // The value type stored in our key-value store.
   private data class Value(

--- a/misk-testing/build.gradle
+++ b/misk-testing/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   compile dep.junitParams
   compile dep.junitEngine
   compile dep.assertj
+  compile dep.kotlinTest
   compile dep.logbackClassic
   compile (dep.okHttpMockWebServer) {
     exclude group: 'junit'

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -11,7 +11,6 @@ sourceSets {
 
 dependencies {
   compile dep.kotlinStdLibJdk8
-  compile dep.kotlinTest
   compile dep.bouncycastle
   compile dep.guava
   compile dep.guice
@@ -59,6 +58,7 @@ dependencies {
   compile project(':misk-prometheus')
   compile project(':misk-service')
 
+  testCompile dep.kotlinTest
   testCompile dep.kotlinxCoroutines
   testCompile dep.mockitoCore
   testCompile project(':misk-testing')

--- a/misk/build.gradle
+++ b/misk/build.gradle
@@ -58,7 +58,6 @@ dependencies {
   compile project(':misk-prometheus')
   compile project(':misk-service')
 
-  testCompile dep.kotlinTest
   testCompile dep.kotlinxCoroutines
   testCompile dep.mockitoCore
   testCompile project(':misk-testing')

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -6,7 +6,6 @@ dependencies {
   compile project(':misk')
   compile project(':misk-prometheus')
 
-  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 

--- a/samples/exemplar/build.gradle
+++ b/samples/exemplar/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
   compile dep.kotlinStdLibJdk8
-  compile dep.kotlinTest
   compile dep.guava
   compile dep.guice
   compile dep.logbackClassic
   compile project(':misk')
   compile project(':misk-prometheus')
 
+  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
   compile dep.kotlinStdLibJdk8
-  compile dep.kotlinTest
   compile dep.guava
   compile dep.guice
   compile dep.logbackClassic
@@ -8,6 +7,7 @@ dependencies {
   compile project(':misk-prometheus')
   compile project(':misk-eventrouter')
 
+  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 

--- a/samples/exemplarchat/build.gradle
+++ b/samples/exemplarchat/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   compile project(':misk-prometheus')
   compile project(':misk-eventrouter')
 
-  testCompile dep.kotlinTest
   testCompile project(':misk-testing')
 }
 


### PR DESCRIPTION
I tracked dependencies using: `ls | grep misk- | xargs sh -c 'for arg do echo $arg; ./gradlew :$arg:dependencies --configuration compileClasspath | grep test; done'`

After this change, only the -testing libraries depend on kotlin-test.