### PR TITLE
Remove get*OrNull calls from FeatureFlags

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -41,15 +41,9 @@ class FakeFeatureFlags @Inject constructor(
       get(feature, key, attributes) as? Int ?: throw IllegalArgumentException(
           "Int flag $feature must be overridden with override() before use")
 
-  override fun getIntOrNull(feature: Feature, key: String, attributes: Attributes): Int? =
-      get(feature, key, attributes) as Int?
-
   override fun getString(feature: Feature, key: String, attributes: Attributes): String =
       get(feature, key, attributes) as? String ?: throw IllegalArgumentException(
           "String flag $feature must be overridden with override() before use")
-
-  override fun getStringOrNull(feature: Feature, key: String, attributes: Attributes): String? =
-      get(feature, key, attributes) as String?
 
   override fun <T : Enum<T>> getEnum(
     feature: Feature,
@@ -60,13 +54,6 @@ class FakeFeatureFlags @Inject constructor(
     @Suppress("unchecked_cast")
     return getOrDefault(feature, key, clazz.enumConstants[0], attributes) as T
   }
-
-  override fun <T : Enum<T>> getEnumOrNull(
-    feature: Feature,
-    key: String,
-    clazz: Class<T>,
-    attributes: Attributes
-  ): T? = getOrDefault(feature, key, null, attributes)
 
   override fun <T> getJson(
     feature: Feature,
@@ -82,19 +69,6 @@ class FakeFeatureFlags @Inject constructor(
         "JSON function did not provide a string")
     return moshi.get().adapter(clazz).fromSafeJson(json)
         ?: throw IllegalArgumentException("null value deserialized from $feature")
-  }
-
-  override fun <T> getJsonOrNull(
-    feature: Feature,
-    key: String,
-    clazz: Class<T>,
-    attributes: Attributes
-  ): T? {
-    val jsonFn = getOrDefault(feature, key, { null }, attributes) as Function0<*>
-    // The JSON is lazily provided to handle the case where the override is provided by the
-    // FakeFeatureFlagModule and the Moshi instance cannot be accessed inside the module.
-    val json = jsonFn.invoke() as? String ?: return null
-    return moshi.get().adapter(clazz).fromSafeJson(json)
   }
 
   override fun getBoolean(feature: Feature) = getBoolean(feature, KEY)

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -4,14 +4,11 @@ import com.squareup.moshi.JsonDataException
 import misk.feature.Attributes
 import misk.feature.Feature
 import misk.feature.getEnum
-import misk.feature.getEnumOrNull
 import misk.feature.getJson
-import misk.feature.getJsonOrNull
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import javax.inject.Inject
@@ -60,11 +57,6 @@ internal class FakeFeatureFlagsTest {
     //Provides the key level override when there is no match on attributes
     assertThat(subject.getInt(FEATURE, "joker", Attributes(mapOf("don't" to "exist"))))
         .isEqualTo(42)
-
-    // Can override with null
-    subject.reset()
-    assertThatThrownBy { subject.getInt(FEATURE, TOKEN) }.hasSameClassAs(IllegalArgumentException())
-    assertThat(subject.getIntOrNull(FEATURE, TOKEN)).isNull()
   }
 
   @Test
@@ -100,14 +92,6 @@ internal class FakeFeatureFlagsTest {
 
     subject.reset()
     assertThat(subject.getEnum<Dinosaur>(FEATURE, TOKEN)).isEqualTo(Dinosaur.PTERODACTYL)
-  }
-
-  @Test
-  fun `getEnumOrNull is null if feature flag is not overridden`() {
-    assertThat(subject.getEnumOrNull<Dinosaur>(FEATURE, TOKEN)).isNull()
-    subject.override(FEATURE, Dinosaur.TYRANNOSAURUS)
-    assertThat(subject.getEnumOrNull<Dinosaur>(FEATURE, TOKEN))
-      .isEqualTo(Dinosaur.TYRANNOSAURUS)
   }
 
   data class JsonFeature(val value : String, val optional : String? = null)
@@ -154,13 +138,6 @@ internal class FakeFeatureFlagsTest {
         .isEqualTo(JsonFeature("test-class"))
     assertThat(subject.getJson<JsonFeature>(FEATURE, "joker"))
         .isEqualTo(JsonFeature("test-key-class"))
-  }
-
-  @Test
-  fun `getJsonOrNull is null if not overridden`() {
-    assertThat(subject.getJsonOrNull<JsonFeature>(FEATURE, TOKEN)).isNull()
-    subject.overrideJson(FEATURE, JsonFeature("test"))
-    assertThat(subject.getJsonOrNull<JsonFeature>(FEATURE, TOKEN)).isEqualTo(JsonFeature("test"))
   }
 
   @Test

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
@@ -26,17 +26,6 @@ interface FeatureFlags {
   ): Int
 
   /**
-   * Calculates the value of an integer feature flag for the given key and attributes, or returns
-   * null if the flag is set to nothing.
-   * @see [getEnum] for param details
-   */
-  fun getIntOrNull(
-    feature: Feature,
-    key: String,
-    attributes: Attributes = Attributes()
-  ): Int?
-
-  /**
    * Calculates the value of a string feature flag for the given key and attributes.
    * @see [getEnum] for param details
    */
@@ -45,17 +34,6 @@ interface FeatureFlags {
     key: String,
     attributes: Attributes = Attributes()
   ): String
-
-  /**
-   * Calculates the value of a string feature flag for the given key and attributes, or returns
-   * null if the flag is set to nothing.
-   * @see [getEnum] for param details
-   */
-  fun getStringOrNull(
-    feature: Feature,
-    key: String,
-    attributes: Attributes = Attributes()
-  ): String?
 
   /**
    * Calculates the value of an enumerated feature flag for the given key and attributes.
@@ -73,13 +51,6 @@ interface FeatureFlags {
     attributes: Attributes = Attributes()
   ): T
 
-  fun <T : Enum<T>> getEnumOrNull(
-    feature: Feature,
-    key: String,
-    clazz: Class<T>,
-    attributes: Attributes = Attributes()
-  ): T?
-
   /**
    * Calculates the value of a JSON feature flag for the given key and attributes.
    *
@@ -94,13 +65,6 @@ interface FeatureFlags {
     attributes: Attributes = Attributes()
   ): T
 
-  fun <T> getJsonOrNull(
-    feature: Feature,
-    key: String,
-    clazz: Class<T>,
-    attributes: Attributes = Attributes()
-  ): T?
-
   // Overloaded functions for use in Java, because @JvmOverloads isn't supported for interfaces
   fun getBoolean(
     feature: Feature,
@@ -112,20 +76,10 @@ interface FeatureFlags {
     key: String
   ) = getInt(feature, key, Attributes())
 
-  fun getIntOrNull(
-    feature: Feature,
-    key: String
-  ) = getIntOrNull(feature, key, Attributes())
-
   fun getString(
     feature: Feature,
     key: String
   ) = getString(feature, key, Attributes())
-
-  fun getStringOrNull(
-    feature: Feature,
-    key: String
-  ) = getStringOrNull(feature, key, Attributes())
 
   fun <T : Enum<T>> getEnum(
     feature: Feature,
@@ -133,17 +87,8 @@ interface FeatureFlags {
     clazz: Class<T>
   ) = getEnum(feature, key, clazz, Attributes())
 
-  fun <T : Enum<T>> getEnumOrNull(
-    feature: Feature,
-    key: String,
-    clazz: Class<T>
-  ) = getEnumOrNull(feature, key, clazz, Attributes())
-
   fun <T> getJson(feature: Feature, key: String, clazz: Class<T>)
       = getJson(feature, key, clazz, Attributes())
-
-  fun <T> getJsonOrNull(feature: Feature, key: String, clazz: Class<T>)
-      = getJsonOrNull(feature, key, clazz, Attributes())
 }
 
 inline fun <reified T : Enum<T>> FeatureFlags.getEnum(
@@ -152,23 +97,11 @@ inline fun <reified T : Enum<T>> FeatureFlags.getEnum(
   attributes: Attributes = Attributes()
 ): T = getEnum(feature, key, T::class.java, attributes)
 
-inline fun <reified T : Enum<T>> FeatureFlags.getEnumOrNull(
-  feature: Feature,
-  key: String,
-  attributes: Attributes = Attributes()
-): T? = getEnumOrNull(feature, key, T::class.java, attributes)
-
 inline fun <reified T> FeatureFlags.getJson(
   feature: Feature,
   key: String,
   attributes: Attributes = Attributes()
 ): T = getJson(feature, key, T::class.java, attributes)
-
-inline fun <reified T> FeatureFlags.getJsonOrNull(
-  feature: Feature,
-  key: String,
-  attributes: Attributes = Attributes()
-): T? = getJsonOrNull(feature, key, T::class.java, attributes)
 
 /**
  * Typed feature string.


### PR DESCRIPTION
This wasn't a good idea - the naming implied a default value, and the case I
initially catered for in LD (off, no default value) should have been
exceptional.