### PR TITLE
Resolve mkdocs build breakages

### DIFF
--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build mkdocs
         run: |
-          pip3 install mkdocs-macros-plugin
+          pip3 install mkdocs mkdocs-material mkdocs-macros-plugin
           mkdocs build
 
       - name: Deploy 🚀

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_name: Misk
 repo_url: https://github.com/cashapp/misk
 site_description: "Misk: Microservice Container for Kotlin"
 site_author: Square, Inc.
+site_url: ''
 remote_branch: gh-pages
 
 copyright: 'Copyright &copy; 2018-2021 Square, Inc.'


### PR DESCRIPTION
Closes #1984:
- explicitly installs mkdocs and mkdocs-material
- explicitly sets a blank site_url to resolve a warning

We can avoid this in the future by adding a requirements.txt with specific versions of mkdocs and friends. Could also use a virtualenv or [Hermit](https://github.com/cashapp/hermit) to make it testable locally.