### PR TITLE
Mark misk.backoff as deprecated

### DIFF
--- a/misk-core/src/main/kotlin/misk/backoff/Backoff.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Backoff.kt
@@ -3,6 +3,7 @@ package misk.backoff
 import java.time.Duration
 
 /** Calculates how long to backoff on a retry. [Backoff]s are stateful and not thread-safe */
+@Deprecated("Use kotlinRetry instead")
 interface Backoff {
   /** Resets the backoff, typically when a request has succeeded  */
   fun reset()

--- a/misk-core/src/main/kotlin/misk/backoff/ExponentialBackoff.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/ExponentialBackoff.kt
@@ -8,6 +8,7 @@ import java.util.concurrent.ThreadLocalRandom
  * functions, so that they can change dynamically as the system is running (e.g.
  * in response to changes in dynamic flags)
  */
+@Deprecated("Use kotlinRetry instead")
 class ExponentialBackoff(
   private val baseDelay: () -> Duration,
   private val maxDelay: () -> Duration,

--- a/misk-core/src/main/kotlin/misk/backoff/FlatBackoff.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/FlatBackoff.kt
@@ -2,6 +2,7 @@ package misk.backoff
 
 import java.time.Duration
 
+@Deprecated("Use kotlinRetry instead")
 class FlatBackoff(val duration: Duration = Duration.ofMillis(0)) : Backoff {
   override fun reset() {}
   override fun nextRetry() = duration

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -5,6 +5,7 @@ package misk.backoff
  * between each retry. The retry function is provided with current retry count, in case this is
  * relevant
  */
+@Deprecated("Use kotlinRetry instead")
 fun <A> retry(upTo: Int, withBackoff: Backoff, f: (retryCount: Int) -> A): A {
   require(upTo > 0) { "must support at least one call" }
 
@@ -35,4 +36,5 @@ fun <A> retry(upTo: Int, withBackoff: Backoff, f: (retryCount: Int) -> A): A {
   throw lastException!!
 }
 
+@Deprecated("Use kotlinRetry and misk.retries.doNotRetry instead")
 class DontRetryException(message: String) : Exception(message)


### PR DESCRIPTION
Marking this deprecated based on the comment made by @mightyguava [here](https://github.com/cashapp/misk/pull/1710#issuecomment-748274299)