### PR TITLE
Remove MiskTestingServiceModule from WebTestingModule

### DIFF
--- a/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteGuideMiskServiceModule.kt
+++ b/misk-grpc-tests/src/main/kotlin/misk/grpc/miskserver/RouteGuideMiskServiceModule.kt
@@ -1,16 +1,18 @@
 package misk.grpc.miskserver
 
 import com.google.inject.Provides
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.jetty.JettyService
 import javax.inject.Named
 
 /** A module that runs a Misk gRPC server: Wire protos and a Jetty backend. */
 class RouteGuideMiskServiceModule : KAbstractModule() {
   override fun configure() {
-    install(WebTestingModule(webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(http2 = true)))
+    install(WebServerTestingModule(webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(http2 = true)))
+    install(MiskTestingServiceModule())
     install(WebActionModule.create<GetFeatureGrpcAction>())
     install(WebActionModule.create<RouteChatGrpcAction>())
   }

--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
@@ -4,6 +4,7 @@ import com.google.inject.util.Modules
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.runBlocking
+import misk.MiskTestingServiceModule
 import misk.grpc.miskclient.MiskGrpcClientModule
 import misk.grpc.miskclient.RouteGuideCallCounter
 import misk.grpc.miskserver.RouteChatGrpcAction

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -1,5 +1,6 @@
 package misk.web
 
+import misk.MiskTestingServiceModule
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
@@ -10,7 +11,28 @@ import misk.security.ssl.SslLoader
  * A module that starts an embedded Jetty web server configured for testing. The server supports
  * both plaintext and TLS.
  */
+@Deprecated(
+  message = "It's replace by WebServerTestingModule + MiskTestingServiceModule to facilitate" +
+    "the composability of testing modules for application owners",
+  replaceWith = ReplaceWith(expression = "WebServerTestingModule", "misk.web")
+)
 class WebTestingModule(
+  private val webConfig: WebConfig = TESTING_WEB_CONFIG
+) : KAbstractModule() {
+  override fun configure() {
+    install(WebServerTestingModule(webConfig))
+    install(MiskTestingServiceModule())
+  }
+  companion object {
+    val TESTING_WEB_CONFIG =  WebServerTestingModule.TESTING_WEB_CONFIG
+  }
+}
+
+/**
+ * A module that starts an embedded Jetty web server configured for testing. The server supports
+ * both plaintext and TLS.
+ */
+class WebServerTestingModule(
   private val webConfig: WebConfig = TESTING_WEB_CONFIG
 ) : KAbstractModule() {
   override fun configure() {

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -1,6 +1,5 @@
 package misk.web
 
-import misk.MiskTestingServiceModule
 import misk.environment.Environment
 import misk.environment.EnvironmentModule
 import misk.inject.KAbstractModule
@@ -16,7 +15,6 @@ class WebTestingModule(
 ) : KAbstractModule() {
   override fun configure() {
     install(EnvironmentModule(Environment.TESTING))
-    install(MiskTestingServiceModule())
     install(MiskWebModule(webConfig))
   }
 

--- a/misk-testing/src/test/kotlin/misk/web/WebTestClientTest.kt
+++ b/misk-testing/src/test/kotlin/misk/web/WebTestClientTest.kt
@@ -1,5 +1,6 @@
 package misk.web
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -18,7 +19,8 @@ class WebTestClientTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<GetAction>())
       install(WebActionModule.create<PostAction>())
     }

--- a/misk/src/test/java/misk/web/extractors/JavaPathParamDispatchTest.java
+++ b/misk/src/test/java/misk/web/extractors/JavaPathParamDispatchTest.java
@@ -4,12 +4,14 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import java.io.IOException;
 import javax.inject.Inject;
+import misk.MiskTestingServiceModule;
 import misk.testing.MiskTest;
 import misk.testing.MiskTestModule;
 import misk.web.Get;
 import misk.web.PathParam;
 import misk.web.ResponseContentType;
 import misk.web.WebActionModule;
+import misk.web.WebServerTestingModule;
 import misk.web.WebTestingModule;
 import misk.web.actions.WebAction;
 import misk.web.jetty.JettyService;
@@ -65,7 +67,8 @@ public class JavaPathParamDispatchTest {
 
   private static final class TestModule extends AbstractModule {
     @Override protected void configure() {
-      install(new WebTestingModule());
+      install(new WebServerTestingModule());
+      install(new MiskTestingServiceModule());
       install(WebActionModule.create(GetObjectDetails.class));
     }
   }

--- a/misk/src/test/kotlin/misk/client/GrpcClientProviderTest.kt
+++ b/misk/src/test/kotlin/misk/client/GrpcClientProviderTest.kt
@@ -23,6 +23,7 @@ import misk.security.ssl.TrustStoreConfig
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -193,8 +194,9 @@ internal class GrpcClientProviderTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
+      install(MiskTestingServiceModule())
       install(HttpClientModule("robots", Names.named("robots")))
-      install(WebTestingModule(webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(http2 = true)))
+      install(WebServerTestingModule(webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(http2 = true)))
       install(WebActionModule.create<LocateGrpcAction>())
       install(WebActionModule.create<SayHelloGrpcAction>())
     }

--- a/misk/src/test/kotlin/misk/client/HttpClientEventListenerTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientEventListenerTest.kt
@@ -8,7 +8,7 @@ import misk.inject.getInstance
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.jetty.JettyService
 import okhttp3.Call
 import okhttp3.EventListener
@@ -81,7 +81,8 @@ internal class HttpClientEventListenerTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
       install(WebActionModule.create<ReturnADinosaurAction>())
     }
   }

