### PR TITLE
Add read write retry helper

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -59,6 +59,7 @@ ext.dep = [
   "kotlinGradlePlugin": "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0",
   "kotlinNoArgPlugin": "org.jetbrains.kotlin:kotlin-noarg:1.4.0",
   "kotlinReflection": "org.jetbrains.kotlin:kotlin-reflect:1.4.0",
+  "kotlinRetry": "com.michael-bull.kotlin-retry:kotlin-retry:1.0.6",
   "kotlinStdLibJdk8": "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0",
   "kotlinTest": "org.jetbrains.kotlin:kotlin-test:1.4.0",
   "kotlinxCoroutines": "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",

--- a/misk-core/build.gradle
+++ b/misk-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
   testImplementation dep.assertj
   testImplementation dep.kotlinTest
+  testImplementation dep.kotlinxCoroutines
   testImplementation project(':misk-testing')
 }
 

--- a/misk-core/build.gradle
+++ b/misk-core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation dep.guiceMultibindings
   implementation dep.kotlinStdLibJdk8
   implementation dep.kotlinReflection
+  api dep.kotlinRetry
   implementation dep.loggingApi
   implementation dep.logbackClassic
   implementation dep.okio

--- a/misk-core/src/main/kotlin/misk/retries/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/retries/Retries.kt
@@ -12,9 +12,6 @@ import com.github.michaelbull.retry.retry
  * - Re-establishing a connection when a request fails due to a connection dropping
  */
 suspend fun <T> retryWithHooks(
-  /**
-   * [beforeRetryHook] is called on retries, before [op].
-   */
   policy: RetryPolicy<Throwable>,
   beforeRetryHook: () -> Unit,
   op: () -> T

--- a/misk-core/src/main/kotlin/misk/retries/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/retries/Retries.kt
@@ -1,0 +1,44 @@
+package misk.retries
+
+import com.github.michaelbull.retry.ContinueRetrying
+import com.github.michaelbull.retry.policy.RetryPolicy
+
+/**
+ * This is a retry helper function that calls [reader] on retries, but not on the first attempt.
+ * Use cases:
+ * - Optimistic locking where the state needs to be reloaded on retries
+ * - Re-establishing a connection when a request fails due to a connection dropping
+ */
+suspend fun <T> readWriteRetry(
+  /**
+   * [reader] is called on retries, before [writer].
+   */
+  retryPolicy: RetryPolicy<Throwable>,
+  reader: () -> Unit,
+  writer: () -> T
+    /**
+     * These values are recommended by @zhxnlai.
+     */
+): T {
+  var numExecutions = 0
+  return com.github.michaelbull.retry.retry(retryPolicy) {
+    if (numExecutions++ > 0) {
+      reader()
+    }
+    writer()
+  }
+}
+
+/**
+ * Returns a [RetryPolicy] that will throw the error that triggered the retry if it is type [T].
+ * Otherwise, it voices no objection to retrying.
+ */
+inline fun <reified T : Exception> doNotRetry(): RetryPolicy<Throwable> {
+  return {
+    if (this.reason is T) {
+      throw this.reason
+    }
+
+    ContinueRetrying
+  }
+}

--- a/misk-core/src/test/kotlin/misk/retries/RetriesKtTest.kt
+++ b/misk-core/src/test/kotlin/misk/retries/RetriesKtTest.kt
@@ -1,0 +1,65 @@
+package misk.retries
+
+import com.github.michaelbull.retry.policy.limitAttempts
+import com.github.michaelbull.retry.policy.plus
+import kotlinx.coroutines.runBlocking
+import misk.testing.MiskTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DummyException: Exception("Testing exception")
+
+@MiskTest
+internal class RetriesTest {
+
+  @Test
+  fun doesNotRetryValidationException() {
+    val policy = limitAttempts(2) + doNotRetry<DummyException>()
+
+    var reads = 0
+    var writes = 0
+
+    assertThrows<Exception> {
+      runBlocking {
+        readWriteRetry(policy,
+            reader = {
+              reads++
+            },
+            writer = {
+              writes++
+              throw DummyException()
+            }
+        )
+      }
+    }
+
+    assertThat(reads).isEqualTo(0)
+    assertThat(writes).isEqualTo(1)
+  }
+
+  @Test
+  fun retriesException() {
+    val policy = limitAttempts(2)
+
+    var writes = 0
+    var reads = 0
+
+    assertThrows<Exception> {
+      runBlocking {
+        readWriteRetry(policy,
+            reader = {
+              reads++
+            },
+            writer = {
+              writes++
+              throw DummyException()
+            }
+        )
+      }
+    }
+
+    assertThat(reads).isEqualTo(1)
+    assertThat(writes).isEqualTo(2)
+  }
+}

--- a/misk-core/src/test/kotlin/misk/retries/RetriesKtTest.kt
+++ b/misk-core/src/test/kotlin/misk/retries/RetriesKtTest.kt
@@ -22,11 +22,11 @@ internal class RetriesTest {
 
     assertThrows<Exception> {
       runBlocking {
-        readWriteRetry(policy,
-            reader = {
+        retryWithHooks(policy,
+            beforeRetryHook = {
               reads++
             },
-            writer = {
+            op = {
               writes++
               throw DummyException()
             }
@@ -47,11 +47,11 @@ internal class RetriesTest {
 
     assertThrows<Exception> {
       runBlocking {
-        readWriteRetry(policy,
-            reader = {
+        retryWithHooks(policy,
+            beforeRetryHook = {
               reads++
             },
-            writer = {
+            op = {
               writes++
               throw DummyException()
             }


### PR DESCRIPTION
The name of this helper is pretty sucky, if you have a better idea please lmk. 

This type of functionality has started to become necessary in a couple of services in two places:
- retrying DynamoDb optimistic locking (the state needs to be reloaded and have the operation re-applied on top of it)
- re-establishing a connection to S3 when it dies unexpectedly (this is admittedly a hacky workaround, but being able to leverage this function would make it less ugly)

If you have a suggestion for a different place for this to live let me know, misk was my go-to because spinning out a new library repo for this seemed like overkill.