### PR TITLE
Cleanup Database Misk Web tab, add LocalDate adapter

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
@@ -9,9 +9,10 @@ import misk.hibernate.Query
 import misk.hibernate.ReflectionQuery
 import misk.hibernate.Session
 import misk.hibernate.Transacter
-import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.checkDynamicQuery
+import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.checkQueryMatchesAction
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.findDatabaseQueryMetadata
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.getTransacterForDatabaseQueryAction
+import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.validateSelectPathsOrDefault
 import misk.scope.ActionScoped
 import misk.web.Post
 import misk.web.RequestBody
@@ -19,12 +20,12 @@ import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.dashboard.AdminDashboardAccess
+import misk.web.interceptors.LogRequestResponse
 import misk.web.mediatype.MediaTypes
 import misk.web.metadata.database.DatabaseQueryMetadata
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.reflect.KClass
-import kotlin.reflect.full.declaredMemberProperties
 
 /** Runs query from Database Query dashboard tab against DB and returns results */
 @Singleton
@@ -38,12 +39,13 @@ internal class HibernateDatabaseQueryDynamicAction @Inject constructor(
   @Post(HIBERNATE_QUERY_DYNAMIC_WEBACTION_PATH)
   @RequestContentType(MediaTypes.APPLICATION_JSON)
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @LogRequestResponse
   @AdminDashboardAccess
   fun query(@RequestBody request: Request): Response {
     val caller = callerProvider.get()!!
     val queryClass = request.queryClass
 
-    checkDynamicQuery(queryClass, true)
+    checkQueryMatchesAction(queryClass, true)
 
     val metadata = findDatabaseQueryMetadata(databaseQueryMetadata, queryClass)
     val transacter = getTransacterForDatabaseQueryAction(injector, metadata)
@@ -63,9 +65,9 @@ internal class HibernateDatabaseQueryDynamicAction @Inject constructor(
     metadata: DatabaseQueryMetadata
   ) = transacter.transaction { session ->
     val dbEntity = transacter.entities().find { it.simpleName == request.entityClass }
-        ?: throw BadRequestException(
-            "[dbEntity=${metadata.entityClass}] is not an installed HibernateEntity"
-        )
+      ?: throw BadRequestException(
+        "[dbEntity=${metadata.entityClass}] is not an installed HibernateEntity"
+      )
     val (selectPaths, rows) = runDynamicQuery(session, dbEntity, request)
     rows.map { row ->
       // TODO (adrw) sort the map based on DbEntity order
@@ -79,18 +81,12 @@ internal class HibernateDatabaseQueryDynamicAction @Inject constructor(
     dbEntity: KClass<out DbEntity<*>>,
     request: Request,
   ): Pair<List<String>, List<List<Any?>>> {
-    val configuredQuery = ReflectionQuery.Factory(queryConfig).dynamicQuery(dbEntity).configureDynamic(request)
-    val selectPaths = getDynamicSelectPaths(dbEntity, request)
+    val configuredQuery =
+      ReflectionQuery.Factory(queryConfig).dynamicQuery(dbEntity).configureDynamic(request)
+    val selectPaths = validateSelectPathsOrDefault(dbEntity, request.query.select?.paths)
     val rows = configuredQuery.dynamicList(session, selectPaths)
     return Pair(selectPaths, rows)
   }
-
-  private fun getDynamicSelectPaths(
-    dbEntity: KClass<out DbEntity<*>>,
-    request: Request
-  ): List<String> = if (request.query.select?.paths?.isNotEmpty() == true) {
-    request.query.select.paths
-  } else { dbEntity.declaredMemberProperties.map { it.name } }
 
   private fun Query<out DbEntity<*>>.configureDynamic(request: Request) = apply {
     request.query.constraints?.forEach { (path, operator, value) ->

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -14,6 +14,7 @@ import java.time.LocalDate
 import javax.inject.Inject
 import kotlin.reflect.KClass
 import kotlin.reflect.full.functions
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 @MiskTest(startService = true)
@@ -24,8 +25,11 @@ class ReflectionQueryFactoryTest {
   val maxMaxRows = 40
   val rowCountErrorLimit = 30
   val rowCountWarningLimit = 20
-  private val queryFactory = ReflectionQuery.Factory(ReflectionQuery.QueryLimitsConfig(
-      maxMaxRows, rowCountErrorLimit, rowCountWarningLimit))
+  private val queryFactory = ReflectionQuery.Factory(
+    ReflectionQuery.QueryLimitsConfig(
+      maxMaxRows, rowCountErrorLimit, rowCountWarningLimit
+    )
+  )
 
   @Inject @Movies lateinit var transacter: Transacter
   @Inject lateinit var logCollector: LogCollector
@@ -50,41 +54,53 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m98.name, m98.releaseDate))
       session.save(DbMovie(m99.name, m99.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThan(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m2)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m2)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThanOrEqualTo(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m2, m3)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m2, m3)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateEqualTo(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactly(m3)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactly(m3)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThanOrEqualTo(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m3, m4, m5)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m3, m4, m5)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThan(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m4, m5)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m4, m5)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotEqualTo(m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m2, m4, m5)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m2, m4, m5)
     }
   }
 
@@ -108,41 +124,53 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m98.name, m98.releaseDate))
       session.save(DbMovie(m99.name, m99.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThan(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThanOrEqualTo(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateEqualTo(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThanOrEqualTo(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateGreaterThan(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotEqualTo(null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
     }
   }
 
@@ -159,17 +187,21 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m98.name, m98.releaseDate))
       session.save(DbMovie(m99.name, m99.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateIsNull()
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m98, m99)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m98, m99)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateIsNotNull()
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m2)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m2)
     }
   }
 