--- a/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/ProtoMessageHttpClientTest.kt
@@ -14,6 +14,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -72,7 +73,8 @@ class ProtoMessageHttpClientTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
       install(WebActionModule.create<ReturnADinosaur>())
     }
   }

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientInterceptorTest.kt
@@ -2,7 +2,6 @@ package misk.client
 
 import com.google.inject.Guice
 import helpers.protos.Dinosaur
-import javax.inject.Inject
 import misk.Action
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
@@ -12,12 +11,13 @@ import misk.testing.MiskTestModule
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.jetty.JettyService
 import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class TypedHttpClientInterceptorTest {
@@ -75,7 +75,8 @@ internal class TypedHttpClientInterceptorTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
       install(WebActionModule.create<ReturnADinosaurAction>())
       multibind<NetworkInterceptor.Factory>().to<ServerHeaderInterceptor.Factory>()
     }

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -15,6 +15,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -138,7 +139,8 @@ internal class TypedHttpClientTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
       install(WebActionModule.create<ReturnADinosaurAction>())
       install(WebActionModule.create<ReturnAProtoDinosaurAction>())
     }

--- a/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedPeerHttpClientTest.kt
@@ -23,8 +23,8 @@ import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
 import misk.web.WebConfig
+import misk.web.WebServerTestingModule
 import misk.web.WebSslConfig
-import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -109,7 +109,7 @@ internal class TypedPeerHttpClientTest {
     override fun configure() {
       // Run a server using a cert that has OU of "Server"
       install(
-        WebTestingModule(
+        WebServerTestingModule(
           WebConfig(
             port = 0,
             idle_timeout = 500000,
@@ -131,6 +131,7 @@ internal class TypedPeerHttpClientTest {
         )
       )
 
+      install(MiskTestingServiceModule())
       bind<Cluster>().toInstance(FakeCluster())
       install(WebActionModule.create<ReturnADinosaurAction>())
     }

--- a/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcConnectivityTest.kt
@@ -5,11 +5,13 @@ import com.squareup.protos.test.grpc.HelloReply
 import com.squareup.protos.test.grpc.HelloRequest
 import com.squareup.wire.Service
 import com.squareup.wire.WireRpc
+import misk.MiskTestingServiceModule
 import misk.exceptions.BadRequestException
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -175,12 +177,13 @@ class GrpcConnectivityTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             http2 = true
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<HelloRpcAction>())
     }
   }

--- a/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
+++ b/misk/src/test/kotlin/misk/tracing/ClientServerTraceTest.kt
@@ -24,6 +24,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -174,7 +175,8 @@ internal class ClientServerTraceTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(MockTracingBackendModule())
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<ReturnADinosaurAction>())
       install(WebActionModule.create<RoarLikeDinosaurAction>())
     }

