### PR TITLE
Add a health check for DynamoDB

### DIFF
--- a/misk-aws-dynamodb-testing/build.gradle.kts
+++ b/misk-aws-dynamodb-testing/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
   implementation(Dependencies.okio)
   implementation(Dependencies.awsDynamodb)
   implementation(Dependencies.awsDynamodbLocal)
+  implementation(project(":misk-aws-dynamodb"))
   api(project(":misk"))
   api(project(":misk-aws"))
   api(project(":misk-core"))

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbModule.kt
@@ -1,8 +1,13 @@
 package misk.aws.dynamodb.testing
 
-import misk.ServiceModule
-import misk.inject.KAbstractModule
+import com.google.inject.Provides
+import javax.inject.Singleton
 import kotlin.reflect.KClass
+import misk.ServiceModule
+import misk.dynamodb.DynamoDbHealthCheck
+import misk.dynamodb.RequiredDynamoDbTable
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
 
 /**
  * Spins up a docker container for testing. It clears the table content before each test starts.
@@ -28,5 +33,10 @@ class DockerDynamoDbModule(
     install(LocalDynamoDbModule(tables))
     install(ServiceModule<CreateTablesService>())
     bind<LocalDynamoDb>().toInstance(DockerDynamoDb.localDynamoDb)
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
+    tables.map { RequiredDynamoDbTable(it.tableName) }
 }

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DynamoDbTable.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/DynamoDbTable.kt
@@ -1,7 +1,9 @@
 package misk.aws.dynamodb.testing
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
 import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
 
 /**
  * Use this with [DockerDynamoDbModule] or [InProcessDynamoDbModule] to configure your DynamoDB
@@ -14,4 +16,11 @@ data class DynamoDbTable(
   val tableClass: KClass<*>,
   val configureTable: (CreateTableRequest) -> CreateTableRequest =
     CreateTablesService.CONFIGURE_TABLE_NOOP
-)
+) {
+  val tableName: String
+    get() {
+      val annotation = tableClass.findAnnotation<DynamoDBTable>()
+        ?: throw IllegalStateException("Expected @DynamoDBTable on $tableClass")
+      return annotation.tableName
+    }
+}

--- a/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
+++ b/misk-aws-dynamodb-testing/src/main/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbModule.kt
@@ -7,15 +7,18 @@ import com.amazonaws.services.dynamodbv2.local.shared.access.LocalDBClient
 import com.amazonaws.services.dynamodbv2.local.shared.access.sqlite.SQLiteDBAccess
 import com.amazonaws.services.dynamodbv2.local.shared.jobs.JobsRegister
 import com.google.inject.Provides
-import misk.ServiceModule
-import misk.concurrent.ExecutorServiceFactory
-import misk.inject.KAbstractModule
-import misk.inject.toKey
 import java.io.File
 import java.util.concurrent.ExecutorService
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.reflect.KClass
+import misk.ServiceModule
+import misk.concurrent.ExecutorServiceFactory
+import misk.dynamodb.DynamoDbHealthCheck
+import misk.dynamodb.RequiredDynamoDbTable
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
+import misk.inject.toKey
 
 /**
  * Executes a DynamoDB service in-process per test. It clears the table content before each test
@@ -41,6 +44,7 @@ class InProcessDynamoDbModule(
       ServiceModule<CreateTablesService>()
         .dependsOn(InProcessDynamoDbService::class.toKey())
     )
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 
   @Provides @Singleton
@@ -79,4 +83,8 @@ class InProcessDynamoDbModule(
   ): AmazonDynamoDBStreams {
     return amazonDynamoDbLocal.amazonDynamoDBStreams()
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
+    tables.map { RequiredDynamoDbTable(it.tableName) }
 }

--- a/misk-aws-dynamodb/build.gradle.kts
+++ b/misk-aws-dynamodb/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
   implementation(Dependencies.guice)
   implementation(Dependencies.awsDynamodb)
   implementation(project(":misk-aws"))
+  implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
 }
 

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
@@ -1,0 +1,30 @@
+package misk.dynamodb
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import javax.inject.Inject
+import javax.inject.Singleton
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import wisp.logging.getLogger
+
+@Singleton
+class DynamoDbHealthCheck @Inject constructor(
+  private val dynamoDb: AmazonDynamoDB,
+  private val requiredTables: List<RequiredDynamoDbTable>,
+) : HealthCheck {
+  override fun status(): HealthStatus {
+    for (table in requiredTables) {
+      try {
+        dynamoDb.describeTable(table.name)
+      } catch (e: Exception) {
+        logger.error(e) { "error performing DynamoDB health check for ${table.name}" }
+        return HealthStatus.unhealthy("DynamoDB: failed to describe ${table.name}")
+      }
+    }
+    return HealthStatus.healthy("DynamoDB")
+  }
+
+  companion object {
+    val logger = getLogger<DynamoDbHealthCheck>()
+  }
+}

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -7,22 +7,28 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreamsClientBuilder
 import com.google.inject.Provides
-import misk.cloud.aws.AwsRegion
-import misk.inject.KAbstractModule
 import javax.inject.Singleton
+import misk.cloud.aws.AwsRegion
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
 
 /**
  * Install this module to have access to an AmazonDynamoDB client. This can be
  * used to create a DynamoDbMapper for querying of a DynamoDb table.
  */
 class RealDynamoDbModule constructor(
-  private val clientConfig: ClientConfiguration = ClientConfiguration()
+  private val clientConfig: ClientConfiguration = ClientConfiguration(),
+  private val requiredTables: List<RequiredDynamoDbTable> = listOf()
 ) :
   KAbstractModule() {
   override fun configure() {
     requireBinding<AWSCredentialsProvider>()
     requireBinding<AwsRegion>()
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> = requiredTables
 
   @Provides @Singleton
   fun providesAmazonDynamoDB(

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
@@ -1,0 +1,11 @@
+package misk.dynamodb
+
+/**
+ * A table that must be available in the DynamoDB instance. If this table doesn't exist, the service
+ * will not start up.
+ *
+ * The table name is sometimes prefixed with the service name, like "urlshortener.urls".
+ */
+data class RequiredDynamoDbTable(
+  val name: String
+)

--- a/misk-aws2-dynamodb-testing/build.gradle.kts
+++ b/misk-aws2-dynamodb-testing/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation(Dependencies.awsDynamodbLocal)
   implementation(project(":misk"))
   implementation(project(":misk-aws"))
+  implementation(project(":misk-aws2-dynamodb"))
   implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
   implementation(project(":misk-service"))

--- a/misk-aws2-dynamodb-testing/src/main/kotlin/misk/aws2/dynamodb/testing/DockerDynamoDbModule.kt
+++ b/misk-aws2-dynamodb-testing/src/main/kotlin/misk/aws2/dynamodb/testing/DockerDynamoDbModule.kt
@@ -1,6 +1,9 @@
 package misk.aws2.dynamodb.testing
 
+import com.google.inject.Provides
+import javax.inject.Singleton
 import misk.ServiceModule
+import misk.aws2.dynamodb.RequiredDynamoDbTable
 import misk.inject.KAbstractModule
 import wisp.aws2.dynamodb.testing.LocalDynamoDb
 
@@ -28,4 +31,8 @@ class DockerDynamoDbModule(
     install(ServiceModule<CreateTablesService>())
     bind<LocalDynamoDb>().toInstance(DockerDynamoDb.localDynamoDb)
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
+    tables.map { RequiredDynamoDbTable(it.tableName) }
 }

--- a/misk-aws2-dynamodb-testing/src/main/kotlin/misk/aws2/dynamodb/testing/InProcessDynamoDbModule.kt
+++ b/misk-aws2-dynamodb-testing/src/main/kotlin/misk/aws2/dynamodb/testing/InProcessDynamoDbModule.kt
@@ -3,10 +3,11 @@ package misk.aws2.dynamodb.testing
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer
 import com.google.inject.Provides
+import javax.inject.Singleton
 import misk.ServiceModule
+import misk.aws2.dynamodb.RequiredDynamoDbTable
 import misk.inject.KAbstractModule
 import misk.inject.toKey
-import javax.inject.Singleton
 
 /**
  * Executes a DynamoDB service in-process per test. It clears the table content before each test
@@ -38,4 +39,8 @@ class InProcessDynamoDbModule(
       arrayOf("-inMemory", "-port", localDynamoDb.url.port.toString())
     )
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
+    tables.map { RequiredDynamoDbTable(it.tableName) }
 }

--- a/misk-aws2-dynamodb/build.gradle.kts
+++ b/misk-aws2-dynamodb/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
 
   implementation(Dependencies.guice)
   implementation(project(":misk-aws"))
+  implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
 }
 

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbHealthCheck.kt
@@ -1,0 +1,33 @@
+package misk.aws2.dynamodb
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest
+import wisp.logging.getLogger
+
+@Singleton
+class DynamoDbHealthCheck @Inject constructor(
+  private val dynamoDb: DynamoDbClient,
+  private val requiredTables: List<RequiredDynamoDbTable>,
+) : HealthCheck {
+  override fun status(): HealthStatus {
+    for (table in requiredTables) {
+      try {
+        dynamoDb.describeTable(DescribeTableRequest.builder()
+          .tableName(table.name)
+          .build())
+      } catch (e: Exception) {
+        logger.error(e) { "error performing DynamoDB health check for ${table.name}" }
+        return HealthStatus.unhealthy("DynamoDB: failed to describe ${table.name}")
+      }
+    }
+    return HealthStatus.healthy("DynamoDB")
+  }
+
+  companion object {
+    val logger = getLogger<DynamoDbHealthCheck>()
+  }
+}

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -1,24 +1,27 @@
 package misk.aws2.dynamodb
 
 import com.google.inject.Provides
+import javax.inject.Singleton
 import misk.cloud.aws.AwsRegion
+import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import javax.inject.Singleton
 
 /**
  * Install this module to have access to a DynamoDbClient.
  */
 class RealDynamoDbModule constructor(
   private val clientOverrideConfig: ClientOverrideConfiguration =
-    ClientOverrideConfiguration.builder().build()
+    ClientOverrideConfiguration.builder().build(),
+  private val requiredTables: List<RequiredDynamoDbTable> = listOf()
 ) : KAbstractModule() {
   override fun configure() {
     requireBinding<AwsCredentialsProvider>()
     requireBinding<AwsRegion>()
+    multibind<HealthCheck>().to<DynamoDbHealthCheck>()
   }
 
   @Provides @Singleton
@@ -32,4 +35,7 @@ class RealDynamoDbModule constructor(
       .overrideConfiguration(clientOverrideConfig)
       .build()
   }
+
+  @Provides @Singleton
+  fun provideRequiredTables(): List<RequiredDynamoDbTable> = requiredTables
 }

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RequiredDynamoDbTable.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RequiredDynamoDbTable.kt
@@ -1,0 +1,11 @@
+package misk.aws2.dynamodb
+
+/**
+ * A table that must be available in the DynamoDB instance. If this table doesn't exist, the service
+ * will not start up.
+ *
+ * The table name is sometimes prefixed with the service name, like "urlshortener.urls".
+ */
+data class RequiredDynamoDbTable(
+  val name: String
+)

--- a/misk-core/src/main/kotlin/misk/healthchecks/HealthCheck.kt
+++ b/misk-core/src/main/kotlin/misk/healthchecks/HealthCheck.kt
@@ -1,10 +1,8 @@
 package misk.healthchecks
 
-import misk.web.actions.ReadinessCheckAction
-
 /**
  * Allows users to define custom health checks. An app with a failing HealthCheck will fail the
- * readiness check in [ReadinessCheckAction], indicating that the app should not accept traffic.
+ * readiness check in `ReadinessCheckAction`, indicating that the app should not accept traffic.
  */
 interface HealthCheck {
   /**


### PR DESCRIPTION
This restores reverted PR #1937, using describeTable() instead
of listTables(). That endpoint requires a lot more configuration,
including wiring the table names all the way through.

This reverts commit c23012833a5d29ab515cd32c842d9e21064596f9.