@@ -184,17 +216,21 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m2.name, m2.releaseDate))
       session.save(DbMovie(m3.name, m3.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg(m1.releaseDate, m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m3)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m3)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf(m1.releaseDate, m3.releaseDate))
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m3)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m1, m3)
     }
   }
 
@@ -209,17 +245,21 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m2.name, m2.releaseDate))
       session.save(DbMovie(m3.name, m3.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotInVararg(m1.releaseDate, m3.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m2)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m2)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateNotInCollection(listOf(m1.releaseDate, m3.releaseDate))
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m2)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactlyInAnyOrder(m2)
     }
   }
 
@@ -232,17 +272,21 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m1.name, m1.releaseDate))
       session.save(DbMovie(m2.name, m2.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg(m1.releaseDate, null)
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactly(m1)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactly(m1)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf(m1.releaseDate, null))
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactly(m1)
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactly(m1)
     }
   }
 
@@ -253,17 +297,21 @@ class ReflectionQueryFactoryTest {
     transacter.transaction { session ->
       session.save(DbMovie(m1.name, m1.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInVararg()
           .allowFullScatter()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateInCollection(listOf())
           .allowFullScatter()
-          .listAsNameAndReleaseDate(session))
-          .isEmpty()
+          .listAsNameAndReleaseDate(session)
+      )
+        .isEmpty()
     }
   }
 
@@ -281,44 +329,45 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m99.name, m99.releaseDate))
 
       val queryObjectResult = queryFactory.newQuery<OperatorsMovieQuery>()