--- a/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
+++ b/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.google.inject.Provides
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientConfig
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
@@ -106,14 +107,15 @@ abstract class AbstractRebalancingTest(
   inner class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             http2 = true,
             close_connection_percent = percent,
             jetty_max_thread_pool_size = jettyMaxThreadPoolSize
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(HttpClientModule("default"))
     }
 

--- a/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ActionScopedWebDispatchTest.kt
@@ -1,5 +1,6 @@
 package misk.web
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
@@ -57,7 +58,8 @@ internal class ActionScopedWebDispatchTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<Hello>())
       install(object : ActionScopedProviderModule() {
         override fun configureProviders() {

--- a/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/ContentBasedDispatchTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -95,7 +96,8 @@ internal class ContentBasedDispatchTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<PostPlainTextReturnAnyText>())
       install(WebActionModule.create<PostAnyTextReturnPlainText>())
       install(WebActionModule.create<PostPlainTextReturnPlainText>())

--- a/misk/src/test/kotlin/misk/web/CorsFilterTest.kt
+++ b/misk/src/test/kotlin/misk/web/CorsFilterTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -91,8 +92,8 @@ class CorsFilterTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             cors = mapOf(
               Pair("/cors-allow/*", CorsConfig()),
               Pair(
@@ -105,6 +106,7 @@ class CorsFilterTest {
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<CorsAllowGetAction>())
       install(WebActionModule.create<RestrictiveCORsAction>())
       install(WebActionModule.create<NoCorsPolicyAction>())

--- a/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
+++ b/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
 import misk.concurrent.ExecutorServiceFactory
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
@@ -132,7 +133,8 @@ internal class DegradedHealthStressTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(Modules.override(WebTestingModule()).with(ClockModule()))
+      install(Modules.override(MiskTestingServiceModule()).with(ClockModule()))
+      install(WebServerTestingModule())
       install(WebActionModule.create<UseConstrainedResourceAction>())
       bind<FakeResourcePool>().asSingleton()
     }

--- a/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
+++ b/misk/src/test/kotlin/misk/web/DeterministicRoutingTest.kt
@@ -1,5 +1,6 @@
 package misk.web
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -61,7 +62,8 @@ internal class DeterministicRoutingTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       val webActions = mutableListOf(
         WholePathAction::class,
         RemainderPathAction::class,

--- a/misk/src/test/kotlin/misk/web/GzipTest.kt
+++ b/misk/src/test/kotlin/misk/web/GzipTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -149,13 +150,14 @@ abstract class AbstractGzipTest {
   class TestModule(val gzip: Boolean) : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             gzip = gzip,
             minGzipSize = 128
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<MiskHypeGetAction>())
       install(WebActionModule.create<MiskHypePostAction>())
       install(WebActionModule.create<CountHypeAction>())

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -3,6 +3,7 @@ package misk.web
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Injector
 import com.google.inject.ProvisionException
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -21,7 +22,8 @@ class InvalidActionsTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<SomeAction>())
       install(WebActionModule.create<IdenticalAction>())
     }

--- a/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyHealthCheckTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
 import misk.concurrent.ExecutorServiceFactory
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
@@ -106,7 +107,7 @@ internal class JettyHealthCheckTest {
   internal class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        Modules.override(WebTestingModule()).with(
+        Modules.override(WebServerTestingModule()).with(
           object : KAbstractModule() {
             override fun configure() {
               val pool = ExecutorThreadPool(
@@ -125,6 +126,8 @@ internal class JettyHealthCheckTest {
           }
         )
       )
+      install(MiskTestingServiceModule())
+
       install(WebActionModule.create<BlockingAction>())
       install(WebActionModule.create<HealthAction>())
       bind<Phaser>().annotatedWith<Requests>().toInstance(Phaser())

--- a/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyServiceMetricsTest.kt
@@ -2,6 +2,7 @@ package misk.web
 
 import com.google.inject.util.Modules
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.moshi.adapter
 import misk.testing.MiskTest
@@ -140,7 +141,7 @@ internal class JettyServiceMetricsTest {
   internal class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        Modules.override(WebTestingModule()).with(
+        Modules.override(WebServerTestingModule()).with(
           object : KAbstractModule() {
             override fun configure() {
               val pool = QueuedThreadPool(
@@ -152,6 +153,7 @@ internal class JettyServiceMetricsTest {
           }
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<HelloAction>())
       install(WebActionModule.create<CurrentPoolMetricsAction>())
     }

--- a/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
+++ b/misk/src/test/kotlin/misk/web/JsonForProtoEndpointsTest.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.GrpcClient
 import com.squareup.wire.GrpcMethod
 import com.squareup.wire.Service
 import com.squareup.wire.WireRpc
+import misk.MiskTestingServiceModule
 import misk.grpc.Http2ClientTestingModule
 import misk.inject.KAbstractModule
 import misk.security.authz.Unauthenticated
@@ -150,12 +151,13 @@ internal class JsonForProtoEndpointsTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             http2 = true
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<ProtoEchoShipmentToken>())
       install(WebActionModule.create<GrpcEchoShipmentToken>())
     }

--- a/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebDispatchTest.kt
@@ -1,6 +1,7 @@
 package misk.web
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -118,7 +119,8 @@ internal class WebDispatchTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<PostHello>())
       install(WebActionModule.create<GetHello>())
       install(WebActionModule.create<PostBye>())

--- a/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
@@ -1,7 +1,7 @@
 package misk.web
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
-import misk.logging.LogCollector
 import misk.logging.LogCollectorModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -51,7 +51,8 @@ internal class WebSocketsTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(LogCollectorModule())
       install(WebActionModule.create<EchoWebSocket>())
     }

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -1,6 +1,7 @@
 package misk.web.actions
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -9,6 +10,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -186,7 +188,8 @@ class NotFoundActionTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<EchoAction>())
       install(WebActionModule.create<EchoFooAction>())
     }

--- a/misk/src/test/kotlin/misk/web/actions/SupportedHttpMethodsTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/SupportedHttpMethodsTest.kt
@@ -1,5 +1,6 @@
 package misk.web.actions
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -10,6 +11,7 @@ import misk.web.Post
 import misk.web.Put
 import misk.web.Response
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -91,7 +93,8 @@ class SupportedHttpMethodsTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<GetAction>())
       install(WebActionModule.create<PostAction>())
       install(WebActionModule.create<PatchAction>())

--- a/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
@@ -5,6 +5,7 @@ import com.squareup.protos.test.parsing.Warehouse
 import com.squareup.wire.Service
 import com.squareup.wire.WireRpc
 import misk.MiskCaller
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.scope.ActionScoped
 import misk.security.authz.AccessAnnotationEntry
@@ -18,7 +19,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
 import javax.inject.Inject
@@ -26,7 +27,8 @@ import javax.inject.Inject
 // Common module for web action-related tests to use to use that bind up some sample web actions
 class TestWebActionModule : KAbstractModule() {
   override fun configure() {
-    install(WebTestingModule())
+    install(WebServerTestingModule())
+    install(MiskTestingServiceModule())
     install(AccessControlModule())
 
     install(WebActionModule.create<CustomServiceAccessAction>())

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
@@ -1,6 +1,7 @@
 package misk.web.exceptions
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.exceptions.ActionException
 import misk.exceptions.StatusCode
 import misk.inject.KAbstractModule
@@ -10,6 +11,7 @@ import misk.web.Get
 import misk.web.PathParam
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -85,7 +87,8 @@ internal class ExceptionMapperTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<ThrowsActionException>())
       install(WebActionModule.create<ThrowsUnmappedError>())
     }

--- a/misk/src/test/kotlin/misk/web/extractors/FormValueParameterTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/FormValueParameterTest.kt
@@ -1,5 +1,6 @@
 package misk.web.extractors
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -7,7 +8,7 @@ import misk.web.FormField
 import misk.web.FormValue
 import misk.web.Post
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import okhttp3.FormBody
@@ -151,7 +152,8 @@ internal class FormValueParameterTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<BasicParamsAction>())
       install(WebActionModule.create<OptionalParamsAction>())
       install(WebActionModule.create<DefaultParamsAction>())

--- a/misk/src/test/kotlin/misk/web/extractors/PathParamDispatchTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/PathParamDispatchTest.kt
@@ -1,5 +1,6 @@
 package misk.web.extractors
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -7,6 +8,7 @@ import misk.web.Get
 import misk.web.PathParam
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -47,7 +49,8 @@ internal class PathParamDispatchTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<GetObjectDetails>())
       install(WebActionModule.create<CustomPathParamName>())
     }

