### PR TITLE
Add new `histo_http_request_latency_ms` histogram metric for http request latency

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -43,12 +43,12 @@ internal class MetricsInterceptor internal constructor(
     m: Metrics,
     private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
   ) : NetworkInterceptor.Factory {
-    private val requestDurationSummary = m.summary(
+    val requestDurationSummary = m.summary(
       name = "http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")
     )
-    private val requestDurationHistogram = m.histogram(
+    val requestDurationHistogram = m.histogram(
       name = "http_request_latency_ms_histo",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -43,7 +43,7 @@ internal class MetricsInterceptor internal constructor(
     m: Metrics,
     private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
   ) : NetworkInterceptor.Factory {
-    val requestDuration = m.summary(
+    internal val requestDuration = m.summary(
       name = "http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -1,9 +1,10 @@
 package misk.web.interceptors
 
+import io.prometheus.client.Histogram
+import io.prometheus.client.Summary
 import misk.Action
 import misk.MiskCaller
-import misk.metrics.Histogram
-import misk.metrics.Metrics
+import misk.metrics.v2.Metrics
 import misk.scope.ActionScoped
 import misk.time.timed
 import misk.web.NetworkChain
@@ -13,7 +14,8 @@ import javax.inject.Singleton
 
 internal class MetricsInterceptor internal constructor(
   private val actionName: String,
-  private val requestDuration: Histogram,
+  private val requestDurationSummary: Summary,
+  private val requestDurationHistogram: Histogram,
   private val caller: ActionScoped<MiskCaller?>
 ) : NetworkInterceptor {
   override fun intercept(chain: NetworkChain) {
@@ -27,7 +29,12 @@ internal class MetricsInterceptor internal constructor(
     }
 
     val statusCode = chain.httpCall.statusCode
-    requestDuration.record(elapsedTimeMillis, actionName, callingPrincipal, statusCode.toString())
+    requestDurationSummary
+      .labels(actionName, callingPrincipal, statusCode.toString())
+      .observe(elapsedTimeMillis)
+    requestDurationHistogram
+      .labels(actionName, callingPrincipal, statusCode.toString())
+      .observe(elapsedTimeMillis)
     return result
   }
 
@@ -36,12 +43,22 @@ internal class MetricsInterceptor internal constructor(
     m: Metrics,
     private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
   ) : NetworkInterceptor.Factory {
-    internal val requestDuration = m.histogram(
+    private val requestDurationSummary = m.summary(
       name = "http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")
     )
+    private val requestDurationHistogram = m.histogram(
+      name = "http_request_latency_ms_histo",
+      help = "count and duration in ms of incoming web requests",
+      labelNames = listOf("action", "caller", "code")
+    )
 
-    override fun create(action: Action) = MetricsInterceptor(action.name, requestDuration, caller)
+    override fun create(action: Action) = MetricsInterceptor(
+      action.name,
+      requestDurationSummary,
+      requestDurationHistogram,
+      caller,
+    )
   }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -43,20 +43,20 @@ internal class MetricsInterceptor internal constructor(
     m: Metrics,
     private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
   ) : NetworkInterceptor.Factory {
-    val requestDurationSummary = m.summary(
+    val requestDuration = m.summary(
       name = "http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")
     )
-    val requestDurationHistogram = m.histogram(
-      name = "http_request_latency_ms_histo",
+    private val requestDurationHistogram = m.histogram(
+      name = "histo_http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
       labelNames = listOf("action", "caller", "code")
     )
 
     override fun create(action: Action) = MetricsInterceptor(
       action.name,
-      requestDurationSummary,
+      requestDuration,
       requestDurationHistogram,
       caller,
     )

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -49,7 +49,7 @@ class MetricsInterceptorTest {
 
   @Test
   fun responseCodes() {
-    val requestDuration = metricsInterceptorFactory.requestDurationSummary
+    val requestDuration = metricsInterceptorFactory.requestDuration
     requestDuration.labels("MetricsInterceptorTestAction", "unknown", "200").observe(1.0)
     assertThat(requestDuration.labels("MetricsInterceptorTestAction", "unknown", "200").get().count.toInt()).isEqualTo(3)
     requestDuration.labels("MetricsInterceptorTestAction", "unknown", "202").observe(1.0)

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -49,21 +49,21 @@ class MetricsInterceptorTest {
 
   @Test
   fun responseCodes() {
-    val requestDuration = metricsInterceptorFactory.requestDuration
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "unknown", "200")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "unknown", "200")).isEqualTo(3)
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "unknown", "202")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "unknown", "202")).isEqualTo(2)
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "unknown", "404")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "unknown", "404")).isEqualTo(2)
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "unknown", "403")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "unknown", "403")).isEqualTo(3)
+    val requestDuration = metricsInterceptorFactory.requestDurationSummary
+    requestDuration.labels("MetricsInterceptorTestAction", "unknown", "200").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "unknown", "200").get().count.toInt()).isEqualTo(3)
+    requestDuration.labels("MetricsInterceptorTestAction", "unknown", "202").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "unknown", "202").get().count.toInt()).isEqualTo(2)
+    requestDuration.labels("MetricsInterceptorTestAction", "unknown", "404").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "unknown", "404").get().count.toInt()).isEqualTo(2)
+    requestDuration.labels("MetricsInterceptorTestAction", "unknown", "403").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "unknown", "403").get().count.toInt()).isEqualTo(3)
 
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "my-peer", "200")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "my-peer", "200")).isEqualTo(5)
+    requestDuration.labels("MetricsInterceptorTestAction", "my-peer", "200").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "my-peer", "200").get().count.toInt()).isEqualTo(5)
 
-    requestDuration.record(1.0, "MetricsInterceptorTestAction", "<user>", "200")
-    assertThat(requestDuration.count("MetricsInterceptorTestAction", "<user>", "200")).isEqualTo(2)
+    requestDuration.labels("MetricsInterceptorTestAction", "<user>", "200").observe(1.0)
+    assertThat(requestDuration.labels("MetricsInterceptorTestAction", "<user>", "200").get().count.toInt()).isEqualTo(2)
   }
 
   fun invoke(


### PR DESCRIPTION
This pull request re-submits https://github.com/cashapp/misk/pull/2145 with a target branch of `master` which has already been approved.

See my comment about what happened to the previous pull request: https://github.com/cashapp/misk/pull/2145

Apologies on the confusion the off-master target created.