### PR TITLE
Do not consume unmatched logs in LogCollector

### DIFF
--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -3,11 +3,14 @@ package misk.logging
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import wisp.logging.LogCollector
+import wisp.logging.WispQueuedLogCollector
+import javax.inject.Provider
 
 class LogCollectorModule : KAbstractModule() {
   override fun configure() {
     bind<LogCollector>().to<RealLogCollector>()
     bind<LogCollectorService>().to<RealLogCollector>()
+    bind<WispQueuedLogCollector>().toProvider(Provider { WispQueuedLogCollector() })
     install(ServiceModule<LogCollectorService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
@@ -10,36 +10,11 @@ import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 @Singleton
-internal class RealLogCollector @Inject constructor() :
-  AbstractIdleService(),
-  LogCollector,
+internal class RealLogCollector @Inject constructor(
+  private val wispQueuedLogCollector: WispQueuedLogCollector
+) : AbstractIdleService(),
+  LogCollector by wispQueuedLogCollector,
   LogCollectorService {
-
-  private val wispQueuedLogCollector = WispQueuedLogCollector()
-
-  override fun takeMessages(
-    loggerClass: KClass<*>?,
-    minLevel: Level,
-    pattern: Regex?
-  ): List<String> = takeEvents(loggerClass, minLevel, pattern).map { it.message }
-
-  override fun takeMessage(
-    loggerClass: KClass<*>?,
-    minLevel: Level,
-    pattern: Regex?
-  ): String = takeEvent(loggerClass, minLevel, pattern).message
-
-  override fun takeEvents(
-    loggerClass: KClass<*>?,
-    minLevel: Level,
-    pattern: Regex?
-  ): List<ILoggingEvent> {
-    return wispQueuedLogCollector.takeEvents(loggerClass, minLevel, pattern)
-  }
-
-  override fun takeEvent(loggerClass: KClass<*>?, minLevel: Level, pattern: Regex?): ILoggingEvent {
-    return wispQueuedLogCollector.takeEvent(loggerClass, minLevel, pattern)
-  }
 
   override fun startUp() {
     wispQueuedLogCollector.startUp()

--- a/wisp-logging-testing/api/wisp-logging-testing.api
+++ b/wisp-logging-testing/api/wisp-logging-testing.api
@@ -4,26 +4,26 @@ public final class org/assertj/core/api/AssertExtensionsKt {
 }
 
 public abstract interface class wisp/logging/LogCollector {
-	public abstract fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Lch/qos/logback/classic/spi/ILoggingEvent;
-	public abstract fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
-	public abstract fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/lang/String;
-	public abstract fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
+	public abstract fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public abstract fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
+	public abstract fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/lang/String;
+	public abstract fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
 }
 
 public final class wisp/logging/LogCollector$DefaultImpls {
-	public static synthetic fun takeEvent$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Lch/qos/logback/classic/spi/ILoggingEvent;
-	public static synthetic fun takeEvents$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun takeMessage$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun takeMessages$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun takeEvent$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public static synthetic fun takeEvents$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun takeMessage$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun takeMessages$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class wisp/logging/WispQueuedLogCollector : wisp/logging/LogCollector {
 	public fun <init> ()V
 	public final fun shutDown ()V
 	public final fun startUp ()V
-	public fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Lch/qos/logback/classic/spi/ILoggingEvent;
-	public fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
-	public fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/lang/String;
-	public fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
+	public fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
+	public fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/lang/String;
+	public fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
 }
 

--- a/wisp-logging-testing/api/wisp-logging-testing.api
+++ b/wisp-logging-testing/api/wisp-logging-testing.api
@@ -4,16 +4,24 @@ public final class org/assertj/core/api/AssertExtensionsKt {
 }
 
 public abstract interface class wisp/logging/LogCollector {
+	public abstract fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Lch/qos/logback/classic/spi/ILoggingEvent;
 	public abstract fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public abstract fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
 	public abstract fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
+	public abstract fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/lang/String;
 	public abstract fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/lang/String;
+	public abstract fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
 	public abstract fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
 }
 
 public final class wisp/logging/LogCollector$DefaultImpls {
+	public static synthetic fun takeEvent$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Lch/qos/logback/classic/spi/ILoggingEvent;
 	public static synthetic fun takeEvent$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public static synthetic fun takeEvents$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun takeEvents$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun takeMessage$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/lang/String;
 	public static synthetic fun takeMessage$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun takeMessages$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun takeMessages$default (Lwisp/logging/LogCollector;Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;ZILjava/lang/Object;)Ljava/util/List;
 }
 
@@ -21,9 +29,13 @@ public final class wisp/logging/WispQueuedLogCollector : wisp/logging/LogCollect
 	public fun <init> ()V
 	public final fun shutDown ()V
 	public final fun startUp ()V
+	public fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Lch/qos/logback/classic/spi/ILoggingEvent;
 	public fun takeEvent (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Lch/qos/logback/classic/spi/ILoggingEvent;
+	public fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
 	public fun takeEvents (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
+	public fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/lang/String;
 	public fun takeMessage (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/lang/String;
+	public fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;)Ljava/util/List;
 	public fun takeMessages (Lkotlin/reflect/KClass;Lch/qos/logback/classic/Level;Lkotlin/text/Regex;Z)Ljava/util/List;
 }
 

--- a/wisp-logging-testing/src/main/kotlin/wisp/logging/LogCollector.kt
+++ b/wisp-logging-testing/src/main/kotlin/wisp/logging/LogCollector.kt
@@ -44,7 +44,16 @@ interface LogCollector {
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
     pattern: Regex? = null,
-    consumeUnmatchedLogs: Boolean = true,
+  ): List<String>
+
+  /**
+   * Takes all matching messages, optionally leaving unmatched logs in this collector.
+   */
+  fun takeMessages(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = false,
   ): List<String>
 
   /**
@@ -55,7 +64,16 @@ interface LogCollector {
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
     pattern: Regex? = null,
-    consumeUnmatchedLogs: Boolean = true,
+  ): String
+
+  /**
+   * Takes the first matching message, optionally leaving unmatched logs in this collector.
+   */
+  fun takeMessage(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = false,
   ): String
 
   /**
@@ -65,8 +83,17 @@ interface LogCollector {
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
     pattern: Regex? = null,
-    consumeUnmatchedLogs: Boolean = true,
     ): List<ILoggingEvent>
+
+  /**
+   * Takes all matching events, optionally leaving unmatched logs in this collector.
+   */
+  fun takeEvents(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = false,
+  ): List<ILoggingEvent>
 
   /**
    * Waits until a matching event is logged, and returns it. The returned event and all preceding
@@ -76,6 +103,15 @@ interface LogCollector {
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
     pattern: Regex? = null,
-    consumeUnmatchedLogs: Boolean = true,
     ): ILoggingEvent
+
+  /**
+   * Take the first matching event, optionally leaving unmatched logs in this collector.
+   */
+  fun takeEvent(
+    loggerClass: KClass<*>? = null,
+    minLevel: Level = Level.INFO,
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = false,
+  ): ILoggingEvent
 }

--- a/wisp-logging-testing/src/main/kotlin/wisp/logging/LogCollector.kt
+++ b/wisp-logging-testing/src/main/kotlin/wisp/logging/LogCollector.kt
@@ -43,7 +43,8 @@ interface LogCollector {
   fun takeMessages(
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
-    pattern: Regex? = null
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = true,
   ): List<String>
 
   /**
@@ -53,7 +54,8 @@ interface LogCollector {
   fun takeMessage(
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
-    pattern: Regex? = null
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = true,
   ): String
 
   /**
@@ -62,8 +64,9 @@ interface LogCollector {
   fun takeEvents(
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
-    pattern: Regex? = null
-  ): List<ILoggingEvent>
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = true,
+    ): List<ILoggingEvent>
 
   /**
    * Waits until a matching event is logged, and returns it. The returned event and all preceding
@@ -72,6 +75,7 @@ interface LogCollector {
   fun takeEvent(
     loggerClass: KClass<*>? = null,
     minLevel: Level = Level.INFO,
-    pattern: Regex? = null
-  ): ILoggingEvent
+    pattern: Regex? = null,
+    consumeUnmatchedLogs: Boolean = true,
+    ): ILoggingEvent
 }

--- a/wisp-logging-testing/src/main/kotlin/wisp/logging/WispQueuedLogCollector.kt
+++ b/wisp-logging-testing/src/main/kotlin/wisp/logging/WispQueuedLogCollector.kt
@@ -5,8 +5,8 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.UnsynchronizedAppenderBase
 import org.slf4j.LoggerFactory
+import java.lang.Thread.sleep
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
 class WispQueuedLogCollector : LogCollector {
@@ -37,38 +37,34 @@ class WispQueuedLogCollector : LogCollector {
     minLevel: Level,
     pattern: Regex?
   ): List<ILoggingEvent> {
-    Thread.sleep(100) // Give the logger some time to flush events.
-    val result = mutableListOf<ILoggingEvent>()
-    while (queue.isNotEmpty()) {
-      val event = takeOrNull(loggerClass, minLevel, pattern)
-      if (event != null) result += event
-    }
-    return result
+    sleep(100) // Give the logger some time to flush events.
+    val resultList = queue.filter { matchLog(loggerClass, it, minLevel, pattern) }.toList()
+    queue.removeAll(resultList)
+    return resultList
   }
 
   override fun takeEvent(loggerClass: KClass<*>?, minLevel: Level, pattern: Regex?): ILoggingEvent {
-    while (true) {
-      val event = takeOrNull(loggerClass, minLevel, pattern)
-      if (event != null) return event
+    require(wasStarted) { "not collecting logs: did you forget to start the service?" }
+    for (i in 1..5) {
+      if (queue.isEmpty()) sleep(100) else continue
     }
+    require(queue.isNotEmpty()) { "no events to take!" }
+    val event = queue.find { matchLog(loggerClass, it, minLevel, pattern) }
+      ?: error("no matching events for (logger=$loggerClass, minLevel=$minLevel, pattern=$pattern)")
+    queue.remove(event)
+    return event
   }
 
-  /** Takes an event. Returns it if it meets the constraints and null if it doesn't. */
-  private fun takeOrNull(
+  private fun matchLog(
     loggerClass: KClass<*>?,
+    event: ILoggingEvent,
     minLevel: Level,
     pattern: Regex?
-  ): ILoggingEvent? {
-    require(wasStarted) { "not collecting logs: did you forget to start the service?" }
-
-    val event = queue.poll(500, TimeUnit.MILLISECONDS)
-      ?: throw IllegalArgumentException("no events to take!")
-
-    if (loggerClass != null && loggerClass.qualifiedName != event.loggerName) return null
-    if (event.level.toInt() < minLevel.toInt()) return null
-    if (pattern != null && !pattern.containsMatchIn(event.message.toString())) return null
-
-    return event
+  ) = when {
+    loggerClass != null && loggerClass.qualifiedName != event.loggerName -> false
+    event.level.toInt() < minLevel.toInt() -> false
+    pattern != null && !pattern.containsMatchIn(event.message.toString()) -> false
+    else -> true
   }
 
   fun startUp() {

--- a/wisp-logging-testing/src/main/kotlin/wisp/logging/WispQueuedLogCollector.kt
+++ b/wisp-logging-testing/src/main/kotlin/wisp/logging/WispQueuedLogCollector.kt
@@ -7,6 +7,7 @@ import ch.qos.logback.core.UnsynchronizedAppenderBase
 import org.slf4j.LoggerFactory
 import java.lang.Thread.sleep
 import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
 class WispQueuedLogCollector : LogCollector {
@@ -23,28 +24,87 @@ class WispQueuedLogCollector : LogCollector {
   override fun takeMessages(
     loggerClass: KClass<*>?,
     minLevel: Level,
-    pattern: Regex?
-  ): List<String> = takeEvents(loggerClass, minLevel, pattern).map { it.message }
+    pattern: Regex?,
+    consumeUnmatchedLogs: Boolean,
+  ): List<String> = takeEvents(
+    loggerClass,
+    minLevel,
+    pattern,
+    consumeUnmatchedLogs
+  ).map { it.message }
 
   override fun takeMessage(
     loggerClass: KClass<*>?,
     minLevel: Level,
-    pattern: Regex?
-  ): String = takeEvent(loggerClass, minLevel, pattern).message
+    pattern: Regex?,
+    consumeUnmatchedLogs: Boolean,
+  ): String = takeEvent(loggerClass, minLevel, pattern, consumeUnmatchedLogs).message
 
   override fun takeEvents(
     loggerClass: KClass<*>?,
     minLevel: Level,
-    pattern: Regex?
+    pattern: Regex?,
+    consumeUnmatchedLogs: Boolean,
   ): List<ILoggingEvent> {
     sleep(100) // Give the logger some time to flush events.
+    if (!consumeUnmatchedLogs) {
+      return takeEvents(loggerClass, minLevel, pattern)
+    }
+    return takeEventsConsuming(loggerClass, minLevel, pattern)
+  }
+
+  /**
+   * Takes all events currently on the queue which match the constraints.
+   * Leaves behind events that don't match.
+   */
+  private fun takeEvents(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): List<ILoggingEvent> {
     val resultList = queue.filter { matchLog(loggerClass, it, minLevel, pattern) }.toList()
     queue.removeAll(resultList)
     return resultList
   }
 
-  override fun takeEvent(loggerClass: KClass<*>?, minLevel: Level, pattern: Regex?): ILoggingEvent {
+  /**
+   * Consumes the whole queue of events, returning only those which match the constraints.
+   */
+  private fun takeEventsConsuming(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): MutableList<ILoggingEvent> {
+    val result = mutableListOf<ILoggingEvent>()
+    while (queue.isNotEmpty()) {
+      val event = takeOrNull(loggerClass, minLevel, pattern)
+      if (event != null) result += event
+    }
+    return result
+  }
+
+  override fun takeEvent(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?,
+    consumeUnmatchedLogs: Boolean,
+  ): ILoggingEvent {
     require(wasStarted) { "not collecting logs: did you forget to start the service?" }
+    if (!consumeUnmatchedLogs) {
+      return take(loggerClass, minLevel, pattern)
+    }
+    return takeConsuming(loggerClass, minLevel, pattern)
+  }
+
+  /**
+   * Takes an event matching the constraints, leaving behind all other non-matching events
+   * in the queue. Throws if there are no matching events.
+   */
+  private fun take(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): ILoggingEvent {
     for (i in 1..5) {
       if (queue.isEmpty()) sleep(100) else continue
     }
@@ -52,6 +112,39 @@ class WispQueuedLogCollector : LogCollector {
     val event = queue.find { matchLog(loggerClass, it, minLevel, pattern) }
       ?: error("no matching events for (logger=$loggerClass, minLevel=$minLevel, pattern=$pattern)")
     queue.remove(event)
+    return event
+  }
+
+  /**
+   * Like [take], but consumes all events in the queue preceding the first match.
+   * Waits forever until there is a matching event.
+   */
+  private fun takeConsuming(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): ILoggingEvent {
+    while (true) {
+      val event = takeOrNull(loggerClass, minLevel, pattern)
+      if (event != null) return event
+    }
+  }
+
+  /** Takes an event. Returns it if it meets the constraints and null if it doesn't. */
+  private fun takeOrNull(
+    loggerClass: KClass<*>?,
+    minLevel: Level,
+    pattern: Regex?
+  ): ILoggingEvent? {
+    require(wasStarted) { "not collecting logs: did you forget to start the service?" }
+
+    val event = queue.poll(500, TimeUnit.MILLISECONDS)
+      ?: throw IllegalArgumentException("no events to take!")
+
+    if (loggerClass != null && loggerClass.qualifiedName != event.loggerName) return null
+    if (event.level.toInt() < minLevel.toInt()) return null
+    if (pattern != null && !pattern.containsMatchIn(event.message.toString())) return null
+
     return event
   }
 


### PR DESCRIPTION
Addresses #2128.

Open to other solutions! Maybe this is actually a bad idea -- my use-case may the outlier here, but I find the current behaviour very odd that `takeMessages(filter)` consumes the whole queue of collected logs and only returns the ones that matched.