### PR TITLE
Add getStringOrNull and getIntOrNull to FeatureFlags

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -41,9 +41,15 @@ class FakeFeatureFlags @Inject constructor(
       get(feature, key, attributes) as? Int ?: throw IllegalArgumentException(
           "Int flag $feature must be overridden with override() before use")
 
+  override fun getIntOrNull(feature: Feature, key: String, attributes: Attributes): Int? =
+      get(feature, key, attributes) as Int?
+
   override fun getString(feature: Feature, key: String, attributes: Attributes): String =
       get(feature, key, attributes) as? String ?: throw IllegalArgumentException(
           "String flag $feature must be overridden with override() before use")
+
+  override fun getStringOrNull(feature: Feature, key: String, attributes: Attributes): String? =
+      get(feature, key, attributes) as String?
 
   override fun <T : Enum<T>> getEnum(
     feature: Feature,

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -9,6 +9,7 @@ import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import javax.inject.Inject
@@ -57,6 +58,11 @@ internal class FakeFeatureFlagsTest {
     //Provides the key level override when there is no match on attributes
     assertThat(subject.getInt(FEATURE, "joker", Attributes(mapOf("don't" to "exist"))))
         .isEqualTo(42)
+
+    // Can override with null
+    subject.reset()
+    assertThatThrownBy { subject.getInt(FEATURE, TOKEN) }.hasSameClassAs(IllegalArgumentException())
+    assertThat(subject.getIntOrNull(FEATURE, TOKEN)).isNull()
   }
 
   @Test

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
@@ -26,6 +26,17 @@ interface FeatureFlags {
   ): Int
 
   /**
+   * Calculates the value of an integer feature flag for the given key and attributes, or returns
+   * null if the flag is set to nothing.
+   * @see [getEnum] for param details
+   */
+  fun getIntOrNull(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes()
+  ): Int?
+
+  /**
    * Calculates the value of a string feature flag for the given key and attributes.
    * @see [getEnum] for param details
    */
@@ -36,11 +47,24 @@ interface FeatureFlags {
   ): String
 
   /**
+   * Calculates the value of a string feature flag for the given key and attributes, or returns
+   * null if the flag is set to nothing.
+   * @see [getEnum] for param details
+   */
+  fun getStringOrNull(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes()
+  ): String?
+
+  /**
    * Calculates the value of an enumerated feature flag for the given key and attributes.
    * @param feature name of the feature flag to evaluate.
    * @param key unique primary key for the entity the flag should be evaluated against.
-   * @param clazz the enum type
+   * @param clazz the enum type.
    * @param attributes additional attributes to provide to flag evaluation.
+   * @throws [RuntimeException] if the service is unavailable.
+   * @throws [IllegalStateException] if the flag is off with no default value.
    */
   fun <T : Enum<T>> getEnum(
     feature: Feature,

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -50,6 +50,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
   override fun getBoolean(feature: Feature, key: String, attributes: Attributes): Boolean {
     val result = ldClient.boolVariationDetail(feature.name, buildUser(feature, key, attributes), false)
     checkDefaultNotUsed(feature, result)
+    checkEvaluationSucceeded(feature, result)
     return result.value
   }
 
@@ -57,14 +58,30 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     checkInitialized()
     val result = ldClient.intVariationDetail(feature.name, buildUser(feature, key, attributes), 0)
     checkDefaultNotUsed(feature, result)
+    checkEvaluationSucceeded(feature, result)
     return result.value
+  }
+
+  override fun getIntOrNull(feature: Feature, key: String, attributes: Attributes): Int? {
+    checkInitialized()
+    val result = ldClient.intVariationDetail(feature.name, buildUser(feature, key, attributes), 0)
+    checkEvaluationSucceeded(feature, result)
+    return if (result.isDefaultValue) null else result.value
   }
 
   override fun getString(feature: Feature, key: String, attributes: Attributes): String {
     checkInitialized()
     val result = ldClient.stringVariationDetail(feature.name, buildUser(feature, key, attributes), "")
     checkDefaultNotUsed(feature, result)
+    checkEvaluationSucceeded(feature, result)
     return result.value
+  }
+
+  override fun getStringOrNull(feature: Feature, key: String, attributes: Attributes): String? {
+    checkInitialized()
+    val result = ldClient.stringVariationDetail(feature.name, buildUser(feature, key, attributes), "")
+    checkEvaluationSucceeded(feature, result)
+    return if (result.isDefaultValue) null else result.value
   }
 
   override fun <T : Enum<T>> getEnum(
@@ -76,6 +93,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     checkInitialized()
     val result = ldClient.stringVariationDetail(feature.name, buildUser(feature, key, attributes), "")
     checkDefaultNotUsed(feature, result)
+    checkEvaluationSucceeded(feature, result)
     return java.lang.Enum.valueOf(clazz, result.value.toUpperCase())
   }
 
@@ -91,6 +109,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
         buildUser(feature, key, attributes),
         LDValue.ofNull())
     checkDefaultNotUsed(feature, result)
+    checkEvaluationSucceeded(feature, result)
     return moshi.adapter(clazz).fromSafeJson(result.value.toJsonString())
         ?: throw IllegalArgumentException("null value deserialized from $feature")
   }
