### PR TITLE
Expose guice deps in misk-inject

### DIFF
--- a/misk-inject/build.gradle
+++ b/misk-inject/build.gradle
@@ -5,8 +5,8 @@ buildscript {
 }
 
 dependencies {
-  implementation dep.guice
-  implementation dep.guiceMultibindings
+  api dep.guice
+  api dep.guiceMultibindings
   implementation dep.kotlinStdLibJdk8
   implementation dep.kotlinReflection
   implementation dep.assertj


### PR DESCRIPTION
If these aren't included then the consumer needs to also import them, which isn't clean