--- a/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryStringRequestTest.kt
@@ -1,5 +1,6 @@
 package misk.web.extractors
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -7,7 +8,7 @@ import misk.web.Get
 import misk.web.QueryParam
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -94,7 +95,8 @@ internal class QueryStringRequestTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<BasicParamsAction>())
       install(WebActionModule.create<OptionalParamsAction>())
       install(WebActionModule.create<DefaultParamsAction>())

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -1,5 +1,6 @@
 package misk.web.interceptors
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessControlModule
 import misk.security.authz.FakeCallerAuthenticator
@@ -13,6 +14,7 @@ import misk.web.Get
 import misk.web.PathParam
 import misk.web.Response
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -85,7 +87,8 @@ class MetricsInterceptorTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(AccessControlModule())
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
       install(WebActionModule.create<MetricsInterceptorTestAction>())
 

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLogContextInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLogContextInterceptorTest.kt
@@ -1,6 +1,7 @@
 package misk.web.interceptors
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.moshi.adapter
 import misk.security.authz.AccessControlModule
@@ -12,6 +13,7 @@ import misk.testing.MiskTestModule
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -67,7 +69,8 @@ internal class RequestLogContextInterceptorTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(AccessControlModule())
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
       install(WebActionModule.create<LogTestAction>())
     }

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -1,6 +1,7 @@
 package misk.web.interceptors
 
 import com.google.common.testing.FakeTicker
