### PR TITLE
Give the gradle JVM 6g of heap and 5g of metaspace

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=5g


### PR DESCRIPTION
That's probably as much as GHA can handle.