-          .releaseDateLessThan(m3.releaseDate)
-          .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session)
+        .releaseDateLessThan(m3.releaseDate)
+        .allowFullScatter().allowTableScan()
+        .listAsNameAndReleaseDate(session)
 
       // Should contain the same items as running the query with a runtime constraint.
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { dynamicAddConstraint("release_date", LT, m3.releaseDate) }
-          .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrderElementsOf(queryObjectResult)
+        .apply { dynamicAddConstraint("release_date", LT, m3.releaseDate) }
+        .allowFullScatter().allowTableScan()
+        .listAsNameAndReleaseDate(session))
+        .containsExactlyInAnyOrderElementsOf(queryObjectResult)
 
       // Should be the same when using a manual projection.
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .releaseDateLessThan(m3.releaseDate)
-          .allowFullScatter().allowTableScan()
-          .dynamicList(session, listOf("name", "release_date"))
-          .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
-          .containsExactlyInAnyOrderElementsOf(queryObjectResult)
+        .releaseDateLessThan(m3.releaseDate)
+        .allowFullScatter().allowTableScan()
+        .dynamicList(session, listOf("name", "release_date"))
+        .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
+        .containsExactlyInAnyOrderElementsOf(queryObjectResult)
 
       // Should be the same when using a JPA selection.
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .releaseDateLessThan(m3.releaseDate)
-          .allowFullScatter().allowTableScan()
-          .dynamicList(session) { criteriaBuilder, queryRoot ->
-            criteriaBuilder.tuple(
-                queryRoot.get<DbMovie>("name"),
-                queryRoot.get<DbMovie>("release_date"))
-          }
-          .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
-          .containsExactlyInAnyOrderElementsOf(queryObjectResult)
+        .releaseDateLessThan(m3.releaseDate)
+        .allowFullScatter().allowTableScan()
+        .dynamicList(session) { criteriaBuilder, queryRoot ->
+          criteriaBuilder.tuple(
+            queryRoot.get<DbMovie>("name"),
+            queryRoot.get<DbMovie>("release_date")
+          )
+        }
+        .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
+        .containsExactlyInAnyOrderElementsOf(queryObjectResult)
 
       // Should also be the same as not using the query object at all.
       assertThat(queryFactory.dynamicQuery(DbMovie::class)
-          .apply { dynamicAddConstraint("release_date", LT, m3.releaseDate) }
-          .allowFullScatter().allowTableScan()
-          .dynamicList(session, listOf("name", "release_date"))
-          .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
-          .containsExactlyInAnyOrderElementsOf(queryObjectResult)
+        .apply { dynamicAddConstraint("release_date", LT, m3.releaseDate) }
+        .allowFullScatter().allowTableScan()
+        .dynamicList(session, listOf("name", "release_date"))
+        .map { NameAndReleaseDate(it[0] as String, it[1] as LocalDate) })
+        .containsExactlyInAnyOrderElementsOf(queryObjectResult)
     }
   }
 
@@ -336,47 +385,54 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m99.name, m99.releaseDate))
 
       // count(*)
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
           .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
             criteriaBuilder.count(queryRoot)
-          }!![0])
-          .isEqualTo(4L)
+          }!![0]
+      )
+        .isEqualTo(4L)
 
       // count(name)
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
           .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
             criteriaBuilder.count(queryRoot.get<DbMovie>("name"))
-          }!![0])
-          .isEqualTo(4L)
+          }!![0]
+      )
+        .isEqualTo(4L)
 
       // count(release_date)
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
           .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
             criteriaBuilder.count(queryRoot.get<DbMovie>("release_date"))
-          }!![0])
-          .isEqualTo(3L)
+          }!![0]
+      )
+        .isEqualTo(3L)
 
       // min(release_date), max(release_date)
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
-            criteriaBuilder.tuple(
-                criteriaBuilder.min(queryRoot.get("release_date")),
-                criteriaBuilder.max(queryRoot.get("release_date")))
-          })
-          .containsExactly(m1.releaseDate, m3.releaseDate)
+        .allowFullScatter().allowTableScan()
+        .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
+          criteriaBuilder.tuple(
+            criteriaBuilder.min(queryRoot.get("release_date")),
+            criteriaBuilder.max(queryRoot.get("release_date"))
+          )
+        })
+        .containsExactly(m1.releaseDate, m3.releaseDate)
 
       // max(release_date) where release_date < m3.release_date
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .releaseDateLessThan(m3.releaseDate)
-          .allowFullScatter().allowTableScan()
-          .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
-            criteriaBuilder.max(queryRoot.get("release_date"))
-          })
-          .containsExactly(m2.releaseDate)
+        .releaseDateLessThan(m3.releaseDate)
+        .allowFullScatter().allowTableScan()
+        .dynamicUniqueResult(session) { criteriaBuilder, queryRoot ->
+          criteriaBuilder.max(queryRoot.get("release_date"))
+        })
+        .containsExactly(m2.releaseDate)
     }
   }
 
@@ -391,32 +447,40 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m2.name, m2.releaseDate))
       session.save(DbMovie(m3.name, m3.releaseDate))
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateEqualTo(m1.releaseDate)
           .allowFullScatter().allowTableScan()
