### PR TITLE
Revert part #1958 to try and fix shutdown deadlock

### DIFF
--- a/misk-service/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk-service/src/main/kotlin/misk/CoordinatedService.kt
@@ -20,14 +20,14 @@ internal class CoordinatedService(
         created.addListener(
           object : Listener() {
             override fun running() {
-              synchronized(this@CoordinatedService) {
+              synchronized(this) {
                 notifyStarted()
               }
               downstreamServices.forEach { it.startIfReady() }
             }
 
             override fun terminated(from: State) {
-              synchronized(this@CoordinatedService) {
+              synchronized(this) {
                 notifyStopped()
               }
               upstreamServices.forEach { it.stopIfReady() }


### PR DESCRIPTION
The change to the synchronization lock object in #1958 appears
to have resulted in an intermittent deadlock. Tests that exercise
this code heavily frequently hit the deadlock and time out.
Details of the thread stacks during the deadlock can be found
in issue #1975.

This patch reverts the change to the synchronization lock object,
which appears incidental to the main change that was being made
in #1958. Hopefully this will fix the deadlock while retaining
the intended functional change. Follow-up PRs can be used to
implement a better solution.

Fixes #1975.