### PR TITLE
Add enabledTlsProtocols to DataSourceConfig

### DIFF
--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -277,8 +277,8 @@ public final class misk/jdbc/DataSourceClustersConfig : java/util/LinkedHashMap,
 }
 
 public final class misk/jdbc/DataSourceConfig {
-	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asReplica ()Lmisk/jdbc/DataSourceConfig;
 	public final fun buildJdbcUrl (Lwisp/deployment/Deployment;)Ljava/lang/String;
 	public final fun canRecoverOnReplica ()Z
@@ -296,8 +296,9 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/lang/String;
 	public final fun component21 ()Z
-	public final fun component22 ()Ljava/lang/String;
-	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/lang/Integer;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -305,8 +306,8 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component7 ()I
 	public final fun component8 ()Ljava/time/Duration;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;)Lmisk/jdbc/DataSourceConfig;
-	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
+	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;)Lmisk/jdbc/DataSourceConfig;
+	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClient_certificate_key_store_password ()Ljava/lang/String;
 	public final fun getClient_certificate_key_store_path ()Ljava/lang/String;
@@ -314,6 +315,7 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun getConnection_max_lifetime ()Ljava/time/Duration;
 	public final fun getConnection_timeout ()Ljava/time/Duration;
 	public final fun getDatabase ()Ljava/lang/String;
+	public final fun getEnabledTlsProtocols ()Ljava/util/List;
 	public final fun getFixed_pool_size ()I
 	public final fun getHost ()Ljava/lang/String;
 	public final fun getJdbc_statement_batch_size ()Ljava/lang/Integer;

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -71,6 +71,9 @@ data class DataSourceConfig(
   val trust_certificate_key_store_path: String? = null,
   val client_certificate_key_store_path: String? = null,
   val verify_server_identity: Boolean = false,
+  // For MySQL: TLS versions to enable, e.g. "TLSv1.2".
+  // Falls back to default driver behavior when not specified.
+  val enabledTlsProtocols: List<String> = listOf(),
   val show_sql: String? = "false",
   // Consider using this if you want Hibernate to automagically batch inserts/updates when it can.
   val jdbc_statement_batch_size: Int? = null
@@ -202,6 +205,10 @@ data class DataSourceConfig(
         }
         queryParams += "&sslMode=$sslMode"
 
+        if (enabledTlsProtocols.isNotEmpty()) {
+          queryParams += "&enabledTLSProtocols=${enabledTlsProtocols.joinToString(",")}"
+        }
+
         "jdbc:tracing:mysql://${config.host}:${config.port}/${config.database}$queryParams"
       }
       DataSourceType.HSQLDB -> {
@@ -260,7 +267,8 @@ data class DataSourceConfig(
       this.trust_certificate_key_store_path,
       this.client_certificate_key_store_path,
       this.verify_server_identity,
-      this.show_sql
+      this.enabledTlsProtocols,
+      this.show_sql,
     )
   }
 

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -173,4 +173,27 @@ class DataSourceConfigTest {
       config.buildJdbcUrl(TESTING)
     )
   }
+
+  @Test
+  fun buildMysqlJDBCUrlWithEnabledTlsProtocols() {
+    val config = DataSourceConfig(
+      DataSourceType.MYSQL,
+      trust_certificate_key_store_url = "file://path/to/truststore",
+      trust_certificate_key_store_password = "changeit",
+      client_certificate_key_store_url = "file://path/to/keystore",
+      client_certificate_key_store_password = "changeit",
+      verify_server_identity = true,
+      enabledTlsProtocols = listOf("TLSv1.2", "TLSv1.3"),
+    )
+    assertEquals(
+      "jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
+        "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
+        "trustCertificateKeyStorePassword=changeit&" +
+        "clientCertificateKeyStoreUrl=file://path/to/keystore&" +
+        "clientCertificateKeyStorePassword=changeit&" +
+        "sslMode=VERIFY_IDENTITY&enabledTLSProtocols=TLSv1.2,TLSv1.3",
+      config.buildJdbcUrl(TESTING)
+    )
+  }
 }


### PR DESCRIPTION
Fun story: Java 17 doesn't support TLS 1.1. MySQL driver by default doesn't support anything above TLS 1.1 if the MySQL version is < 5.7.28. The latest on AWS Aurora is 5.7.12, despite supporting TLS 1.2. This setting is necessary to get it working.