### PR TITLE
Remove Spotless plugin because the auto-apply doesn't work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,6 @@ buildscript {
     classpath dep.junitGradlePlugin
     classpath dep.mavenPublishGradlePlugin
     classpath dep.jgit
-    classpath(dep.spotless5Plugin) {
-      exclude group:'org.slf4j', module:'slf4j-api'
-    }
     classpath dep.wireGradlePlugin
   }
 }
@@ -36,7 +33,6 @@ tasks.register("testShardHibernate") {
 subprojects { subProject ->
   apply plugin: 'java'
   apply plugin: 'kotlin'
-  apply plugin: 'com.diffplug.spotless'
   apply plugin: 'org.jetbrains.dokka'
 
   buildscript {
@@ -72,22 +68,6 @@ subprojects { subProject ->
     main.java.srcDirs += 'src/main/kotlin/'
     test.java.srcDirs += 'src/test/kotlin/'
   }
-
-
-  spotless {
-    ratchetFrom 'origin/master'
-    enforceCheck false
-    kotlin {
-      target "**/*.kt"
-      ktlint(dep.ktlintVersion).userData([
-              'indent_size'             : '2',
-              'continuation_indent_size': '2',
-              'max_line_length'         : '100',
-              'disabled_rules'          : 'import-ordering'
-      ])
-    }
-  }
-  compileKotlin.dependsOn 'spotlessKotlinApply'
 
   dependencies {
     testImplementation dep.junitApi

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -102,7 +102,6 @@ ext.dep = [
   "servletApi": "javax.servlet:javax.servlet-api:3.1.0",
   "shadowJarPlugin": "com.github.jengelman.gradle.plugins:shadow:5.1.0",
   "slf4jApi": "org.slf4j:slf4j-api:1.7.28",
-  "spotless5Plugin": "com.diffplug.spotless:spotless-plugin-gradle:5.7.0",
   "tink": "com.google.crypto.tink:tink:1.2.0",
   "tracingDatadog": "com.datadoghq:dd-trace-api:0.75.0",
   "vitess": "io.vitess:vitess-jdbc:3.0.0",


### PR DESCRIPTION
Spotless, if it worked as painlessly as Prettier in JS-land, would be a great asset. But instead, the `apply` doesn't work and contributors are forced to one-by-one solve inconsequential linting errors which is a waste of time. Once a real linting robot solution is available that auto-formats without manual intervention, I'm all for enabling it. As of now, Spotless is more headache than it is worth.