### PR TITLE
Upgrade zookeeper dependency

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -116,6 +116,6 @@ object Dependencies {
   val wireGrpcClient = "com.squareup.wire:wire-grpc-client:3.7.0"
   val wireMoshiAdapter = "com.squareup.wire:wire-moshi-adapter:3.7.0"
   val wireRuntime = "com.squareup.wire:wire-runtime:3.7.0"
-  val zookeeper = "org.apache.zookeeper:zookeeper:3.5.4-beta"
+  val zookeeper = "org.apache.zookeeper:zookeeper:3.5.9"
 }
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.

--- a/misk-zookeeper-testing/src/main/kotlin/misk/zookeeper/testing/EmbeddedZookeeper.kt
+++ b/misk-zookeeper-testing/src/main/kotlin/misk/zookeeper/testing/EmbeddedZookeeper.kt
@@ -11,7 +11,7 @@ class EmbeddedZookeeper(val basePort: Int) {
   private val peerPort = ExposedPort.tcp(PEER_PORT)
   private val leaderPort = ExposedPort.tcp(LEADER_PORT)
   private val composer = Composer("e-zk", Container({
-    withImage("zookeeper:3.5.4-beta")
+    withImage("zookeeper:3.5.9")
       .withName("zookeeper")
       .withCmd(listOf("zkServer.sh", "start-foreground"))
       .withExposedPorts(clientPort, peerPort, leaderPort)


### PR DESCRIPTION
This upgrade will unlock stronger encryption/TLS options

Zookeeper client security options are described in further detail [here](https://github.com/apache/zookeeper/blob/7fdadf7273f34dd0552db25a3771cf55b65e9208/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md)