### PR TITLE
Make RedisService not internal

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/RedisService.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisService.kt
@@ -7,7 +7,7 @@ import javax.inject.Singleton
 
 /** Controls the connection lifecycle for Redis. */
 @Singleton
-internal class RedisService @Inject internal constructor(
+class RedisService @Inject internal constructor(
   private val redisProvider: Provider<Redis>
 ) : AbstractIdleService() {
   // We initialize the client in startUp because creating the client will connect it to Redis


### PR DESCRIPTION
As a user of the `RedisService`, I want to be able to have another `ServiceModule`  depend on Redis being active. However since `RedisService` is currently an `internal` class, I'm unable to do this.

Proposing to make `RedisService` no longer `internal` so that users can access it. Please advise if there are other implications of this that I have not considered.