### PR TITLE
Introduce the Quota-Path header for better concurrency limiting

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimiterFactory.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimiterFactory.kt
@@ -6,6 +6,11 @@ import misk.Action
 /**
  * Multibind an instance to provide a custom Limiter for concurrency shedding.
  * The first instance to return non-null is used.
+ *
+ * Misk's ConcurrencyLimitsInterceptor honors the `Quota-Path` HTTP header to give callers control
+ * of how their calls are aggregated when computing system throughput. The [create] function will be
+ * called for each unique Quota-Path received from an application. If the same Quota-Path header is
+ * used on different actions, [create] is only called for the first action that uses the header.
  */
 interface ConcurrencyLimiterFactory {
   fun create(action: Action): Limiter<String>?


### PR DESCRIPTION
If a single action is used for different types of work this header can
be provided by callers to bucket work by kind. This allows the concurrency
limiter to make better predictions of timeouts and should increase overall
availability for endpoints that handle heterogeneous traffic.

The initial use case for this is internal endpoints that handle different
event topics.