### PR TITLE
Introduce new exception class to replace ActionException

### DIFF
--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -1,6 +1,17 @@
 package misk.exceptions
 
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.HttpURLConnection.HTTP_CONFLICT
+import java.net.HttpURLConnection.HTTP_ENTITY_TOO_LARGE
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT
+import java.net.HttpURLConnection.HTTP_NOT_FOUND
+import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
+import java.net.HttpURLConnection.HTTP_UNAVAILABLE
+import java.net.HttpURLConnection.HTTP_UNSUPPORTED_TYPE
+
 /** Common status codes for actions */
+@Deprecated("Use java.net.HttpURLConnection.* or status code ints directly instead")
 enum class StatusCode(val code: Int) {
   BAD_REQUEST(400),
   NOT_FOUND(404),
@@ -23,51 +34,72 @@ enum class StatusCode(val code: Int) {
 }
 
 /** Base class for exceptions thrown by actions, translated into responses */
+@Deprecated("Use WebActionException instead")
 open class ActionException(
   val statusCode: StatusCode,
   message: String = statusCode.name,
   cause: Throwable? = null
 ) : Exception(message, cause)
 
+open class WebActionException(
+  /** The HTTP status code. Should be 400..599. */
+  val code: Int,
+  /**
+   * This is returned to the caller as is. Be mindful not to leak internal implementation details
+   * and possible vulnerabilities in the response body.
+   */
+  val responseBody: String,
+  message: String,
+  cause: Throwable?
+) : Exception(message, cause) {
+  val isClientError = code in (400..499)
+  val isServerError = code in (500..599)
+}
+
 /** Base exception for when resources are not found */
 open class NotFoundException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.NOT_FOUND, message, cause)
+  WebActionException(HTTP_NOT_FOUND, message, message, cause)
 
 /** Base exception for when authentication fails */
 open class UnauthenticatedException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.UNAUTHENTICATED, message, cause)
+  WebActionException(HTTP_UNAUTHORIZED, message, message, cause)
 
 /** Base exception for when authenticated credentials lack access to a resource */
 open class UnauthorizedException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.FORBIDDEN, message, cause)
+  WebActionException(HTTP_FORBIDDEN, message, message, cause)
 
-/** Base exception for when a resource is unavailable */
+/**
+ * Base exception for when a resource is unavailable. The message is not exposed to the caller.
+ */
 open class ResourceUnavailableException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.SERVICE_UNAVAILABLE, message, cause)
+  WebActionException(HTTP_UNAVAILABLE, "RESOURCE_UNAVAILABLE", message, cause)
 
 /** Base exception for bad client requests */
 open class BadRequestException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.BAD_REQUEST, message, cause)
+  WebActionException(HTTP_BAD_REQUEST, message, message, cause)
 
 /** Base exception for when a request causes a conflict */
 open class ConflictException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.CONFLICT, message, cause)
+  WebActionException(HTTP_CONFLICT, message, message, cause)
 
 open class UnprocessableEntityException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.UNPROCESSABLE_ENTITY, message, cause)
+  WebActionException(422, message, message, cause)
 
 open class TooManyRequestsException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.TOO_MANY_REQUESTS, message, cause)
+  WebActionException(429, message, message, cause)
 
-/** Base exception for when a server is acting as a gateway and cannot get a response in time */
+/**
+ * Base exception for when a server is acting as a gateway and cannot get a response in time.
+ * The message is not exposed to the caller.
+ */
 open class GatewayTimeoutException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.GATEWAY_TIMEOUT, message, cause)
+  WebActionException(HTTP_GATEWAY_TIMEOUT, "GATEWAY_TIMEOUT", message, cause)
 
 open class PayloadTooLargeException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.PAYLOAD_TOO_LARGE, message, cause)
+  WebActionException(HTTP_ENTITY_TOO_LARGE, message, message, cause)
 
 open class UnsupportedMediaTypeException(message: String = "", cause: Throwable? = null) :
