### PR TITLE
Allow binding for application interceptors in grpc and typed clients

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -367,6 +367,10 @@ public final class misk/client/ClientAction {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class misk/client/ClientApplicationInterceptorFactory {
+	public abstract fun create (Lmisk/client/ClientAction;)Lokhttp3/Interceptor;
+}
+
 public abstract interface class misk/client/ClientChain {
 	public abstract fun getAction ()Lmisk/client/ClientAction;
 	public abstract fun getArgs ()Ljava/util/List;

--- a/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorFactory.kt
+++ b/misk/src/main/kotlin/misk/client/ClientApplicationInterceptorFactory.kt
@@ -1,0 +1,7 @@
+package misk.client
+
+import okhttp3.Interceptor
+
+interface ClientApplicationInterceptorFactory {
+  fun create(action: ClientAction): Interceptor?
+}

--- a/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
@@ -38,6 +38,7 @@ class GrpcClientModule<T : Service, G : T>(
       .`in`(Singleton::class.java)
 
     // Initialize empty sets for our multibindings.
+    newMultibinder<ClientApplicationInterceptorFactory>()
     newMultibinder<ClientNetworkInterceptor.Factory>()
   }
 

--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -33,6 +33,7 @@ class TypedHttpClientModule<T : Any>(
 
   override fun configure() {
     // Initialize empty sets for our multibindings.
+    newMultibinder<ClientApplicationInterceptorFactory>()
     newMultibinder<ClientNetworkInterceptor.Factory>()
 
     // Install raw HTTP client support
@@ -98,6 +99,7 @@ class TypedPeerHttpClientModule<T : Any>(
     requireBinding(PeerClientFactory::class.java)
 
     // Initialize empty sets for our multibindings.
+    newMultibinder<ClientApplicationInterceptorFactory>()
     newMultibinder<ClientNetworkInterceptor.Factory>()
 
     @Suppress("UNCHECKED_CAST")
@@ -145,6 +147,10 @@ class TypedClientFactory @Inject constructor() {
   @Inject
   private lateinit var clientNetworkInterceptorFactories:
     Provider<List<ClientNetworkInterceptor.Factory>>
+
+  @Inject
+  private lateinit var clientApplicationInterceptorFactories:
+    Provider<List<ClientApplicationInterceptorFactory>>
 
   @Inject
   private lateinit var clientMetricsInterceptorFactory: ClientMetricsInterceptor.Factory
@@ -212,6 +218,7 @@ class TypedClientFactory @Inject constructor() {
       retrofit,
       client,
       clientNetworkInterceptorFactories,
+      clientApplicationInterceptorFactories,
       eventListenerFactory,
       tracer,
       moshi,


### PR DESCRIPTION
We can configure network interceptors using guice multibindings, but theres currently no way to configure application interceptors. This PR creates a similar multibind to add application interceptors.

### Why?

I'm using okreplay to capture in dev and replay responses without hitting the backend in CI. This cant use a network interceptor because they will error if proceed isn't called. Or as the docs say:
![image](https://user-images.githubusercontent.com/2247982/140670054-ab3e3c4f-72b8-4e72-a0e4-8816de8dd186.png)
