### PR TITLE
Revert "Use AmazonSQSBufferedAsyncClient for sends (#1748)"

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -3,10 +3,7 @@ package misk.jobqueue.sqs
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
-import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient
-import com.amazonaws.services.sqs.buffered.QueueBufferConfig
 import com.google.inject.Provider
 import com.google.inject.Provides
 import com.google.inject.Singleton
@@ -113,62 +110,30 @@ class AwsSqsJobQueueModule(
   }
 
   companion object {
-    /**
-     * Build an [AmazonSQS] impl based on supplied arguments.
-     *
-     * When [forSqsReceiving] is true, it returns an unbuffered [AmazonSQS] impl.
-     * When [forSqsReceiving] is false, it returns a buffered [AmazonSQS] impl with pre-fetching disabled.
-     */
     private fun buildClient(
-      config: AwsSqsJobQueueConfig,
-      credentials: AWSCredentialsProvider,
-      region: AwsRegion,
-      forSqsReceiving: Boolean
+      config: AwsSqsJobQueueConfig, credentials: AWSCredentialsProvider, region: AwsRegion, forSqsReceiving: Boolean
     ): AmazonSQS {
+      // Defaults from SDK
+      val clientConfiguration = ClientConfiguration()
+          .withSocketTimeout(25000)
+          .withConnectionTimeout(1000)
 
-      return if (forSqsReceiving) {
-        // We don't need any buffering functionality for receiving; build a regular sync client.
-        AmazonSQSClientBuilder.standard()
+      val builder = AmazonSQSClientBuilder.standard()
           .withCredentials(credentials)
           .withRegion(region.name)
-          .withClientConfiguration(ClientConfiguration()
-            .withSocketTimeout(25_000)
-            .withConnectionTimeout(1_000)
-            // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
-            // level resource limiting knobs (e.g # of parallel receivers).
-            // We only do this for receiving, as sending does not have equivalent knobs.
-            .withMaxConnections(Int.MAX_VALUE))
-          .build()
+      if (forSqsReceiving) {
+        // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
+        // level resource limiting knobs (e.g # of parallel receivers).
+        // We only do this for receiving, as sending does not have equivalent knobs.
+        builder.withClientConfiguration(clientConfiguration.withMaxConnections(Int.MAX_VALUE))
       } else {
-        // Use a buffered client for sending, to group enqueues and deletes into batches.
-        // The trade-off is fewer network calls (which costs less $ since SQS cost is directly
-        // proportional to API calls) at a slightly higher individual call duration.
-        // Every call individual SendMessage and DeleteMessage request will wait up to 200ms
-        // for similar requests and sent in a batch. Batches are immediately sent once full.
-        val asyncClient = AmazonSQSAsyncClientBuilder.standard()
-          .withCredentials(credentials)
-          .withRegion(region.name)
-          .withClientConfiguration(ClientConfiguration()
+        builder.withClientConfiguration(clientConfiguration
             .withSocketTimeout(config.sqs_sending_socket_timeout_ms)
             .withConnectionTimeout(config.sqs_sending_connect_timeout_ms)
-            .withRequestTimeout(config.sqs_sending_request_timeout_ms))
-          .build()
-
-        // NB: It's unlikely this client will be used for receiving (i.e. to issue ReceiveMessage
-        // requests) but turn off pre-fetching in any case. Without pre-fetching, receives are
-        // on-demand (i.e. work exactly the same as a non-buffered client) and won't spawn extra
-        // background threads to pre-fill receive buffers.
-        val bufferConfig = QueueBufferConfig().withNoPrefetching()
-
-        AmazonSQSBufferedAsyncClient(asyncClient, bufferConfig)
+            .withRequestTimeout(config.sqs_sending_request_timeout_ms)
+        )
       }
+      return builder.build()
     }
   }
-}
-
-/** Modify a [QueueBufferConfig] to disable all receive pre-fetching settings. */
-fun QueueBufferConfig.withNoPrefetching() : QueueBufferConfig {
-  return withMaxInflightReceiveBatches(0)
-    .withAdapativePrefetching(false)
-    .withMaxDoneReceiveBatches(0)
 }


### PR DESCRIPTION
This reverts commit 486dff3d46b794b84388a439ff50f3deccec9c83.

---

Was missing feature flag. New version (gated by flag): https://github.com/cashapp/misk/pull/1753