-          .uniqueName(session))
-          .isEqualTo(m1.name)
+          .uniqueName(session)
+      )
+        .isEqualTo(m1.name)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateLessThanOrEqualTo(m2.releaseDate)
           .allowFullScatter().allowTableScan()
-          .listAsNames(session))
-          .containsExactlyInAnyOrder(m1.name, m2.name)
+          .listAsNames(session)
+      )
+        .containsExactlyInAnyOrder(m1.name, m2.name)
     }
   }
 
   @Test
   fun singleColumnProjectionIsEmpty() {
     transacter.transaction { session ->
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
-          .uniqueName(session))
-          .isNull()
+          .uniqueName(session)
+      )
+        .isNull()
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
-          .listAsNames(session))
-          .isEmpty()
+          .listAsNames(session)
+      )
+        .isEmpty()
     }
   }
 
@@ -433,8 +497,10 @@ class ReflectionQueryFactoryTest {
       }
     }
     transacter.transaction { session ->
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>().allowTableScan().allowFullScatter()
-          .list(session)).hasSize(18)
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>().allowTableScan().allowFullScatter()
+          .list(session)
+      ).hasSize(18)
     }
     assertThat(logCollector.takeMessages(loggerClass = ReflectionQuery::class)).isEmpty()
 
@@ -445,12 +511,16 @@ class ReflectionQueryFactoryTest {
       }
     }
     transacter.transaction { session ->
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
-          .list(session)).hasSize(21)
+          .list(session)
+      ).hasSize(21)
     }
-    assertThat(getOnlyElement(
-        logCollector.takeMessages(loggerClass = ReflectionQuery::class, minLevel = Level.WARN))
+    assertThat(
+      getOnlyElement(
+        logCollector.takeMessages(loggerClass = ReflectionQuery::class, minLevel = Level.WARN)
+      )
     ).startsWith("Unbounded query returned 21 rows.")
 
     // 31 rows logs an error.
@@ -460,21 +530,25 @@ class ReflectionQueryFactoryTest {
       }
     }
     transacter.allowCowrites().transaction { session ->
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .allowFullScatter().allowTableScan()
-          .list(session)).hasSize(31)
+          .list(session)
+      ).hasSize(31)
     }
-    assertThat(getOnlyElement(
-        logCollector.takeMessages(loggerClass = ReflectionQuery::class, minLevel = Level.ERROR))
+    assertThat(
+      getOnlyElement(
+        logCollector.takeMessages(loggerClass = ReflectionQuery::class, minLevel = Level.ERROR)
+      )
     ).startsWith("Unbounded query returned 31 rows.")
 
     // An explicit max row count suppresses the warning.
     transacter.allowCowrites().transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .apply { maxRows = 32 }
-          .list(session))
-          .hasSize(31)
+        .allowFullScatter().allowTableScan()
+        .apply { maxRows = 32 }
+        .list(session))
+        .hasSize(31)
     }
     assertThat(logCollector.takeMessages(loggerClass = ReflectionQuery::class)).isEmpty()
 
@@ -487,8 +561,8 @@ class ReflectionQueryFactoryTest {
     assertThat(assertFailsWith<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .allowFullScatter().allowTableScan()
-            .list(session)
+          .allowFullScatter().allowTableScan()
+          .list(session)
       }
     }).hasMessage("query truncated at 41 rows")
   }
@@ -503,10 +577,10 @@ class ReflectionQueryFactoryTest {
 
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .apply { maxRows = 4 }
-          .listAsNames(session))
-          .hasSize(3)
+        .allowFullScatter().allowTableScan()
+        .apply { maxRows = 4 }
+        .listAsNames(session))
+        .hasSize(3)
     }
   }
 
@@ -529,20 +603,20 @@ class ReflectionQueryFactoryTest {
     // List.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { maxRows = 2 }
-          .allowFullScatter().allowTableScan()
-          .list(session)
-          .map { it.name })
-          .hasSize(2)
+        .apply { maxRows = 2 }
+        .allowFullScatter().allowTableScan()
+        .list(session)
+        .map { it.name })
+        .hasSize(2)
     }
 
     // List projection.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .apply { maxRows = 2 }
-          .listAsNames(session))
-          .hasSize(2)
+        .allowFullScatter().allowTableScan()
+        .apply { maxRows = 2 }
+        .listAsNames(session))
+        .hasSize(2)
     }
   }
 