-  ActionException(StatusCode.UNSUPPORTED_MEDIA_TYPE, message, cause)
+  WebActionException(HTTP_UNSUPPORTED_TYPE, message, message, cause)
 
 /** Similar to [kotlin.require], but throws [BadRequestException] if the check fails */
 inline fun requireRequest(check: Boolean, lazyMessage: () -> String) {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateExceptionMappers.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateExceptionMappers.kt
@@ -85,8 +85,8 @@ internal object ConflictExceptionResponder {
   private val CONFLICT_EXCEPTION = ConflictException()
 
   fun toResponse(): Response<ResponseBody> {
-    val message = CONFLICT_EXCEPTION.statusCode.name
-    val statusCode = CONFLICT_EXCEPTION.statusCode.code
+    val message = "CONFLICT_EXCEPTION"
+    val statusCode = CONFLICT_EXCEPTION.code
     return Response(message.toResponseBody(), HEADERS, statusCode = statusCode)
   }
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -8,6 +8,7 @@ import misk.MiskCaller
 import misk.MiskDefault
 import misk.ServiceModule
 import misk.exceptions.ActionException
+import misk.exceptions.WebActionException
 import misk.grpc.GrpcFeatureBinding
 import misk.inject.KAbstractModule
 import misk.queuing.TimedBlockingQueue
@@ -26,6 +27,7 @@ import misk.web.exceptions.EofExceptionMapper
 import misk.web.exceptions.ExceptionHandlingInterceptor
 import misk.web.exceptions.ExceptionMapperModule
 import misk.web.exceptions.IOExceptionMapper
+import misk.web.exceptions.WebActionExceptionMapper
 import misk.web.extractors.FormValueFeatureBinding
 import misk.web.extractors.PathParamFeatureBinding
 import misk.web.extractors.QueryParamFeatureBinding
@@ -151,6 +153,7 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
       .to<RequestBodyLoggingInterceptor.Factory>()
 
     install(ExceptionMapperModule.create<ActionException, ActionExceptionMapper>())
+    install(ExceptionMapperModule.create<WebActionException, WebActionExceptionMapper>())
     install(ExceptionMapperModule.create<IOException, IOExceptionMapper>())
     install(ExceptionMapperModule.create<EofException, EofExceptionMapper>())
 

--- a/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ActionExceptionMapper.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
  * are returned with just a status code and minimal messaging, to avoid leaking internal
  * implementation details and possible vulnerabilities
  */
+@Deprecated("Superseded by WebActionExceptionMapper")
 internal class ActionExceptionMapper @Inject internal constructor(
   val config: ActionExceptionLogLevelConfig
 ) : ExceptionMapper<ActionException> {

--- a/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
@@ -1,0 +1,33 @@
+package misk.web.exceptions
+
+import misk.exceptions.WebActionException
+import misk.web.Response
+import misk.web.ResponseBody
+import misk.web.mediatype.MediaTypes
+import misk.web.toResponseBody
+import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
+import javax.inject.Inject
+
+/**
+ * Maps [WebActionException]s into the appropriate status code. [WebActionException]s' response
+ * bodies are always returned to the caller.
+ */
+internal class WebActionExceptionMapper @Inject internal constructor(
+  val config: ActionExceptionLogLevelConfig
+) : ExceptionMapper<WebActionException> {
+  override fun toResponse(th: WebActionException): Response<ResponseBody> {
+    return Response(th.responseBody.toResponseBody(), HEADERS, statusCode = th.code)
+  }
+
+  override fun canHandle(th: Throwable): Boolean = th is WebActionException
+
+  override fun loggingLevel(th: WebActionException) =
+    if (th.isClientError) config.client_error_level
+    else config.server_error_level
+
+  private companion object {
+    val HEADERS: Headers =
+      listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap().toHeaders()
+  }
+}

--- a/misk/src/test/kotlin/misk/web/exceptions/ActionExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ActionExceptionMapperTest.kt
@@ -1,7 +1,7 @@
 package misk.web.exceptions
 
-import misk.exceptions.NotFoundException
-import misk.exceptions.ResourceUnavailableException
+import misk.exceptions.ActionException
+import misk.exceptions.StatusCode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.slf4j.event.Level
@@ -12,7 +12,7 @@ internal class ActionExceptionMapperTest {
   fun clientExceptionLoggingLevel() {
     val config = ActionExceptionLogLevelConfig(client_error_level = Level.INFO)
     val mapper = ActionExceptionMapper(config)
-    assertThat(mapper.loggingLevel(NotFoundException()))
+    assertThat(mapper.loggingLevel(ActionException(StatusCode.NOT_FOUND)))
       .isEqualTo(Level.INFO)
   }
 
@@ -20,7 +20,7 @@ internal class ActionExceptionMapperTest {
   fun serverExceptionLoggingLevel() {
     val config = ActionExceptionLogLevelConfig(server_error_level = Level.INFO)
     val mapper = ActionExceptionMapper(config)
-    assertThat(mapper.loggingLevel(ResourceUnavailableException()))
+    assertThat(mapper.loggingLevel(ActionException(StatusCode.SERVICE_UNAVAILABLE)))
       .isEqualTo(Level.INFO)
   }
 }

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperResolverTest.kt
@@ -2,6 +2,7 @@ package misk.web.exceptions
 
 import misk.exceptions.ActionException
 import misk.exceptions.NotFoundException
+import misk.exceptions.WebActionException
 import misk.web.Response
 import misk.web.ResponseBody
 import org.assertj.core.api.Assertions.assertThat
@@ -24,10 +25,10 @@ internal class ExceptionMapperResolverTest {
 
   @Test
   fun resolvesToSuperClassMapper() {
-    mappers[ActionException::class] = ActionExceptionMapper()
+    mappers[WebActionException::class] = WebActionExceptionMapper()
 
     assertThat(resolver.mapperFor(NotFoundException()))
-      .isInstanceOf(ActionExceptionMapper::class.java)
+      .isInstanceOf(WebActionExceptionMapper::class.java)
   }
 
   @Test
@@ -47,6 +48,7 @@ internal class ExceptionMapperResolverTest {
   class NotFoundExceptionMapper : BaseExceptionMapper<NotFoundException>()
   class ActionExceptionMapper : BaseExceptionMapper<ActionException>()
   class ArithmeticExceptionMapper : BaseExceptionMapper<ArithmeticException>()
+  class WebActionExceptionMapper : BaseExceptionMapper<WebActionException>()
 
   open class BaseExceptionMapper<in T : Throwable> : ExceptionMapper<T> {
     override fun toResponse(th: T): Response<ResponseBody> {


### PR DESCRIPTION
ActionException uses StatusCode, which is a closed enum that contains a subset of all
possible HTTP status codes. This means people wanting to throw ActionExceptions with
custom status codes are unable to do so without changing Misk. We also don't need to
have all possible status codes in Misk, especially for non-standard ones e.g. 432-499.

This replacement, WebActionException, lets you enter any custom status code, and makes
it clearer how the exception translates to the response.

Breaking change: the convenience exceptions (NotFoundException, etc) now inherit
WebActionException, and no longer have access to statusCode and
isClientError/isServerError.