### PR TITLE
Revert "Use FakeMetrics in MiskTestingServiceModule"

### DIFF
--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -28,6 +28,7 @@ class MoviesTestModule(
     install(LogCollectorModule())
     install(
       Modules.override(MiskTestingServiceModule()).with(
+        FakeClockModule(),
         MockTracingBackendModule()
       )
     )

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
@@ -11,9 +11,8 @@ import io.prometheus.client.Summary
  *
  * The only way to create an instance of this is with [FakeMetricsModule].
  */
-class FakeMetrics internal constructor(
-  private val registry: CollectorRegistry
-) : Metrics {
+class FakeMetrics internal constructor() : Metrics {
+  private val registry = CollectorRegistry(true)
 
   override fun counter(name: String, help: String?, labelNames: List<String>): Counter =
     Counter.build(name, help)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetricsModule.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetricsModule.kt
@@ -1,13 +1,10 @@
 package misk.metrics
 
-import io.prometheus.client.CollectorRegistry
 import misk.inject.KAbstractModule
 
 class FakeMetricsModule : KAbstractModule() {
   override fun configure() {
-    val collectorRegistry = CollectorRegistry(true)
-    bind<CollectorRegistry>().toInstance(collectorRegistry)
+    bind<FakeMetrics>().toInstance(FakeMetrics())
     bind<Metrics>().to<FakeMetrics>()
-    bind<FakeMetrics>().toInstance(FakeMetrics(collectorRegistry))
   }
 }

--- a/misk-testing/build.gradle.kts
+++ b/misk-testing/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
   api(project(":misk-actions"))
   api(project(":misk-core"))
   api(project(":misk-inject"))
-  api(project(":misk-metrics-testing"))
   api(project(":misk-service"))
 }
 

--- a/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
+++ b/misk-testing/src/main/kotlin/misk/MiskTestingServiceModule.kt
@@ -3,7 +3,6 @@ package misk
 import misk.concurrent.FakeSleeperModule
 import misk.environment.FakeEnvVarModule
 import misk.inject.KAbstractModule
-import misk.metrics.FakeMetricsModule
 import misk.random.FakeRandomModule
 import misk.resources.TestingResourceLoaderModule
 import misk.time.FakeClockModule
@@ -20,12 +19,11 @@ import misk.tokens.FakeTokenGeneratorModule
 class MiskTestingServiceModule : KAbstractModule() {
   override fun configure() {
     install(TestingResourceLoaderModule())
-    install(FakeClockModule())
     install(FakeEnvVarModule())
-    install(FakeMetricsModule())
-    install(FakeRandomModule())
+    install(FakeClockModule())
     install(FakeSleeperModule())
     install(FakeTickerModule())
+    install(FakeRandomModule())
     install(FakeTokenGeneratorModule())
     install(MiskCommonServiceModule())
   }

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -28,7 +28,6 @@ class MiskRealServiceModule : KAbstractModule() {
     install(TickerModule())
     install(TokenGeneratorModule())
     install(MiskCommonServiceModule())
-    install(PrometheusMetricsClientModule())
   }
 }
 
@@ -41,6 +40,7 @@ class MiskCommonServiceModule : KAbstractModule() {
     binder().requireExactBindingAnnotations()
     install(ExecutorsModule())
     install(ServiceManagerModule())
+    install(PrometheusMetricsClientModule())
     install(MoshiModule(useWireToRead = true, useWireToWrite = true))
 
     // Initialize empty sets for our multibindings.


### PR DESCRIPTION
Reverts cashapp/misk#1947

Unit tests should install it separately instead if they need metrics. 

