### PR TITLE
Use AmazonSQSBufferedAsyncClient for sends

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -3,7 +3,10 @@ package misk.jobqueue.sqs
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient
+import com.amazonaws.services.sqs.buffered.QueueBufferConfig
 import com.google.inject.Provider
 import com.google.inject.Provides
 import com.google.inject.Singleton
@@ -110,30 +113,62 @@ class AwsSqsJobQueueModule(
   }
 
   companion object {
+    /**
+     * Build an [AmazonSQS] impl based on supplied arguments.
+     *
+     * When [forSqsReceiving] is true, it returns an unbuffered [AmazonSQS] impl.
+     * When [forSqsReceiving] is false, it returns a buffered [AmazonSQS] impl with pre-fetching disabled.
+     */
     private fun buildClient(
-      config: AwsSqsJobQueueConfig, credentials: AWSCredentialsProvider, region: AwsRegion, forSqsReceiving: Boolean
+      config: AwsSqsJobQueueConfig,
+      credentials: AWSCredentialsProvider,
+      region: AwsRegion,
+      forSqsReceiving: Boolean
     ): AmazonSQS {
-      // Defaults from SDK
-      val clientConfiguration = ClientConfiguration()
-          .withSocketTimeout(25000)
-          .withConnectionTimeout(1000)
 
-      val builder = AmazonSQSClientBuilder.standard()
+      return if (forSqsReceiving) {
+        // We don't need any buffering functionality for receiving; build a regular sync client.
+        AmazonSQSClientBuilder.standard()
           .withCredentials(credentials)
           .withRegion(region.name)
-      if (forSqsReceiving) {
-        // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
-        // level resource limiting knobs (e.g # of parallel receivers).
-        // We only do this for receiving, as sending does not have equivalent knobs.
-        builder.withClientConfiguration(clientConfiguration.withMaxConnections(Int.MAX_VALUE))
+          .withClientConfiguration(ClientConfiguration()
+            .withSocketTimeout(25_000)
+            .withConnectionTimeout(1_000)
+            // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
+            // level resource limiting knobs (e.g # of parallel receivers).
+            // We only do this for receiving, as sending does not have equivalent knobs.
+            .withMaxConnections(Int.MAX_VALUE))
+          .build()
       } else {
-        builder.withClientConfiguration(clientConfiguration
+        // Use a buffered client for sending, to group enqueues and deletes into batches.
+        // The trade-off is fewer network calls (which costs less $ since SQS cost is directly
+        // proportional to API calls) at a slightly higher individual call duration.
+        // Every call individual SendMessage and DeleteMessage request will wait up to 200ms
+        // for similar requests and sent in a batch. Batches are immediately sent once full.
+        val asyncClient = AmazonSQSAsyncClientBuilder.standard()
+          .withCredentials(credentials)
+          .withRegion(region.name)
+          .withClientConfiguration(ClientConfiguration()
             .withSocketTimeout(config.sqs_sending_socket_timeout_ms)
             .withConnectionTimeout(config.sqs_sending_connect_timeout_ms)
-            .withRequestTimeout(config.sqs_sending_request_timeout_ms)
-        )
+            .withRequestTimeout(config.sqs_sending_request_timeout_ms))
+          .build()
+
+        // NB: It's unlikely this client will be used for receiving (i.e. to issue ReceiveMessage
+        // requests) but turn off pre-fetching in any case. Without pre-fetching, receives are
+        // on-demand (i.e. work exactly the same as a non-buffered client) and won't spawn extra
+        // background threads to pre-fill receive buffers.
+        val bufferConfig = QueueBufferConfig().withNoPrefetching()
+
+        AmazonSQSBufferedAsyncClient(asyncClient, bufferConfig)
       }
-      return builder.build()
     }
   }
+}
+
+/** Modify a [QueueBufferConfig] to disable all receive pre-fetching settings. */
+fun QueueBufferConfig.withNoPrefetching() : QueueBufferConfig {
+  return withMaxInflightReceiveBatches(0)
+    .withAdapativePrefetching(false)
+    .withMaxDoneReceiveBatches(0)
 }


### PR DESCRIPTION
`AmazonSQSBufferedAsyncClient` attempts to group similar `SendMessage` and
`DeleteMessage` requests into batch requests. Each request will wait up to 200ms
for similar requests before being sent. Batches are immediately sent once full.

The trade-off is fewer network calls (which costs less $ since SQS cost is
proportional to API calls) at a slightly higher individual call duration.

This buffered client is only used for sending/deleting messages (not receiving)
but it's configured with no pre-fetching, meaning any receives are on-demand
(i.e. just like a unbuffered client) and don't spawn any extra background
threads for pre-fetching.

---

This is an optimization that had been planned since we swapped Jobsy with SQS but wasn't
picked up because we needed all hands on deck to replace Evently and weren't aware of
`AmazonSQSBufferedAsyncClient` (i.e. thought we'd have to build buffering ourselves).

Turns out it's pretty trivial.

By pooling sends and deletes, we'll reduce the number of outbound SQS calls and put less
strain on our proxy, which should help alleviate SQS request/response times under periods of
intense load.

- [ ] Buffered behavior behind feature flag