### PR TITLE
Add system prop so hibernate logs to slf4j

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -54,6 +54,13 @@ class HibernateModule(
   readerConfig: DataSourceConfig?,
   val databasePool: DatabasePool = RealDatabasePool
 ) : KAbstractModule() {
+
+  // Make sure Hibernate logs use slf4j. Otherwise, it will base its decision on the classpath and
+  // prefer log4j: https://docs.jboss.org/hibernate/orm/4.3/topical/html/logging/Logging.html
+  init {
+    System.setProperty("org.jboss.logging.provider", "slf4j")
+  }
+
   val config = config.withDefaults()
   val readerConfig = readerConfig?.withDefaults()
 


### PR DESCRIPTION
Otherwise its logging defaults to log4j/log4j 2 if the jar classpath contains it: https://docs.jboss.org/hibernate/orm/4.3/topical/html/logging/Logging.html

This seemed like an appropriate point because [JBoss will load the logger integration on static init](https://github.com/jboss-logging/jboss-logging/blob/7e8fd0134f8c05803915591d84001a1c5b7fd7ae/src/main/java/org/jboss/logging/LoggerProviders.java#L29). This point is early enough on code that it hasn't happened, but specific to hibernate.