### PR TITLE
Add a health check for DynamoDB

### DIFF
--- a/misk-aws-dynamodb-testing/build.gradle.kts
+++ b/misk-aws-dynamodb-testing/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
   implementation(Dependencies.okio)
   implementation(Dependencies.awsDynamodb)
   implementation(Dependencies.awsDynamodbLocal)
+  implementation(project(":misk-aws-dynamodb"))
   api(project(":misk"))
   api(project(":misk-aws"))
   api(project(":misk-core"))

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
@@ -1,8 +1,10 @@
 package misk.aws.dynamodb.testing
 
-import misk.ServiceModule
-import misk.inject.KAbstractModule
 import kotlin.reflect.KClass
+import misk.ServiceModule
+import misk.dynamodb.DynamoDbHealthCheck
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
 
 /**
  * Spins up a docker container for testing. It clears the table content before each test starts.
@@ -28,5 +30,6 @@ class DockerDynamoDbModule(
     install(LocalDynamoDbModule(tables))
     install(ServiceModule<CreateTablesService>())
     bind<LocalDynamoDb>().toInstance(DockerDynamoDb.localDynamoDb)
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 }

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
@@ -7,15 +7,17 @@ import com.amazonaws.services.dynamodbv2.local.shared.access.LocalDBClient
 import com.amazonaws.services.dynamodbv2.local.shared.access.sqlite.SQLiteDBAccess
 import com.amazonaws.services.dynamodbv2.local.shared.jobs.JobsRegister
 import com.google.inject.Provides
-import misk.ServiceModule
-import misk.concurrent.ExecutorServiceFactory
-import misk.inject.KAbstractModule
-import misk.inject.toKey
 import java.io.File
 import java.util.concurrent.ExecutorService
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.reflect.KClass
+import misk.ServiceModule
+import misk.concurrent.ExecutorServiceFactory
+import misk.dynamodb.DynamoDbHealthCheck
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
+import misk.inject.toKey
 
 /**
  * Executes a DynamoDB service in-process per test. It clears the table content before each test
@@ -41,6 +43,7 @@ class InProcessDynamoDbModule(
       ServiceModule<CreateTablesService>()
         .dependsOn(InProcessDynamoDbService::class.toKey())
     )
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 
   @Provides @Singleton

--- a/misk-aws-dynamodb/build.gradle.kts
+++ b/misk-aws-dynamodb/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
   implementation(Dependencies.guice)
   implementation(Dependencies.awsDynamodb)
   implementation(project(":misk-aws"))
+  implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
 }
 

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
@@ -1,0 +1,27 @@
+package misk.dynamodb
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import javax.inject.Inject
+import javax.inject.Singleton
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import wisp.logging.getLogger
+
+@Singleton
+class DynamoDbHealthCheck @Inject constructor(
+  private val dynamoDb: AmazonDynamoDB
+) : HealthCheck {
+  override fun status(): HealthStatus {
+    try {
+      dynamoDb.listTables(3)
+      return HealthStatus.healthy("DynamoDB")
+    } catch (e: Exception) {
+      logger.error(e) { "error performing DynamoDB health check" }
+      return HealthStatus.unhealthy("DynamoDB: failed to list table names")
+    }
+  }
+
+  companion object {
+    val logger = getLogger<DynamoDbHealthCheck>()
+  }
+}

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -7,9 +7,10 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreamsClientBuilder
 import com.google.inject.Provides
-import misk.cloud.aws.AwsRegion
-import misk.inject.KAbstractModule
 import javax.inject.Singleton
+import misk.cloud.aws.AwsRegion
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
 
 /**
  * Install this module to have access to an AmazonDynamoDB client. This can be
@@ -22,6 +23,7 @@ class RealDynamoDbModule constructor(
   override fun configure() {
     requireBinding<AWSCredentialsProvider>()
     requireBinding<AwsRegion>()
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 
   @Provides @Singleton

--- a/misk-aws2-dynamodb-testing/build.gradle.kts
+++ b/misk-aws2-dynamodb-testing/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation(Dependencies.awsDynamodbLocal)
   implementation(project(":misk"))
   implementation(project(":misk-aws"))
+  implementation(project(":misk-aws2-dynamodb"))
   implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
   implementation(project(":misk-service"))

--- a/misk-aws2-dynamodb/build.gradle.kts
+++ b/misk-aws2-dynamodb/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 
   implementation(Dependencies.guice)
   implementation(project(":misk-aws"))
+  implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
 }
 

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbHealthCheck.kt
@@ -1,0 +1,30 @@
+package misk.aws2.dynamodb
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest
+import wisp.logging.getLogger
+
+@Singleton
+class DynamoDbHealthCheck @Inject constructor(
+  private val dynamoDb: DynamoDbClient
+) : HealthCheck {
+  override fun status(): HealthStatus {
+    try {
+      dynamoDb.listTables(ListTablesRequest.builder()
+        .limit(3)
+        .build())
+      return HealthStatus.healthy("DynamoDB")
+    } catch (e: Exception) {
+      logger.error(e) { "error performing DynamoDB health check" }
+      return HealthStatus.unhealthy("DynamoDB: failed to list table names")
+    }
+  }
+
+  companion object {
+    val logger = getLogger<DynamoDbHealthCheck>()
+  }
+}

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -1,13 +1,14 @@
 package misk.aws2.dynamodb
 
 import com.google.inject.Provides
+import javax.inject.Singleton
 import misk.cloud.aws.AwsRegion
+import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import javax.inject.Singleton
 
 /**
  * Install this module to have access to a DynamoDbClient.
@@ -19,6 +20,7 @@ class RealDynamoDbModule constructor(
   override fun configure() {
     requireBinding<AwsCredentialsProvider>()
     requireBinding<AwsRegion>()
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 
   @Provides @Singleton

--- a/misk-core/src/main/kotlin/misk/healthchecks/HealthCheck.kt
+++ b/misk-core/src/main/kotlin/misk/healthchecks/HealthCheck.kt
@@ -1,10 +1,8 @@
 package misk.healthchecks
 
-import misk.web.actions.ReadinessCheckAction
-
 /**
  * Allows users to define custom health checks. An app with a failing HealthCheck will fail the
- * readiness check in [ReadinessCheckAction], indicating that the app should not accept traffic.
+ * readiness check in `ReadinessCheckAction`, indicating that the app should not accept traffic.
  */
 interface HealthCheck {
   /**


### PR DESCRIPTION
This will make sure Misk services can successfully connect to DynamoDB before
self-reporting as healthy.

This may have a small availability benefit: connecting to DynamoDB before we
serve live traffic will mean the DynamoDB connection will be initialized when
traffic arrives.

Note that this PR also promotes HealthCheck from misk/ to misk-core/.