@@ -558,43 +632,43 @@ class ReflectionQueryFactoryTest {
     // List.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { maxRows = 1; firstResult = 1 }
-          .allowFullScatter().allowTableScan()
-          .releaseDateAsc()
-          .list(session)
-          .map { it.name })
-          .containsExactly("Rocky 2")
+        .apply { maxRows = 1; firstResult = 1 }
+        .allowFullScatter().allowTableScan()
+        .releaseDateAsc()
+        .list(session)
+        .map { it.name })
+        .containsExactly("Rocky 2")
     }
 
     // List projection.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .releaseDateAsc()
-          .apply { maxRows = 1; firstResult = 1 }
-          .listAsNameAndReleaseDate(session)
-          .map { it.name })
-          .containsExactly("Rocky 2")
+        .allowFullScatter().allowTableScan()
+        .releaseDateAsc()
+        .apply { maxRows = 1; firstResult = 1 }
+        .listAsNameAndReleaseDate(session)
+        .map { it.name })
+        .containsExactly("Rocky 2")
     }
 
     // Unique.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { maxRows = 1; firstResult = 1 }
-          .allowFullScatter().allowTableScan()
-          .releaseDateAsc()
-          .uniqueResult(session)!!.name)
-          .isEqualTo("Rocky 2")
+        .apply { maxRows = 1; firstResult = 1 }
+        .allowFullScatter().allowTableScan()
+        .releaseDateAsc()
+        .uniqueResult(session)!!.name)
+        .isEqualTo("Rocky 2")
     }
 
     // Unique runtime path.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { maxRows = 1; firstResult = 1 }
-          .allowFullScatter().allowTableScan()
-          .releaseDateAsc()
-          .dynamicUniqueResult(session, listOf("name", "release_date"))!![0])
-          .isEqualTo("Rocky 2")
+        .apply { maxRows = 1; firstResult = 1 }
+        .allowFullScatter().allowTableScan()
+        .releaseDateAsc()
+        .dynamicUniqueResult(session, listOf("name", "release_date"))!![0])
+        .isEqualTo("Rocky 2")
     }
   }
 
@@ -609,20 +683,20 @@ class ReflectionQueryFactoryTest {
     // List.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { firstResult = 1 }
-          .allowFullScatter().allowTableScan()
-          .list(session)
-          .map { it.name })
-          .hasSize(2)
+        .apply { firstResult = 1 }
+        .allowFullScatter().allowTableScan()
+        .list(session)
+        .map { it.name })
+        .hasSize(2)
     }
 
     // List projection.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .apply { firstResult = 1 }
-          .listAsNames(session))
-          .hasSize(2)
+        .allowFullScatter().allowTableScan()
+        .apply { firstResult = 1 }
+        .listAsNames(session))
+        .hasSize(2)
     }
   }
 
@@ -637,20 +711,20 @@ class ReflectionQueryFactoryTest {
     // List.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { firstResult = 3 }
-          .allowFullScatter().allowTableScan()
-          .list(session)
-          .map { it.name })
-          .hasSize(0)
+        .apply { firstResult = 3 }
+        .allowFullScatter().allowTableScan()
+        .list(session)
+        .map { it.name })
+        .hasSize(0)
     }
 
     // List projection.
     transacter.transaction { session ->
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .apply { firstResult = 3 }
-          .listAsNames(session))
-          .hasSize(0)
+        .allowFullScatter().allowTableScan()
+        .apply { firstResult = 3 }
+        .listAsNames(session))
+        .hasSize(0)
     }
   }
 
@@ -666,8 +740,8 @@ class ReflectionQueryFactoryTest {
     assertThat(assertFailsWith<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .allowFullScatter().allowTableScan()
-            .uniqueResult(session)
+          .allowFullScatter().allowTableScan()
+          .uniqueResult(session)
       }
     }).hasMessageContaining("query expected a unique result but was")
 
@@ -675,8 +749,8 @@ class ReflectionQueryFactoryTest {
     assertThat(assertFailsWith<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .allowFullScatter().allowTableScan()
-            .uniqueName(session)
+          .allowFullScatter().allowTableScan()
+          .uniqueName(session)
       }
     }).hasMessageContaining("query expected a unique result but was")
   }
