### PR TITLE
Make WebActionException a RuntimeException

### DIFF
--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -10,6 +10,10 @@ import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 import java.net.HttpURLConnection.HTTP_UNAVAILABLE
 import java.net.HttpURLConnection.HTTP_UNSUPPORTED_TYPE
 
+/**
+ * Even though all kotlin exceptions are runtime exceptions.
+ * To ensure java inter-op all exception need to extend from RuntimeException.
+ */
 open class WebActionException(
   /** The HTTP status code. Should be 400..599. */
   val code: Int,
@@ -23,7 +27,7 @@ open class WebActionException(
    */
   message: String,
   cause: Throwable? = null
-) : Exception(message, cause) {
+) : RuntimeException(message, cause) {
   val isClientError = code in (400..499)
   val isServerError = code in (500..599)
 


### PR DESCRIPTION
Is there a reason why we have WebActionException an Exception instead of a RuntimeException. This works okay in kotlin as all exceptions are treated by default as runtime exceptions. But the issue comes with the inter-op with java libraries. 

For my specific case, when a checked exception is thrown inside a transaction in jooq, it gets wrapped into a DataAccessException whereas a RuntimeException is rethrown as is. 
