### PR TITLE
Show proto fields for protobuf based web actions

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -17,6 +17,7 @@ import okhttp3.MediaType
 import java.util.regex.Matcher
 import javax.inject.Provider
 import javax.servlet.http.HttpServletRequest
+import kotlin.reflect.KType
 
 /**
  * Decodes an HTTP request into a call to a web action, then encodes its response into an HTTP
@@ -139,6 +140,7 @@ internal class BoundAction<A : WebAction>(
       parameters = action.parameters,
       requestType = action.requestType,
       returnType = action.returnType,
+      responseType = determineResponseType(action.returnType),
       pathPattern = pathPattern,
       applicationInterceptors = applicationInterceptors,
       networkInterceptors = networkInterceptors,
@@ -151,6 +153,13 @@ internal class BoundAction<A : WebAction>(
         AccessInterceptor::allowedCapabilities
       )
     )
+  }
+
+  private fun determineResponseType(returnType: KType): KType? {
+    if (returnType.arguments.isNotEmpty()) {
+      return returnType.arguments[0].type
+    }
+    return null
   }
 
   private fun fetchAllowedCallers(

--- a/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadata.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadata.kt
@@ -26,7 +26,9 @@ data class WebActionMetadata(
   val parameters: List<ParameterMetaData>,
   val requestType: String?,
   val returnType: String,
+  val responseType: String,
   val types: Map<String, MiskWebFormBuilder.Type>,
+  val responseTypes: Map<String, MiskWebFormBuilder.Type>,
   val pathPattern: String,
   val applicationInterceptors: List<String>,
   val networkInterceptors: List<String>,
@@ -45,6 +47,7 @@ data class WebActionMetadata(
     parameters: List<KParameter>,
     requestType: KType?,
     returnType: KType,
+    responseType: KType?,
     pathPattern: PathPattern,
     applicationInterceptors: List<ApplicationInterceptor>,
     networkInterceptors: List<NetworkInterceptor>,
@@ -69,7 +72,9 @@ data class WebActionMetadata(
     },
     requestType = requestType.toString(),
     returnType = returnType.toString(),
+    responseType = responseType.toString(),
     types = MiskWebFormBuilder().calculateTypes(requestType),
+    responseTypes = MiskWebFormBuilder().calculateTypes(responseType),
     pathPattern = pathPattern.toString(),
     applicationInterceptors = applicationInterceptors.map {
       ClassNameFormatter.format(it::class)

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
@@ -5,7 +5,7 @@ import WebActionCollapse from "./WebActionCollapse"
 import WebActionSendRequest from "./WebActionSendRequest"
 import WebActionRequestParameters from "./WebActionRequestParameters"
 import WebActionDescription from "./WebActionDescription"
-import WebActionResponseType from "./WebActionResponseType";
+import WebActionResponseType from "./WebActionResponseType"
 
 interface Props {
   webActionMetadata: WebActionMetadata

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
@@ -3,8 +3,9 @@ import { Menu, H5, UL } from "@blueprintjs/core"
 import { WebActionMetadata } from "./types"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionSendRequest from "./WebActionSendRequest"
-import WebActionParameters from "./WebActionParameters"
+import WebActionRequestParameters from "./WebActionRequestParameters"
 import WebActionDescription from "./WebActionDescription"
+import WebActionResponseType from "./WebActionResponseType";
 
 interface Props {
   webActionMetadata: WebActionMetadata
@@ -29,12 +30,8 @@ export default function WebActionCardBody({ webActionMetadata }: Props) {
     >
       <div style={{ gridColumn: "auto / span 2" }}>
         <WebActionDescription description={webActionMetadata.description} />
-        <WebActionParameters webActionMetadata={webActionMetadata} />
-        <WebActionCollapse title={"Response Type"} doubleWidth={true}>
-          <UL style={{ listStyle: "none" }}>
-            <li>{webActionMetadata.returnType}</li>
-          </UL>
-        </WebActionCollapse>
+        <WebActionRequestParameters webActionMetadata={webActionMetadata} />
+        <WebActionResponseType webActionMetadata={webActionMetadata} />
       </div>
       <WebActionCollapse
         title={webActionMetadata.responseMediaType}

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionCardBody.tsx
@@ -3,8 +3,8 @@ import { Menu, H5, UL } from "@blueprintjs/core"
 import { WebActionMetadata } from "./types"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionSendRequest from "./WebActionSendRequest"
-import WebActionParameters from "./WebActionParameters";
-import WebActionDescription from "./WebActionDescription";
+import WebActionParameters from "./WebActionParameters"
+import WebActionDescription from "./WebActionDescription"
 
 interface Props {
   webActionMetadata: WebActionMetadata
@@ -29,14 +29,10 @@ export default function WebActionCardBody({ webActionMetadata }: Props) {
     >
       <div style={{ gridColumn: "auto / span 2" }}>
         <WebActionDescription description={webActionMetadata.description} />
-        <WebActionParameters parameters={webActionMetadata.parameters} />
-        <WebActionCollapse
-          title={"Response Type"}
-          doubleWidth={true}>
-          <UL style={{listStyle: "none"}}>
-            <li>
-              {webActionMetadata.returnType}
-            </li>
+        <WebActionParameters webActionMetadata={webActionMetadata} />
+        <WebActionCollapse title={"Response Type"} doubleWidth={true}>
+          <UL style={{ listStyle: "none" }}>
+            <li>{webActionMetadata.returnType}</li>
           </UL>
         </WebActionCollapse>
       </div>

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionDescription.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionDescription.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { UL } from "@blueprintjs/core"
-import WebActionCollapse from "./WebActionCollapse";
+import WebActionCollapse from "./WebActionCollapse"
 
 interface Props {
   description: String
@@ -9,13 +9,9 @@ interface Props {
 export default function WebActionDescription({ description }: Props) {
   if (description) {
     return (
-      <WebActionCollapse
-        title={"Description"}
-        doubleWidth={true}>
-        <UL style={{listStyle: "none"}}>
-          <li>
-            {description}
-          </li>
+      <WebActionCollapse title={"Description"} doubleWidth={true}>
+        <UL style={{ listStyle: "none" }}>
+          <li>{description}</li>
         </UL>
       </WebActionCollapse>
     )

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionParameter.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionParameter.tsx
@@ -5,7 +5,7 @@ interface Props {
   parameter: ParameterMetaData
 }
 export default function WebActionParameter({ parameter }: Props) {
-  const cellStyle = {border: "none", padding: "0px 11px 0px 0px"}
+  const cellStyle = { border: "none", padding: "0px 11px 0px 0px" }
   return (
     <tr>
       <td style={cellStyle}>{parameter.annotations.join(",")}</td>

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionParameters.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionParameters.tsx
@@ -1,32 +1,52 @@
 import React from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
-import { ParameterMetaData } from "./types"
+import { WebActionMetadata} from "./types"
 import WebActionParameter from "./WebActionParameter"
-import WebActionCollapse from "./WebActionCollapse";
+import WebActionCollapse from "./WebActionCollapse"
+import WebActionProtoField from "./WebActionProtoField";
 
 interface Props {
-  parameters: ParameterMetaData[]
+  webActionMetadata: WebActionMetadata
 }
 
-export default function WebActionParameters({ parameters }: Props) {
+export default function WebActionParameters({ webActionMetadata }: Props) {
+  const requestType = webActionMetadata.types[webActionMetadata.requestType]
+  const parameters = webActionMetadata.parameters
 
   if (parameters.length == 0) {
     return null
   }
 
   return (
-    <WebActionCollapse
-      title={"Request Parameters"}
-      doubleWidth={true}>
-      <UL style={{listStyle: "none"}}>
-        <li>
-          <HTMLTable style={{marginBottom: "0px"}}>
-            {parameters.map(parameter => (
-              <WebActionParameter parameter={parameter} />
-            ))}
-          </HTMLTable>
-        </li>
-      </UL>
-    </WebActionCollapse>
+    <>
+      {requestType ? (
+        <WebActionCollapse
+          title={"Request Parameters"}
+          subtitle={webActionMetadata.requestType}
+          doubleWidth={true}>
+          <UL style={{ listStyle: "none" }}>
+            <li>
+              <HTMLTable style={{ marginBottom: "0px" }}>
+                {requestType.fields.map(field => (
+                  <WebActionProtoField field={field} />
+                ))}
+              </HTMLTable>
+            </li>
+          </UL>
+        </WebActionCollapse>
+      ) : (
+        <WebActionCollapse title={"Request Parameters"} doubleWidth={true}>
+          <UL style={{ listStyle: "none" }}>
+            <li>
+              <HTMLTable style={{ marginBottom: "0px" }}>
+                {parameters.map(parameter => (
+                  <WebActionParameter parameter={parameter} />
+                ))}
+              </HTMLTable>
+            </li>
+          </UL>
+        </WebActionCollapse>
+      )}
+    </>
   )
 }

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionProtoField.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionProtoField.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { ProtoField } from "./types"
+
+interface Props {
+  field: ProtoField
+}
+export default function WebActionProtoField({ field }: Props) {
+  const cellStyle = { border: "none", padding: "0px 11px 0px 0px" }
+  return (
+    <tr>
+      <td style={cellStyle}>{field.name}</td>
+      <td style={cellStyle}>{field.type}</td>
+      <td style={cellStyle}>{field.repeated ? "repeated" : null}</td>
+    </tr>
+  )
+}

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
@@ -3,7 +3,7 @@ import { HTMLTable, UL } from "@blueprintjs/core"
 import { WebActionMetadata} from "./types"
 import WebActionParameter from "./WebActionParameter"
 import WebActionCollapse from "./WebActionCollapse"
-import WebActionProtoField from "./WebActionProtoField";
+import WebActionProtoField from "./WebActionProtoField"
 
 interface Props {
   webActionMetadata: WebActionMetadata

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
@@ -9,7 +9,7 @@ interface Props {
   webActionMetadata: WebActionMetadata
 }
 
-export default function WebActionParameters({ webActionMetadata }: Props) {
+export default function WebActionRequestParameters({ webActionMetadata }: Props) {
   const requestType = webActionMetadata.types[webActionMetadata.requestType]
   const parameters = webActionMetadata.parameters
 

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { HTMLTable, UL } from "@blueprintjs/core"
+import { WebActionMetadata} from "./types"
+import WebActionParameter from "./WebActionParameter"
+import WebActionCollapse from "./WebActionCollapse"
+import WebActionProtoField from "./WebActionProtoField";
+
+interface Props {
+  webActionMetadata: WebActionMetadata
+}
+
+export default function WebActionResponseType({ webActionMetadata }: Props) {
+  const responseType = webActionMetadata.responseTypes[webActionMetadata.responseType]
+  const parameters = webActionMetadata.parameters
+
+  if (parameters.length == 0) {
+    return null
+  }
+
+  return (
+    <>
+      {responseType ? (
+        <WebActionCollapse
+          title={"Response Type"}
+          subtitle={webActionMetadata.responseType}
+          doubleWidth={true}>
+          <UL style={{ listStyle: "none" }}>
+            <li>
+              <HTMLTable style={{ marginBottom: "0px" }}>
+                {responseType.fields.map(field => (
+                  <WebActionProtoField field={field} />
+                ))}
+              </HTMLTable>
+            </li>
+          </UL>
+        </WebActionCollapse>
+      ) : (
+        <WebActionCollapse title={"Response Type"} doubleWidth={true}>
+          <UL style={{ listStyle: "none" }}>
+            <li>{webActionMetadata.returnType}</li>
+          </UL>
+        </WebActionCollapse>
+      )}
+    </>
+  )
+}

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
 import { WebActionMetadata} from "./types"
 import WebActionCollapse from "./WebActionCollapse"
-import WebActionProtoField from "./WebActionProtoField";
+import WebActionProtoField from "./WebActionProtoField"
 
 interface Props {
   webActionMetadata: WebActionMetadata

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
 import { WebActionMetadata} from "./types"
-import WebActionParameter from "./WebActionParameter"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionProtoField from "./WebActionProtoField";
 

--- a/misk/web/tabs/web-actions/src/rewrite/types.ts
+++ b/misk/web/tabs/web-actions/src/rewrite/types.ts
@@ -20,7 +20,9 @@ export interface WebActionMetadata {
   parameters: ParameterMetaData[]
   requestType: string
   returnType: string
+  responseType: string
   types: { [key: string]: ProtoType }
+  responseTypes: { [key: string]: ProtoType }
   pathPattern: string
   applicationInterceptors: string[]
   networkInterceptors: string[]


### PR DESCRIPTION
When an action's request type or response type is a proto show the field definitions for that proto.

Before:

![Misk Web Actions - Google Docs 2021-04-22 11-52-37](https://user-images.githubusercontent.com/1823/115644055-3d44b400-a361-11eb-8467-4e977252a97a.png)

After:

![Misk Web Actions - Google Docs 2021-04-22 11-53-10](https://user-images.githubusercontent.com/1823/115644094-52b9de00-a361-11eb-96ea-e56f0e72c49b.png)
