### PR TITLE
Change ClientMetricsInterceptor into an OkHttp interceptor

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -102,10 +102,10 @@ ext.dep = [
   "tink": "com.google.crypto.tink:tink:1.2.0",
   "tracingDatadog": "com.datadoghq:dd-trace-api:0.70.0",
   "vitess": "io.vitess:vitess-jdbc:3.0.0",
-  "wireGradlePlugin": "com.squareup.wire:wire-gradle-plugin:3.5.0",
-  "wireGrpcClient": "com.squareup.wire:wire-grpc-client:3.5.0",
-  "wireMoshiAdapter": "com.squareup.wire:wire-moshi-adapter:3.5.0",
-  "wireRuntime": "com.squareup.wire:wire-runtime:3.2.0",
+  "wireGradlePlugin": "com.squareup.wire:wire-gradle-plugin:3.6.0",
+  "wireGrpcClient": "com.squareup.wire:wire-grpc-client:3.6.0",
+  "wireMoshiAdapter": "com.squareup.wire:wire-moshi-adapter:3.6.0",
+  "wireRuntime": "com.squareup.wire:wire-runtime:3.6.0",
   "zookeeper": "org.apache.zookeeper:zookeeper:3.5.4-beta",
 ]
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.

--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -2,23 +2,29 @@ package misk.client
 
 import com.google.common.base.Stopwatch
 import com.google.common.base.Ticker
-import misk.metrics.Histogram
-import misk.metrics.Metrics
-import okhttp3.Response
+import com.squareup.wire.GrpcMethod
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import misk.metrics.Histogram
+import misk.metrics.Metrics
+import okhttp3.Interceptor
+import okhttp3.Response
+import retrofit2.Invocation
 
-class ClientMetricsInterceptor internal constructor(
-  private val actionName: String,
+class ClientMetricsInterceptor private constructor(
+  val clientName: String,
   private val requestDuration: Histogram
-) : ClientNetworkInterceptor {
+) : Interceptor {
 
-  override fun intercept(chain: ClientNetworkChain): Response {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val actionName = actionName(chain)
+      ?: return chain.proceed(chain.request())
+
     val stopwatch = Stopwatch.createStarted(Ticker.systemTicker())
     try {
-      val result = chain.proceed(chain.request)
+      val result = chain.proceed(chain.request())
       val elapsedMillis = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS).toDouble()
       requestDuration.record(elapsedMillis, actionName, "${result.code}")
       return result
@@ -29,14 +35,23 @@ class ClientMetricsInterceptor internal constructor(
     }
   }
 
+  private fun actionName(chain: Interceptor.Chain): String? {
+    val invocation = chain.request().tag(Invocation::class.java)
+    if (invocation != null) return "$clientName.${invocation.method().name}"
+
+    val grpcMethod = chain.request().tag(GrpcMethod::class.java)
+    if (grpcMethod != null) return "$clientName.${grpcMethod.path.substringAfterLast("/")}"
+
+    return null
+  }
+
   @Singleton
-  class Factory @Inject internal constructor(m: Metrics) : ClientNetworkInterceptor.Factory {
+  class Factory @Inject internal constructor(m: Metrics) {
     internal val requestDuration = m.histogram(
         name = "client_http_request_latency_ms",
         help = "count and duration in ms of outgoing client requests",
         labelNames = listOf("action", "code"))
 
-    override fun create(action: ClientAction) =
-        ClientMetricsInterceptor(action.name, requestDuration)
+    fun create(clientName: String) = ClientMetricsInterceptor(clientName, requestDuration)
   }
 }

--- a/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorsModule.kt
+++ b/misk/src/main/kotlin/misk/client/ClientNetworkInterceptorsModule.kt
@@ -7,6 +7,5 @@ import misk.inject.KAbstractModule
  */
 class ClientNetworkInterceptorsModule : KAbstractModule() {
   override fun configure() {
-    multibind<ClientNetworkInterceptor.Factory>().to<ClientMetricsInterceptor.Factory>()
   }
 }

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -7,15 +7,15 @@ import com.google.inject.name.Names
 import com.google.inject.util.Types
 import com.squareup.moshi.Moshi
 import io.opentracing.Tracer
+import java.lang.reflect.Proxy
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 import misk.clustering.Cluster
 import misk.inject.KAbstractModule
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import java.lang.reflect.Proxy
-import javax.inject.Singleton
-import kotlin.reflect.KClass
-import kotlin.reflect.cast
 
 /**
  * Creates a retrofit-backed typed client given an API interface and an HTTP configuration.
@@ -145,6 +145,9 @@ class TypedClientFactory @Inject constructor() {
   private lateinit var clientNetworkInterceptorFactories: Provider<List<ClientNetworkInterceptor.Factory>>
 
   @Inject
+  private lateinit var clientMetricsInterceptorFactory: ClientMetricsInterceptor.Factory
+
+  @Inject
   private lateinit var clientApplicationInterceptorFactories: Provider<List<ClientApplicationInterceptor.Factory>>
 
   @Inject
@@ -212,7 +215,9 @@ class TypedClientFactory @Inject constructor() {
         clientApplicationInterceptorFactories,
         eventListenerFactory,
         tracer,
-        moshi)
+        moshi,
+        clientMetricsInterceptorFactory
+    )
 
     return kclass.cast(Proxy.newProxyInstance(
         ClassLoader.getSystemClassLoader(),

--- a/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
@@ -84,7 +84,6 @@ internal class ClientMetricsInterceptorTest {
     override fun configure() {
       install(MiskTestingServiceModule())
       install(TypedHttpClientModule.create<Pinger>("pinger", Names.named("pinger")))
-      multibind<ClientNetworkInterceptor.Factory>().to<ClientMetricsInterceptor.Factory>()
       bind<MockWebServer>().toInstance(MockWebServer())
     }
 


### PR DESCRIPTION
It was a Misk ClientNetworkInterceptor. This is our only ClientNetworkInterceptor
across all Misk apps. This change makes it possible to delete that feature
from Misk.