### PR TITLE
Fix a test compile error

### DIFF
--- a/wisp-config/src/test/kotlin/wisp/config/WispConfigTest.kt
+++ b/wisp-config/src/test/kotlin/wisp/config/WispConfigTest.kt
@@ -107,8 +107,8 @@ internal class WispConfigTest {
     assertEquals("RRRRRRRRRRRRRRRRR", myConfig.aws.AWS_SECRET_ACCESS_KEY.value)
 
     // values should be masked
-    assertNotEquals("AAAAAAAAAAAAAAAA", myConfig.aws.AWS_ACCESS_KEY_ID)
-    assertNotEquals("RRRRRRRRRRRRRRRRR", myConfig.aws.AWS_SECRET_ACCESS_KEY)
+    assertNotEquals("AAAAAAAAAAAAAAAA", myConfig.aws.AWS_ACCESS_KEY_ID.toString())
+    assertNotEquals("RRRRRRRRRRRRRRRRR", myConfig.aws.AWS_SECRET_ACCESS_KEY.toString())
   }
 
   @Test
@@ -125,8 +125,8 @@ internal class WispConfigTest {
     assertEquals("RRRRRRRRRRRRRRRRR", myConfig.AWS_SECRET_ACCESS_KEY.value)
 
     // values should be masked
-    assertNotEquals("AAAAAAAAAAAAAAAA", myConfig.AWS_ACCESS_KEY_ID)
-    assertNotEquals("RRRRRRRRRRRRRRRRR", myConfig.AWS_SECRET_ACCESS_KEY)
+    assertNotEquals("AAAAAAAAAAAAAAAA", myConfig.AWS_ACCESS_KEY_ID.toString())
+    assertNotEquals("RRRRRRRRRRRRRRRRR", myConfig.AWS_SECRET_ACCESS_KEY.toString())
   }
 
   // TODO(chrisryan): add tests to support other formats


### PR DESCRIPTION
I got this error:

    e: /home/runner/work/misk/misk/wisp-config/src/test/kotlin/wisp/config/WispConfigTest.kt: (110, 5): Type inference failed. The value of the type parameter T should be mentioned in input types (argument types, receiver type or expected type). Try to specify it explicitly.