### PR TITLE
Renamed ExternalKeyManager

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -66,7 +66,7 @@ class CryptoModule(
       } catch (e: IllegalArgumentException) {
         throw IllegalArgumentException("Found local key with no 'encrypted_key' value", e)
       }
-      keyManagerBinder.addBinding().toInstance(LocalConfigKeyProvider(keys, config.kms_uri))
+      keyManagerBinder.addBinding().toInstance(LocalConfigKeyResolver(keys, config.kms_uri))
 
       keys.forEach {
         bindKeyToProvider(it.key_name, it.key_type)

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoModule.kt
@@ -56,7 +56,7 @@ class CryptoModule(
      * name can only exist in one of the providers. This makes migrating keys between stores less
      * error-prone.
      */
-    val keyManagerBinder = newMultibinder(ExternalKeyManager::class)
+    val keyManagerBinder = newMultibinder(KeyResolver::class)
     val serviceKeys = mutableMapOf<KeyAlias, KeyType>()
 
     /* Parse and include all local keys first. */
@@ -93,7 +93,7 @@ class CryptoModule(
     if (externalDataKeys.isNotEmpty()) {
       requireBinding<AmazonS3>()
 
-      keyManagerBinder.addBinding().to<S3ExternalKeyManager>()
+      keyManagerBinder.addBinding().to<ExternalKeyResolver>()
 
       val internalAndExternal = keyNames.intersect(externalDataKeys.keys)
       check(internalAndExternal.isEmpty()) {

--- a/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/CryptoTestModule.kt
@@ -55,14 +55,14 @@ class CryptoTestModule(
     val keys = mutableListOf<Key>()
     config.keys?.let { keys.addAll(it) }
 
-    val keyManagerBinder = newMultibinder(ExternalKeyManager::class)
-    keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(keys))
+    val keyManagerBinder = newMultibinder(KeyResolver::class)
+    keyManagerBinder.addBinding().toInstance(FakeKeyResolver(keys))
 
     val externalDataKeys = config.external_data_keys ?: emptyMap()
     bind(object : TypeLiteral<Map<KeyAlias, KeyType>>() {})
       .annotatedWith(ExternalDataKeys::class.java)
       .toInstance(externalDataKeys)
-    keyManagerBinder.addBinding().toInstance(FakeExternalKeyManager(externalDataKeys))
+    keyManagerBinder.addBinding().toInstance(FakeKeyResolver(externalDataKeys))
 
     if (externalDataKeys.isNotEmpty()) {
       externalDataKeys.entries.forEach { entry ->

--- a/misk-crypto/src/main/kotlin/misk/crypto/FakeExternalKeyManagerModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/FakeExternalKeyManagerModule.kt
@@ -8,8 +8,8 @@ class FakeExternalKeyManagerModule(private val config: CryptoConfig) : KAbstract
   override fun configure() {
     requireBinding(wisp.deployment.Deployment::class.java)
     requireBinding(Deployment::class.java)
-    bind<ExternalKeyManager>().toInstance(
-      FakeExternalKeyManager(config.external_data_keys.orEmpty())
+    bind<KeyResolver>().toInstance(
+      FakeKeyResolver(config.external_data_keys.orEmpty())
     )
   }
 }

--- a/misk-crypto/src/main/kotlin/misk/crypto/FakeKeyResolver.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/FakeKeyResolver.kt
@@ -3,7 +3,7 @@ package misk.crypto
 import misk.config.MiskConfig
 import java.lang.UnsupportedOperationException
 
-class FakeExternalKeyManager : ExternalKeyManager {
+class FakeKeyResolver : KeyResolver {
   private var returnedKeysets: MutableMap<KeyAlias, Key> = mutableMapOf()
 
   override val allKeyAliases: Map<KeyAlias, KeyType>

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyProviders.kt
@@ -34,7 +34,7 @@ open class KeyReader {
 
   @Inject lateinit var kmsClient: KmsClient
 
-  @Inject lateinit var keySources: Set<ExternalKeyManager>
+  @Inject lateinit var keySources: Set<KeyResolver>
 
   private val logger = getLogger<KeyReader>()
 

--- a/misk-crypto/src/main/kotlin/misk/crypto/KeyResolver.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KeyResolver.kt
@@ -13,10 +13,10 @@ typealias KeyAlias = String
 class ExternalKeyManagerException(message: String) : IOException(message)
 
 /**
- * [ExternalKeyManager] provides an interface to access keys in a remote location indexed by
- * aliases. Optionally, callers can register a callback to be invoked when a key is updated.
+ * [KeyResolver] provides an interface to access keys indexed by aliases.
+ * Optionally, callers can register a callback to be invoked when a key is updated.
  */
-interface ExternalKeyManager {
+interface KeyResolver {
 
   val allKeyAliases: Map<KeyAlias, KeyType>
 
@@ -25,3 +25,9 @@ interface ExternalKeyManager {
    */
   fun getKeyByAlias(alias: KeyAlias): Key?
 }
+
+/**
+ * [ExternalKeyResolver] is used to access keys stored externally from the service.
+ * For example, for keys listed in [CryptoConfig.external_data_keys].
+ */
+interface ExternalKeyResolver : KeyResolver

--- a/misk-crypto/src/main/kotlin/misk/crypto/LocalConfigKeyProvider.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/LocalConfigKeyProvider.kt
@@ -7,7 +7,7 @@ package misk.crypto
 class LocalConfigKeyProvider(
   private val keys: List<Key>,
   private val kmsUri: String
-) : ExternalKeyManager {
+) : KeyResolver {
 
   override val allKeyAliases: Map<KeyAlias, KeyType> =
     keys.map { key -> key.key_name to key.key_type }.toMap()

--- a/misk-crypto/src/main/kotlin/misk/crypto/LocalConfigKeyResolver.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/LocalConfigKeyResolver.kt
@@ -1,10 +1,10 @@
 package misk.crypto
 
 /**
- * [LocalConfigKeyProvider] provides keys that are stored locally and protected by a single KMS
+ * [LocalConfigKeyResolver] provides keys that are stored locally and protected by a single KMS
  * key.
  */
-class LocalConfigKeyProvider(
+class LocalConfigKeyResolver(
   private val keys: List<Key>,
   private val kmsUri: String
 ) : KeyResolver {

--- a/misk-crypto/src/main/kotlin/misk/crypto/S3KeyResolver.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/S3KeyResolver.kt
@@ -1,6 +1,5 @@
 package misk.crypto
 
-import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
@@ -11,7 +10,7 @@ import misk.environment.Env
 import wisp.logging.getLogger
 
 /**
- * [S3ExternalKeyManager] implements an [ExternalKeyManager] that fetches Tink keysets from an S3
+ * [S3KeyResolver] implements an [KeyResolver] that fetches Tink keysets from an S3
  * bucket. Keysets are indexed by an alias and a region, and are encrypted with a key in the KMS
  * using an envelope key encryption scheme. Each Keyset is protected by a KMS key in each service
  * region.
@@ -32,7 +31,7 @@ import wisp.logging.getLogger
  *
  *  If a requested key alias does not exist, this will raise a [ExternalKeyManagerException]
  */
-class S3ExternalKeyManager @Inject constructor(
+class S3KeyResolver @Inject constructor(
   private val env: Env,
 
   private val defaultS3: AmazonS3,
@@ -48,7 +47,7 @@ class S3ExternalKeyManager @Inject constructor(
   // in; if BucketNameSource provides a non-standard bucket region, we need to create a new S3
   // client for that bucket, and to do that we need credentials again.
   private val awsCredentials: AWSCredentialsProvider,
-) : ExternalKeyManager {
+) : ExternalKeyResolver {
 
   private val s3: AmazonS3 = bucketNameSource.getBucketRegion(env)?.let { region ->
     logger.info("creating S3ExternalKeyManager S3 client for $region")
@@ -101,7 +100,7 @@ class S3ExternalKeyManager @Inject constructor(
 
     private const val METADATA_KEY_KEY_TYPE = "key-type"
 
-    private val logger = getLogger<S3ExternalKeyManager>()
+    private val logger = getLogger<S3KeyResolver>()
   }
 
 }

--- a/misk-crypto/src/main/kotlin/misk/crypto/TestKeysets.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/TestKeysets.kt
@@ -8,7 +8,7 @@ import misk.config.MiskConfig
 import java.io.ByteArrayOutputStream
 
 /**
- * These test keys are used by the [FakeExternalKeyManager] class.
+ * These test keys are used by the [FakeKeyResolver] class.
  * *DO NOT USE IN ANY OTHER SITUATION*
  */
 internal class TestKeysets {

--- a/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
+++ b/misk-crypto/src/test/kotlin/misk/crypto/CryptoModuleTest.kt
@@ -124,7 +124,7 @@ class CryptoModuleTest {
     )
     val config = CryptoConfig(listOf(key), "test_master_key")
     val injector = Guice.createInjector(CryptoTestModule(config), DeploymentModule.forTesting())
-    val externalKeyManager = LocalConfigKeyProvider(config.keys!!, config.kms_uri)
+    val externalKeyManager = LocalConfigKeyResolver(config.keys!!, config.kms_uri)
     val hybridEncryptKeyManager = injector.getInstance(HybridEncryptKeyManager::class.java)
     assertThat(externalKeyManager.getKeyByAlias("test-hybrid"))
       .extracting("kms_uri")


### PR DESCRIPTION
renamed `ExternalKeyManager` to `KeyResolver`. 
Also added another interface called `ExternalKeyResolver`.

This change is the first in a series of changes needed to be done in order to abstract away specific implementations of how keys are being loaded in misk-crypto.