### PR TITLE
When evaluating JSON LD feature flags, log unknown fields once 

### DIFF
--- a/misk-launchdarkly-core/build.gradle.kts
+++ b/misk-launchdarkly-core/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   testImplementation(Dependencies.mockitoCore)
   testImplementation(Dependencies.moshiKotlin)
   testImplementation(Dependencies.moshiAdapters)
+  testImplementation(project(":wisp-logging-testing"))
 }
 
 afterEvaluate {

--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -7,6 +7,7 @@ import com.launchdarkly.sdk.LDUser
 import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface
 import com.launchdarkly.shaded.com.google.common.base.Preconditions.checkState
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import wisp.feature.FeatureFlagValidation
 import misk.feature.FeatureService
@@ -29,6 +30,9 @@ class LaunchDarklyFeatureFlags @Inject constructor(
   private val ldClient: LDClientInterface,
   private val moshi: Moshi
 ) : AbstractIdleService(), FeatureFlags, FeatureService {
+
+  private var featuresWithMigrationWarnings: List<Feature> = listOf()
+
   override fun startUp() {
     var attempts = 300
     val intervalMillis = 100L
@@ -120,7 +124,9 @@ class LaunchDarklyFeatureFlags @Inject constructor(
       LDValue.ofNull()
     )
     checkDefaultNotUsed(feature, result)
-    return moshi.adapter(clazz).fromSafeJson(result.value.toJsonString())
+    return moshi.adapter(clazz).fromSafeJson(result.value.toJsonString()) {
+      logJsonMigrationWarningOnce(feature, it)
+    }
       ?: throw IllegalArgumentException("null value deserialized from $feature")
   }
 
@@ -154,7 +160,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     attributes: Attributes,
     executor: Executor,
     tracker: (Boolean) -> Unit
-  ) = track(feature, key, attributes, { it.booleanValue() }, executor, tracker )
+  ) = track(feature, key, attributes, { it.booleanValue() }, executor, tracker)
 
   override fun trackDouble(
     feature: Feature,
@@ -162,7 +168,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     attributes: Attributes,
     executor: Executor,
     tracker: (Double) -> Unit
-  ) = track(feature, key, attributes, { it.doubleValue() }, executor, tracker )
+  ) = track(feature, key, attributes, { it.doubleValue() }, executor, tracker)
 
   override fun trackInt(
     feature: Feature,
@@ -170,7 +176,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     attributes: Attributes,
     executor: Executor,
     tracker: (Int) -> Unit
-  ) = track(feature, key, attributes, { it.intValue() }, executor, tracker )
+  ) = track(feature, key, attributes, { it.intValue() }, executor, tracker)
 
   override fun trackString(
     feature: Feature,
@@ -178,7 +184,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     attributes: Attributes,
     executor: Executor,
     tracker: (String) -> Unit
-  ) = track(feature, key, attributes, { it.stringValue() }, executor, tracker )
+  ) = track(feature, key, attributes, { it.stringValue() }, executor, tracker)
 
   override fun <T : Enum<T>> trackEnum(
     feature: Feature,
@@ -207,7 +213,11 @@ class LaunchDarklyFeatureFlags @Inject constructor(
     feature,
     key,
     attributes,
-    { moshi.adapter(clazz).fromSafeJson(it.toJsonString())!! },
+    {
+      moshi.adapter(clazz).fromSafeJson(it.toJsonString()) {
+        logJsonMigrationWarningOnce(feature, it)
+      }!!
+    },
     executor,
     tracker
   )
@@ -277,6 +287,16 @@ class LaunchDarklyFeatureFlags @Inject constructor(
       builder.anonymous(true)
     }
     return builder.build()
+  }
+
+  private fun logJsonMigrationWarningOnce(feature: Feature, exception: JsonDataException) {
+    if (!featuresWithMigrationWarnings.contains(feature)) {
+      featuresWithMigrationWarnings = featuresWithMigrationWarnings + feature
+
+      logger.warn(exception) {
+        "failed to parse JSON due to unknown fields. ignoring those fields and trying again"
+      }
+    }
   }
 
   companion object {

--- a/wisp-feature/src/main/kotlin/wisp/feature/MoshiExt.kt
+++ b/wisp-feature/src/main/kotlin/wisp/feature/MoshiExt.kt
@@ -10,13 +10,15 @@ private val logger = KotlinLogging.logger(FeatureFlags::class.qualifiedName!!)
  * Attempts to use [JsonAdapter.failOnUnknown] and logs any issues before falling back to ignoring
  * the unknown fields.
  */
-fun <T> JsonAdapter<T>.toSafeJson(value: T): String {
+fun <T> JsonAdapter<T>.toSafeJson(value: T, onUnknownFields: (JsonDataException) -> Unit = {
+  logger.warn(it) {
+    "failed to parse JSON due to unknown fields. ignoring those fields and trying again"
+  }
+}): String {
   return try {
     failOnUnknown().toJson(value)
   } catch (e: JsonDataException) {
-    logger.error(e) {
-      "failed to serialize JSON due to unknown fields. ignoring those fields and trying again"
-    }
+    onUnknownFields(e)
     return toJson(value)
   }
 }
@@ -25,13 +27,15 @@ fun <T> JsonAdapter<T>.toSafeJson(value: T): String {
  * Attempts to use [JsonAdapter.failOnUnknown] and logs any issues before falling back to ignoring
  * the unknown fields.
  */
-fun <T> JsonAdapter<T>.fromSafeJson(json: String): T? {
+fun <T> JsonAdapter<T>.fromSafeJson(json: String, onUnknownFields: (JsonDataException) -> Unit = {
+  logger.warn(it) {
+    "failed to parse JSON due to unknown fields. ignoring those fields and trying again"
+  }
+}): T? {
   return try {
     failOnUnknown().fromJson(json)
   } catch (e: JsonDataException) {
-    logger.error(e) {
-      "failed to parse JSON due to unknown fields. ignoring those fields and trying again"
-    }
+    onUnknownFields(e)
     return fromJson(json)
   }
 }

--- a/wisp-logging-testing/build.gradle.kts
+++ b/wisp-logging-testing/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
   implementation(Dependencies.kotlinStdLibJdk8)
   implementation(Dependencies.kotlinReflection)
   api(Dependencies.loggingApi)
-  implementation(Dependencies.logbackClassic)
+  api(Dependencies.logbackClassic)
   implementation(Dependencies.slf4jApi)
   implementation(Dependencies.assertj)
 


### PR DESCRIPTION
Closes #1991.

Also includes:
* wisp-testing-logging should have an api dep on logback 
