### PR TITLE
Downgrade gRPC requiring HTTP/2 check to log.warn

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -68,8 +68,12 @@ internal class WebActionsServlet @Inject constructor(
     }
     // Check http2 is enabled if any gRPC actions are bound.
     if (boundActions.any { it.action.dispatchMechanism == DispatchMechanism.GRPC }) {
-      check(config.http2) {
-        "HTTP/2 must be enabled if any gRPC actions are bound."
+      if(config.http2) {
+        log.warn { "HTTP/2 must be enabled if any gRPC actions are bound. " +
+          "This will cause an error in the future. Check these actions: " +
+          "${boundActions
+            .filter { it.action.dispatchMechanism == DispatchMechanism.GRPC  }
+            .map { it.action.name }}" }
       }
     }
   }

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -11,6 +11,7 @@ import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.web.actions.WebAction
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import javax.inject.Inject
@@ -50,7 +51,8 @@ class InvalidActionsTest {
     fun hello() = "hello"
   }
 
-  @Test fun failGrpcWithHttp2Disabled() {
+  // TODO (r3mariano): Fail with errors for real.
+  @Ignore @Test fun failGrpcWithHttp2Disabled() {
     val exception = assertThrows<ProvisionException>("Should throw an exception") {
       Guice.createInjector(GrpcActionsModule()).getInstance(ServiceManager::class.java)
         .startAsync().awaitHealthy()

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -11,7 +11,7 @@ import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.web.actions.WebAction
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import javax.inject.Inject
@@ -52,7 +52,7 @@ class InvalidActionsTest {
   }
 
   // TODO (r3mariano): Fail with errors for real.
-  @Ignore @Test fun failGrpcWithHttp2Disabled() {
+  @Disabled @Test fun failGrpcWithHttp2Disabled() {
     val exception = assertThrows<ProvisionException>("Should throw an exception") {
       Guice.createInjector(GrpcActionsModule()).getInstance(ServiceManager::class.java)
         .startAsync().awaitHealthy()


### PR DESCRIPTION
Also adds information about which actions to change.