+import misk.MiskTestingServiceModule
 import misk.exceptions.BadRequestException
 import misk.inject.KAbstractModule
 import misk.logging.LogCollectorModule
@@ -18,6 +19,7 @@ import misk.web.RequestBody
 import misk.web.RequestHeaders
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
@@ -233,7 +235,8 @@ internal class RequestLoggingInterceptorTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(AccessControlModule())
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(LogCollectorModule())
       multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
       install(TestActionsModule())

--- a/misk/src/test/kotlin/misk/web/interceptors/TracingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/TracingInterceptorTest.kt
@@ -2,6 +2,7 @@ package misk.web.interceptors
 
 import com.google.inject.Guice
 import io.opentracing.tag.Tags
+import misk.MiskTestingServiceModule
 import misk.asAction
 import misk.exceptions.ActionException
 import misk.exceptions.StatusCode
@@ -19,6 +20,7 @@ import misk.web.NetworkInterceptor
 import misk.web.RealNetworkChain
 import misk.web.Response
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -192,7 +194,8 @@ class TracingInterceptorTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(MockTracingBackendModule())
       install(WebActionModule.create<TracingTestAction>())
       install(WebActionModule.create<FailedTracingTestAction>())

--- a/misk/src/test/kotlin/misk/web/interceptors/UserInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/UserInterceptorTest.kt
@@ -3,6 +3,7 @@ package misk.web.interceptors
 import misk.Action
 import misk.ApplicationInterceptor
 import misk.Chain
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -13,6 +14,7 @@ import misk.web.PathParam
 import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -127,7 +129,8 @@ class UserInterceptorTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       multibind<NetworkInterceptor.Factory>().toInstance(UserCreatedNetworkInterceptor.Factory())
       multibind<ApplicationInterceptor.Factory>().toInstance(UserCreatedInterceptor.Factory())
 