@@ -100,14 +119,16 @@ class LaunchDarklyFeatureFlags @Inject constructor(
         "LaunchDarkly feature flags not initialized. Did you forget to make your service depend on [FeatureFlags]?")
   }
 
-  private fun <T> checkDefaultNotUsed(feature: Feature, detail: EvaluationDetail<T>) {
-    if (!detail.isDefaultValue) {
-      return
-    }
-
+  private fun <T> checkEvaluationSucceeded(feature: Feature, detail: EvaluationDetail<T>) {
     if (detail.reason.kind == EvaluationReason.Kind.ERROR) {
       val reason = detail.reason as EvaluationReason.Error
       throw RuntimeException("Feature flag $feature evaluation failed: ${detail.reason}", reason.exception)
+    }
+  }
+
+  private fun <T> checkDefaultNotUsed(feature: Feature, detail: EvaluationDetail<T>) {
+    if (!detail.isDefaultValue) {
+      return
     }
 
     throw IllegalStateException("Feature flag $feature is off but no off variation is specified")

--- a/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
+++ b/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito
 import org.mockito.Mockito.any
@@ -184,5 +185,47 @@ internal class LaunchDarklyFeatureFlagsTest {
   enum class Dinosaur {
     PTERODACTYL,
     TYRANNOSAURUS
+  }
+
+  @Test
+  fun `getString throws on default value`() {
+    Mockito
+      .`when`(client.stringVariationDetail(anyString(), any(LDUser::class.java), anyString()))
+      .thenReturn(EvaluationDetail(EvaluationReason.off(), null, "PTERODACTYL"))
+
+    assertThrows<IllegalStateException> {
+      featureFlags.getString(Feature("which-dinosaur"), "a-token")
+    }
+  }
+
+  @Test
+  fun `getStringOrNull returns null on default value`() {
+    Mockito
+      .`when`(client.stringVariationDetail(anyString(), any(LDUser::class.java), anyString()))
+      .thenReturn(EvaluationDetail(EvaluationReason.off(), null, "PTERODACTYL"))
+
+    assertThat(featureFlags.getStringOrNull(Feature("which-dinosaur"), "a-token"))
+      .isNull()
+  }
+
+  @Test
+  fun `getInt throws on default value`() {
+    Mockito
+      .`when`(client.intVariationDetail(anyString(), any(LDUser::class.java), anyInt()))
+      .thenReturn(EvaluationDetail(EvaluationReason.off(), null, 999))
+
+    assertThrows<IllegalStateException> {
+      featureFlags.getInt(Feature("which-dinosaur"), "a-token")
+    }
+  }
+
+  @Test
+  fun `getIntOrNull returns null on default value`() {
+    Mockito
+      .`when`(client.intVariationDetail(anyString(), any(LDUser::class.java), anyInt()))
+      .thenReturn(EvaluationDetail(EvaluationReason.off(), null, 999))
+
+    assertThat(featureFlags.getIntOrNull(Feature("which-dinosaur"), "a-token"))
+      .isNull()
   }
 }


### PR DESCRIPTION
These will return nulls if the flag is set to nothing (for Launch
Darkly, off with no default variation), which gives callers flexibility
around how they handle this case.

The *OrNull calls should still throw an exception if the service throws
an unexpected error.