### PR TITLE
Add OPA Policy gradle testing plugin

### DIFF
--- a/misk-policy-testing/build.gradle.kts
+++ b/misk-policy-testing/build.gradle.kts
@@ -1,14 +1,34 @@
+plugins {
+  `kotlin-dsl`
+}
+
 dependencies {
+  implementation(gradleApi())
+  implementation(Dependencies.docker)
   implementation(Dependencies.guice)
   implementation(Dependencies.loggingApi)
   implementation(Dependencies.moshiKotlin)
   implementation(project(":misk-inject"))
   implementation(project(":misk-policy"))
+  implementation(Dependencies.okio)
 
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.logbackClassic)
   testImplementation(project(":misk-testing"))
   testImplementation(Dependencies.mockitoCore)
+}
+
+gradlePlugin {
+  plugins {
+    create("opa-gradle-plugin") {
+      id = "misk.opa"
+      implementationClass = "misk.policy.opa.OpaTestPlugin"
+    }
+  }
+}
+
+kotlinDslPluginOptions {
+  experimentalWarning.set(false)
 }
 
 afterEvaluate {

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaTestPlugin.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaTestPlugin.kt
@@ -1,0 +1,81 @@
+package misk.policy.opa
+
+import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.Binds
+import com.github.dockerjava.api.model.Frame
+import com.github.dockerjava.api.model.HostConfig
+import com.github.dockerjava.api.model.Volume
+import com.github.dockerjava.core.DockerClientBuilder
+import com.github.dockerjava.core.async.ResultCallbackTemplate
+import com.github.dockerjava.core.command.WaitContainerResultCallback
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory
+import okio.Buffer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.create
+
+interface OpaTestConfig {
+  val policyDir: Property<String>
+}
+
+class OpaTestPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    val config: OpaTestConfig = project.extensions.create("opa")
+
+    val opaTestWithDocker = project.tasks.create("opaTestWithDocker") {
+      group = "OPA"
+      description = "Evaluate OPA tests via docker OPA instance"
+
+      doLast {
+        val dockerClient = DockerClientBuilder.getInstance()
+          .withDockerCmdExecFactory(NettyDockerCmdExecFactory())
+          .build()
+        val policyDir = project.projectDir.absolutePath + "/" + config.policyDir.get()
+        val containerId = dockerClient.createContainerCmd("openpolicyagent/opa")
+          .withCmd(listOf("test", "/repo", "-b", "--explain", "fails"))
+          .withHostConfig(
+            HostConfig.newHostConfig()
+              .withAutoRemove(true)
+              .withBinds(Binds(Bind(policyDir, Volume("/repo"))))
+          )
+          .withName("opa_tester")
+          .withTty(true)
+          .exec().id
+
+        dockerClient.startContainerCmd(containerId)
+          .withContainerId(containerId)
+          .exec()
+
+        val buffer = Buffer()
+        dockerClient.logContainerCmd(containerId)
+          .withSince(0)
+          .withStdErr(true)
+          .withStdOut(true)
+          .withFollowStream(true)
+          .exec(Callback(buffer))
+          .awaitStarted()
+          .awaitCompletion()
+
+        val awaitStatusCode = dockerClient.waitContainerCmd(containerId)
+          .withContainerId(containerId)
+          .exec(WaitContainerResultCallback())
+          .awaitStatusCode()
+
+        val logs = buffer.readUtf8()
+        if (awaitStatusCode != 0) {
+          throw IllegalStateException(logs)
+        }
+        println(logs)
+      }
+    }
+
+    project.tasks.getByName("check").dependsOn(opaTestWithDocker)
+  }
+
+  class Callback(val buffer: Buffer) : ResultCallbackTemplate<Callback, Frame>() {
+    override fun onNext(item: Frame) {
+      buffer.write(item.payload)
+    }
+  }
+}


### PR DESCRIPTION
Gradle plugin which is distributed with misk-policy-testing. The plugin will launch an opa docker container, make policy from the src/policy folder available and run `opa test` on the contents.

The point of this is to make CI testing of OPA policy as easy as possible for service owners. This allows us to simply add a dependency to on misk-policy-testing as part of the services buildscripts configuration and apply the plugin for the service. 