### PR TITLE
Filter headers being captured in request/response logging interceptor

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/Response.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Response.kt
@@ -9,7 +9,9 @@ data class Response<out T>(
   val body: T,
   val headers: Headers = headersOf(),
   val statusCode: Int = 200
-)
+) {
+  override fun toString(): String = "body=$body, statusCode=$statusCode"
+}
 
 interface ResponseBody {
   fun writeTo(sink: BufferedSink)


### PR DESCRIPTION
For requests it keeps a shorter list; for responses it keeps none.