### PR TITLE
Add SVG to the list of known media types

### DIFF
--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -565,6 +565,7 @@ public final class misk/web/mediatype/MediaTypes {
 	public static final field APPLICATION_OCTETSTREAM Ljava/lang/String;
 	public static final field APPLICATION_PROTOBUF Ljava/lang/String;
 	public static final field IMAGE_PNG Ljava/lang/String;
+	public static final field IMAGE_SVG Ljava/lang/String;
 	public static final field INSTANCE Lmisk/web/mediatype/MediaTypes;
 	public static final field TEXT_CSS Ljava/lang/String;
 	public static final field TEXT_HTML Ljava/lang/String;
@@ -577,6 +578,7 @@ public final class misk/web/mediatype/MediaTypes {
 	public final fun getAPPLICATION_OCTETSTREAM_MEDIA_TYPE ()Lokhttp3/MediaType;
 	public final fun getAPPLICATION_PROTOBUF_MEDIA_TYPE ()Lokhttp3/MediaType;
 	public final fun getIMAGE_PNG_MEDIA_TYPE ()Lokhttp3/MediaType;
+	public final fun getIMAGE_SVG_MEDIA_TYPE ()Lokhttp3/MediaType;
 	public final fun getTEXT_CSS_MEDIA_TYPE ()Lokhttp3/MediaType;
 	public final fun getTEXT_HTML_MEDIA_TYPE ()Lokhttp3/MediaType;
 	public final fun getTEXT_PLAIN_UTF8_MEDIA_TYPE ()Lokhttp3/MediaType;

--- a/misk-core/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
+++ b/misk-core/src/main/kotlin/misk/web/mediatype/MediaTypes.kt
@@ -33,6 +33,9 @@ object MediaTypes {
   const val IMAGE_PNG = "image/png"
   val IMAGE_PNG_MEDIA_TYPE = IMAGE_PNG.asMediaType()
 
+  const val IMAGE_SVG = "image/svg+xml"
+  val IMAGE_SVG_MEDIA_TYPE = IMAGE_SVG.asMediaType()
+
   const val APPLICATION_GRPC = "application/grpc"
   val APPLICATION_GRPC_MEDIA_TYPE = APPLICATION_GRPC.asMediaType()
 
@@ -42,6 +45,7 @@ object MediaTypes {
       "html", "htm" -> TEXT_HTML_MEDIA_TYPE
       "js" -> APPLICATION_JAVASCRIPT_MEDIA_TYPE
       "png" -> IMAGE_PNG_MEDIA_TYPE
+      "svg" -> IMAGE_SVG_MEDIA_TYPE
       else -> APPLICATION_OCTETSTREAM_MEDIA_TYPE
     }
   }


### PR DESCRIPTION
Currently when misk serves up an SVG as a static resource, it
uses the application/octetstream type which makes the image fail
to render in web browsers.