### PR TITLE
Reinstate misk.feature.*

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -24,7 +24,7 @@ import misk.jobqueue.TransactionalJobQueue
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueConfig
 import misk.tasks.RepeatedTaskQueueFactory
-import wisp.feature.FeatureFlags
+import misk.feature.FeatureFlags
 import javax.inject.Inject
 
 /** [AwsSqsJobQueueModule] installs job queue support provided by SQS. */

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClient.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/FlaggedBufferedSqsClient.kt
@@ -6,8 +6,8 @@ import com.amazonaws.services.sqs.model.DeleteMessageRequest
 import com.amazonaws.services.sqs.model.DeleteMessageResult
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import com.amazonaws.services.sqs.model.SendMessageResult
-import wisp.feature.Feature
-import wisp.feature.FeatureFlags
+import misk.feature.Feature
+import misk.feature.FeatureFlags
 
 /**
  * Temporary shim for buffered and unbuffered [AmazonSQS] implementations, for feature-flagged rollout of buffered

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -17,8 +17,8 @@ import misk.tasks.RepeatedTaskQueue
 import misk.tasks.Status
 import misk.time.timed
 import misk.tracing.traceWithNewRootSpan
-import wisp.feature.Feature
-import wisp.feature.FeatureFlags
+import misk.feature.Feature
+import misk.feature.FeatureFlags
 import wisp.logging.getLogger
 import java.time.Duration
 import java.util.concurrent.CompletableFuture

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlags.kt
@@ -3,10 +3,11 @@ package misk.feature.testing
 import com.google.common.util.concurrent.AbstractIdleService
 import com.squareup.moshi.Moshi
 import misk.feature.FeatureService
-import wisp.feature.Attributes
+import misk.feature.Attributes
 import misk.feature.DynamicConfig
-import wisp.feature.Feature
+import misk.feature.Feature
 import misk.feature.FeatureFlags
+import misk.feature.toMisk
 import wisp.feature.toSafeJson
 import java.util.concurrent.Executor
 import javax.inject.Inject
@@ -16,7 +17,10 @@ import javax.inject.Singleton
  * In-memory test implementation of [FeatureFlags] that allows flags to be overridden.
  */
 @Singleton
