### PR TITLE
When using test data keys, inject them using a provider as well

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -16,6 +16,8 @@ import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.inject.name.Names
+import misk.config.MiskConfig
+import misk.config.Secret
 import misk.crypto.pgp.PgpDecrypter
 import misk.crypto.pgp.PgpDecrypterProvider
 import misk.crypto.pgp.PgpEncrypter
@@ -50,11 +52,15 @@ class CryptoTestModule(
     Security.addProvider(BouncyCastleProvider())
 
     config ?: return
-    val keys = config.keys ?: return
+    val keys = config.keys as MutableList<Key>? ?: return
 
     val keyManagerBinder = newMultibinder(ExternalKeyManager::class)
     keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(keys))
     config.external_data_keys?.let {
+      it.entries.forEach {entry ->
+        val fakeFake = Key(entry.key, entry.value, MiskConfig.RealSecret(""))
+        keys.add(fakeFake)
+      }
       keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(it))
     }
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/FakeExternalKeyManager.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/FakeExternalKeyManager.kt
@@ -29,8 +29,8 @@ class FakeExternalKeyManager : ExternalKeyManager {
         KeyType.STREAMING_AEAD -> StreamingAeadKeyTemplates.AES128_GCM_HKDF_4KB
         KeyType.MAC -> MacKeyTemplates.HMAC_SHA256_128BITTAG
         KeyType.DIGITAL_SIGNATURE -> SignatureKeyTemplates.ECDSA_P256
-        KeyType.HYBRID_ENCRYPT -> HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM
-        KeyType.HYBRID_ENCRYPT_DECRYPT -> HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM
+        KeyType.HYBRID_ENCRYPT, KeyType.HYBRID_ENCRYPT_DECRYPT ->
+          HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM
         KeyType.PGP_DECRYPT, KeyType.PGP_ENCRYPT ->
           throw UnsupportedOperationException("fake manager doesn't support pgp keys")
       }


### PR DESCRIPTION
When data keys are being used in tests, they could only be accessed via the key manager.
This PR changes that behavior so they'd be accessible using the `Named` annotation as well.
