### PR TITLE
Don't publish enforcedPlatforms to downstream consumers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,13 +74,13 @@ subprojects {
     add("testRuntimeOnly", Dependencies.junitEngine)
 
     // Platform/BOM dependencies constrain versions only.
-    add("api", enforcedPlatform(Dependencies.grpcBom))
-    add("api", enforcedPlatform(Dependencies.guava))
-    add("api", enforcedPlatform(Dependencies.jacksonBom))
-    add("api", enforcedPlatform(Dependencies.jerseyBom))
-    add("api", enforcedPlatform(Dependencies.jettyBom))
-    add("api", enforcedPlatform(Dependencies.kotlinBom))
-    add("api", enforcedPlatform(Dependencies.nettyBom))
+    add("api", platform(Dependencies.grpcBom))
+    add("api", platform(Dependencies.guava))
+    add("api", platform(Dependencies.jacksonBom))
+    add("api", platform(Dependencies.jerseyBom))
+    add("api", platform(Dependencies.jettyBom))
+    add("api", platform(Dependencies.kotlinBom))
+    add("api", platform(Dependencies.nettyBom))
   }
 
   tasks.withType<DokkaTask>().configureEach {


### PR DESCRIPTION
When an enforcedPlatform is used in the dependency list,
it forces all downstream consumers of that artifact to use the
exact same version that is specified. This is generally not
desirable, and in fact gradle 7.2 produces the following error:

```
> Invalid publication 'maven':
    - Variant 'apiElements' contains a dependency on enforced platform 'io.grpc:grpc-bom'
    - Variant 'runtimeElements' contains a dependency on enforced platform 'io.grpc:grpc-bom'
  In general publishing dependencies to enforced platforms is a mistake: enforced platforms shouldn't be used for published components because they behave like forced dependencies and leak to consumers. This can result in hard to diagnose dependency resolution errors.
```

Although the error can be suppressed if we are doing this
intentionally, I believe we are NOT doing this intentionally,
and so instead we should avoid using enforcedPlatform, and use
platform instead.