### PR TITLE
Remove internal visibility modifier from PrometheusHttpService

### DIFF
--- a/misk-prometheus/api/misk-prometheus.api
+++ b/misk-prometheus/api/misk-prometheus.api
@@ -16,6 +16,9 @@ public final class misk/metrics/backends/prometheus/PrometheusConfig : wisp/conf
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class misk/metrics/backends/prometheus/PrometheusHttpService : com/google/common/util/concurrent/AbstractIdleService {
+}
+
 public final class misk/metrics/backends/prometheus/PrometheusMetricsClientModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 }

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusHttpService.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusHttpService.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal class PrometheusHttpService @Inject internal constructor(
+class PrometheusHttpService @Inject internal constructor(
   private val config: PrometheusConfig,
   private val registry: CollectorRegistry
 ) : AbstractIdleService() {


### PR DESCRIPTION
We would like to monitor the shut down latency for our service and noticed the metrics aren't being emitted, after digging more into the logs -- I think this is because the `PrometheusHttpService` is being shut down before our service, thus we are unable to flush out the metrics.

Removing the `internal` modifier so we can add a dependency in our service. Thank you!