### PR TITLE
Allow @Nested MiskTest

### DIFF
--- a/misk-testing/README.md
+++ b/misk-testing/README.md
@@ -1,0 +1,19 @@
+# misk-testing
+
+Tests annotated with `@MiskTest` are misk tests. Misk tests automate injector setup and Guava 
+`Service` lifecycle.
+
+A misk test requires the annotated class to have a field of type `Module` annotated 
+`@MiskTestModule`. This module will be used to create the injector and inject any other fields.
+
+Guava `Service` lifecycle is opt-in; do this by specifying `@MiskTest(startService = true)`.
+
+Note that injection and `Service` start/stop occur for each test method. This provides a fresh setup 
+for each test method for state changed by injection/services. 
+
+Misk tests are also compatible with JUnit's `@Nested` classes. Any `@Nested` classes inherit all the
+misk test setup from their outermost class. This means that only the outermost test class can have 
+`@MiskTest`, `@MiskTestModule`, `@MiskExternalDependency` annotations. They are ignored on `@Nested` 
+classes. Additionally, the injector only injects members into the outermost class. Any injected 
+fields of inner classes will also be ignored.  
+

--- a/misk-testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/ExtensionContextExtensions.kt
@@ -2,6 +2,12 @@ package misk.testing
 
 import org.junit.jupiter.api.extension.ExtensionContext
 
