### PR TITLE
Fix JVM tests via Github Actions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -67,5 +67,6 @@ jobs:
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         with:
+          check_name: Test Report - ${{ matrix.cmd }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -13,8 +13,32 @@ env:
   TERM: dumb
 
 jobs:
-  build:
+  js:
     runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        cmd:
+          - sudo npm install -g @misk/cli && miskweb ci-build -e
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: ${{ matrix.cmd }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  jvm:
+    runs-on: ${{ matrix.os }}
+
     services:
       mysql:
         image: mysql:5.7
@@ -26,25 +50,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [12]
-        include:
-          # These builds consistently break. Use the circleci build instead for now.
-#          - shard: ./gradlew testShardHibernate -i --scan
-#          - shard: ./gradlew testShardNonHibernate -i --scan
-          - shard: sudo npm install -g @misk/cli && miskweb ci-build -e
+        cmd:
+          - ./gradlew testShardHibernate -i --scan
+          - ./gradlew testShardNonHibernate -i --scan --parallel
 
     steps:
-      - name: Checkout the repo
+      - name: Checkout
         uses: actions/checkout@v2
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
       - name: Configure JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 14
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Test
-        run: ${{ matrix.shard }}
-
+        run: ${{ matrix.cmd }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -30,12 +30,6 @@ jobs:
       - name: Test
         run: ${{ matrix.cmd }}
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   jvm:
     runs-on: ${{ matrix.os }}
 
@@ -69,3 +63,9 @@ jobs:
 
       - name: Test
         run: ${{ matrix.cmd }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also splits out the JS and JVM builds, and upgrades setup-java. Looks like the change to adopt @ 11 was the key piece to fixing it.