### PR TITLE
Expose prometheusClient dep in misk-metrics

### DIFF
--- a/misk-metrics/build.gradle
+++ b/misk-metrics/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  implementation dep.prometheusClient
+  api dep.prometheusClient
   implementation dep.prometheusHotspot
   implementation dep.kotlinStdLibJdk8
   implementation dep.guava


### PR DESCRIPTION
The `Metrics` class returns classes from this dependency, so it should be exposed to consumers of this lib