### PR TITLE
Adds access to the fakeClock from static context.

### DIFF
--- a/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -6,6 +6,10 @@ import java.time.Clock
 class FakeClockModule : KAbstractModule() {
   override fun configure() {
     bind<Clock>().to<FakeClock>()
-    bind<FakeClock>().toInstance(FakeClock())
+    bind<FakeClock>().toInstance(fakeClock)
+  }
+
+  companion object {
+    val fakeClock by lazy { FakeClock() }
   }
 }


### PR DESCRIPTION
For unit-tests as well as areas where bindings are not always available, we need to be able to access directly the fakeclock instance.