### PR TITLE
Require boolean fake feature flags to overridden

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -33,9 +33,10 @@ class FakeFeatureFlags @Inject constructor(
 
   private val overrides = ConcurrentHashMap<MapKey, PriorityQueue<MapValue>>()
 
-  override fun getBoolean(feature: Feature, key: String, attributes: Attributes): Boolean {
-    return getOrDefault(feature, key, false, attributes)
-  }
+  override fun getBoolean(feature: Feature, key: String, attributes: Attributes): Boolean =
+    get(feature, key, attributes) as? Boolean ?: throw IllegalArgumentException(
+      "Boolean flag $feature must be overridden with override() before use; the default value of false has been DEPRECATED"
+    )
 
   override fun getInt(feature: Feature, key: String, attributes: Attributes): Int =
     get(feature, key, attributes) as? Int ?: throw IllegalArgumentException(

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -154,8 +154,8 @@ internal class FakeFeatureFlagsTest {
 
   @Test
   fun getBoolean() {
-    // Default returns false and not throw as the other variants.
-    assertThat(subject.getBoolean(FEATURE, TOKEN)).isEqualTo(false)
+    // Default throws.
+    assertThrows<RuntimeException> { subject.getBoolean(FEATURE, TOKEN) }
 
     // Can be overridden
     subject.override(FEATURE, true)


### PR DESCRIPTION
Match the behaviour of all other fake feature flag types.

This is a breaking API change. I think it's a good API break.