### PR TITLE
Disable github actions java build

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,8 +26,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - shard: ./gradlew testShardHibernate -i --scan
-          - shard: ./gradlew testShardNonHibernate -i --scan
+          # These builds consistently break. Use the circleci build instead for now.
+#          - shard: ./gradlew testShardHibernate -i --scan
+#          - shard: ./gradlew testShardNonHibernate -i --scan
           - shard: sudo npm install -g @misk/cli && miskweb ci-build -e
 
     steps:


### PR DESCRIPTION
This part of the build seems to consistently break in PRs. Disable it for now.