### PR TITLE
Remove incompatible Spanner config

### DIFF
--- a/misk-gcp/api/misk-gcp.api
+++ b/misk-gcp/api/misk-gcp.api
@@ -115,23 +115,21 @@ public final class misk/cloud/gcp/spanner/GoogleSpannerService$Companion {
 }
 
 public final class misk/cloud/gcp/spanner/SpannerConfig : wisp/config/Config {
-	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;)V
-	public synthetic fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/google/auth/Credentials;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lmisk/cloud/gcp/TransportConfig;
-	public final fun copy (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;)Lmisk/cloud/gcp/spanner/SpannerConfig;
-	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerConfig;Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Lmisk/cloud/gcp/TransportConfig;ILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerConfig;
+	public final fun copy (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;)Lmisk/cloud/gcp/spanner/SpannerConfig;
+	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerConfig;Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCredentials ()Lcom/google/auth/Credentials;
 	public final fun getDatabase ()Ljava/lang/String;
 	public final fun getEmulator ()Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
 	public final fun getInstance_id ()Ljava/lang/String;
 	public final fun getProject_id ()Ljava/lang/String;
-	public final fun getTransport ()Lmisk/cloud/gcp/TransportConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModule.kt
@@ -43,13 +43,6 @@ class GoogleSpannerModule(
     } else {
       builder = builder
         .setCredentials(credentials)
-        .setHost(config.transport.host)
-        .setTransportOptions(
-          HttpTransportOptions.newBuilder()
-            .setConnectTimeout(config.transport.connect_timeout_ms)
-            .setReadTimeout(config.transport.read_timeout_ms)
-            .build()
-        )
     }
 
     return builder.build().service

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
@@ -44,11 +44,6 @@ data class SpannerConfig(
    * > GCP project - any string will do.
    */
   val project_id: String,
-
-  /**
-   * Options for how requests are made to the Spanner APIs.
-   */
-  val transport: TransportConfig = TransportConfig(),
 ) : Config
 
 /**


### PR DESCRIPTION
Spanner only works over the gRPC transport, which doesn't have settings for timeouts. Providing the HTTP transport setting causes the app to fail on startup, so we need to get rid of it.