### PR TITLE
Emit client http latency as a histogram (in addition to a summary)

### DIFF
--- a/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/client/ClientMetricsInterceptorTest.kt
@@ -3,13 +3,14 @@ package misk.client
 import com.google.inject.Provides
 import com.google.inject.name.Named
 import com.google.inject.name.Names
+import io.prometheus.client.Histogram
+import io.prometheus.client.Summary
 import java.net.SocketTimeoutException
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
-import misk.metrics.Histogram
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.mediatype.MediaTypes
@@ -37,11 +38,13 @@ internal class ClientMetricsInterceptorTest {
   @Inject private lateinit var factory: ClientMetricsInterceptor.Factory
   @Inject private lateinit var mockWebServer: MockWebServer
 
-  private lateinit var requestDuration: Histogram
+  private lateinit var requestDurationSummary: Summary
+  private lateinit var requestDurationHistogram: Histogram
 
   @BeforeEach
   fun before() {
-    requestDuration = factory.requestDuration
+    requestDurationSummary = factory.requestDuration
+    requestDurationHistogram = factory.requestDurationHistogram
   }
 
   @Test
@@ -60,11 +63,17 @@ internal class ClientMetricsInterceptorTest {
     assertThat(client.ping(AppRequest(503)).execute().code()).isEqualTo(503)
 
     SoftAssertions.assertSoftly { softly ->
-      softly.assertThat(requestDuration.count("pinger.ping", "202")).isEqualTo(1)
-      softly.assertThat(requestDuration.count("pinger.ping", "404")).isEqualTo(1)
-      softly.assertThat(requestDuration.count("pinger.ping", "403")).isEqualTo(1)
-      softly.assertThat(requestDuration.count("pinger.ping", "403")).isEqualTo(1)
-      softly.assertThat(requestDuration.count("pinger.ping", "503")).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "202").get().count.toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "404").get().count.toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "403").get().count.toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "403").get().count.toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "503").get().count.toInt()).isEqualTo(1)
+
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "202").get().buckets.sum().toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "404").get().buckets.sum().toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "403").get().buckets.sum().toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "403").get().buckets.sum().toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "503").get().buckets.sum().toInt()).isEqualTo(1)
     }
   }
 
@@ -75,7 +84,8 @@ internal class ClientMetricsInterceptorTest {
     }
 
     SoftAssertions.assertSoftly { softly ->
-      softly.assertThat(requestDuration.count("pinger.ping", "timeout")).isEqualTo(1)
+      softly.assertThat(requestDurationSummary.labels("pinger.ping", "timeout").get().count.toInt()).isEqualTo(1)
+      softly.assertThat(requestDurationHistogram.labels("pinger.ping", "timeout").get().buckets.sum().toInt()).isEqualTo(1)
     }
   }
 

--- a/misk/src/test/kotlin/misk/client/GrpcClientProviderTest.kt
+++ b/misk/src/test/kotlin/misk/client/GrpcClientProviderTest.kt
@@ -90,7 +90,7 @@ internal class GrpcClientProviderTest {
       ">> robots.Locate /RobotLocator/Locate",
       "<< robots.Locate /RobotLocator/Locate 200"
     )
-    assertThat(clientMetricsInterceptorFactory.requestDuration.count("robots.SayHello", "200"))
+    assertThat(clientMetricsInterceptorFactory.requestDuration.labels("robots.SayHello", "200").get().count.toInt())
       .isEqualTo(1)
   }
 


### PR DESCRIPTION
Creates a new metric (histo_client_http_request_latency_ms) which is a latency histogram for request latency. It mirrors the summary metric for request latency (client_http_request_latency_ms) but with a different metric type.

This pull request is identical to https://github.com/cashapp/misk/pull/2150 which emitted server latency as a histogram except that this pull request updates client latency instead.