@@ -696,21 +770,27 @@ class ReflectionQueryFactoryTest {
       session.save(rocky)
       session.save(starWars)
 
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateAsc()
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactly(m2, m3, m1)
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactly(m2, m3, m1)
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateDesc()
           .allowFullScatter().allowTableScan()
-          .listAsNameAndReleaseDate(session))
-          .containsExactly(m1, m3, m2)
-      assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
+          .listAsNameAndReleaseDate(session)
+      )
+        .containsExactly(m1, m3, m2)
+      assertThat(
+        queryFactory.newQuery<OperatorsMovieQuery>()
           .releaseDateDesc()
           .allowFullScatter().allowTableScan()
-          .list(session))
-          .containsExactly(jurassicPark, starWars, rocky)
+          .list(session)
+      )
+        .containsExactly(jurassicPark, starWars, rocky)
     }
   }
 
@@ -728,16 +808,16 @@ class ReflectionQueryFactoryTest {
       session.save(starWars)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { dynamicAddOrder("release_date", false) }
-          .allowFullScatter().allowTableScan()
-          .list(session))
-          .containsExactly(jurassicPark, starWars, rocky)
+        .apply { dynamicAddOrder("release_date", false) }
+        .allowFullScatter().allowTableScan()
+        .list(session))
+        .containsExactly(jurassicPark, starWars, rocky)
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .apply { dynamicAddOrder("created_at", true) }
-          .allowFullScatter().allowTableScan()
-          .list(session))
-          .containsExactly(jurassicPark, rocky, starWars)
+        .apply { dynamicAddOrder("created_at", true) }
+        .allowFullScatter().allowTableScan()
+        .list(session))
+        .containsExactly(jurassicPark, rocky, starWars)
     }
   }
 
@@ -750,15 +830,15 @@ class ReflectionQueryFactoryTest {
     assertThat(assertFailsWith<IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .allowFullScatter().allowTableScan()
-            .releaseDateAsc().delete(session)
+          .allowFullScatter().allowTableScan()
+          .releaseDateAsc().delete(session)
       }
     }).hasMessageContaining("orderBy shouldn't be used for a delete")
 
     transacter.allowCowrites().transaction { session ->
       val rocky = queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .uniqueName(session)
+        .allowFullScatter().allowTableScan()
+        .uniqueName(session)
       assertThat(rocky).isEqualTo("Rocky 1")
     }
   }
@@ -802,17 +882,17 @@ class ReflectionQueryFactoryTest {
     // count all entities
     val allCount = transacter.transaction { session ->
       queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .count(session)
+        .allowFullScatter().allowTableScan()
+        .count(session)
     }
     assertThat(allCount).isEqualTo(3)
 
     // count with filter
     transacter.transaction { session ->
       val jurassicParkCount = queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .name("Jurassic Park")
-          .count(session)
+        .allowFullScatter().allowTableScan()
+        .name("Jurassic Park")
+        .count(session)
       assertThat(jurassicParkCount).isEqualTo(1)
     }
 
@@ -820,9 +900,9 @@ class ReflectionQueryFactoryTest {
     assertFailsWith<java.lang.IllegalStateException> {
       transacter.transaction { session ->
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .allowFullScatter().allowTableScan()
-            .apply { maxRows = 2 }
-            .count(session)
+          .allowFullScatter().allowTableScan()
+          .apply { maxRows = 2 }
+          .count(session)
       }
     }
   }
@@ -839,13 +919,13 @@ class ReflectionQueryFactoryTest {
       session.save(DbMovie(m3.name, m3.releaseDate))
 
       assertThat(queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter().allowTableScan()
-          .or {
-            option { name("Rocky 1") }
-            option { name("Rocky 3") }
-          }
-          .listAsNameAndReleaseDate(session))
-          .containsExactlyInAnyOrder(m1, m3)
+        .allowFullScatter().allowTableScan()
+        .or {
+          option { name("Rocky 1") }
+          option { name("Rocky 3") }
+        }
+        .listAsNameAndReleaseDate(session))
+        .containsExactlyInAnyOrder(m1, m3)
     }
   }
 
