### PR TITLE
Add a Pager.listAll overload that takes a Session

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/Pager.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/Pager.kt
@@ -34,3 +34,16 @@ fun <T : DbEntity<T>, R> Pager<T>.listAll(
   }
   return results
 }
+
+fun <T : DbEntity<T>, R> Pager<T>.listAll(
+  session: Session,
+  transform: (T) -> R
+): List<R> {
+  val results = mutableListOf<R>()
+  while (hasNext()) {
+    val nextPage = nextPage(session)
+    val pageContents = nextPage?.contents ?: emptyList()
+    results.addAll(pageContents.map(transform))
+  }
+  return results
+}

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
@@ -49,6 +49,25 @@ class RealPagerTest {
     assertThat(actualCharacterIds).containsExactlyElementsOf(expectedCharacterIds)
   }
 
+  @Test fun idAscPaginationWithSession() {
+    val movieId = givenStarWarsMovie()
+    givenStormtrooperCharacters(movieId, count = 100)
+    val expectedCharacterIds = transacter.transaction { session ->
+      queryFactory.newQuery(CharacterQuery::class)
+        .movieId(movieId)
+        .idAsc()
+        .list(session)
+        .map { it.id }
+    }
+    val actualCharacterIds = transacter.transaction { session ->
+      queryFactory.newQuery(CharacterQuery::class)
+        .movieId(movieId)
+        .newPager(idAscPaginator(), pageSize = 3)
+        .listAll(session) { it.id }
+    }
+    assertThat(actualCharacterIds).containsExactlyElementsOf(expectedCharacterIds)
+  }
+
   @Test fun idDescPagination() {
     val movieId = givenStarWarsMovie()
     givenStormtrooperCharacters(movieId, count = 100)


### PR DESCRIPTION
This is mostly for convenience; sometimes it's useful to use the listAll
function from inside an existing transaction.