### PR TITLE
Add admin dashboard config to web config

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -85,7 +85,7 @@ data class WebConfig(
   /** If true, disables automatic load shedding when degraded. */
   val concurrency_limiter_disabled: Boolean = false,
 
-  val adminDashboard: AdminDashboardConfig
+  val admin_dashboard: AdminDashboardConfig = AdminDashboardConfig()
 ) : Config
 
 data class WebSslConfig(
@@ -156,5 +156,5 @@ data class AdminDashboardConfig(
   /**
    * URL that can be used by the admin dashboard to link to protobuf definitions
    */
-  val protobufDefinitionUrl: String? = null,
+  val protobuf_definition_url: String? = null,
 )

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -84,6 +84,8 @@ data class WebConfig(
 
   /** If true, disables automatic load shedding when degraded. */
   val concurrency_limiter_disabled: Boolean = false,
+
+  val adminDashboard: AdminDashboardConfig
 ) : Config
 
 data class WebSslConfig(
@@ -148,4 +150,11 @@ data class CorsConfig(
   val chainPreflight: Boolean = true,
   /** A comma separated list of HTTP headers that are allowed to be exposed on the client. */
   val exposedHeaders: Array<String> = arrayOf()
+)
+
+data class AdminDashboardConfig(
+  /**
+   * URL that can be used by the admin dashboard to link to protobuf definitions
+   */
+  val protobufDefinitionUrl: String? = null,
 )

--- a/misk/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
@@ -3,10 +3,12 @@ package misk.web.metadata
 import misk.MiskCaller
 import misk.scope.ActionScoped
 import misk.security.authz.Unauthenticated
+import misk.web.AdminDashboardConfig
 import misk.web.Get
 import misk.web.PathParam
 import misk.web.RequestContentType
 import misk.web.ResponseContentType
+import misk.web.WebConfig
 import misk.web.actions.WebAction
 import misk.web.dashboard.DashboardHomeUrl
 import misk.web.dashboard.DashboardNavbarItem
@@ -35,6 +37,7 @@ class DashboardMetadataAction @Inject constructor() : WebAction {
   @Inject private lateinit var allNavbarStatus: List<DashboardNavbarStatus>
   @Inject private lateinit var allHomeUrls: List<DashboardHomeUrl>
   @Inject lateinit var callerProvider: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+  @Inject lateinit var webConfig: WebConfig
 
   @Get("/api/dashboard/{dashboard_slug}/metadata")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
@@ -64,7 +67,8 @@ class DashboardMetadataAction @Inject constructor() : WebAction {
       home_url = homeUrl,
       navbar_items = navbarItems,
       navbar_status = navbarStatus,
-      tabs = authorizedDashboardTabs
+      tabs = authorizedDashboardTabs,
+      admin_dashboard = webConfig.adminDashboard
     )
     return Response(
       dashboardMetadata = dashboardMetadata
@@ -75,7 +79,8 @@ class DashboardMetadataAction @Inject constructor() : WebAction {
     val home_url: String = "",
     val navbar_items: List<String> = listOf(),
     val navbar_status: String = "",
-    val tabs: List<DashboardTab> = listOf()
+    val tabs: List<DashboardTab> = listOf(),
+    val admin_dashboard: AdminDashboardConfig = AdminDashboardConfig()
   )
 
   data class Response(val dashboardMetadata: DashboardMetadata = DashboardMetadata())

--- a/misk/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
@@ -68,7 +68,7 @@ class DashboardMetadataAction @Inject constructor() : WebAction {
       navbar_items = navbarItems,
       navbar_status = navbarStatus,
       tabs = authorizedDashboardTabs,
-      admin_dashboard = webConfig.adminDashboard
+      admin_dashboard = webConfig.admin_dashboard
     )
     return Response(
       dashboardMetadata = dashboardMetadata

--- a/samples/exemplar/src/main/resources/exemplar-common.yaml
+++ b/samples/exemplar/src/main/resources/exemplar-common.yaml
@@ -1,6 +1,8 @@
 web:
   port: 8080
   idle_timeout: 30000
+  admin_dashboard:
+    protobuf_definition_url: "https://example.com"
 
 prometheus:
   http_port: 8081


### PR DESCRIPTION
This PR adds an admin dashboard config to misk's web config. It will be used to render links to protobuf definitions from the misk web action dashboard.

For the exemplar app with the following configuration:

```
web:
  port: 8080
  idle_timeout: 30000
  admin_dashboard:
    protobuf_definition_url: "https://example.com"
```

When rendering the web actions tab for the action: `HelloWebProtoAction` we would render a link to `https://example.com/com.squareup.exemplar.protos.HelloWebRequest` for the request parameter.

This PR does not make any changes to web action dashboard, as a follow up misk-web change is required to provide this context.