### PR TITLE
Ensure service metadata environment is uppercased

### DIFF
--- a/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
@@ -7,7 +7,7 @@ import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
-import wisp.deployment.getDeploymentFromEnvironmentVariable
+import wisp.deployment.Deployment
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,9 +39,8 @@ class ServiceMetadataAction @Inject constructor(
    * https://github.com/google/guice/wiki/FrequentlyAskedQuestions#how-can-i-inject-optional-parameters-into-a-constructor
    */
   @Singleton
-  class OptionalBinder @Inject constructor(@AppName val appName: String) {
+  class OptionalBinder @Inject constructor(@AppName val appName: String, deployment: Deployment) {
     @com.google.inject.Inject(optional = true)
-    var serviceMetadata: ServiceMetadata =
-      ServiceMetadata(appName, getDeploymentFromEnvironmentVariable().name)
+    var serviceMetadata: ServiceMetadata = ServiceMetadata(appName, deployment.name.toUpperCase())
   }
 }

--- a/misk/src/test/kotlin/misk/web/metadata/ServiceMetadataActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/metadata/ServiceMetadataActionTest.kt
@@ -1,0 +1,62 @@
+package misk.web.metadata
+
+import com.squareup.moshi.Moshi
+import misk.client.HttpClientEndpointConfig
+import misk.client.HttpClientFactory
+import misk.moshi.adapter
+import misk.security.authz.FakeCallerAuthenticator
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.jetty.JettyService
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class ServiceMetadataActionTest {
+  @MiskTestModule
+  val module = MetadataTestingModule()
+
+  @Inject private lateinit var jetty: JettyService
+  @Inject private lateinit var httpClientFactory: HttpClientFactory
+  @Inject private lateinit var moshi: Moshi
+
+  @Test fun `service metadata environment uses correct case mapping`() {
+    val response = executeRequest()
+    assertThat(response.serviceMetadata.environment).isUpperCase
+  }
+
+  private fun executeRequest(
+    path: String = "/api/service/metadata",
+    service: String? = null,
+    user: String? = null,
+    capabilities: String? = null
+  ): ServiceMetadataAction.Response {
+    val client = createOkHttpClient()
+
+    val baseUrl = jetty.httpServerUrl
+    val requestBuilder = Request.Builder()
+      .url(baseUrl.resolve(path)!!)
+    service?.let {
+      requestBuilder.header(FakeCallerAuthenticator.SERVICE_HEADER, service)
+    }
+    user?.let {
+      requestBuilder.header(FakeCallerAuthenticator.USER_HEADER, user)
+    }
+    capabilities?.let {
+      requestBuilder.header(FakeCallerAuthenticator.CAPABILITIES_HEADER, capabilities)
+    }
+    val call = client.newCall(requestBuilder.build())
+    val response = call.execute()
+
+    val responseAdaptor = moshi.adapter<ServiceMetadataAction.Response>()
+    return responseAdaptor.fromJson(response.body!!.source())!!
+  }
+
+  private fun createOkHttpClient(): OkHttpClient {
+    val config = HttpClientEndpointConfig(jetty.httpServerUrl.toString())
+    return httpClientFactory.create(config)
+  }
+}


### PR DESCRIPTION
Misk Web expects an upper-cased environment from its service metadata ([ref](https://github.com/cashapp/misk-web/blob/f122ea6a19ee6ee16ca1a0f19929ccda53103335/packages/@misk/core/src/utilities/interfaces.ts#L39-L44)). 

For example, a response from `/api/service/metadata` should look like the following:

```
{"serviceMetadata":{"app_name":"example","environment":"PRODUCTION"}}
```

The recent removal of Environment (see https://github.com/cashapp/misk/pull/1967) caused this endpoint to start returning lowercase environment names. As a result, services with Misk Web UIs that choose to render their environment names could no longer do so.

This change fixes that regression and ensures compatibility with present versions of misk-web.

