### PR TITLE
Use AmazonSQSBufferedAsyncClient for sends

### DIFF
--- a/misk-aws/build.gradle
+++ b/misk-aws/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation dep.junitParams
   testImplementation dep.docker
   testImplementation dep.awaitility
+  testImplementation dep.mockitoCore
   testImplementation project(':misk-testing')
   testImplementation project(':misk-feature-testing')
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -3,7 +3,10 @@ package misk.jobqueue.sqs
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient
+import com.amazonaws.services.sqs.buffered.QueueBufferConfig
 import com.google.inject.Provider
 import com.google.inject.Provides
 import com.google.inject.Singleton
@@ -11,6 +14,7 @@ import misk.ServiceModule
 import misk.cloud.aws.AwsRegion
 import misk.clustering.lease.LeaseManager
 import misk.concurrent.ExecutorServiceModule
+import misk.config.AppName
 import misk.feature.FeatureFlags
 import misk.inject.KAbstractModule
 import misk.inject.keyOf
@@ -79,13 +83,18 @@ class AwsSqsJobQueueModule(
   }
 
   @Provides @Singleton
-  fun provideSQSClient(region: AwsRegion, credentials: AWSCredentialsProvider): AmazonSQS {
-    return buildClient(config, credentials, region, false)
+  fun provideSQSClient(
+    @AppName appName: String,
+    region: AwsRegion,
+    credentials: AWSCredentialsProvider,
+    features: FeatureFlags
+  ): AmazonSQS {
+    return buildClient(appName, config, credentials, region, features)
   }
 
   @Provides @Singleton @ForSqsReceiving
   fun provideSQSClientForReceiving(region: AwsRegion, credentials: AWSCredentialsProvider): AmazonSQS {
-    return buildClient(config, credentials, region, true)
+    return buildReceivingClient(credentials, region)
   }
 
   @Provides @ForSqsHandling @Singleton
@@ -102,38 +111,84 @@ class AwsSqsJobQueueModule(
       config.task_queue ?: RepeatedTaskQueueConfig(num_parallel_tasks = -1)
 
   private class AmazonSQSProvider(
-    val config: AwsSqsJobQueueConfig, val region: AwsRegion, val forSqsReceiving: Boolean
+    val config: AwsSqsJobQueueConfig,
+    val region: AwsRegion,
+    val forSqsReceiving: Boolean
   ) : Provider<AmazonSQS> {
     @Inject lateinit var credentials: AWSCredentialsProvider
+    @Inject lateinit var features: FeatureFlags
+    @Inject @AppName lateinit var appName: String
 
-    override fun get() = buildClient(config, credentials, region, forSqsReceiving)
+    override fun get() : AmazonSQS {
+      return if (forSqsReceiving) {
+        buildReceivingClient(credentials, region)
+      } else {
+        buildClient(appName, config, credentials, region, features)
+      }
+    }
   }
 
   companion object {
-    private fun buildClient(
-      config: AwsSqsJobQueueConfig, credentials: AWSCredentialsProvider, region: AwsRegion, forSqsReceiving: Boolean
-    ): AmazonSQS {
-      // Defaults from SDK
-      val clientConfiguration = ClientConfiguration()
-          .withSocketTimeout(25000)
-          .withConnectionTimeout(1000)
+    /** Build an unbuffered [AmazonSQS] client for receiving messages. */
+    private fun buildReceivingClient(
+      credentials: AWSCredentialsProvider,
+      region: AwsRegion
+    ) : AmazonSQS {
+      // We don't need any buffering functionality for receiving; build a regular sync client.
+      return AmazonSQSClientBuilder.standard()
+        .withCredentials(credentials)
+        .withRegion(region.name)
+        .withClientConfiguration(ClientConfiguration()
+          .withSocketTimeout(25_000)
+          .withConnectionTimeout(1_000)
+          // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
+          // level resource limiting knobs (e.g # of parallel receivers).
+          // We only do this for receiving, as sending does not have equivalent knobs.
+          .withMaxConnections(Int.MAX_VALUE))
+        .build()
+    }
 
-      val builder = AmazonSQSClientBuilder.standard()
-          .withCredentials(credentials)
-          .withRegion(region.name)
-      if (forSqsReceiving) {
-        // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
-        // level resource limiting knobs (e.g # of parallel receivers).
-        // We only do this for receiving, as sending does not have equivalent knobs.
-        builder.withClientConfiguration(clientConfiguration.withMaxConnections(Int.MAX_VALUE))
-      } else {
-        builder.withClientConfiguration(clientConfiguration
-            .withSocketTimeout(config.sqs_sending_socket_timeout_ms)
-            .withConnectionTimeout(config.sqs_sending_connect_timeout_ms)
-            .withRequestTimeout(config.sqs_sending_request_timeout_ms)
-        )
-      }
-      return builder.build()
+    /** Build a buffered [AmazonSQS] client for sending and deleting messages (job enqueue & ack respectively). */
+    private fun buildClient(
+      appName: String,
+      config: AwsSqsJobQueueConfig,
+      credentials: AWSCredentialsProvider,
+      region: AwsRegion,
+      features: FeatureFlags
+    ): AmazonSQS {
+      // Use a buffered client for sending, to group enqueues and deletes into batches.
+      // The trade-off is fewer network calls (which costs less $ since SQS cost is directly
+      // proportional to API calls) at a slightly higher individual call duration.
+      // Every call individual SendMessage and DeleteMessage request will wait up to 200ms
+      // for similar requests and sent in a batch. Batches are immediately sent once full.
+      val asyncClient = AmazonSQSAsyncClientBuilder.standard()
+        .withCredentials(credentials)
+        .withRegion(region.name)
+        .withClientConfiguration(ClientConfiguration()
+          .withSocketTimeout(config.sqs_sending_socket_timeout_ms)
+          .withConnectionTimeout(config.sqs_sending_connect_timeout_ms)
+          .withRequestTimeout(config.sqs_sending_request_timeout_ms))
+        .build()
+
+      // NB: It's unlikely this client will be used for receiving (i.e. to issue ReceiveMessage
+      // requests) but turn off pre-fetching in any case. Without pre-fetching, receives are
+      // on-demand (i.e. work exactly the same as a non-buffered client) and won't spawn extra
+      // background threads to pre-fill receive buffers.
+      val bufferConfig = QueueBufferConfig().withNoPrefetching()
+      // TODO(bruno): Replace with AmazonSQSBufferedAsyncClient(asyncClient, bufferConfig) once rollout proves safe.
+      return FlaggedBufferedSqsClient(
+        asyncClient,
+        AmazonSQSBufferedAsyncClient(asyncClient, bufferConfig),
+        appName,
+        features
+      )
     }
   }
+}
+
+/** Modify a [QueueBufferConfig] to disable all receive pre-fetching settings. */
+fun QueueBufferConfig.withNoPrefetching() : QueueBufferConfig {
+  return withMaxInflightReceiveBatches(0)
+    .withAdapativePrefetching(false)
+    .withMaxDoneReceiveBatches(0)
 }

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClient.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClient.kt
@@ -1,0 +1,66 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient
+import com.amazonaws.services.sqs.model.DeleteMessageRequest
+import com.amazonaws.services.sqs.model.DeleteMessageResult
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import com.amazonaws.services.sqs.model.SendMessageResult
+import misk.feature.Feature
+import misk.feature.FeatureFlags
+
+/**
+ * Temporary shim for buffered and unbuffered [AmazonSQS] implementations, for feature-flagged rollout of buffered
+ * SQS operations across cash cloud apps.
+ *
+ * Flag allows gates functionality on a per-service basis.
+ *
+ * Calls to [sendMessage] and [deleteMessage] will be routed to either buffered or unbuffered clients depending on the
+ * state of the feature flag for this service. All other operations are delegated to the unbufferd implementation.
+ *
+ * Once usage of the buffered client is proven safe, this shim should be deleted and substituted with
+ * [AmazonSQSBufferedAsyncClient].
+ *
+ * Flag: https://app.launchdarkly.com/cash/production/features/jobqueue-buffered-sqs-client/targeting
+ */
+class FlaggedBufferedSqsClient(
+  private val unbufferedSqs : AmazonSQS,
+  private val bufferedSqs : AmazonSQS,
+  private val appName: String,
+  private val featureFlags: FeatureFlags
+) : AmazonSQS by unbufferedSqs {
+  override fun sendMessage(sendMessageRequest: SendMessageRequest): SendMessageResult {
+    return client().sendMessage(sendMessageRequest)
+  }
+
+  override fun sendMessage(queueUrl: String, messageBody: String): SendMessageResult {
+    return client().sendMessage(queueUrl, messageBody)
+  }
+
+  override fun deleteMessage(deleteMessageRequest: DeleteMessageRequest): DeleteMessageResult {
+    return client().deleteMessage(deleteMessageRequest)
+  }
+
+  override fun deleteMessage(queueUrl: String, receiptHandle: String): DeleteMessageResult {
+    return client().deleteMessage(queueUrl, receiptHandle)
+  }
+
+  override fun shutdown() {
+    unbufferedSqs.shutdown()
+    // NB: buffered client shutdown should be immediate since we only buffer outgoing send/delete requests and should
+    // never be using receive pre-fetching (receive pre-fetch keeps bg threads running so this could take a few secs).
+    bufferedSqs.shutdown()
+  }
+
+  private fun client() : AmazonSQS {
+    return if (featureFlags.getBoolean(FEATURE, appName)) {
+      bufferedSqs
+    } else {
+      unbufferedSqs
+    }
+  }
+
+  companion object {
+    val FEATURE = Feature("jobqueue-buffered-sqs-client")
+  }
+}

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClientTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClientTest.kt
@@ -1,0 +1,69 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.DeleteMessageRequest
+import com.amazonaws.services.sqs.model.DeleteMessageResult
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import com.amazonaws.services.sqs.model.SendMessageResult
+import com.squareup.moshi.Moshi
+import misk.feature.testing.FakeFeatureFlags
+import misk.mockito.Mockito.mock
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.verifyNoMoreInteractions
+
+internal class FlaggedBufferedSqsClientTest {
+  @Test fun `dynamically switches between underlying clients based on feature status`() {
+    val flags = FakeFeatureFlags { Moshi.Builder().build() }
+    flags.override(FlaggedBufferedSqsClient.FEATURE, false)
+
+    val unbuffered = mock<AmazonSQS>()
+    val buffered = mock<AmazonSQS>()
+    // stub the feature-flag gated methods for both clients
+    listOf(unbuffered, buffered).forEach { client ->
+      `when`(client.sendMessage(any())).thenReturn(SendMessageResult())
+      `when`(client.sendMessage(anyString(), anyString())).thenReturn(SendMessageResult())
+      `when`(client.deleteMessage(any())).thenReturn(DeleteMessageResult())
+      `when`(client.deleteMessage(anyString(), anyString())).thenReturn(DeleteMessageResult())
+    }
+
+    val sendRequest = SendMessageRequest()
+      .withQueueUrl("queueUrl")
+      .withMessageBody("body")
+    val deleteRequest = DeleteMessageRequest()
+      .withQueueUrl("queueUrl")
+      .withReceiptHandle("receipt")
+    val client = FlaggedBufferedSqsClient(unbuffered, buffered, "test-app", flags)
+    val executeRequests = {
+      client.sendMessage(sendRequest)
+      client.sendMessage(sendRequest.queueUrl, sendRequest.messageBody)
+      client.deleteMessage(deleteRequest)
+      client.deleteMessage(deleteRequest.queueUrl, deleteRequest.receiptHandle)
+    }
+
+    // default/flag off, use unbuffered client
+    executeRequests()
+    verifyNoInteractions(buffered)
+    verify(unbuffered).sendMessage(sendRequest)
+    verify(unbuffered).sendMessage(sendRequest.queueUrl, sendRequest.messageBody)
+    verify(unbuffered).deleteMessage(deleteRequest)
+    verify(unbuffered).deleteMessage(deleteRequest.queueUrl, deleteRequest.receiptHandle)
+
+    // flip flag, confirm usage of buffered client
+    flags.overrideKey(FlaggedBufferedSqsClient.FEATURE, "test-app", true)
+    executeRequests()
+    verifyNoMoreInteractions(unbuffered)
+    verify(buffered).sendMessage(sendRequest)
+    verify(buffered).sendMessage(sendRequest.queueUrl, sendRequest.messageBody)
+    verify(buffered).deleteMessage(deleteRequest)
+    verify(buffered).deleteMessage(deleteRequest.queueUrl, deleteRequest.receiptHandle)
+
+    client.shutdown()
+    verify(buffered).shutdown()
+    verify(unbuffered).shutdown()
+  }
+}


### PR DESCRIPTION
Experiment with SQS buffering behind feature flag. Flag (disabled by default)
can toggle (real-time, per service; no restart required) whether to use
buffering or not — i.e. switches between using `AmazonSQSBufferedAsyncClient`
or a non-buffering impl (status quo).

`AmazonSQSBufferedAsyncClient` attempts to group similar `SendMessage` and
`DeleteMessage` requests into batch requests. Each request will wait up to 200ms
for similar requests before being sent. Batches are immediately sent once full.

The trade-off is fewer network calls (which costs less $ since SQS cost is
proportional to API calls) at a slightly higher individual call duration.

This buffered client is only used for sending/deleting messages (not receiving)
but it's configured with no pre-fetching, meaning any receives are on-demand
(i.e. just like a unbuffered client) and don't spawn any extra background
threads for pre-fetching.

---

This is an optimization that had been planned since we swapped Jobsy with SQS but wasn't
picked up because we needed all hands on deck to replace Evently and weren't aware of
`AmazonSQSBufferedAsyncClient` (i.e. thought we'd have to build buffering ourselves).

Turns out it's pretty trivial.

By pooling sends and deletes, we'll reduce the number of outbound SQS calls and put less
strain on our proxy, which should help alleviate SQS request/response times under periods of
intense load.

Feature flag:
* staging: https://app.launchdarkly.com/cash/staging/features/jobqueue-buffered-sqs-client/targeting
* prod: https://app.launchdarkly.com/cash/production/features/jobqueue-buffered-sqs-client/targeting