### PR TITLE
Record client metrics for incomplete HTTP connections.

### DIFF
--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -36,6 +36,13 @@ class ClientMetricsInterceptor private constructor(
       requestDurationSummary.labels(actionName, "timeout").observe(elapsedMillis)
       requestDurationHistogram.labels(actionName, "timeout").observe(elapsedMillis)
       throw e
+    } catch (e: Exception) {
+      // Something else happened while the connection was in progress and we didn't receive
+      // a complete response. We still want to record any long-running calls, however.
+      val elapsedMillis = stopwatch.stop().elapsed(TimeUnit.MILLISECONDS).toDouble()
+      requestDurationSummary.labels(actionName, "incomplete-response").observe(elapsedMillis)
+      requestDurationHistogram.labels(actionName, "incomplete-response").observe(elapsedMillis)
+      throw e
     }
   }
 


### PR DESCRIPTION
The $Pay team has strict SLAs for payments, and aborts any payment that exceeds them. Sometimes these SLAs are exceeded when a downstream service is slow to return a response, but since we cancel the connection (which triggers an exception) our metrics do not show these slow requests. This change allows RPC Outgoing dashboards to reflect the full set of connections, not just the ones that either time out or return a complete response.