### PR TITLE
Revreted to using TypeLIteral to bind a generic type

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -17,6 +17,7 @@ import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.inject.Singleton
+import com.google.inject.TypeLiteral
 import com.google.inject.name.Names
 import misk.crypto.pgp.PgpDecrypter
 import misk.crypto.pgp.PgpDecrypterProvider
@@ -78,8 +79,8 @@ class CryptoModule(
     }
 
     val externalDataKeys = config.external_data_keys ?: emptyMap()
-    bind<Map<KeyAlias, KeyType>>()
-      .annotatedWith<ExternalDataKeys>()
+    bind(object : TypeLiteral<Map<KeyAlias, KeyType>>() {})
+      .annotatedWith(ExternalDataKeys::class.java)
       .toInstance(externalDataKeys)
 
     /* Include all configured remotely-provided keys. */

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -15,6 +15,7 @@ import com.google.crypto.tink.hybrid.HybridConfig
 import com.google.crypto.tink.mac.MacConfig
 import com.google.crypto.tink.signature.SignatureConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
+import com.google.inject.TypeLiteral
 import com.google.inject.name.Names
 import misk.config.MiskConfig
 import misk.crypto.pgp.PgpDecrypter
@@ -58,8 +59,8 @@ class CryptoTestModule(
     keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(keys))
 
     val externalDataKeys = config.external_data_keys ?: emptyMap()
-    bind<Map<KeyAlias, KeyType>>()
-      .annotatedWith<ExternalDataKeys>()
+    bind(object : TypeLiteral<Map<KeyAlias, KeyType>>() {})
+      .annotatedWith(ExternalDataKeys::class.java)
       .toInstance(externalDataKeys)
     keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(externalDataKeys))
 


### PR DESCRIPTION
Apparently, some incopatibility between Kotlin and Java doesn't like the
"kotlinized" version of the bind statement when it used with a generic type.

So Guice sees `bind<Map<K,V>().annotatedWith<SomeAnnotation>()` as `@SomeAnnotation Map` instead of `@SoneAnnotation Map<K,V>`
I decided to resolve this issue by using a more Java-esque syntax to explicitly tell the bind statement that we're trying to bind a Map with specific generic types.