### PR TITLE
Update test to show override

### DIFF
--- a/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -106,8 +106,8 @@ class MiskConfigTest {
         .map { File(it.file) }
 
     val config = MiskConfig.load<TestConfig>("test_app", defaultEnv, overrides)
-    assertThat(config.consumer_a).isEqualTo(ConsumerConfig(14, 1))
-    assertThat(config.consumer_b).isEqualTo(ConsumerConfig(34, 79))
+    assertThat(config.consumer_a).isEqualTo(ConsumerConfig(14, 27))
+    assertThat(config.consumer_b).isEqualTo(ConsumerConfig(34, 122))
   }
 
   @Test
@@ -129,7 +129,7 @@ class MiskConfigTest {
       .map { File(it.file) }
 
     val config = MiskConfig.load<TestConfig>("test_app", defaultEnv, overrides)
-    assertThat(config.consumer_a).isEqualTo(ConsumerConfig(14, 1))
+    assertThat(config.consumer_a).isEqualTo(ConsumerConfig(14, 27))
     assertThat(config.consumer_b).isEqualTo(ConsumerConfig(34, 79))
   }
 

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -149,7 +149,7 @@ class Http2ConnectivityTest {
 
       override fun writeTo(sink: BufferedSink) {
         for (i in 0 until 1024 * 1024) {
-          sink.writeUtf8("impossible\n")
+          sink.writeUtf8("impossible: $i\n")
         }
       }
     }

--- a/misk/src/test/resources/overrides/override-test-app1.yaml
+++ b/misk/src/test/resources/overrides/override-test-app1.yaml
@@ -1,3 +1,5 @@
+consumer_a:
+  max_items: 27
 consumer_b:
   min_items: 34
   max_items: 79

--- a/misk/src/test/resources/overrides/override-test-app2.yaml
+++ b/misk/src/test/resources/overrides/override-test-app2.yaml
@@ -1,2 +1,4 @@
 consumer_a:
   min_items: 14
+consumer_b:
+  max_items: 122


### PR DESCRIPTION
Changes to MiskConfig loading broke a test in Skim.

Updating test to show the override value in action.

Other test was flaking out occasionally.