-class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleService(), FeatureFlags, FeatureService, DynamicConfig {
+class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleService(),
+  FeatureFlags,
+  FeatureService,
+  DynamicConfig {
   companion object {
     const val KEY = "fake_dynamic_flag"
     val defaultAttributes = Attributes()
@@ -76,7 +80,7 @@ class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleServi
     attributes: Attributes,
     executor: Executor,
     tracker: (Boolean) -> Unit
-  ) = delegate.trackBoolean(feature, key, attributes, executor, tracker)
+  ) = delegate.trackBoolean(feature, key, attributes, executor, tracker).toMisk()
 
   override fun trackInt(
     feature: Feature,
@@ -84,7 +88,7 @@ class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleServi
     attributes: Attributes,
     executor: Executor,
     tracker: (Int) -> Unit
-  ) = delegate.trackInt(feature, key, attributes, executor, tracker)
+  ) = delegate.trackInt(feature, key, attributes, executor, tracker).toMisk()
 
   override fun trackString(
     feature: Feature,
@@ -92,7 +96,7 @@ class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleServi
     attributes: Attributes,
     executor: Executor,
     tracker: (String) -> Unit
-  ) = delegate.trackString(feature, key, attributes, executor, tracker)
+  ) = delegate.trackString(feature, key, attributes, executor, tracker).toMisk()
 
   override fun <T : Enum<T>> trackEnum(
     feature: Feature,
@@ -101,7 +105,7 @@ class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleServi
     attributes: Attributes,
     executor: Executor,
     tracker: (T) -> Unit
-  ) = delegate.trackEnum(feature, key, clazz, attributes, executor, tracker)
+  ) = delegate.trackEnum(feature, key, clazz, attributes, executor, tracker).toMisk()
 
   override fun <T> trackJson(
     feature: Feature,
@@ -110,39 +114,39 @@ class FakeFeatureFlags @Inject constructor(val moshi: Moshi) : AbstractIdleServi
     attributes: Attributes,
     executor: Executor,
     tracker: (T) -> Unit
-  ) = delegate.trackJson(feature, key, clazz, attributes, executor, tracker)
+  ) = delegate.trackJson(feature, key, clazz, attributes, executor, tracker).toMisk()
 
   override fun trackBoolean(
     feature: Feature,
     executor: Executor,
     tracker: (Boolean) -> Unit
-  ) = delegate.trackBoolean(feature, KEY, executor, tracker)
+  ) = delegate.trackBoolean(feature, KEY, executor, tracker).toMisk()
 
   override fun trackInt(
     feature: Feature,
     executor: Executor,
     tracker: (Int) -> Unit
-  ) = delegate.trackInt(feature, KEY, executor, tracker)
+  ) = delegate.trackInt(feature, KEY, executor, tracker).toMisk()
 
   override fun trackString(
     feature: Feature,
     executor: Executor,
     tracker: (String) -> Unit
-  ) = delegate.trackString(feature, KEY, executor, tracker)
+  ) = delegate.trackString(feature, KEY, executor, tracker).toMisk()
 
   override fun <T : Enum<T>> trackEnum(
     feature: Feature,
     clazz: Class<T>,
     executor: Executor,
     tracker: (T) -> Unit
-  ) = delegate.trackEnum(feature, KEY, clazz, executor, tracker)
+  ) = delegate.trackEnum(feature, KEY, clazz, executor, tracker).toMisk()
 
   override fun <T> trackJson(
     feature: Feature,
     clazz: Class<T>,
     executor: Executor,
     tracker: (T) -> Unit
-  ) = delegate.trackJson(feature, KEY, clazz, executor, tracker)
+  ) = delegate.trackJson(feature, KEY, clazz, executor, tracker).toMisk()
 
   fun override(
     feature: Feature,

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -6,8 +6,8 @@ import misk.ServiceModule
 import misk.feature.FeatureService
 import misk.inject.KAbstractModule
 import misk.inject.toKey
-import wisp.feature.DynamicConfig
-import wisp.feature.FeatureFlags
+import misk.feature.DynamicConfig
+import misk.feature.FeatureFlags
 import kotlin.reflect.KClass
 
 /**
@@ -24,10 +24,8 @@ class FakeFeatureFlagsModule(
     val key = FakeFeatureFlags::class.toKey(qualifier)
     bind(key).toInstance(testFeatureFlags)
     bind(FeatureFlags::class.toKey(qualifier)).to(key)
-    bind(misk.feature.FeatureFlags::class.toKey(qualifier)).to(key)
     bind(FeatureService::class.toKey(qualifier)).to(key)
     bind(DynamicConfig::class.toKey(qualifier)).to(key)
-    bind(misk.feature.DynamicConfig::class.toKey(qualifier)).to(key)
     install(ServiceModule(FeatureService::class.toKey(qualifier)))
     overrides.forEach {
       it.invoke(testFeatureFlags)

--- a/misk-feature-testing/src/test/java/misk/feature/testing/FakeFeatureFlagsJavaTest.java
+++ b/misk-feature-testing/src/test/java/misk/feature/testing/FakeFeatureFlagsJavaTest.java
@@ -6,8 +6,8 @@ import misk.inject.KAbstractModule;
 import misk.testing.MiskTest;
 import misk.testing.MiskTestModule;
 import org.junit.jupiter.api.Test;
-import wisp.feature.Attributes;
-import wisp.feature.Feature;
+import misk.feature.Attributes;
+import misk.feature.Feature;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -3,9 +3,9 @@ package misk.feature.testing
 import com.google.inject.Guice
 import misk.feature.testing.FakeFeatureFlagsTest.JsonFeature
 import org.junit.jupiter.api.Test
-import wisp.feature.Feature
-import wisp.feature.FeatureFlags
-import wisp.feature.getJson
+import misk.feature.Feature
+import misk.feature.FeatureFlags
+import misk.feature.getJson
 import kotlin.test.assertEquals
 
 class FakeFeatureFlagsModuleTest {

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsTest.kt
@@ -7,10 +7,10 @@ import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import wisp.feature.Attributes
-import wisp.feature.Feature
-import wisp.feature.getEnum
-import wisp.feature.getJson
+import misk.feature.Attributes
+import misk.feature.Feature
+import misk.feature.getEnum
+import misk.feature.getJson
 import javax.inject.Inject
 
 @MiskTest

--- a/misk-feature/src/main/kotlin/misk/feature/DynamicConfig.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/DynamicConfig.kt
@@ -1,3 +1,92 @@
 package misk.feature
 
-interface DynamicConfig : wisp.feature.DynamicConfig
+import java.util.concurrent.Executor
+
+/**
+ * Interface for evaluating dynamic flags. Dynamic flags are similar to feature flags, but they
+ * don't support different variations for different keys.
+ */
+interface DynamicConfig {
+  /**
+   * Returns the value of an boolean dynamic flag.
+   */
+  fun getBoolean(feature: Feature): Boolean
+
+  /**
+   * Returns the value of an integer dynamic flag.
+   */
+  fun getInt(feature: Feature): Int
+
+  /**
+   * Returns the value of a string dynamic flag.
+   */
+  fun getString(feature: Feature): String
+
+  /**
+   * Returns the value of an enumerated dynamic flag.
+   */
+  fun <T : Enum<T>> getEnum(feature: Feature, clazz: Class<T>): T
+
+  /**
+   * Returns the value of a JSON dynamic flag.
+   */
+  fun <T> getJson(feature: Feature, clazz: Class<T>): T
+
+  /**
+   * Registers a boolean dynamic config tracker which will be invoked whenever the boolean
+   * dynamic config changes value.
+   *
+   * Returns a tracker reference which can be used to un-register the tracker.
+   */
+  fun trackBoolean(feature: Feature, executor: Executor, tracker: (Boolean) -> Unit): TrackerReference
+
+  /**
+   * Registers a integer dynamic config tracker which will be invoked whenever the integer
+   * dynamic config changes value.
+   *
+   * Returns a tracker reference which can be used to un-register the tracker.
+   */
+  fun trackInt(feature: Feature, executor: Executor, tracker: (Int) -> Unit): TrackerReference
+
+  /**
+   * Registers a string dynamic config tracker which will be invoked whenever the string
+   * dynamic config changes value.
+   *
+   * Returns a tracker reference which can be used to un-register the tracker.
+   */
+  fun trackString(feature: Feature, executor: Executor, tracker: (String) -> Unit): TrackerReference
+
+  /**
+   * Registers a enum dynamic config tracker which will be invoked whenever the enum
+   * dynamic config changes value.
+   *
+   * Returns a tracker reference which can be used to un-register the tracker.
+   */
+  fun <T: Enum<T>>trackEnum(feature: Feature, clazz: Class<T>, executor: Executor, tracker: (T) -> Unit): TrackerReference
+
+  /**
+   * Registers a json dynamic config tracker which will be invoked whenever the json
+   * dynamic config changes value.
+   *
+   * Returns a tracker reference which can be used to un-register the tracker.
+   */
+  fun <T> trackJson(feature: Feature, clazz: Class<T>, executor: Executor, tracker: (T) -> Unit): TrackerReference
+}
+
+inline fun <reified T : Enum<T>> DynamicConfig.getEnum(
+  feature: Feature
+): T = getEnum(feature, T::class.java)
+
+inline fun <reified T : Enum<T>> DynamicConfig.trackEnum(
+  feature: Feature,
+  executor: Executor,
+  noinline tracker: (T) -> Unit
+): TrackerReference = trackEnum(feature, T::class.java, executor, tracker)
+
+inline fun <reified T> DynamicConfig.getJson(feature: Feature): T = getJson(feature, T::class.java)
+
+inline fun <reified T> DynamicConfig.trackJson(
+  feature: Feature,
+  executor: Executor,
+  noinline tracker: (T) -> Unit
+): TrackerReference = trackJson(feature, T::class.java, executor, tracker)

--- a/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/FeatureFlags.kt
@@ -1,3 +1,234 @@
 package misk.feature
 
-interface FeatureFlags : wisp.feature.FeatureFlags
+import java.util.concurrent.Executor
+
+/**
+ * Interface for evaluating feature flags.
+ */
+interface FeatureFlags {
+
+  /**
+   * Calculates the value of an boolean feature flag for the given key and attributes.
+   * @see [getEnum] for param details
+   */
+  fun getBoolean(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes()
+  ): Boolean
+
+  /**
+   * Calculates the value of an integer feature flag for the given key and attributes.
+   * @see [getEnum] for param details
+   */
+  fun getInt(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes()
+  ): Int
+
+  /**
+   * Calculates the value of a string feature flag for the given key and attributes.
+   * @see [getEnum] for param details
+   */
+  fun getString(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes()
+  ): String
+
+  /**
+   * Calculates the value of an enumerated feature flag for the given key and attributes.
+   * @param feature name of the feature flag to evaluate.
+   * @param key unique primary key for the entity the flag should be evaluated against.
+   * @param clazz the enum type.
+   * @param attributes additional attributes to provide to flag evaluation.
+   * @throws [RuntimeException] if the service is unavailable.
+   * @throws [IllegalStateException] if the flag is off with no default value.
+   */
+  fun <T : Enum<T>> getEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    attributes: Attributes = Attributes()
+  ): T
+
+  /**
+   * Calculates the value of a JSON feature flag for the given key and attributes.
+   *
+   * @param clazz the type to convert the JSON string into. It is expected that a Moshi type adapter
+   * is registered with the impl.
+   * @see [getEnum] for param details
+   */
+  fun <T> getJson(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    attributes: Attributes = Attributes()
+  ): T
+
+  /**
+   * Registers a tracker for the value of an boolean feature flag for the given key and attributes.
+   * @see [trackEnum] for param details
+   */
+  fun trackBoolean(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes(),
+    executor: Executor,
+    tracker: (Boolean) -> Unit
+  ): TrackerReference
+
+  /**
+   * Registers a tracker for the value of an integer feature flag for the given key and attributes.
+   * @see [trackEnum] for param details
+   */
+  fun trackInt(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes(),
+    executor: Executor,
+    tracker: (Int) -> Unit
+  ): TrackerReference
+
+  /**
+   * Registers a tracker for the value of a string feature flag for the given key and attributes.
+   * @see [trackEnum] for param details
+   */
+  fun trackString(
+    feature: Feature,
+    key: String,
+    attributes: Attributes = Attributes(),
+    executor: Executor,
+    tracker: (String) -> Unit
+  ): TrackerReference
+
+  /**
+   * Registers a tracker for the value of an enumerated feature flag for the given key and attributes.
+   * @param feature name of the feature flag to evaluate.
+   * @param key unique primary key for the entity the flag should be evaluated against.
+   * @param clazz the enum type.
+   * @param attributes additional attributes to provide to flag evaluation.
+   * @param tracker a tracker to be registered for processing of changed values
+   * @throws [RuntimeException] if the service is unavailable.
+   * @throws [IllegalStateException] if the flag is off with no default value.
+   * @return a reference to the registered tracker allowing to un-register it
+   */
+  fun <T : Enum<T>> trackEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    attributes: Attributes = Attributes(),
+    executor: Executor,
+    tracker: (T) -> Unit
+  ): TrackerReference
+
+  /**
+   * Registers a tracker for the value of a JSON feature flag for the given key and attributes.
+   *
+   * @param clazz the type to convert the JSON string into. It is expected that a Moshi type adapter
+   * is registered with the impl.
+   * @see [trackEnum] for param details
+   */
+  fun <T> trackJson(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    attributes: Attributes = Attributes(),
+    executor: Executor,
+    tracker: (T) -> Unit
+  ): TrackerReference
+
+  // Overloaded functions for use in Java, because @JvmOverloads isn't supported for interfaces
+  fun getBoolean(
+    feature: Feature,
+    key: String
+  ) = getBoolean(feature, key, Attributes())
+
+  fun getInt(
+    feature: Feature,
+    key: String
+  ) = getInt(feature, key, Attributes())
+
+  fun getString(
+    feature: Feature,
+    key: String
+  ) = getString(feature, key, Attributes())
+
+  fun <T : Enum<T>> getEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>
+  ) = getEnum(feature, key, clazz, Attributes())
+
+  fun <T> getJson(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>
+  ) = getJson(feature, key, clazz, Attributes())
+
+  fun trackBoolean(
+    feature: Feature,
+    key: String,
+    executor: Executor,
+    tracker: (Boolean) -> Unit
+  ) = trackBoolean(feature, key, Attributes(), executor, tracker)
+
+  fun trackInt(
+    feature: Feature,
+    key: String,
+    executor: Executor,
+    tracker: (Int) -> Unit
+  ) = trackInt(feature, key, Attributes(), executor, tracker)
+
+  fun trackString(
+    feature: Feature,
+    key: String,
+    executor: Executor,
+    tracker: (String) -> Unit
+  ) = trackString(feature, key, Attributes(), executor, tracker)
+
+  fun <T : Enum<T>> trackEnum(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    executor: Executor,
+    tracker: (T) -> Unit
+  ) = trackEnum(feature, key, clazz, Attributes(), executor, tracker)
+
+  fun <T> trackJson(
+    feature: Feature,
+    key: String,
+    clazz: Class<T>,
+    executor: Executor,
+    tracker: (T) -> Unit
+  ) = trackJson(feature, key, clazz, Attributes(), executor, tracker)
+}
+
+inline fun <reified T : Enum<T>> FeatureFlags.getEnum(
+  feature: Feature,
+  key: String,
+  attributes: Attributes = Attributes()
+): T = getEnum(feature, key, T::class.java, attributes)
+
+inline fun <reified T> FeatureFlags.getJson(
+  feature: Feature,
+  key: String,
+  attributes: Attributes = Attributes()
+): T = getJson(feature, key, T::class.java, attributes)
+
+inline fun <reified T : Enum<T>> FeatureFlags.trackEnum(
+  feature: Feature,
+  key: String,
+  attributes: Attributes = Attributes(),
+  executor: Executor,
+  noinline tracker: (T) -> Unit
+): TrackerReference = trackEnum(feature, key, T::class.java, attributes, executor, tracker)
+
+inline fun <reified T> FeatureFlags.trackJson(
+  feature: Feature,
+  key: String,
+  attributes: Attributes = Attributes(),
+  executor: Executor,
+  noinline tracker: (T) -> Unit
+): TrackerReference = trackJson(feature, key, T::class.java, attributes, executor, tracker)

