### PR TITLE
Isolate internal locking in CoordinatedService to avoid potential shutdown deadlocks

### DIFF
--- a/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -1,13 +1,51 @@
 package misk
 
+import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
+import com.google.inject.Key
 import com.google.inject.Provider
+import com.google.inject.name.Names
 import misk.ServiceGraphBuilderTest.AppendingService
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 import kotlin.test.assertFailsWith
 
 class CoordinatedServiceTest {
+
+  @RepeatedTest(100) fun fuzzCoordinatedServiceGraphStartAndStop() {
+    fun service(id: String): Pair<Key<*>, Service> = key(id) to FakeService(id).toCoordinated()
+
+    val services = List(10) { service("$it") }.shuffled()
+
+    // Build randomized service graph and dependency chain
+    val manager = ServiceGraphBuilder().also { builder ->
+      services.forEach { (key, service) ->
+        builder.addService(key, service)
+      }
+      val randomKeys = services.shuffled().map { it.first }.toMutableList()
+      val dependencies = mutableListOf<Key<*>>()
+      while(randomKeys.isNotEmpty()) {
+        val next = randomKeys.removeFirst()
+        if (dependencies.isNotEmpty()) {
+          builder.addDependency(dependent = dependencies.random(), dependsOn = next)
+        }
+        dependencies += next
+      }
+    }.build()
+
+    manager.startAsync()
+    manager.awaitHealthy()
+
+    assertThat(services).allMatch { (_, service) -> service.state() == Service.State.RUNNING }
+
+    manager.stopAsync()
+    manager.awaitStopped()
+
+    assertThat(services).allMatch { (_, service) -> service.state() == Service.State.TERMINATED }
+  }
+
   @Test fun cannotAddRunningServiceAsDependency() {
     val target = StringBuilder()
     val runningService = CoordinatedService(
@@ -45,4 +83,16 @@ class CoordinatedServiceTest {
 
     service.stopAsync()
   }
+
+  private class FakeService(
+    val name: String
+  ) : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+    override fun toString() = "FakeService-$name"
+  }
+
+  private fun Service.toCoordinated() = CoordinatedService(Provider { this })
+
+  private fun key(name: String) = Key.get(Service::class.java, Names.named(name))
 }


### PR DESCRIPTION
I've been investigating a regular deadlock i've been seeing when integration tests are cleaning up. Internal slack thread outlining the problem [here](https://cash.slack.com/archives/C01MYFT6796/p1632858873416700), with some indication other teams have been having issues with this too. 

Below outlines how I believe the deadlock is occurring, and why I believe the PR should resolve the issue. 

### Investigation

I was able to capture a thread dump of this deadlock. There are two interesting threads that are both using the same lock.
The `Test worker@1`, waiting on lock `0x3324`
```
"Test worker@1" prio=5 tid=0x1 nid=NA waiting for monitor entry
  java.lang.Thread.State: BLOCKED
   waiting for BackfilaStartupConfigurator STOPPING@13083 to release lock on <0x3324> (a misk.CoordinatedService)
    at misk.CoordinatedService.stopIfReady(CoordinatedService.kt:155)
    at misk.CoordinatedService.doStop(CoordinatedService.kt:151)
    at com.google.common.util.concurrent.AbstractService.stopAsync(AbstractService.java:281)
```

and one called `BackfilaStartupConfigurator` which is holding `0x3324` but then blocking on a Monitor itself.

```
"BackfilaStartupConfigurator STOPPING@13083" prio=5 tid=0x50 nid=NA waiting
  java.lang.Thread.State: WAITING
   blocks Test worker@1
    at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
...
    at com.google.common.util.concurrent.Monitor.enter(Monitor.java:384)
    at com.google.common.util.concurrent.AbstractService.notifyStopped(AbstractService.java:429)
    at misk.CoordinatedService.access$notifyStopped(CoordinatedService.kt:11)
    at misk.CoordinatedService$service$2$1$1.terminated(CoordinatedService.kt:31)
    - locked <0x335e> (a misk.CoordinatedService$service$2$1$1)
...
    at com.google.common.util.concurrent.AbstractService.stopAsync(AbstractService.java:293)
    at misk.CoordinatedService.stopIfReady(CoordinatedService.kt:164)
    - locked <0x3324> (a misk.CoordinatedService)
    at misk.CoordinatedService.access$stopIfReady(CoordinatedService.kt:11)
    at misk.CoordinatedService$service$2$1$1.terminated(CoordinatedService.kt:33)
```

Also note a relevant relationship between `BackfilaStartupConfigurator` & `DynamoDbService` in our testing module. `BackfilaStartupConfigurator` depends on `DynamoDbService`.

```
BackfillModule(
  config = config,
  loggingSetupProvider = BackfilaClientMDCLoggingSetupProvider::class,
  dependsOn = listOf(DynamoDbService::class.toKey())
) 
```

### Deadlock

The `Test worker@1` thread is indefinitely blocked when calling `serviceManager.stopAsync()` line in test cleanup. This blocks indefinitely on [this line](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L155). The wrapped service instance based on logging is `DynamoDbService`.

The `BackfilaStartupConfigurator` thread is indefinitely blocked when it shutsdown, and invokes it's upstream service to (`DynamoDbService`) to shutdown. This happens like this:
1. `BackfilaStartupConfigurator` is shutdown triggering `terminated` callback [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L29).
2. This triggers upstream `DynamoDbService` shutdown [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L33)
3. This invokes the inner service shutdown from `stopIfReady` (note `synchronized`) [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L164)
4. This triggers the `terminated` callback for `DynamoDbService` itself which then calls `notifyShutdown()` on its outer `CoordinatedService` [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L31)

I believe the deadlock occurs from the following race:
1. `stopAsync` is called on the outer `CoordinatedService`for `DynamoDbService`. This grabs a lock via `monitor` in the extended `class AbstractService` [here](https://github.com/google/guava/blob/574710c0daf1c70a3b192c49d520cd0502b53378/guava/src/com/google/common/util/concurrent/AbstractService.java#L267).
2. Context switch!
3. `BackfilaStartupConfigurator` shutdown is triggered on separate thread (`AbstractIdleService`). This triggers `stopIfReady` to be invoked on upstream service `CoordinatedService (wrapping DynamoDbService)` [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L33) , and entering `synchronized` block on class [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L155).
4. `DynamoDbService` service terminates triggering `notifyStopped()` call to outer `CoordinatedService` to complete shutdown [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L31), but this call requires `monitor` lock held by `1.`
5. Context switch!
6. `stopAsync` continues from `1.`, but this is now blocked on the `synchronized` lock held by `3.` [here](https://github.com/cashapp/misk/blob/12ed7f69bab1d4e419a2ee29d9626faf526d9f3b/misk-service/src/main/kotlin/misk/CoordinatedService.kt#L155)

### Proposed Fix

Reducing scope of internal locking (and removing entirely where not needed). `AbstractService` itself mostly guarantees thread safety - the only areas we need to worry about is the state changes between Started -> Started & Stopped -> Terminated where we make internal state changes from multiple Threads. This is limited to:
- `startIfReady` where we need to call `service.startAsync()` exactly once when all upstream services are RUNNING. We can achieve via `AtomicBoolean`.
- `stopIfReady` I believe does not need guarantees. `stopAsync` can safely be called multiple times and guarantees the internal side-effect of starting the service will only be triggered once.

I believe the remaining locks are not required, and only increase the chance of potential future deadlocks.

### Scary Change Acknowledgement 

I acknowledgement diving into a core class that is responsible for startup and shutdown of our services, and ripping out `synchronised ` statements is a scary change. Open to recommendations on better validation / failing that could canary an internal release to test against select services.
