### PR TITLE
fix: do not require List<Client*Interceptor> to be bound when using TypedClientFactory stand-alone

### DIFF
--- a/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/TypedHttpClientModule.kt
@@ -144,13 +144,15 @@ class TypedClientFactory @Inject constructor() {
   // Use Providers for the interceptors so Guice can properly detect cycles when apps inject
   // an HTTP Client in an Interceptor.
   // https://gist.github.com/ryanhall07/e3eac6d2d47b72a4c37bce87219d7ced
-  @Inject
-  private lateinit var clientNetworkInterceptorFactories:
-    Provider<List<ClientNetworkInterceptor.Factory>>
+  // Also, these are optional because the end user may not have used TypedHttpClientModule at all
+  // and thus may not have had multibindings provided here.
+  @Inject(optional = true)
+  private val clientNetworkInterceptorFactories:
+    Provider<List<ClientNetworkInterceptor.Factory>> = Provider { emptyList() }
 
-  @Inject
-  private lateinit var clientApplicationInterceptorFactories:
-    Provider<List<ClientApplicationInterceptorFactory>>
+  @Inject(optional = true)
+  private val clientApplicationInterceptorFactories:
+    Provider<List<ClientApplicationInterceptorFactory>> = Provider { emptyList() }
 
   @Inject
   private lateinit var clientMetricsInterceptorFactory: ClientMetricsInterceptor.Factory

--- a/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
+++ b/misk/src/test/kotlin/misk/client/TypedHttpClientTest.kt
@@ -67,6 +67,18 @@ internal class TypedHttpClientTest {
   fun buildDynamicClients() {
     val typedClientFactory = clientInjector.getInstance(TypedClientFactory::class.java)
 
+    testBuildAndUseDynamicClient(typedClientFactory)
+  }
+
+  @Test
+  fun buildDynamicClientWithoutHavingBuiltAnyOtherClients() {
+    val injector = Guice.createInjector(MiskTestingServiceModule())
+    val typedClientFactory = injector.getInstance(TypedClientFactory::class.java)
+
+    testBuildAndUseDynamicClient(typedClientFactory)
+  }
+
+  private fun testBuildAndUseDynamicClient(typedClientFactory: TypedClientFactory) {
     val dinoClient = typedClientFactory.build<ReturnADinosaur>(
       HttpClientEndpointConfig(jetty.httpServerUrl.toString()),
       "dynamicDino"


### PR DESCRIPTION
When an app does not use TypedHttpClientModule and tries to use TypedClientFactory, it asks for lists of client interceptors. These are usually bound to an empty list (new multibinder) in TypedHttpClientModule, so without that module bound it fails.