### PR TITLE
Don't install /error action by default.

### DIFF
--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -25,7 +25,6 @@ import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
 import misk.security.authz.MiskCallerAuthenticator
 import misk.security.ssl.CertificatesModule
-import misk.web.actions.InternalErrorAction
 import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
 import misk.web.actions.ReadinessCheckAction
@@ -187,7 +186,6 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
     install(CertificatesModule())
 
     // Bind build-in actions.
-    install(WebActionModule.create<InternalErrorAction>())
     install(WebActionModule.create<StatusAction>())
     install(WebActionModule.create<ReadinessCheckAction>())
     install(WebActionModule.create<LivenessCheckAction>())


### PR DESCRIPTION
For services that are exposed to the public internet, this endpoint is an easy way to cause havoc with error logs and 5xx detectors.