@@ -854,9 +934,9 @@ class ReflectionQueryFactoryTest {
     transacter.transaction { session ->
       assertFailsWith<IllegalStateException> {
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .or {
-            }
-            .list(session)
+          .or {
+          }
+          .list(session)
       }
     }
   }
@@ -866,10 +946,10 @@ class ReflectionQueryFactoryTest {
     transacter.transaction { session ->
       assertFailsWith<IllegalStateException> {
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .or {
-              option { }
-            }
-            .list(session)
+          .or {
+            option { }
+          }
+          .list(session)
       }
     }
   }
@@ -879,17 +959,17 @@ class ReflectionQueryFactoryTest {
     transacter.transaction { session ->
       assertFailsWith<IllegalStateException> {
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .or {
-              option { list(session) }
-            }
-            .list(session)
+          .or {
+            option { list(session) }
+          }
+          .list(session)
       }
       assertFailsWith<IllegalStateException> {
         queryFactory.newQuery<OperatorsMovieQuery>()
-            .or {
-              option { releaseDateAsc() }
-            }
-            .list(session)
+          .or {
+            option { releaseDateAsc() }
+          }
+          .list(session)
       }
     }
   }
@@ -904,10 +984,10 @@ class ReflectionQueryFactoryTest {
 
     val jurassicCount = transacter.transaction { session ->
       queryFactory.newQuery<OperatorsMovieQuery>()
-          .allowFullScatter()
-          .allowTableScan()
-          .constraint { root -> like(root.get("name"), "Jurassic%") }
-          .count(session)
+        .allowFullScatter()
+        .allowTableScan()
+        .constraint { root -> like(root.get("name"), "Jurassic%") }
+        .count(session)
     }
     assertThat(jurassicCount).isEqualTo(2)
   }
@@ -921,9 +1001,9 @@ class ReflectionQueryFactoryTest {
     }
 
     val original = queryFactory.newQuery<OperatorsMovieQuery>()
-        .allowFullScatter()
-        .allowTableScan()
-        .constraint { root -> like(root.get("name"), "Jurassic%") }
+      .allowFullScatter()
+      .allowTableScan()
+      .constraint { root -> like(root.get("name"), "Jurassic%") }
 
     val clone = original.clone<OperatorsMovieQuery>()
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryStaticActionTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryStaticActionTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import javax.inject.Inject
+import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
@@ -61,8 +62,6 @@ class HibernateDatabaseQueryStaticActionTest {
     }
   }
 
-  // TODO (adrw) re-enable once LocalDate Moshi adapter is written/bound to support DbMovie.release_date
-  @Disabled
   @Test
   fun `default request`() {
     val results = realActionRequestExecuter.executeRequest(
@@ -70,14 +69,13 @@ class HibernateDatabaseQueryStaticActionTest {
         entityClass = DbMovie::class.simpleName!!,
         queryClass = OperatorsMovieQuery::class.simpleName!!,
         query = mapOf()
-      )
+      ),
+      user = "joey",
+      capabilities = AUTHORIZED_CAPABILITIES
     )
-    assertThat(results.results).containsAll(
-      listOf(
-        mapOf("name" to "Jurassic Park", "created_at" to "2018-01-01T00:00:00.000Z"),
-        mapOf("name" to "Pulp Fiction", "created_at" to "2018-01-01T00:00:00.000Z"),
-        mapOf("name" to "Die Hard", "created_at" to "2018-01-01T00:00:00.000Z"),
-      )
+    assertEquals(3, results.results.size)
+    assertThat(results.results.map { (it as Map<String, Any>).keys }.first()).containsAll(
+      DbMovie::class.declaredMemberProperties.map { it.name }
     )
   }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryTestingModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryTestingModule.kt