--- a/misk-feature/src/main/kotlin/misk/feature/TrackerReference.kt
+++ b/misk-feature/src/main/kotlin/misk/feature/TrackerReference.kt
@@ -1,0 +1,12 @@
+package misk.feature
+
+interface TrackerReference : wisp.feature.TrackerReference
+
+fun wisp.feature.TrackerReference.toMisk(): TrackerReference {
+  val delegate = this
+  return object : TrackerReference {
+    override fun unregister() {
+      delegate.unregister()
+    }
+  }
+}

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyDynamicConfig.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyDynamicConfig.kt
@@ -1,8 +1,8 @@
 package misk.feature.launchdarkly
 
-import wisp.feature.Attributes
+import misk.feature.Attributes
 import misk.feature.DynamicConfig
-import wisp.feature.Feature
+import misk.feature.Feature
 import misk.feature.FeatureFlags
 import java.util.concurrent.Executor
 import javax.inject.Singleton

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -11,10 +11,10 @@ import com.squareup.moshi.Moshi
 import wisp.feature.FeatureFlagValidation
 import misk.feature.FeatureService
 import mu.KotlinLogging
-import wisp.feature.Attributes
-import wisp.feature.Feature
+import misk.feature.Attributes
+import misk.feature.Feature
 import misk.feature.FeatureFlags
