### PR TITLE
misk-policy-testing: Add OpaDevelopmentModule

### DIFF
--- a/misk-policy-testing/build.gradle.kts
+++ b/misk-policy-testing/build.gradle.kts
@@ -1,16 +1,14 @@
-plugins {
-  `kotlin-dsl`
-}
-
 dependencies {
   implementation(Dependencies.guice)
-  implementation(Dependencies.loggingApi)
   implementation(Dependencies.moshiKotlin)
+  implementation(Dependencies.docker)
+  implementation(Dependencies.okio)
+  implementation(Dependencies.loggingApi)
   implementation(project(":misk-inject"))
-  implementation(project(":misk-policy"))
+  api(project(":misk-policy"))
+  api(project(":misk-service"))
 
   testImplementation(Dependencies.assertj)
-  testImplementation(Dependencies.logbackClassic)
   testImplementation(project(":misk-testing"))
   testImplementation(Dependencies.mockitoCore)
 }

--- a/misk-policy-testing/build.gradle.kts
+++ b/misk-policy-testing/build.gradle.kts
@@ -4,6 +4,8 @@ dependencies {
   implementation(Dependencies.docker)
   implementation(Dependencies.okio)
   implementation(Dependencies.loggingApi)
+  implementation(Dependencies.okHttp)
+  implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
   api(project(":misk-policy"))
   api(project(":misk-service"))

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.model.Bind
 import com.github.dockerjava.api.model.Binds
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Frame
+import com.github.dockerjava.api.model.HealthCheck
 import com.github.dockerjava.api.model.HostConfig
 import com.github.dockerjava.api.model.PortBinding
 import com.github.dockerjava.api.model.Ports
@@ -39,6 +40,12 @@ class LocalOpaService(
   override fun startUp() {
     val policyDir = File(policyPath).absolutePath
 
+    try {
+      dockerClient.pingCmd().exec()
+    } catch(e: Exception) {
+      throw IllegalStateException("Couldn't connect to Docker daemon", e)
+    }
+
     // Pull the image to the local docker registry.
     dockerClient.pullImageCmd(OPA_DOCKER_IMAGE).exec(PullImageResultCallback())
       .awaitCompletion()
@@ -61,6 +68,7 @@ class LocalOpaService(
             PortBinding(Ports.Binding.bindPort(OPA_EXPOSED_PORT), ExposedPort.tcp(OPA_EXPOSED_PORT))
           )
       )
+//      .withHealthcheck(HealthCheck())
       .withExposedPorts(ExposedPort.tcp(OPA_EXPOSED_PORT))
       .withName(OPA_CONTAINER_NAME)
       .withTty(true)

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
@@ -124,7 +124,7 @@ class LocalOpaService(
       {
         val client = OkHttpClient()
         val request = Request.Builder()
-          .url("http://localhost:8181/health")
+          .url("http://localhost:$OPA_EXPOSED_PORT/health")
           .build()
 
         client.newCall(request).execute().use { response ->

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
@@ -1,0 +1,98 @@
+package misk.policy.opa
+
+import com.github.dockerjava.api.DockerClient
+import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.Binds
+import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.Frame
+import com.github.dockerjava.api.model.HealthCheck
+import com.github.dockerjava.api.model.HostConfig
+import com.github.dockerjava.api.model.PortBinding
+import com.github.dockerjava.api.model.Ports
+import com.github.dockerjava.api.model.Volume
+import com.github.dockerjava.core.DockerClientBuilder
+import com.github.dockerjava.core.async.ResultCallbackTemplate
+import com.github.dockerjava.core.command.PullImageResultCallback
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory
+import com.google.common.util.concurrent.AbstractIdleService
+import okio.Buffer
+import wisp.logging.getLogger
+import java.io.File
+import javax.inject.Singleton
+
+@Singleton
+class LocalOpaService(
+  private val policyPath: String = DEFAULT_POLICY_DIRECTORY
+) : AbstractIdleService() {
+  private var containerId: String = ""
+  private val dockerClient: DockerClient = DockerClientBuilder.getInstance()
+    .withDockerCmdExecFactory(NettyDockerCmdExecFactory())
+    .build()
+
+  companion object {
+    const val DEFAULT_POLICY_DIRECTORY = "service/src/policy"
+    const val OPA_DOCKER_IMAGE = "openpolicyagent/opa:latest-debug"
+    const val OPA_CONTAINER_NAME = "opa_development"
+    const val OPA_EXPOSED_PORT = 8181
+
+    private val logger = getLogger<LocalOpaService>()
+  }
+
+  override fun startUp() {
+    val policyDir = File(policyPath).absolutePath
+
+    // Pull the image to the local docker registry.
+    dockerClient.pullImageCmd(OPA_DOCKER_IMAGE).exec(PullImageResultCallback())
+      .awaitCompletion()
+    // Remove any stale test container.
+    dockerClient.listContainersCmd()
+      .withNameFilter(listOf(OPA_CONTAINER_NAME))
+      .withShowAll(true)
+      .exec()
+      .forEach { container ->
+        dockerClient.removeContainerCmd(container.id).withForce(true).exec()
+      }
+
+    // Create a new test container.
+    containerId = dockerClient.createContainerCmd(OPA_DOCKER_IMAGE)
+      .withCmd(listOf("run", "-b", "-s", "/repo"))
+      .withHostConfig(
+        HostConfig.newHostConfig()
+          .withBinds(Binds(Bind(policyDir, Volume("/repo"))))
+          .withPortBindings(
+            PortBinding(Ports.Binding.bindPort(OPA_EXPOSED_PORT), ExposedPort.tcp(OPA_EXPOSED_PORT))
+          )
+      )
+      .withExposedPorts(ExposedPort.tcp(OPA_EXPOSED_PORT))
+      .withName(OPA_CONTAINER_NAME)
+      .withTty(true)
+      .exec().id
+
+    // Start the container and let it run.
+    dockerClient.startContainerCmd(containerId)
+      .withContainerId(containerId)
+      .exec()
+
+    // Attach an okio backed buffer to dump the container logs.
+    dockerClient.logContainerCmd(containerId)
+      .withSince(0)
+      .withStdErr(true)
+      .withStdOut(true)
+      .withFollowStream(true)
+      .exec(Callback())
+      .awaitStarted()
+  }
+
+  override fun shutDown() {
+    dockerClient.removeContainerCmd(containerId).withForce(true).exec()
+  }
+
+  class Callback : ResultCallbackTemplate<Callback, Frame>() {
+    private val buffer: Buffer = Buffer()
+
+    override fun onNext(item: Frame) {
+      buffer.write(item.payload)
+      logger.info(buffer.readUtf8())
+    }
+  }
+}

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.Bind
 import com.github.dockerjava.api.model.Binds
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Frame
-import com.github.dockerjava.api.model.HealthCheck
 import com.github.dockerjava.api.model.HostConfig
 import com.github.dockerjava.api.model.PortBinding
 import com.github.dockerjava.api.model.Ports
@@ -18,10 +17,10 @@ import com.google.common.util.concurrent.AbstractIdleService
 import okio.Buffer
 import wisp.logging.getLogger
 import java.io.File
-import javax.inject.Singleton
 
 class LocalOpaService(
-  private val policyPath: String
+  private val policyPath: String,
+  private val withLogging: Boolean
 ) : AbstractIdleService() {
   private var containerId: String = ""
   private val dockerClient: DockerClient = DockerClientBuilder.getInstance()
@@ -73,13 +72,15 @@ class LocalOpaService(
       .exec()
 
     // Attach an okio backed buffer to dump the container logs.
-    dockerClient.logContainerCmd(containerId)
-      .withSince(0)
-      .withStdErr(true)
-      .withStdOut(true)
-      .withFollowStream(true)
-      .exec(Callback())
-      .awaitStarted()
+    if (withLogging) {
+      dockerClient.logContainerCmd(containerId)
+        .withSince(0)
+        .withStdErr(true)
+        .withStdOut(true)
+        .withFollowStream(true)
+        .exec(Callback())
+        .awaitStarted()
+    }
   }
 
   override fun shutDown() {

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/LocalOpaService.kt
@@ -20,9 +20,8 @@ import wisp.logging.getLogger
 import java.io.File
 import javax.inject.Singleton
 
-@Singleton
 class LocalOpaService(
-  private val policyPath: String = DEFAULT_POLICY_DIRECTORY
+  private val policyPath: String
 ) : AbstractIdleService() {
   private var containerId: String = ""
   private val dockerClient: DockerClient = DockerClientBuilder.getInstance()

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
@@ -1,0 +1,10 @@
+package misk.policy.opa
+
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+
+class OpaDevelopmentModule : KAbstractModule() {
+  override fun configure() {
+    install(ServiceModule<LocalOpaService>())
+  }
+}

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
@@ -2,9 +2,14 @@ package misk.policy.opa
 
 import misk.ServiceModule
 import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.policy.opa.LocalOpaService.Companion.DEFAULT_POLICY_DIRECTORY
 
-class OpaDevelopmentModule : KAbstractModule() {
+class OpaDevelopmentModule(
+  private val policyDirectory : String = DEFAULT_POLICY_DIRECTORY
+) : KAbstractModule() {
   override fun configure() {
     install(ServiceModule<LocalOpaService>())
+    bind(keyOf<LocalOpaService>()).toInstance(LocalOpaService(policyDirectory))
   }
 }

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
@@ -6,10 +6,11 @@ import misk.inject.keyOf
 import misk.policy.opa.LocalOpaService.Companion.DEFAULT_POLICY_DIRECTORY
 
 class OpaDevelopmentModule(
-  private val policyDirectory : String = DEFAULT_POLICY_DIRECTORY
+  private val policyDirectory: String = DEFAULT_POLICY_DIRECTORY,
+  private val withLogging: Boolean = false
 ) : KAbstractModule() {
   override fun configure() {
     install(ServiceModule<LocalOpaService>())
-    bind(keyOf<LocalOpaService>()).toInstance(LocalOpaService(policyDirectory))
+    bind(keyOf<LocalOpaService>()).toInstance(LocalOpaService(policyDirectory, withLogging))
   }
 }

--- a/misk-policy/build.gradle.kts
+++ b/misk-policy/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   api(project(":wisp-logging"))
 
   testImplementation(Dependencies.assertj)
-  testImplementation(Dependencies.logbackClassic)
   testImplementation(project(":misk-testing"))
   testImplementation(Dependencies.mockitoCore)
   testImplementation(Dependencies.retrofitMock)


### PR DESCRIPTION
The OpaDevelopmentModule will stand up a docker container, running OPA as a side service. With this, local development may run against the real service policy.