### PR TITLE
Delete the obsolete VITESS datasource type

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -90,7 +90,7 @@ internal class SessionFactoryService(
       applySetting(AvailableSettings.USE_GET_GENERATED_KEYS, "true")
       applySetting(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS, "false")
       applySetting(AvailableSettings.JDBC_TIME_ZONE, "UTC")
-      if (config.type != DataSourceType.VITESS && config.type != DataSourceType.VITESS_MYSQL) {
+      if (config.type != DataSourceType.VITESS_MYSQL) {
         // This tells Hibernate that autocommit is always false, so Hibernate won't try to set it
         // for every transaction.
         // https://vladmihalcea.com/why-you-should-always-use-hibernate-connection-provider_disables_autocommit-for-resource-local-jpa-transactions/

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesConfig.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesConfig.kt
@@ -4,7 +4,6 @@ import misk.config.Config
 import misk.jdbc.DataSourceConfig
 
 internal data class MoviesConfig(
-  val vitess_data_source: DataSourceConfig,
   val vitess_mysql_data_source: DataSourceConfig,
   val mysql_data_source: DataSourceConfig,
   val cockroachdb_data_source: DataSourceConfig,

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -39,7 +39,6 @@ class MoviesTestModule(
 
   private fun selectDataSourceConfig(config: MoviesConfig): DataSourceConfig {
     return when (type) {
-      DataSourceType.VITESS -> config.vitess_data_source
       DataSourceType.VITESS_MYSQL -> config.vitess_mysql_data_source
       DataSourceType.MYSQL -> config.mysql_data_source
       DataSourceType.COCKROACHDB -> config.cockroachdb_data_source
@@ -48,5 +47,4 @@ class MoviesTestModule(
       DataSourceType.HSQLDB -> throw RuntimeException("Not supported (yet?)")
     }
   }
-
 }

--- a/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
+++ b/misk-hibernate/src/test/resources/moviestestmodule-common.yaml
@@ -1,8 +1,3 @@
-vitess_data_source:
-  type: VITESS
-  username: vt_app
-  password: whatever
-  vitess_schema_resource_root: classpath:/misk/hibernate/moviestestmodule-schema
 vitess_mysql_data_source:
   type: VITESS_MYSQL
   username: vt_app

--- a/misk-jdbc-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
+++ b/misk-jdbc-testing/src/main/kotlin/misk/jdbc/TruncateTablesService.kt
@@ -53,7 +53,7 @@ class TruncateTablesService(
               DataSourceType.HSQLDB -> {
                 "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.SYSTEM_TABLES WHERE TABLE_TYPE='TABLE'"
               }
-              DataSourceType.VITESS, DataSourceType.VITESS_MYSQL -> {
+              DataSourceType.VITESS_MYSQL -> {
                 "SHOW VSCHEMA TABLES"
               }
               DataSourceType.COCKROACHDB, DataSourceType.POSTGRESQL -> {

--- a/misk-jdbc-testing/src/main/kotlin/misk/vitess/VitessScaleSafetyChecks.kt
+++ b/misk-jdbc-testing/src/main/kotlin/misk/vitess/VitessScaleSafetyChecks.kt
@@ -67,7 +67,7 @@ class VitessScaleSafetyChecks(
   private val fullTableScanDetector = TableScanDetector()
 
   override fun decorate(dataSource: DataSource): DataSource {
-    if (config.type != DataSourceType.VITESS && config.type != DataSourceType.VITESS_MYSQL) return dataSource
+    if (config.type != DataSourceType.VITESS_MYSQL) return dataSource
 
     connect()?.let {
       ScaleSafetyChecks.turnOnSqlGeneralLogging(it)

--- a/misk-jdbc/src/main/kotlin/misk/database/DockerVitessCluster.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/DockerVitessCluster.kt
@@ -254,12 +254,6 @@ class DockerVitessCluster(
     val schemaVolume = Volume("/vt/src/vitess.io/vitess/schema")
     val confVolume = Volume("/vt/src/vitess.io/vitess/config/miskcnf")
     val httpPort = ExposedPort.tcp(cluster.httpPort)
-    if (cluster.config.type == DataSourceType.VITESS) {
-      if (cluster.config.port != null && cluster.config.port != cluster.grpcPort) {
-        throw RuntimeException(
-            "Config port ${cluster.config.port} has to match Vitess Docker container: ${cluster.grpcPort}")
-      }
-    }
     if (cluster.config.type == DataSourceType.VITESS_MYSQL) {
       if (cluster.config.port != null && cluster.config.port != cluster.vtgateMysqlPort) {
         throw RuntimeException(

--- a/misk-jdbc/src/main/kotlin/misk/database/StartDatabaseService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/StartDatabaseService.kt
@@ -105,7 +105,7 @@ class StartDatabaseService(
 
     private fun createDatabaseServer(config: CacheKey): DatabaseServer? =
         when (config.config.type) {
-          DataSourceType.VITESS_MYSQL, DataSourceType.VITESS -> {
+          DataSourceType.VITESS_MYSQL -> {
             DockerVitessCluster(
                 name = config.name,
                 config = config.config,

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -68,13 +68,13 @@ class DataSourceService(
     hikariConfig.validationTimeout = config.validation_timeout.toMillis()
     hikariConfig.maxLifetime = config.connection_max_lifetime.toMillis()
 
-    if (config.type != DataSourceType.VITESS && config.type != DataSourceType.VITESS_MYSQL) {
+    if (config.type != DataSourceType.VITESS_MYSQL) {
       // Our Hibernate settings expect autocommit to be disabled, see
       // CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT in SessionFactoryService
       hikariConfig.isAutoCommit = false
     }
 
-    if (config.type == DataSourceType.MYSQL || config.type == DataSourceType.VITESS || config.type == DataSourceType.VITESS_MYSQL || config.type == DataSourceType.TIDB) {
+    if (config.type == DataSourceType.MYSQL || config.type == DataSourceType.VITESS_MYSQL || config.type == DataSourceType.TIDB) {
       hikariConfig.minimumIdle = 5
       if (config.type == DataSourceType.MYSQL) {
         hikariConfig.connectionInitSql = "SET time_zone = '+00:00'"

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigratorService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigratorService.kt
@@ -21,7 +21,7 @@ class SchemaMigratorService internal constructor(
     val connector = connectorProvider.get()
     if (environment == Environment.TESTING || environment == Environment.DEVELOPMENT) {
       val type = connector.config().type
-      if (type != DataSourceType.VITESS && type != DataSourceType.VITESS_MYSQL) {
+      if (type != DataSourceType.VITESS_MYSQL) {
         val appliedMigrations = schemaMigrator.initialize()
         migrationState = schemaMigrator.applyAll("SchemaMigratorService", appliedMigrations)
       } else {

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -7,65 +7,85 @@ import kotlin.test.assertEquals
 class DataSourceConfigTest {
   @Test
   fun buildVitessJDBCUrlNoSSL() {
-    val config = DataSourceConfig(DataSourceType.VITESS)
-    assertEquals("jdbc:vitess://127.0.0.1:27001/", config.buildJdbcUrl(Environment.TESTING))
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL)
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&sslMode=PREFERRED",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildVitessJDBCUrlWithTruststore() {
-    val config = DataSourceConfig(DataSourceType.VITESS,
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL,
         trust_certificate_key_store_url = "path/to/truststore",
         trust_certificate_key_store_password = "changeit")
-    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
-        "trustStorePassword=changeit&useSSL=true",
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&" +
+        "trustCertificateKeyStoreUrl=path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
         config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildVitessJDBCUrlWithKeystore() {
-    val config = DataSourceConfig(DataSourceType.VITESS,
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL,
         client_certificate_key_store_url = "path/to/keystore",
         client_certificate_key_store_password = "changeit")
-    assertEquals("jdbc:vitess://127.0.0.1:27001/?keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true",
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&" +
+        "clientCertificateKeyStoreUrl=path/to/keystore&clientCertificateKeyStorePassword=" +
+        "changeit&sslMode=VERIFY_CA",
         config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildVitessJDBCUrlWithFullTLS() {
-    val config = DataSourceConfig(DataSourceType.VITESS,
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL,
         trust_certificate_key_store_url = "path/to/truststore",
         trust_certificate_key_store_password = "changeit",
         client_certificate_key_store_url = "path/to/keystore",
         client_certificate_key_store_password = "changeit")
-    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
-        "trustStorePassword=changeit&keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true",
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&" +
+        "trustCertificateKeyStoreUrl=path/to/truststore&trustCertificateKeyStorePassword=" +
+        "changeit&clientCertificateKeyStoreUrl=path/to/keystore&" +
+        "clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
         config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildVitessJDBCUrlWithPath() {
-    val config = DataSourceConfig(DataSourceType.VITESS,
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL,
         trust_certificate_key_store_path = "path/to/truststore",
         trust_certificate_key_store_password = "changeit",
         client_certificate_key_store_path = "path/to/keystore",
         client_certificate_key_store_password = "changeit")
-    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
-        "trustStorePassword=changeit&keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&trustCertificateKeyStorePassword" +
+        "=changeit&clientCertificateKeyStoreUrl=file://path/to/keystore&" +
+        "clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test
   fun buildVitessJDBCUrlWithActualUrl() {
-    val config = DataSourceConfig(DataSourceType.VITESS,
+    val config = DataSourceConfig(DataSourceType.VITESS_MYSQL,
         trust_certificate_key_store_url = "file://path/to/truststore",
         trust_certificate_key_store_password = "changeit",
         client_certificate_key_store_url = "file://path/to/keystore",
         client_certificate_key_store_password = "changeit")
-    assertEquals("jdbc:vitess://127.0.0.1:27001/?trustStore=path/to/truststore&" +
-        "trustStorePassword=changeit&keyStore=path/to/keystore&" +
-        "keyStorePassword=changeit&useSSL=true", config.buildJdbcUrl(Environment.TESTING))
+    assertEquals("jdbc:tracing:mysql://127.0.0.1:27003/@master?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "useServerPrepStmts=false&useUnicode=true&jdbcCompliantTruncation=false&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&clientCertificateKeyStoreUrl=" +
+        "file://path/to/keystore&clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA",
+        config.buildJdbcUrl(Environment.TESTING))
   }
 
   @Test

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SpanInjectorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SpanInjectorTest.kt
@@ -1,26 +1,16 @@
 package misk.jdbc
 
-import datadog.trace.core.DDSpan
 import datadog.opentracing.DDTracer
 import datadog.trace.common.writer.Writer
+import datadog.trace.core.DDSpan
+import io.opentracing.mock.MockTracer
 import net.ttddyy.dsproxy.transform.TransformInfo
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import io.opentracing.mock.MockTracer
-import org.assertj.core.api.Assertions.assertThat
 import javax.sql.DataSource
 
 class SpanInjectorTest {
-  @Test
-  fun testNotDecorateIfItsVitess() {
-    val tracer = MockTracer()
-    val config = DataSourceConfig(DataSourceType.VITESS)
-    val injector = SpanInjector(tracer, config)
-    val ds = Mockito.mock(DataSource::class.java)
-
-    assertThat(injector.decorate(ds)).isSameAs(ds)
-  }
-
   @Test
   fun testDecoratesIfItsVitessMysql() {
     val tracer = MockTracer()


### PR DESCRIPTION
It's replaced with VITESS_MYSQL. The VITESS type no longer works now that we've
split up misk-jdbc and misk-hibernate.