### PR TITLE
expose hibernateCore dep in misk-hibernate

### DIFF
--- a/misk-hibernate/build.gradle
+++ b/misk-hibernate/build.gradle
@@ -15,12 +15,12 @@ allOpen {
 }
 
 dependencies {
-  implementation dep.hibernateCore
+  api dep.hibernateCore
   implementation dep.tink
   implementation project(':misk')
   implementation project(':misk-actions')
   implementation project(':misk-crypto')
-  implementation project(':misk-jdbc')
+  api project(':misk-jdbc')
 
   testImplementation dep.docker
   // The docker-java we use in tests depends on an old version of junixsocket that depends on


### PR DESCRIPTION
This patches two breaks introduced in #1699. Consumers of this library rely on it to publish the `javax.persistence:javax.persistence-api:2.2` artifact, which this library gets from hibernateCore. Consumers also rely on `misk-jdbc`. Changing `implementation` to `api` means that the dependencies are transitively published, like they were before #1699