--- a/misk/src/test/kotlin/misk/web/jetty/WebActionsServletTest.kt
+++ b/misk/src/test/kotlin/misk/web/jetty/WebActionsServletTest.kt
@@ -1,6 +1,7 @@
 package misk.web.jetty
 
 import misk.Action
+import misk.MiskTestingServiceModule
 import wisp.client.UnixDomainSocketFactory
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
@@ -11,6 +12,7 @@ import misk.web.NetworkInterceptor
 import misk.web.ResponseContentType
 import misk.web.SocketAddress
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.WebUnixDomainSocketConfig
 import misk.web.actions.WebAction
@@ -132,12 +134,13 @@ class WebActionsServletTest {
   inner class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             unix_domain_socket = WebUnixDomainSocketConfig(path = socketName)
           )
         )
       )
+      install(MiskTestingServiceModule())
 
       multibind<NetworkInterceptor.Factory>().toInstance(
         WebActionsServletNetworkInterceptor.Factory()

--- a/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonRequestTest.kt
@@ -1,6 +1,7 @@
 package misk.web.marshal
 
 import com.squareup.moshi.Moshi
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -9,6 +10,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
@@ -82,7 +84,8 @@ internal class JsonRequestTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<PassAsObject>())
       install(WebActionModule.create<PassAsString>())
       install(WebActionModule.create<PassAsByteString>())

--- a/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/JsonResponseTest.kt
@@ -1,5 +1,6 @@
 package misk.web.marshal
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -7,8 +8,8 @@ import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
-import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
@@ -117,7 +118,8 @@ internal class JsonResponseTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<ReturnAsObject>())
       install(WebActionModule.create<ReturnAsString>())
       install(WebActionModule.create<ReturnAsByteString>())

--- a/misk/src/test/kotlin/misk/web/marshal/MultipartRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/MultipartRequestTest.kt
@@ -1,5 +1,6 @@
 package misk.web.marshal
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -8,6 +9,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -103,7 +105,8 @@ internal class MultipartRequestTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<EchoMultipart>())
     }
   }

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextRequestTest.kt
@@ -1,5 +1,6 @@
 package misk.web.marshal
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -8,6 +9,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
@@ -51,7 +53,8 @@ internal class PlainTextRequestTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<PassAsString>())
       install(WebActionModule.create<PassAsByteString>())
     }

--- a/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/PlainTextResponseTest.kt
@@ -1,5 +1,6 @@
 package misk.web.marshal
 
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -7,6 +8,7 @@ import misk.web.Get
 import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
@@ -115,7 +117,8 @@ internal class PlainTextResponseTest {
 
   class TestModule : KAbstractModule() {
     override fun configure() {
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<ReturnAsObject>())
       install(WebActionModule.create<ReturnAsString>())
       install(WebActionModule.create<ReturnAsByteString>())

--- a/misk/src/test/kotlin/misk/web/proxy/WebProxyActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/proxy/WebProxyActionTest.kt
@@ -3,10 +3,12 @@ package misk.web.proxy
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebActionEntry
 import misk.web.jetty.JettyService
@@ -413,7 +415,8 @@ class WebProxyActionTest {
           WebProxyEntry("/local/prefix/", upstreamServer.url("/").toString())
         }
       )
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
     }
   }
 }