+internal val ExtensionContext.rootRequiredTestInstance: Any
+  get() = requiredTestInstances.allInstances.first()
+
+internal val ExtensionContext.rootRequiredTestClass: Class<*>
+  get() = rootRequiredTestInstance.javaClass
+
 /** Stores an object scoped to the test class on the context */
 fun <T> ExtensionContext.store(name: String, value: T) {
   val namespace = ExtensionContext.Namespace.create(requiredTestClass)
@@ -11,5 +17,45 @@ fun <T> ExtensionContext.store(name: String, value: T) {
 /** @return A previously stored object scoped to the test class */
 inline fun <reified T> ExtensionContext.retrieve(name: String): T {
   val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-  return getStore(namespace)[name, T::class.java]
+  return getStore(namespace).get(name, T::class.java)
+}
+
+/**
+ * Retrieve value of [storeKey] from the [ExtensionContext] store. If no value exists, compute using
+ * [creator], save in store and return the new value.
+ */
+internal inline fun <reified T> ExtensionContext.getFromStoreOrCompute(
+  storeKey: String,
+  noinline creator: ExtensionContext.() -> T,
+) = getFromStoreOrCompute(T::class.java, storeKey, creator)
+
+private fun <T> ExtensionContext.getFromStoreOrCompute(
+  typeClass: Class<T>,
+  storeKey: String,
+  creator: ExtensionContext.() -> T,
+): T {
+  val namespace = ExtensionContext.Namespace.create(rootRequiredTestClass)
+  return getStore(namespace).getOrComputeIfAbsent(storeKey, { this.creator() }, typeClass)
+}
+
+/** Find [A]-annotated [T]s on the outermost test class and recursively on base classes. */
+internal inline fun <reified A : Annotation, T> ExtensionContext.fieldsAnnotatedBy(): Iterable<T> =
+    fieldsAnnotatedBy(A::class.java)
+
+/** Find [annotation]-annotated [T]s on the outermost test class and recursively on base classes. */
+private fun <T> ExtensionContext.fieldsAnnotatedBy(
+  annotation: Class<out Annotation>
+): Iterable<T> {
+  val rootRequiredTestInstance = rootRequiredTestInstance
+  @Suppress("UNCHECKED_CAST")
+  return generateSequence(rootRequiredTestInstance.javaClass) { c -> c.superclass }
+      .flatMap { it.declaredFields.asSequence() }
+      .filter {
+        it.isAnnotationPresent(annotation)
+      }
+      .map {
+        it.isAccessible = true
+        it.get(rootRequiredTestInstance) as T
+      }
+      .toList()
 }

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -65,7 +65,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
     val injector = context.retrieve<Injector>("injector")
 
     injector.getInstance<Callbacks>().afterEach(context)
-    uninject(context.requiredTestInstance)
+    uninject(context.rootRequiredTestInstance)
 
     for (dep in context.getExternalDependencies()) {
       dep.afterEach()
@@ -110,11 +110,11 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
   class InjectUninject @Inject constructor() : BeforeEachCallback, AfterEachCallback {
     override fun beforeEach(context: ExtensionContext) {
       val injector = context.retrieve<Injector>("injector")
-      injector.injectMembers(context.requiredTestInstance)
+      injector.injectMembers(context.rootRequiredTestInstance)
     }
 
     override fun afterEach(context: ExtensionContext) {
-      uninject(context.requiredTestInstance)
+      uninject(context.rootRequiredTestInstance)
     }
   }
 
@@ -148,51 +148,17 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
 }
 
 private fun ExtensionContext.startService(): Boolean {
-  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-  // First check the context cache
-  return getStore(namespace).getOrComputeIfAbsent("startService",
-      { requiredTestClass.getAnnotationsByType(MiskTest::class.java)[0].startService },
-      Boolean::class.java)
+  return getFromStoreOrCompute("startService") {
+    rootRequiredTestClass.getAnnotationsByType(MiskTest::class.java)[0].startService
+  }
 }
 
 private fun ExtensionContext.getActionTestModules(): Iterable<Module> {
-  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-  // First check the context cache
-  @Suppress("UNCHECKED_CAST")
-  return getStore(namespace).getOrComputeIfAbsent("module",
-      { modulesViaReflection() }) as Iterable<Module>
-}
-
-// Find [MiskTestModule]-annotated [Module]s on the test class and, recursively, its base classes.
-private fun ExtensionContext.modulesViaReflection(): Iterable<Module> {
-  return generateSequence(requiredTestClass) { c -> c.superclass }
-      .flatMap { it.declaredFields.asSequence() }
-      .filter { it.isAnnotationPresent(MiskTestModule::class.java) }
-      .map {
-        it.isAccessible = true
-        it.get(requiredTestInstance) as Module
-      }
-      .toList()
+  return getFromStoreOrCompute("module") { fieldsAnnotatedBy<MiskTestModule, Module>() }
 }
 
 private fun ExtensionContext.getExternalDependencies(): Iterable<ExternalDependency> {
-  val namespace = ExtensionContext.Namespace.create(requiredTestClass)
-  // First check the context cache
-  @Suppress("UNCHECKED_CAST")
-  return getStore(namespace).getOrComputeIfAbsent("external-dependencies") {
-    externalDependenciesViaReflection()
-  } as Iterable<ExternalDependency>
-}
-
-// Find [MiskExternalDependency]-annotated [ExternalDependency]s on the test class and, recursively,
-// its base classes.
-private fun ExtensionContext.externalDependenciesViaReflection(): Iterable<ExternalDependency> {
-  return generateSequence(requiredTestClass) { c -> c.superclass }
-      .flatMap { it.declaredFields.asSequence() }
-      .filter { it.isAnnotationPresent(MiskExternalDependency::class.java) }
-      .map {
-        it.isAccessible = true
-        it.get(requiredTestInstance) as ExternalDependency
-      }
-      .toList()
+  return getFromStoreOrCompute("external-dependencies") {
+    fieldsAnnotatedBy<MiskExternalDependency, ExternalDependency>()
+  }
 }

--- a/misk-testing/src/test/kotlin/misk/testing/NestedTestsTest.kt
+++ b/misk-testing/src/test/kotlin/misk/testing/NestedTestsTest.kt
@@ -1,0 +1,91 @@
+package misk.testing
+
+import com.google.common.util.concurrent.AbstractIdleService
+import misk.ServiceManagerModule
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+class NestedTestsTest {
+  @Inject lateinit var store: Bookstore
+  @Inject lateinit var boringService: BoringService
+
+  @MiskTestModule
+  val module = object : KAbstractModule() {
+    override fun configure() {
+      install(ServiceManagerModule())
+      install(ServiceModule<BoringService>())
+    }
+  }
+
+  @Test
+  fun `injected fields are stateless across tests 1`() {
+    assertThat(store.count()).isEqualTo("Bookstore 1")
+    // The BoringService is stateless across tests AND always starts before the test method.
+    assertThat(boringService.localStartUps).isOne()
+    assertThat(startUps - shutDowns).isOne()
+  }
+
+  @Test
+  fun `injected fields are stateless across tests 2`() {
+    assertThat(store.count()).isEqualTo("Bookstore 1")
+    // The BoringService is stateless across tests AND always starts before the test method.
+    assertThat(boringService.localStartUps).isOne()
+    assertThat(startUps - shutDowns).isOne()
+  }
+
+  @Nested
+  inner class FirstNested {
+
+    @Test
+    fun `nested can access to injected fields`() {
+      assertThat(store.count()).isEqualTo("Bookstore 1")
+      // The BoringService is stateless across tests AND always starts before the test method.
+      assertThat(boringService.localStartUps).isOne()
+      assertThat(startUps - shutDowns).isOne()
+    }
+
+    @Nested
+    inner class SecondNested {
+      @Test
+      fun `multiple nested levels access injected fields`() {
+        assertThat(store.count()).isEqualTo("Bookstore 1")
+        // The BoringService is stateless across tests AND always starts before the test method.
+        assertThat(boringService.localStartUps).isOne()
+        assertThat(startUps - shutDowns).isOne()
+      }
+
+    }
+  }
+
+  @Singleton
+  class Bookstore @Inject constructor() {
+    private var counter = 0
+
+    fun count() = "Bookstore ${++counter}"
+  }
+
+  @Singleton
+  class BoringService @Inject constructor() : AbstractIdleService() {
+    var localStartUps = 0
+
+    override fun startUp() {
+      localStartUps++
+      startUps++
+    }
+
+    override fun shutDown() {
+      shutDowns++
+    }
+  }
+
+  companion object {
+    var startUps = 0
+    var shutDowns = 0
+  }
+}


### PR DESCRIPTION
Strictly we only allow `@MiskTest`, `@MiskTestModule` and `@MiskExternalDependencies` on the outermost / root test class in Misk test. This is easy to reason about: nested classes inherit what ever the root class specifies. We inject members for each test, nested or not.

The main motivation here is to used `@Nested` classes to provide namespacing withing large tests suites. This means that related tests methods can share variables without putting awkward contraints on tests that don't need them. For example, since `@Nested` classes inherit `@BeforeEach` setup, we can use sibling nested classes to isolate different setups.

For this purpose its enough to limit a global misk/guice definition rather than allowing custome modules / injections for each nested class.
The injector will not inject `@Nested` classes' members, injections are only for the root class