### PR TITLE
Set protobuf url prefix for rendering links to protobuf docs

### DIFF
--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -166,7 +166,12 @@ class AdminDashboardTestingModule : KAbstractModule() {
         )
       )
     )
-    install(AdminDashboardModule(true))
+    install(
+      AdminDashboardModule(
+        isDevelopment = true,
+        dashboardProtobufDocUrlPrefix = "https://example.com/"
+      )
+    )
   }
 }
 

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -26,7 +26,7 @@ import javax.inject.Qualifier
  */
 class AdminDashboardModule(
   private val isDevelopment: Boolean,
-  private val dashboardProtobufDocUrlPrefix: String = ""
+  private val dashboardProtobufDocUrlPrefix: String? = null
 ) : KAbstractModule() {
 
   @Deprecated("Environment is deprecated")

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -24,7 +24,10 @@ import javax.inject.Qualifier
  *   Dashboard Annotation [AdminDashboard]. Tabs are then included in the admin dashboard menu
  *   grouping according to the [DashboardTab].category field and sorting by [DashboardTab].name
  */
-class AdminDashboardModule(private val isDevelopment: Boolean) : KAbstractModule() {
+class AdminDashboardModule(
+  private val isDevelopment: Boolean,
+  private val dashboardProtobufDocUrlPrefix: String = ""
+) : KAbstractModule() {
 
   @Deprecated("Environment is deprecated")
   constructor(env: Environment) : this(env == Environment.TESTING || env == Environment.DEVELOPMENT)
@@ -32,6 +35,9 @@ class AdminDashboardModule(private val isDevelopment: Boolean) : KAbstractModule
   override fun configure() {
     // Install base dashboard support
     install(DashboardModule())
+
+    bind<AdminDashboardProtobufDocUrlPrefix>()
+      .toInstance(AdminDashboardProtobufDocUrlPrefix(dashboardProtobufDocUrlPrefix))
 
     // Adds open CORS headers in development to allow through API calls from webpack servers
     multibind<NetworkInterceptor.Factory>().to<WideOpenDevelopmentInterceptorFactory>()

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardProtobufDocUrlPrefix.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardProtobufDocUrlPrefix.kt
@@ -1,5 +1,5 @@
 package misk.web.dashboard
 
 data class AdminDashboardProtobufDocUrlPrefix(
-  val url: String
-) : ValidWebEntry(url_path_prefix = url)
+  val url: String?
+) : ValidWebEntry(url_path_prefix = url ?: "/")

--- a/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardProtobufDocUrlPrefix.kt
+++ b/misk/src/main/kotlin/misk/web/dashboard/AdminDashboardProtobufDocUrlPrefix.kt
@@ -1,0 +1,5 @@
+package misk.web.dashboard
+
+data class AdminDashboardProtobufDocUrlPrefix(
+  val url: String
+) : ValidWebEntry(url_path_prefix = url)

--- a/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadataAction.kt
@@ -5,6 +5,7 @@ import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.dashboard.AdminDashboardAccess
+import misk.web.dashboard.AdminDashboardProtobufDocUrlPrefix
 import misk.web.jetty.WebActionsServlet
 import misk.web.mediatype.MediaTypes
 import javax.inject.Inject
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 @Singleton
 class WebActionMetadataAction @Inject constructor() : WebAction {
   @Inject internal lateinit var servletProvider: Provider<WebActionsServlet>
+  @Inject internal lateinit var protobufDocUrlPrefix: AdminDashboardProtobufDocUrlPrefix
 
   @Get("/api/webaction/metadata")
   @RequestContentType(MediaTypes.APPLICATION_JSON)
@@ -21,9 +23,13 @@ class WebActionMetadataAction @Inject constructor() : WebAction {
   @AdminDashboardAccess
   fun getAll(): Response {
     return Response(
+      protobufDocUrlPrefix = protobufDocUrlPrefix.url,
       webActionMetadata = servletProvider.get().webActionsMetadata
     )
   }
 
-  data class Response(val webActionMetadata: List<WebActionMetadata>)
+  data class Response(
+    val protobufDocUrlPrefix: String,
+    val webActionMetadata: List<WebActionMetadata>
+  )
 }

--- a/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionMetadataAction.kt
@@ -29,7 +29,7 @@ class WebActionMetadataAction @Inject constructor() : WebAction {
   }
 
   data class Response(
-    val protobufDocUrlPrefix: String,
+    val protobufDocUrlPrefix: String?,
     val webActionMetadata: List<WebActionMetadata>
   )
 }

--- a/misk/src/test/kotlin/misk/web/metadata/webaction/WebActionMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/metadata/webaction/WebActionMetadataActionTest.kt
@@ -58,6 +58,13 @@ class WebActionMetadataActionTest {
     assertThat(metadata.types).isNotEmpty
   }
 
+  @Test fun `protobuf documentation url prefix`() {
+    val response = webActionMetadataAction.getAll()
+
+    val protobufDocUrlPrefix = response.protobufDocUrlPrefix
+    assertThat(protobufDocUrlPrefix).isEqualTo("https://example.com/")
+  }
+
   @Test fun `grpc`() {
     val response = webActionMetadataAction.getAll()
 

--- a/misk/web/tabs/web-actions/src/rewrite/LinkToProtoDoc.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/LinkToProtoDoc.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from "react"
+import {ProtobufDocUrlPrefix} from "./TabContainer"
+
+interface Props {
+  protoClass: String
+}
+
+export default function LinkToProtoDoc({ protoClass }: Props) {
+  const protobufDocUrlPrefix = useContext(ProtobufDocUrlPrefix)
+
+  return (
+    <>
+      {protobufDocUrlPrefix ? (
+        <a href={protobufDocUrlPrefix + protoClass}>{protoClass}</a>
+      ) : null}
+    </>
+  )
+}

--- a/misk/web/tabs/web-actions/src/rewrite/TabContainer.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/TabContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { createContext, useEffect, useState } from "react"
 import { H1, H2 } from "@blueprintjs/core"
 import axios, { AxiosResponse } from "axios"
 import { WebActionMetadataResponse, WebActionsByPackage } from "./types"
@@ -6,9 +6,15 @@ import WebActionCards from "./WebActionCards"
 import LoadingState from "./LoadingState"
 import Spacer from "./Spacer"
 
+export const ProtobufDocUrlPrefix = createContext(null)
+
 export default function TabContainer() {
   const [webActionsByPackage, setWebActionsByPacakge] = useState<
     WebActionsByPackage | undefined
+  >()
+
+  const [protobufDocUrlPrefix, setProtobufDocUrlPrefix] = useState<
+    String | undefined
   >()
 
   useEffect(() => {
@@ -18,6 +24,8 @@ export default function TabContainer() {
         response.data.webActionMetadata.sort((a, b) =>
           a.name.localeCompare(b.name)
         )
+
+        setProtobufDocUrlPrefix(response.data.protobufDocUrlPrefix)
 
         const webActionsByPackage = response.data.webActionMetadata.reduce(
           (packages, action) => {
@@ -40,7 +48,7 @@ export default function TabContainer() {
   }
 
   return (
-    <>
+    <ProtobufDocUrlPrefix.Provider value={protobufDocUrlPrefix}>
       <div
         style={{ display: "flex", alignItems: "center", marginBottom: "8px" }}
       >
@@ -59,6 +67,6 @@ export default function TabContainer() {
             <WebActionCards webActions={webActionsByPackage[packageName]} />
           </>
         ))}
-    </>
+    </ProtobufDocUrlPrefix.Provider>
   )
 }

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
@@ -1,17 +1,22 @@
-import React from "react"
+import React, { useContext } from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
-import { WebActionMetadata} from "./types"
+import { WebActionMetadata } from "./types"
 import WebActionParameter from "./WebActionParameter"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionProtoField from "./WebActionProtoField"
+import { ProtobufDocUrlPrefix } from "./TabContainer"
 
 interface Props {
   webActionMetadata: WebActionMetadata
 }
 
-export default function WebActionRequestParameters({ webActionMetadata }: Props) {
+export default function WebActionRequestParameters({
+  webActionMetadata
+}: Props) {
   const requestType = webActionMetadata.types[webActionMetadata.requestType]
   const parameters = webActionMetadata.parameters
+
+  const protobufDocUrlPrefix = useContext(ProtobufDocUrlPrefix)
 
   if (parameters.length == 0) {
     return null
@@ -23,9 +28,11 @@ export default function WebActionRequestParameters({ webActionMetadata }: Props)
         <WebActionCollapse
           title={"Request Parameters"}
           subtitle={webActionMetadata.requestType}
-          doubleWidth={true}>
+          doubleWidth={true}
+        >
           <UL style={{ listStyle: "none" }}>
             <li>
+              <a href={protobufDocUrlPrefix + webActionMetadata.requestType}>{webActionMetadata.requestType}</a>
               <HTMLTable style={{ marginBottom: "0px" }}>
                 {requestType.fields.map(field => (
                   <WebActionProtoField field={field} />

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionRequestParameters.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from "react"
+import React from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
 import { WebActionMetadata } from "./types"
 import WebActionParameter from "./WebActionParameter"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionProtoField from "./WebActionProtoField"
-import { ProtobufDocUrlPrefix } from "./TabContainer"
+import LinkToProtoDoc from "./LinkToProtoDoc"
 
 interface Props {
   webActionMetadata: WebActionMetadata
@@ -15,8 +15,6 @@ export default function WebActionRequestParameters({
 }: Props) {
   const requestType = webActionMetadata.types[webActionMetadata.requestType]
   const parameters = webActionMetadata.parameters
-
-  const protobufDocUrlPrefix = useContext(ProtobufDocUrlPrefix)
 
   if (parameters.length == 0) {
     return null
@@ -32,7 +30,7 @@ export default function WebActionRequestParameters({
         >
           <UL style={{ listStyle: "none" }}>
             <li>
-              <a href={protobufDocUrlPrefix + webActionMetadata.requestType}>{webActionMetadata.requestType}</a>
+              <LinkToProtoDoc protoClass={webActionMetadata.requestType} />
               <HTMLTable style={{ marginBottom: "0px" }}>
                 {requestType.fields.map(field => (
                   <WebActionProtoField field={field} />

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
@@ -1,9 +1,9 @@
-import React, {useContext} from "react"
+import React from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
 import { WebActionMetadata } from "./types"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionProtoField from "./WebActionProtoField"
-import {ProtobufDocUrlPrefix} from "./TabContainer"
+import LinkToProtoDoc from "./LinkToProtoDoc"
 
 interface Props {
   webActionMetadata: WebActionMetadata
@@ -18,8 +18,6 @@ export default function WebActionResponseType({ webActionMetadata }: Props) {
     return null
   }
 
-  const protobufDocUrlPrefix = useContext(ProtobufDocUrlPrefix)
-
   return (
     <>
       {responseType ? (
@@ -29,8 +27,8 @@ export default function WebActionResponseType({ webActionMetadata }: Props) {
           doubleWidth={true}
         >
           <UL style={{ listStyle: "none" }}>
-            <a href={protobufDocUrlPrefix + webActionMetadata.responseType}>{webActionMetadata.requestType}</a>
             <li>
+              <LinkToProtoDoc protoClass={webActionMetadata.requestType} />
               <HTMLTable style={{ marginBottom: "0px" }}>
                 {responseType.fields.map(field => (
                   <WebActionProtoField field={field} />

--- a/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
+++ b/misk/web/tabs/web-actions/src/rewrite/WebActionResponseType.tsx
@@ -1,20 +1,24 @@
-import React from "react"
+import React, {useContext} from "react"
 import { HTMLTable, UL } from "@blueprintjs/core"
-import { WebActionMetadata} from "./types"
+import { WebActionMetadata } from "./types"
 import WebActionCollapse from "./WebActionCollapse"
 import WebActionProtoField from "./WebActionProtoField"
+import {ProtobufDocUrlPrefix} from "./TabContainer"
 
 interface Props {
   webActionMetadata: WebActionMetadata
 }
 
 export default function WebActionResponseType({ webActionMetadata }: Props) {
-  const responseType = webActionMetadata.responseTypes[webActionMetadata.responseType]
+  const responseType =
+    webActionMetadata.responseTypes[webActionMetadata.responseType]
   const parameters = webActionMetadata.parameters
 
   if (parameters.length == 0) {
     return null
   }
+
+  const protobufDocUrlPrefix = useContext(ProtobufDocUrlPrefix)
 
   return (
     <>
@@ -22,8 +26,10 @@ export default function WebActionResponseType({ webActionMetadata }: Props) {
         <WebActionCollapse
           title={"Response Type"}
           subtitle={webActionMetadata.responseType}
-          doubleWidth={true}>
+          doubleWidth={true}
+        >
           <UL style={{ listStyle: "none" }}>
+            <a href={protobufDocUrlPrefix + webActionMetadata.responseType}>{webActionMetadata.requestType}</a>
             <li>
               <HTMLTable style={{ marginBottom: "0px" }}>
                 {responseType.fields.map(field => (

--- a/misk/web/tabs/web-actions/src/rewrite/types.ts
+++ b/misk/web/tabs/web-actions/src/rewrite/types.ts
@@ -38,6 +38,7 @@ export interface ParameterMetaData {
 }
 
 export interface WebActionMetadataResponse {
+  protobufDocUrlPrefix: string
   webActionMetadata: WebActionMetadata[]
 }
 

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -28,7 +28,10 @@ fun main(args: Array<String>) {
     DeploymentModule(deployment, env),
     PrometheusMetricsServiceModule(config.prometheus),
     EnvironmentModule(environment = environment),
-    AdminDashboardModule(isDevelopment = true),
+    AdminDashboardModule(
+      isDevelopment = true,
+      dashboardProtobufDocUrlPrefix = "https://example.com/"
+    ),
     ConfigDashboardTabModule(isDevelopment = true)
   ).run(args)
 }


### PR DESCRIPTION
Optionally adds a link to protobuf documentation if `dashboardProtobufDocUrlPrefix` is provided when instantiating the `AdminDashboardModule`

![ 2021-05-05 15-38-49](https://user-images.githubusercontent.com/1823/117100795-09817980-adb8-11eb-8915-e7d7d4b1997f.png)
 