@@ -21,8 +21,9 @@ class HibernateDatabaseQueryTestingModule : KAbstractModule() {
       override fun configureHibernate() {
         installHibernateAdminDashboardWebActions()
 
-        addEntities(DbActor::class, DbCharacter::class)
+        addEntities(DbActor::class)
         addEntityWithDynamicQuery<DbMovie, DynamicMovieQueryAccess>()
+        addEntityWithDynamicQuery<DbCharacter, DynamicMovieQueryAccess>()
         addEntityWithStaticQuery<DbMovie, OperatorsMovieQuery, OperatorsMovieQueryAccess>()
       }
     }))

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/actions/RealActionRequestExecuter.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/actions/RealActionRequestExecuter.kt
@@ -66,6 +66,9 @@ internal class RealActionRequestExecuter<RQ : Any, RS : Any> @Inject constructor
       response.isSuccessful -> {
         responseAdaptor.fromJson(response.body!!.source())!!
       }
+      response.code == 400 -> {
+        throw BadRequestException(response.message)
+      }
       response.code == 403 -> {
        throw UnauthorizedException(response.message)
       }

--- a/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -9,6 +9,7 @@ import misk.inject.KAbstractModule
 import misk.moshi.adapters.BigDecimalAdapter
 import misk.moshi.okio.ByteStringAdapter
 import misk.moshi.time.InstantAdapter
+import misk.moshi.time.LocalDateAdapter
 import misk.moshi.wire.WireMessageAdapter
 import java.util.Date
 import javax.inject.Singleton
@@ -20,6 +21,7 @@ internal class MoshiModule : KAbstractModule() {
     install(MoshiAdapterModule<Date>(Rfc3339DateJsonAdapter()))
     install(MoshiAdapterModule(InstantAdapter))
     install(MoshiAdapterModule(BigDecimalAdapter))
+    install(MoshiAdapterModule(LocalDateAdapter))
   }
 
   @Provides

--- a/misk/src/main/kotlin/misk/moshi/time/LocalDateAdapter.kt
+++ b/misk/src/main/kotlin/misk/moshi/time/LocalDateAdapter.kt
@@ -1,0 +1,21 @@
+package misk.moshi.time
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+
+object LocalDateAdapter {
+  @FromJson fun fromJson(date: Date?): LocalDate? {
+    return LocalDate.ofInstant(date?.toInstant(), ZoneId.systemDefault())
+  }
+
+  @ToJson fun toJson(value: LocalDate?): Date? {
+    return when {
+      value != null -> Date.from(value.atStartOfDay(ZoneId.systemDefault()).toInstant())
+      else -> null
+    }
+  }
+}

--- a/misk/web/tabs/admin-dashboard/miskTab.json
+++ b/misk/web/tabs/admin-dashboard/miskTab.json
@@ -6,6 +6,7 @@
   "rawIndex": true,
   "rawPackageJson": {},
   "rawTsconfig": {},
+  "rawTsconfigInclude": [],
   "rawTslint": {},
   "rawWebpackConfig": {},
   "relative_path_prefix": "_admin/",

--- a/misk/web/tabs/config/miskTab.json
+++ b/misk/web/tabs/config/miskTab.json
@@ -6,6 +6,7 @@
   "rawIndex": false,
   "rawPackageJson": {},
   "rawTsconfig": {},
+  "rawTsconfigInclude": [],
   "rawTslint": {},
   "rawWebpackConfig": {},
   "relative_path_prefix": "",

--- a/misk/web/tabs/database/miskTab.json
+++ b/misk/web/tabs/database/miskTab.json
@@ -6,6 +6,7 @@
   "rawIndex": false,
   "rawPackageJson": {},
   "rawTsconfig": {},
+  "rawTsconfigInclude": [],
   "rawTslint": {},
   "rawWebpackConfig": {},
   "relative_path_prefix": "",

--- a/misk/web/tabs/web-actions/miskTab.json
+++ b/misk/web/tabs/web-actions/miskTab.json
@@ -6,6 +6,7 @@
   "rawIndex": false,
   "rawPackageJson": {},
   "rawTsconfig": {},
+  "rawTsconfigInclude": [],
   "rawTslint": {},
   "rawWebpackConfig": {},
   "relative_path_prefix": "",


### PR DESCRIPTION
Unless otherwise configured, we attempt to mimic `select *` by including all DbEntity declared member properties as the select paths. Some of these aren't actually queryable and so we've added a deny list of paths to make the default unconfigured query experience in the dashboard tab more intuitive. Additionally, the lack of a LocalDate adapter caused this default query to fail.

Motivation: I had experienced this myself but it was also quickly experienced by folks trying out the new tab.