### PR TITLE
Add jvmargs to gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
+
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Was getting an out of memory error when releasing.