### PR TITLE
ConcurrencyLimitsInterceptor only uses rate limited ERROR-level logging

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -71,12 +71,10 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
   private fun logShedRequest() {
     val nowMs = clock.millis()
     val durationSinceLastErrorMs = nowMs - lastErrorLoggedAtMs
-    var level = Level.INFO
     if (lastErrorLoggedAtMs == -1L || durationSinceLastErrorMs >= durationBetweenErrorsMs) {
       lastErrorLoggedAtMs = nowMs
-      level = Level.ERROR
+      logger.log(level = Level.ERROR) { "concurrency limits interceptor shedding $actionName" }
     }
-    logger.log(level = level) { "concurrency limits interceptor shedding $actionName" }
   }
 
   @Singleton


### PR DESCRIPTION
IMO, the rate limited error logging in this is enough. As commented previously, folks can reliably use RPC response code metrics to understand how often load shedding is occurring.

Unconditional `INFO`-level logging just fills high traffic services' logs with an unactionable message. Even if logs are cheap, this feels like a waste of resources in addition to filling logs with noise.