### PR TITLE
Support Customization of gRPC status by mappers

### DIFF
--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
@@ -25,7 +25,6 @@ import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
-import org.awaitility.kotlin.withPollDelay
 import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -130,7 +129,7 @@ class MiskClientMiskServerTest {
       val e = assertFailsWith<GrpcException> {
         routeGuide.GetFeature().execute(point)
       }
-      assertThat(e.grpcMessage).isEqualTo("Internal Server Error")
+      assertThat(e.grpcMessage).isEqualTo("unexpected latitude error!")
       assertThat(e.grpcStatus).isEqualTo(GrpcStatus.UNKNOWN)
 
       // Assert that _metrics_ counted a 500 and no 200s, even though an HTTP 200 was returned

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -44,10 +44,10 @@ class ExceptionHandlingInterceptor(
       chain.proceed(chain.httpCall)
     } catch (th: Throwable) {
       val response = toResponse(th)
-      chain.httpCall.statusCode = response.statusCode
       if (chain.httpCall.dispatchMechanism == DispatchMechanism.GRPC) {
-        sendGrpcFailure(chain.httpCall, response)
+        sendGrpcFailure(chain.httpCall, response.statusCode, toGrpcResponse(th))
       } else {
+        chain.httpCall.statusCode = response.statusCode
         sendHttpFailure(chain.httpCall, response)
       }
     }
@@ -67,16 +67,18 @@ class ExceptionHandlingInterceptor(
    * One thing to note is for our metrics we want to pretend that the HTTP code is what we sent.
    * Otherwise gRPC requests that crashed and yielded an HTTP 200 code will confuse operators.
    */
-  private fun sendGrpcFailure(httpCall: HttpCall, response: Response<*>) {
-    httpCall.setStatusCodes(httpCall.statusCode, 200)
+  private fun sendGrpcFailure(httpCall: HttpCall, httpStatus: Int, response: GrpcErrorResponse) {
+    // set the statusCode to what we would've sent for an HTTP error so that metrics on HTTP
+    // status continue to count errors, instead of forcing them all to "200" on account of gRPC.
+    httpCall.setStatusCodes(httpStatus, 200)
     httpCall.requireTrailers()
     httpCall.setResponseHeader("grpc-encoding", "identity")
     httpCall.setResponseHeader("Content-Type", MediaTypes.APPLICATION_GRPC)
     httpCall.setResponseTrailer(
       "grpc-status",
-      toGrpcStatus(response.statusCode).code.toString()
+      response.status.code.toString()
     )
-    httpCall.setResponseTrailer("grpc-message", this.grpcMessage(response))
+    httpCall.setResponseTrailer("grpc-message", response.message ?: response.status.name)
     httpCall.takeResponseBody()?.use { responseBody: BufferedSink ->
       GrpcMessageSink(responseBody, ProtoAdapter.BYTES, grpcEncoding = "identity")
         .use { messageSink ->
@@ -91,20 +93,6 @@ class ExceptionHandlingInterceptor(
     return buffer.readUtf8()
   }
 
-  /** https://grpc.github.io/grpc/core/md_doc_http-grpc-status-mapping.html */
-  private fun toGrpcStatus(statusCode: Int): GrpcStatus {
-    return when (statusCode) {
-      400 -> GrpcStatus.INTERNAL
-      401 -> GrpcStatus.UNAUTHENTICATED
-      403 -> GrpcStatus.PERMISSION_DENIED
-      404 -> GrpcStatus.UNIMPLEMENTED
-      429 -> GrpcStatus.UNAVAILABLE
-      502 -> GrpcStatus.UNAVAILABLE
-      503 -> GrpcStatus.UNAVAILABLE
-      504 -> GrpcStatus.UNAVAILABLE
-      else -> GrpcStatus.UNKNOWN
-    }
-  }
 
   private fun toResponse(th: Throwable): Response<*> = when (th) {
     is UnauthenticatedException -> UNAUTHENTICATED_RESPONSE
@@ -115,6 +103,23 @@ class ExceptionHandlingInterceptor(
       log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
       it.toResponse(th)
     } ?: toInternalServerError(th)
+  }
+
+  private fun toGrpcResponse(th: Throwable): GrpcErrorResponse = when (th) {
+    is UnauthenticatedException -> GrpcErrorResponse(GrpcStatus.UNAUTHENTICATED, th.message)
+    is UnauthorizedException -> GrpcErrorResponse(GrpcStatus.PERMISSION_DENIED, th.message)
+    is InvocationTargetException -> toGrpcResponse(th.targetException)
+    is UncheckedExecutionException -> toGrpcResponse(th.cause!!)
+    else -> mapperResolver.mapperFor(th)?.let {
+      log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+      val grpcResponse = it.toGrpcResponse(th)
+      if (grpcResponse == null) {
+        val httpResponse = toResponse(th)
+        GrpcErrorResponse(toGrpcStatus(httpResponse.statusCode), grpcMessage(httpResponse))
+      } else {
+        grpcResponse
+      }
+    } ?: GrpcErrorResponse.INTERNAL_SERVER_ERROR
   }
 
   private fun toInternalServerError(th: Throwable): Response<*> {
@@ -148,5 +153,20 @@ class ExceptionHandlingInterceptor(
       listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap().toHeaders(),
       HttpURLConnection.HTTP_FORBIDDEN
     )
+  }
+}
+
+/** https://grpc.github.io/grpc/core/md_doc_http-grpc-status-mapping.html */
+fun toGrpcStatus(statusCode: Int): GrpcStatus {
+  return when (statusCode) {
+    400 -> GrpcStatus.INTERNAL
+    401 -> GrpcStatus.UNAUTHENTICATED
+    403 -> GrpcStatus.PERMISSION_DENIED
+    404 -> GrpcStatus.UNIMPLEMENTED
+    429 -> GrpcStatus.UNAVAILABLE
+    502 -> GrpcStatus.UNAVAILABLE
+    503 -> GrpcStatus.UNAVAILABLE
+    504 -> GrpcStatus.UNAVAILABLE
+    else -> GrpcStatus.UNKNOWN
   }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionMapper.kt
@@ -18,6 +18,13 @@ interface ExceptionMapper<in T : Throwable> {
   // then the action method return value
   fun toResponse(th: T): Response<ResponseBody>
 
+  // gRPC has a different response mechanism where it leaves the body empty, sends HTTP 200, and
+  // sets two _headers_, :grpc-status and :grpc-message. ExceptionMappers can _optionally_ override
+  // toGrpcResponse to have more control over the status and message returned to gRPC clients.
+  // If not overridden, a default mapping will be used that converts the HTTP status to a gRPC
+  // status and puts the ResponseBody text in :grpc-message.
+  fun toGrpcResponse(th: T): GrpcErrorResponse? = null
+
   /**
    * @return the level at which the given exception should be logged. defaults to ERROR but can
    * be overridden by the mapper for the given exception

--- a/misk/src/main/kotlin/misk/web/exceptions/GrpcErrorResponse.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/GrpcErrorResponse.kt
@@ -1,0 +1,9 @@
+package misk.web.exceptions
+
+import com.squareup.wire.GrpcStatus
+
+data class GrpcErrorResponse(val status: GrpcStatus, val message: String?) {
+  companion object {
+    val INTERNAL_SERVER_ERROR = GrpcErrorResponse(GrpcStatus.UNKNOWN, "internal server error")
+  }
+}

--- a/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
@@ -26,6 +26,10 @@ internal class WebActionExceptionMapper @Inject internal constructor(
     return Response(message.toResponseBody(), HEADERS, statusCode = th.code)
   }
 
+  override fun toGrpcResponse(th: WebActionException): GrpcErrorResponse {
+    return GrpcErrorResponse(toGrpcStatus(th.code), th.responseBody)
+  }
+
   private fun friendlyMessage(code: Int): String =
     EnglishReasonPhraseCatalog.INSTANCE.getReason(code, Locale.ENGLISH)
 


### PR DESCRIPTION
Instead of always mapping an HTTP status code to a gRPC status, give ExceptionMappers a chance to
explicitly produce a gRPC status and message. This gives us more fine-grained control over exactly
what gets returned in :grpc-message headers.

In particular, we want to return the raw exception message in gRPC responses while still masking it
for HTTP responses. This is because gRPC clients are generally internal, while HTTP clients may be
external organizations that we don't want to leak internal information to.