### PR TITLE
DynamoDbService, a service for other services to depend upon

### DIFF
--- a/misk-aws-dynamodb/build.gradle.kts
+++ b/misk-aws-dynamodb/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
   implementation(project(":misk-aws"))
   implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
+  implementation(project(":misk-service"))
 }
 
 afterEvaluate {

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbService.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbService.kt
@@ -1,0 +1,9 @@
+package misk.dynamodb
+
+import com.google.common.util.concurrent.Service
+
+/**
+ * Service that's running when DynamoDb is usable. Configure your service to depend on this service
+ * if it needs DynamoDb.
+ */
+interface DynamoDbService : Service

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -7,10 +7,13 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreamsClientBuilder
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Provides
+import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
+import misk.ServiceModule
 import misk.cloud.aws.AwsRegion
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
@@ -35,6 +38,8 @@ class RealDynamoDbModule constructor(
     requireBinding<AWSCredentialsProvider>()
     requireBinding<AwsRegion>()
     multibind<HealthCheck>().to<DynamoDbHealthCheck>()
+    bind<DynamoDbService>().to<RealDynamoDbService>()
+    install(ServiceModule<DynamoDbService>())
   }
 
   @Provides @Singleton
@@ -64,5 +69,12 @@ class RealDynamoDbModule constructor(
       .withCredentials(awsCredentialsProvider)
       .withClientConfiguration(clientConfig)
       .build()
+  }
+
+  /** We don't currently perform any startup work to connect to DynamoDB. */
+  @Singleton
+  private class RealDynamoDbService @Inject constructor() : AbstractService(), DynamoDbService {
+    override fun doStart() = notifyStarted()
+    override fun doStop() = notifyStopped()
   }
 }

--- a/misk-aws2-dynamodb/build.gradle.kts
+++ b/misk-aws2-dynamodb/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
   implementation(project(":misk-aws"))
   implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
+  implementation(project(":misk-service"))
 }
 
 afterEvaluate {

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbService.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/DynamoDbService.kt
@@ -1,0 +1,9 @@
+package misk.aws2.dynamodb
+
+import com.google.common.util.concurrent.Service
+
+/**
+ * Service that's running when DynamoDb is usable. Configure your service to depend on this service
+ * if it needs DynamoDb.
+ */
+interface DynamoDbService : Service

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -1,7 +1,10 @@
 package misk.aws2.dynamodb
 
+import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Provides
+import javax.inject.Inject
 import javax.inject.Singleton
+import misk.ServiceModule
 import misk.cloud.aws.AwsRegion
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
@@ -22,6 +25,8 @@ class RealDynamoDbModule constructor(
     requireBinding<AwsCredentialsProvider>()
     requireBinding<AwsRegion>()
     multibind<HealthCheck>().to<DynamoDbHealthCheck>()
+    bind<DynamoDbService>().to<RealDynamoDbService>()
+    install(ServiceModule<DynamoDbService>())
   }
 
   @Provides @Singleton
@@ -38,4 +43,11 @@ class RealDynamoDbModule constructor(
 
   @Provides @Singleton
   fun provideRequiredTables(): List<RequiredDynamoDbTable> = requiredTables
+
+  /** We don't currently perform any startup work to connect to DynamoDB. */
+  @Singleton
+  private class RealDynamoDbService @Inject constructor() : AbstractService(), DynamoDbService {
+    override fun doStart() = notifyStarted()
+    override fun doStop() = notifyStopped()
+  }
 }


### PR DESCRIPTION
This can be used with ServiceModule to ensure that DynamoDB is ready before
another service performs its own work.