### PR TITLE
Uppercase service metadata environment in response

### DIFF
--- a/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/ServiceMetadataAction.kt
@@ -23,9 +23,12 @@ class ServiceMetadataAction @Inject constructor(
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
   fun getAll(): Response {
-    return Response(
-      serviceMetadata = optionalBinder.serviceMetadata
-    )
+    // Misk-web expects an UPPERCASE environment. Since this action could get a serviceMetadata
+    // object from anywhere, it must be transformed here.
+    val metadata = with(optionalBinder.serviceMetadata) {
+      copy(environment = this.environment.toUpperCase())
+    }
+    return Response(serviceMetadata = metadata)
   }
 
   data class ServiceMetadata(
@@ -41,6 +44,6 @@ class ServiceMetadataAction @Inject constructor(
   @Singleton
   class OptionalBinder @Inject constructor(@AppName val appName: String, deployment: Deployment) {
     @com.google.inject.Inject(optional = true)
-    var serviceMetadata: ServiceMetadata = ServiceMetadata(appName, deployment.name.toUpperCase())
+    var serviceMetadata: ServiceMetadata = ServiceMetadata(appName, deployment.name)
   }
 }


### PR DESCRIPTION
This is a follow-up to #2013. Turns out that my previous patch was not sufficient, because serviceMetadata can be provided from anywhere.

This small patch moves the case mapping to the response construction, which ensures it cannot be overridden by other serviceMetadata providers.