### PR TITLE
Use safe call on RequestResponseCapture.get

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
@@ -90,9 +90,7 @@ internal class RequestResponseCapture @Inject constructor() {
     private val capture = ThreadLocal<RequestResponseBody>()
   }
 
-  fun get(): RequestResponseBody {
-    return capture.get()
-  }
+  fun get(): RequestResponseBody? = capture.get()
 
   fun set(value: RequestResponseBody) {
     capture.set(value)


### PR DESCRIPTION
bodyCapture.get() sometimes throws exceptions, adding try/catch to
capture them.