-import wisp.feature.TrackerReference
+import misk.feature.TrackerReference
 import wisp.feature.fromSafeJson
 import java.util.concurrent.Executor
 import javax.inject.Inject

--- a/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
+++ b/misk-launchdarkly-core/src/test/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsTest.kt
@@ -20,11 +20,11 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import wisp.feature.Attributes
-import wisp.feature.Feature
-import wisp.feature.FeatureFlags
-import wisp.feature.getEnum
-import wisp.feature.getJson
+import misk.feature.Attributes
+import misk.feature.Feature
+import misk.feature.FeatureFlags
+import misk.feature.getEnum
+import misk.feature.getJson
 
 internal class LaunchDarklyFeatureFlagsTest {
   private val client = mock(LDClientInterface::class.java)

--- a/misk-launchdarkly/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsModule.kt
+++ b/misk-launchdarkly/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsModule.kt
@@ -14,8 +14,8 @@ import misk.resources.ResourceLoader
 import misk.security.ssl.SslContextFactory
 import misk.security.ssl.SslLoader
 import wisp.config.Config
-import wisp.feature.DynamicConfig
-import wisp.feature.FeatureFlags
+import misk.feature.DynamicConfig
+import misk.feature.FeatureFlags
 import java.net.URI
 import java.time.Duration
 import javax.inject.Provider


### PR DESCRIPTION
The delegates still exist, so there's still  core functionality outside Misk, albeit somewhat duplicated.