### PR TITLE
LaunchDarklyFeatureFlags.featuresWithMigrationWarnings is a mutable list

### DIFF
--- a/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/misk-launchdarkly-core/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -31,7 +31,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
   private val moshi: Moshi
 ) : AbstractIdleService(), FeatureFlags, FeatureService {
 
-  private var featuresWithMigrationWarnings: List<Feature> = listOf()
+  private val featuresWithMigrationWarnings: MutableList<Feature> = mutableListOf()
 
   override fun startUp() {
     var attempts = 300
@@ -291,7 +291,7 @@ class LaunchDarklyFeatureFlags @Inject constructor(
 
   private fun logJsonMigrationWarningOnce(feature: Feature, exception: JsonDataException) {
     if (!featuresWithMigrationWarnings.contains(feature)) {
-      featuresWithMigrationWarnings = featuresWithMigrationWarnings + feature
+      featuresWithMigrationWarnings += feature
 
       logger.warn(exception) {
         "failed to parse JSON due to unknown fields. ignoring those fields and trying again"


### PR DESCRIPTION
This makes it a bit more explicit.