### PR TITLE
Added annotation classes to specify instances of AWSKMS and KmsClient

### DIFF
--- a/misk-crypto/src/main/kotlin/misk/crypto/KmsClientModule.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/KmsClientModule.kt
@@ -6,6 +6,7 @@ import com.google.crypto.tink.integration.gcpkms.GcpKmsClient
 import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.inject.KAbstractModule
+import javax.inject.Qualifier
 
 /**
  * AWS specific KMS client module.
@@ -32,3 +33,27 @@ class GcpKmsClientModule(private val credentialsPath: String? = null) : KAbstrac
   fun getKmsClient(): KmsClient = credentialsPath?.let { GcpKmsClient().withCredentials(it) }
     ?: GcpKmsClient().withDefaultCredentials()
 }
+
+/**
+ * This annotation is used to specify which [com.amazonaws.services.kms.AWSKMS]
+ * instance should be used by misk to construct a [KmsClient] and communicate with the KMS service
+ */
+@Qualifier
+@Target(
+  AnnotationTarget.FIELD,
+  AnnotationTarget.VALUE_PARAMETER
+)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MiskAWSKMS
+
+/**
+ * This annotation is used to specify the [KmsClient] that's
+ * being used by misk to load encryption keys
+ */
+@Qualifier
+@Target(
+  AnnotationTarget.FIELD,
+  AnnotationTarget.VALUE_PARAMETER
+)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MiskKmsClient


### PR DESCRIPTION
These annotation classes will be used to decorate an `AWSKMS` instance with `MiskAWSKMS` and a `KmsClient` with `MiskKmsClient`.
That way, the misk-crypto will be able to know exactly which instance to use when loading keys.

Why is this important?
1. Some services might need to initialize more than one instance of `KmsClient`. This way, we can easily distinguish them.
2. In some environments, initializing the `AWSKMS` object requires additional setup, for example of the service is running behind a proxy.