### PR TITLE
Defer creating Service instances until dependencies are started

### DIFF
--- a/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -39,7 +39,7 @@ class CoordinatedServiceTest {
     service.startAsync()
 
     val failure = assertFailsWith<IllegalStateException> {
-      CoordinatedService(Provider<Service> { service })
+      CoordinatedService(Provider<Service> { service }).startAsync().awaitRunning()
     }
     assertThat(failure).hasMessage("Running Service must be NEW for it to be coordinated")
 

--- a/misk-service/src/test/kotlin/misk/ServiceManagerModuleTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceManagerModuleTest.kt
@@ -1,18 +1,20 @@
 package misk
 
 import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.AbstractService
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Guice
 import com.google.inject.Provides
 import com.google.inject.Scopes
 import com.google.inject.Singleton
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.inject.keyOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 internal class ServiceManagerModuleTest {
   @com.google.inject.Singleton
@@ -139,5 +141,72 @@ internal class ServiceManagerModuleTest {
         "misk.ServiceManagerModuleTest\$NonSingletonService1, " +
         "misk.ServiceManagerModuleTest\$NonSingletonService2"
     )
+  }
+
+  @Singleton
+  class ProducerService @Inject constructor(
+    private val log: StringBuilder
+  ) : AbstractService() {
+    init {
+      log.append("ProducerService.init\n")
+    }
+    override fun doStart() {
+      log.append("ProducerService.startUp\n")
+      notifyStarted()
+    }
+
+    override fun doStop() {
+      log.append("ProducerService.shutDown\n")
+      notifyStopped()
+    }
+  }
+
+  @Singleton
+  class ConsumerService @Inject constructor(
+    private val log: StringBuilder
+  ) : AbstractService() {
+    init {
+      log.append("ConsumerService.init\n")
+    }
+    override fun doStart() {
+      log.append("ConsumerService.startUp\n")
+      notifyStarted()
+    }
+
+    override fun doStop() {
+      log.append("ConsumerService.shutDown\n")
+      notifyStopped()
+    }
+  }
+
+  @Test fun serviceNotProvidedUntilDependenciesAllCreated() {
+    val log = StringBuilder()
+    val injector = Guice.createInjector(
+      MiskTestingServiceModule(),
+      object : KAbstractModule() {
+        override fun configure() {
+          bind<StringBuilder>().toInstance(log)
+          install(ServiceModule<ProducerService>())
+          install(ServiceModule<ConsumerService>().dependsOn<ProducerService>())
+        }
+      }
+    )
+
+    val serviceManager = injector.getInstance<ServiceManager>()
+    serviceManager.startAsync()
+    serviceManager.awaitHealthy()
+    log.append("healthy\n")
+    serviceManager.stopAsync()
+    serviceManager.awaitStopped()
+
+    assertThat(log.toString()).isEqualTo("""
+      |ProducerService.init
+      |ProducerService.startUp
+      |ConsumerService.init
+      |ConsumerService.startUp
+      |healthy
+      |ConsumerService.shutDown
+      |ProducerService.shutDown
+      |""".trimMargin())
   }
 }

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -33,7 +33,7 @@ class InvalidActionsTest {
     assertThrows<ProvisionException>(
       "Actions [SomeAction, IdenticalAction] have identical routing annotations."
     ) {
-      injector.getInstance(ServiceManager::class.java)
+      injector.getInstance(ServiceManager::class.java).startAsync().awaitHealthy()
     }
   }
 


### PR DESCRIPTION
This makes it easier to directly inject upstream dependencies without Providers
or other indirections.