### PR TITLE
Reinstate WebActionExceptionMapper sending a response body based on…

### DIFF
--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -14,9 +14,8 @@ open class WebActionException(
   /** The HTTP status code. Should be 400..599. */
   val code: Int,
   /**
-   * This is returned to the caller as is for 4xx responses. 5xx responses are always masked.
-   * Be mindful not to leak internal implementation details and possible vulnerabilities in the
-   * response body.
+   * This is returned to the caller as is. Be mindful not to leak internal implementation details
+   * and possible vulnerabilities in the response body.
    */
   val responseBody: String,
   /**

--- a/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/ExceptionMapperTest.kt
@@ -41,10 +41,10 @@ internal class ExceptionMapperTest {
   }
 
   @Test
-  fun masksMessageOnServerError() {
+  fun returnsMessageOnServerError() {
     val response = get("/throws/action/503")
     assertThat(response.code).isEqualTo(HTTP_UNAVAILABLE)
-    assertThat(response.body?.string()).isEqualTo("Service Unavailable")
+    assertThat(response.body?.string()).isEqualTo("you asked for an error")
   }
 
   @Test


### PR DESCRIPTION
…the WebActionException's responseBody

This turned out to be a useful feature.

Partially reverts e60e0ef.