### PR TITLE
Properly shut down Google Spanner clients

### DIFF
--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
@@ -216,6 +216,7 @@ class GoogleSpannerEmulator @Inject constructor(
    * Stops a Docker container running the Google Spanner emulator.
    */
   override fun shutDown() {
+    client.close()
     logger.info(
       "Leaving Spanner docker container running in the background. " +
         "If you need to kill it because you messed up migrations or something use:" +

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorModule.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorModule.kt
@@ -9,7 +9,10 @@ class GoogleSpannerEmulatorModule(
   private val config: SpannerConfig,
 ): KAbstractModule() {
   override fun configure() {
-    install(ServiceModule<GoogleSpannerEmulator>())
+    install(
+      ServiceModule<GoogleSpannerEmulator>()
+        .dependsOn<GoogleSpannerService>()
+    )
     bind(keyOf<GoogleSpannerEmulator>()).toInstance(
       GoogleSpannerEmulator(config)
     )

--- a/misk-gcp/api/misk-gcp.api
+++ b/misk-gcp/api/misk-gcp.api
@@ -106,6 +106,14 @@ public final class misk/cloud/gcp/spanner/GoogleSpannerModule : misk/inject/KAbs
 	public final fun provideCloudSpanner (Lmisk/cloud/gcp/spanner/SpannerConfig;)Lcom/google/cloud/spanner/Spanner;
 }
 
+public final class misk/cloud/gcp/spanner/GoogleSpannerService : com/google/common/util/concurrent/AbstractIdleService {
+	public static final field Companion Lmisk/cloud/gcp/spanner/GoogleSpannerService$Companion;
+	public fun <init> (Lcom/google/cloud/spanner/Spanner;)V
+}
+
+public final class misk/cloud/gcp/spanner/GoogleSpannerService$Companion {
+}
+
 public final class misk/cloud/gcp/spanner/SpannerConfig : wisp/config/Config {
 	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;)V
 	public synthetic fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModuleTest.kt
+++ b/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModuleTest.kt
@@ -6,7 +6,10 @@ import misk.MiskTestingServiceModule
 import misk.environment.DeploymentModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import wisp.deployment.TESTING
 import javax.inject.Inject
@@ -31,7 +34,9 @@ class GoogleSpannerModuleTest {
   )
 
   @Inject lateinit var spanner: Spanner
+  @Inject lateinit var spannerService: GoogleSpannerService
 
+  @Order(1)
   @Test
   fun `it creates a Spanner client and emulator to develop with`() {
     assertTrue(spanner.instanceAdminClient
@@ -39,5 +44,26 @@ class GoogleSpannerModuleTest {
       .getDatabase(spannerConfig.database)
       .exists()
     )
+  }
+
+  @Nested
+  inner class `GoogleSpannerService tests` {
+    @Order(2)
+    @Test
+    fun `it binds an open Spanner client when started`() {
+      // Since startService=true is specified, this should already be running.
+      assertTrue(spannerService.isRunning)
+
+      // The client should be callable for requests.
+      assertFalse(spanner.isClosed)
+    }
+
+    @Order(3)
+    @Test
+    fun `it shuts down the Spanner client when stopped`() {
+      spannerService.stopAsync()
+      spannerService.awaitTerminated()
+      assertTrue(spanner.isClosed)
+    }
   }
 }


### PR DESCRIPTION
When a Google Spanner client or emulator is shut down, the client should be closed so that the sessions are released. Previously, the sessions were left open or terminated in an abrupt way (whereas it should drain the requests first).