### PR TITLE
Provide loggingApi in the miskCore artifact

### DIFF
--- a/misk-core/build.gradle
+++ b/misk-core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   implementation dep.kotlinStdLibJdk8
   implementation dep.kotlinReflection
   api dep.kotlinRetry
-  implementation dep.loggingApi
+  api dep.loggingApi
   implementation dep.logbackClassic
   implementation dep.okio
   implementation dep.okHttp


### PR DESCRIPTION
The mu.KLogger is required if the "getLogger" is used. This should not required an additional library import