### PR TITLE
Put the aws2Dynamodb dependency in the api configuration

### DIFF
--- a/misk-aws2-dynamodb/build.gradle
+++ b/misk-aws2-dynamodb/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
+  api dep.aws2Dynamodb
+
   implementation dep.guice
-  implementation dep.aws2Dynamodb
   implementation project(':misk-aws')
   implementation project(':misk-inject')
 }


### PR DESCRIPTION
When using the RealDynamoDbModule, we need to have access to the ClientOverrideConfiguration class. This should be included in the provided artifact