### PR TITLE
Fix up publish stanza for misk-bom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     maven(url = "https://plugins.gradle.org/m2/")
   }
 
@@ -82,6 +81,10 @@ subprojects {
       add("api", platform(Dependencies.jettyBom))
       add("api", platform(Dependencies.kotlinBom))
       add("api", platform(Dependencies.nettyBom))
+    }
+
+    tasks.withType<GenerateModuleMetadata> {
+      suppressedValidationErrors.add("enforced-platform")
     }
   }
 

--- a/misk-bom/build.gradle.kts
+++ b/misk-bom/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   `java-platform`
-  `maven-publish`
 }
 
 dependencies {
@@ -11,11 +10,16 @@ dependencies {
   }
 }
 
+apply(plugin = "com.vanniktech.maven.publish.base")
 
-publishing {
-  publications {
-    create<MavenPublication>("maven") {
-      from(components["javaPlatform"])
+mavenPublishing {
+  pomFromGradleProperties()
+
+  publishing {
+    publications {
+      create<MavenPublication>("maven") {
+        from(components["javaPlatform"])
+      }
     }
   }
 }


### PR DESCRIPTION
Also suppresses the enforced-platform error message. We're intentionally enforcing logging lib versions.