### PR TITLE
Always mask 5xx errors in WebActionExceptionMapper.kt

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,6 +37,7 @@ object Dependencies {
   val hopliteToml = "com.sksamuel.hoplite:hoplite-toml:1.4.0"
   val hopliteYaml = "com.sksamuel.hoplite:hoplite-yaml:1.4.0"
   val hsqldb = "org.hsqldb:hsqldb:2.4.0"
+  val httpComponentsCore5 = "org.apache.httpcomponents.core5:httpcore5:5.1.1"
   val jCommander = "com.beust:jcommander:1.72"
   val jacksonBom = "com.fasterxml.jackson:jackson-bom:2.12.2"
   val jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:2.12.2"

--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -45,12 +45,16 @@ open class WebActionException(
   /** The HTTP status code. Should be 400..599. */
   val code: Int,
   /**
-   * This is returned to the caller as is. Be mindful not to leak internal implementation details
-   * and possible vulnerabilities in the response body.
+   * This is returned to the caller as is for 4xx responses. 5xx responses are always masked.
+   * Be mindful not to leak internal implementation details and possible vulnerabilities in the
+   * response body.
    */
   val responseBody: String,
+  /**
+   * This is logged as the exception message.
+   */
   message: String,
-  cause: Throwable?
+  cause: Throwable? = null
 ) : Exception(message, cause) {
   val isClientError = code in (400..499)
   val isServerError = code in (500..599)
@@ -87,11 +91,17 @@ open class BadRequestException(message: String = "", cause: Throwable? = null) :
 open class ConflictException(message: String = "", cause: Throwable? = null) :
   WebActionException(HTTP_CONFLICT, message, message, cause)
 
+/** This exception is custom to Misk. */
 open class UnprocessableEntityException(message: String = "", cause: Throwable? = null) :
   WebActionException(422, message, message, cause)
 
+/** This exception is custom to Misk. */
 open class TooManyRequestsException(message: String = "", cause: Throwable? = null) :
   WebActionException(429, message, message, cause)
+
+/** This exception is custom to Misk. */
+open class ClientClosedRequestException(message: String = "", cause: Throwable? = null) :
+  WebActionException(499, message, message, cause)
 
 /**
  * Base exception for when a server is acting as a gateway and cannot get a response in time.

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   implementation(Dependencies.moshiCore)
   implementation(Dependencies.moshiKotlin)
   implementation(Dependencies.moshiAdapters)
+  implementation(Dependencies.httpComponentsCore5)
   implementation(Dependencies.jettyHttp2)
   implementation(Dependencies.jettyServer)
   implementation(Dependencies.jettyUnixSocket)


### PR DESCRIPTION
This brings the mapper back to parity with the deprecated
ActionExceptionMapper, and reduces the opportunity for leaking
internal details.

I added Apache HTTP Components to replace the enum-based message
with a generic status message.

This is a change of behaviour from https://github.com/cashapp/misk/pull/1801