--- a/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/resource/StaticResourceActionTest.kt
@@ -1,6 +1,7 @@
 package misk.web.resource
 
 import com.google.inject.name.Names
+import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientsConfig
@@ -10,6 +11,7 @@ import misk.resources.ResourceLoader
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes.APPLICATION_JAVASCRIPT
@@ -270,7 +272,8 @@ class StaticResourceActionTest {
       multibind<StaticResourceEntry>()
         .toInstance(StaticResourceEntry("/nasa/tabs/o2fuel/", "memory:/web/nasa/tabs/o2fuel/"))
 
-      install(WebTestingModule())
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
     }
   }
 

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -23,6 +23,7 @@ import misk.web.Response
 import misk.web.ResponseBody
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.interceptors.MetricsInterceptor
@@ -228,12 +229,13 @@ class Http2ConnectivityTest {
     override fun configure() {
       install(LogCollectorModule())
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             http2 = true
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<HelloAction>())
       install(WebActionModule.create<DisconnectWithEmptyResponseAction>())
       install(WebActionModule.create<DisconnectWithLargeResponseAction>())

--- a/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/JceksSslClientServerTest.kt
@@ -26,8 +26,8 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebSslConfig
-import misk.web.WebTestingModule
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
@@ -95,9 +95,10 @@ internal class JceksSslClientServerTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(WebActionModule.create<HelloAction>())
+      install(MiskTestingServiceModule())
       install(
-        WebTestingModule(
-          WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             ssl = WebSslConfig(
               0,
               cert_store = CertStoreConfig(

--- a/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/PemSslClientServerTest.kt
@@ -26,6 +26,7 @@ import misk.web.RequestBody
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
 import misk.web.WebSslConfig
 import misk.web.WebTestingModule
 import misk.web.actions.WebAction
@@ -101,8 +102,8 @@ internal class PemSslClientServerTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             ssl = WebSslConfig(
               0,
               cert_store = CertStoreConfig(
@@ -119,6 +120,7 @@ internal class PemSslClientServerTest {
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<HelloAction>())
     }
   }

--- a/misk/src/test/kotlin/misk/web/uds/UDSHttp2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/uds/UDSHttp2ConnectivityTest.kt
@@ -6,7 +6,6 @@ import misk.MiskTestingServiceModule
 import misk.client.HttpClientEndpointConfig
 import misk.client.HttpClientModule
 import misk.client.HttpClientsConfig
-import wisp.client.UnixDomainSocketFactory
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.testing.MiskTest
@@ -14,7 +13,7 @@ import misk.testing.MiskTestModule
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.WebActionModule
-import misk.web.WebTestingModule
+import misk.web.WebServerTestingModule
 import misk.web.WebUnixDomainSocketConfig
 import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
@@ -25,6 +24,7 @@ import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import wisp.client.UnixDomainSocketFactory
 import java.io.File
 import java.util.UUID
 import javax.inject.Inject
@@ -74,8 +74,8 @@ class UDSHttp2ConnectivityTest {
   inner class TestModule : KAbstractModule() {
     override fun configure() {
       install(
-        WebTestingModule(
-          webConfig = WebTestingModule.TESTING_WEB_CONFIG.copy(
+        WebServerTestingModule(
+          webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             http2 = true,
             unix_domain_socket = WebUnixDomainSocketConfig(
               path = socketName
@@ -83,6 +83,7 @@ class UDSHttp2ConnectivityTest {
           )
         )
       )
+      install(MiskTestingServiceModule())
       install(WebActionModule.create<HelloAction>())
     }
   }


### PR DESCRIPTION
Most misk tests already requires the inclusion of `MiskTestingServiceModule`, and if there's more than one module importing you will get the following error
```
A binding to com.google.common.util.concurrent.ServiceManager was already configured at misk.ServiceManagerModule.provideServiceManager$misk_service() 
```