### PR TITLE
Make StringConverter and converterFor visbility public.

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1737,6 +1737,10 @@ public final class misk/web/exceptions/GrpcErrorResponse$Companion {
 	public final fun getINTERNAL_SERVER_ERROR ()Lmisk/web/exceptions/GrpcErrorResponse;
 }
 
+public final class misk/web/extractors/StringConverterKt {
+	public static final fun converterFor (Lkotlin/reflect/KType;)Lkotlin/jvm/functions/Function1;
+}
+
 public final class misk/web/formatter/ClassNameFormatter {
 	public static final field Companion Lmisk/web/formatter/ClassNameFormatter$Companion;
 	public fun <init> ()V

--- a/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/StringConverter.kt
@@ -18,9 +18,9 @@ private val doubleTypeNullable: KType = Double::class.createType(nullable = true
 private val booleanType: KType = Boolean::class.createType(nullable = false)
 private val booleanTypeNullable: KType = Boolean::class.createType(nullable = true)
 
-internal typealias StringConverter = (String) -> Any?
+typealias StringConverter = (String) -> Any?
 
-internal fun converterFor(type: KType): StringConverter? {
+fun converterFor(type: KType): StringConverter? {
 
   return when {
     type.isSubtypeOf(stringType) -> { it -> it }


### PR DESCRIPTION
In order to allow misk application to validate query parameters
these functions are necessary.