### PR TITLE
Remove the HTTP boundary in the in-process DynamoDB

### DIFF
--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
@@ -1,9 +1,21 @@
 package misk.aws.dynamodb.testing
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams
+import com.amazonaws.services.dynamodbv2.local.shared.access.AmazonDynamoDBLocal
+import com.amazonaws.services.dynamodbv2.local.shared.access.LocalDBClient
+import com.amazonaws.services.dynamodbv2.local.shared.access.sqlite.SQLiteDBAccess
+import com.amazonaws.services.dynamodbv2.local.shared.jobs.JobsRegister
+import com.google.inject.Provides
+import java.io.File
+import java.util.concurrent.ExecutorService
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.reflect.KClass
 import misk.ServiceModule
+import misk.concurrent.ExecutorServiceFactory
 import misk.inject.KAbstractModule
 import misk.inject.toKey
-import kotlin.reflect.KClass
 
 /**
  * Executes a DynamoDB service in-process per test. It clears the table content before each test
@@ -21,9 +33,48 @@ class InProcessDynamoDbModule(
   constructor(vararg tables: KClass<*>) : this(tables.map { DynamoDbTable(it) })
 
   override fun configure() {
-    install(LocalDynamoDbModule(tables))
+    for (table in tables) {
+      multibind<DynamoDbTable>().toInstance(table)
+    }
     install(ServiceModule<InProcessDynamoDbService>())
     install(ServiceModule<CreateTablesService>()
         .dependsOn(InProcessDynamoDbService::class.toKey()))
+  }
+
+  @Provides @Singleton
+  fun provideSqliteDbAccess(): SQLiteDBAccess {
+    Libsqlite4JavaLibraryPathInitializer.init()
+    return SQLiteDBAccess(null as File?)
+  }
+
+  @Provides @Singleton @Named("InProcessDynamoDb")
+  fun provideExecutorService(
+    executorServiceFactory: ExecutorServiceFactory
+  ): ExecutorService {
+    return executorServiceFactory.fixed("InProcessDynamoDb", 10)
+  }
+
+  @Provides @Singleton
+  fun provideLocalDbClient(
+    sqliteDbAccess: SQLiteDBAccess,
+    @Named("InProcessDynamoDb") executorService: ExecutorService
+  ): AmazonDynamoDBLocal {
+    val delayTransientStatuses = false
+    val jobsRegister = JobsRegister(executorService, delayTransientStatuses)
+    return LocalDBClient(sqliteDbAccess, jobsRegister)
+  }
+
+  @Provides @Singleton
+  fun provideAmazonDynamoDb(
+    amazonDynamoDbLocal: AmazonDynamoDBLocal
+  ): AmazonDynamoDB {
+    return amazonDynamoDbLocal.amazonDynamoDB()
+  }
+
+  @Provides @Singleton
+  fun provideAmazonDynamoDbStreams(
+    amazonDynamoDbLocal: AmazonDynamoDBLocal
+  ): AmazonDynamoDBStreams {
+    return amazonDynamoDbLocal.amazonDynamoDBStreams()
   }
 }

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbService.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbService.kt
@@ -1,71 +1,18 @@
 package misk.aws.dynamodb.testing
 
-import com.amazonaws.services.dynamodbv2.local.main.ServerRunner
-import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer
+import com.amazonaws.services.dynamodbv2.local.shared.access.AmazonDynamoDBLocal
 import com.google.common.util.concurrent.AbstractIdleService
-import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class InProcessDynamoDbService @Inject constructor(
-  private val localDynamoDb: LocalDynamoDb
+  private val amazonDynamoDbLocal: AmazonDynamoDBLocal
 ) : AbstractIdleService() {
-  lateinit var server: DynamoDBProxyServer
-
   override fun startUp() {
-    val libraryFile = libsqlite4javaNativeLibrary()
-    System.setProperty("sqlite4java.library.path", libraryFile.parent)
-
-    server = ServerRunner.createServerFromCommandLineArgs(
-        arrayOf("-inMemory", "-port", localDynamoDb.url.port.toString())
-    )
-    server.start()
-  }
-
-  private fun libsqlite4javaNativeLibrary(): File {
-    val prefix = libsqlite4javaPrefix()
-    val classpath = System.getProperty("java.class.path")
-    val classpathElements = classpath.split(File.pathSeparator)
-    for (element in classpathElements) {
-      val file = File(element)
-      if (file.name.startsWith(prefix)) {
-        return file
-      }
-    }
-    throw IllegalArgumentException("couldn't find native library for $prefix")
-  }
-
-  /**
-   * Returns the prefix of the sqlite4java native library for the current platform.
-   *
-   * Observed values of os.arch include:
-   *  * x86_64
-   *  * amd64
-   *
-   * Observed values of os.name include:
-   *  * Linux
-   *  * Mac OS X
-   *
-   * Available native versions of sqlite4java are:
-   *  * libsqlite4java-linux-amd64-1.0.392.so
-   *  * libsqlite4java-linux-i386-1.0.392.so
-   *  * libsqlite4java-osx-1.0.392.dylib
-   *  * sqlite4java-win32-x64-1.0.392.dll
-   *  * sqlite4java-win32-x86-1.0.392.dll
-   */
-  private fun libsqlite4javaPrefix(): String {
-    val osArch = System.getProperty("os.arch")
-    val osName = System.getProperty("os.name")
-
-    return when {
-      osName == "Linux" && osArch == "amd64" -> "libsqlite4java-linux-amd64-"
-      osName == "Mac OS X" && osArch == "x86_64" -> "libsqlite4java-osx-"
-      else -> throw IllegalStateException("unexpected platform: os.name=$osName os.arch=$osArch")
-    }
   }
 
   override fun shutDown() {
-    server.stop()
+    amazonDynamoDbLocal.shutdownNow()
   }
 }

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/Libsqlite4JavaLibraryPathInitializer.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/Libsqlite4JavaLibraryPathInitializer.kt
@@ -1,0 +1,57 @@
+package misk.aws.dynamodb.testing
+
+import java.io.File
+
+internal object Libsqlite4JavaLibraryPathInitializer {
+  private var initialized = false
+
+  fun init() {
+    if (initialized) return
+    initialized = true
+
+    val libraryFile = libsqlite4javaNativeLibrary()
+    System.setProperty("sqlite4java.library.path", libraryFile.parent)
+  }
+
+  private fun libsqlite4javaNativeLibrary(): File {
+    val prefix = libsqlite4javaPrefix()
+    val classpath = System.getProperty("java.class.path")
+    val classpathElements = classpath.split(File.pathSeparator)
+    for (element in classpathElements) {
+      val file = File(element)
+      if (file.name.startsWith(prefix)) {
+        return file
+      }
+    }
+    throw IllegalArgumentException("couldn't find native library for $prefix")
+  }
+
+  /**
+   * Returns the prefix of the sqlite4java native library for the current platform.
+   *
+   * Observed values of os.arch include:
+   *  * x86_64
+   *  * amd64
+   *
+   * Observed values of os.name include:
+   *  * Linux
+   *  * Mac OS X
+   *
+   * Available native versions of sqlite4java are:
+   *  * libsqlite4java-linux-amd64-1.0.392.so
+   *  * libsqlite4java-linux-i386-1.0.392.so
+   *  * libsqlite4java-osx-1.0.392.dylib
+   *  * sqlite4java-win32-x64-1.0.392.dll
+   *  * sqlite4java-win32-x86-1.0.392.dll
+   */
+  private fun libsqlite4javaPrefix(): String {
+    val osArch = System.getProperty("os.arch")
+    val osName = System.getProperty("os.name")
+
+    return when {
+      osName == "Linux" && osArch == "amd64" -> "libsqlite4java-linux-amd64-"
+      osName == "Mac OS X" && osArch == "x86_64" -> "libsqlite4java-osx-"
+      else -> throw IllegalStateException("unexpected platform: os.name=$osName os.arch=$osArch")
+    }
+  }
+}


### PR DESCRIPTION
We had an unnecessary HTTP client and server in each call to DynamoDB. This didn't add
any value to our tests!