### PR TITLE
add message.attributes to sqs job attributes

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -25,6 +25,7 @@ internal class SqsJob(
     message.messageAttributes
         .filter { (key, _) -> key != JOBQUEUE_METADATA_ATTR }
         .map { (key, value) -> key to value.stringValue }.toMap()
+        .plus(message.attributes)
   }
 
   private val queue: ResolvedQueue = queues.getForReceiving(queueName)

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -103,17 +103,17 @@ internal class SqsJobQueueTest {
         "ik-8",
         "ik-9"
     )
-    assertThat(sortedJobs.map { it.attributes }).containsExactly(
-        mapOf("index" to "0"),
-        mapOf("index" to "1"),
-        mapOf("index" to "2"),
-        mapOf("index" to "3"),
-        mapOf("index" to "4"),
-        mapOf("index" to "5"),
-        mapOf("index" to "6"),
-        mapOf("index" to "7"),
-        mapOf("index" to "8"),
-        mapOf("index" to "9")
+    assertThat(sortedJobs.map { it.attributes["index"] }).containsExactly(
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9"
     )
 
     // Confirm metrics

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -9,6 +9,7 @@ import misk.jobqueue.QueueName
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -25,6 +26,7 @@ internal class SqsJobTest {
   @Inject lateinit var queueResolver: QueueResolver
   @Inject lateinit var sqsMetrics: SqsMetrics
   @Inject lateinit var moshi: Moshi
+  @Inject lateinit var clock: FakeClock
 
   private val testQueue = QueueName("test")
 
@@ -52,6 +54,29 @@ internal class SqsJobTest {
     assertThat(job.idempotenceKey).isEqualTo("ik-0")
     assertThat(job.attributes)
         .containsEntry("foo", "bar")
+        .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
+  }
+
+  @Test
+  fun attributesAndMessageAttributesInJobAttributes() {
+    val message = Message().apply {
+      messageId = "id-0"
+      body = "body-0"
+      addAttributesEntry("SentTimestamp", clock.instant().toEpochMilli().toString())
+      addMessageAttributesEntry("foo", MessageAttributeValue().withDataType("String").withStringValue("bar"))
+      addMessageAttributesEntry(SqsJob.JOBQUEUE_METADATA_ATTR,
+          MessageAttributeValue().withDataType("String").withStringValue("""{
+                |  "${SqsJob.JOBQUEUE_METADATA_ORIGIN_QUEUE}": "test",
+                |  "${SqsJob.JOBQUEUE_METADATA_IDEMPOTENCE_KEY}": "ik-0",
+                |  "${SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID}": "oti-0"
+                |}""".trimMargin()))
+    }
+    val job = SqsJob(QueueName("test"), queueResolver, sqsMetrics, moshi, message)
+
+    assertThat(job.idempotenceKey).isEqualTo("ik-0")
+    assertThat(job.attributes)
+        .containsEntry("foo", "bar")
+        .containsEntry("SentTimestamp", clock.instant().toEpochMilli().toString())
         .doesNotContainKey(SqsJob.JOBQUEUE_METADATA_ATTR)
   }
 }


### PR DESCRIPTION
We are adding this timestamp so invest-core can get metrics on the time it takes a message to get processed once it has been enqueued by an external queue (drivewealth to be specific). This timestamp is necessary for getting that metric