### PR TITLE
Add a MDC sentry tag to Misk for custom senrtry routing - clear it by default

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLogContextInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLogContextInterceptor.kt
@@ -58,10 +58,13 @@ internal class RequestLogContextInterceptor private constructor(
     const val MDC_REQUEST_URI = "request_uri"
     const val MDC_PROTOCOL = "protocol"
     const val MDC_HTTP_METHOD = "http_method"
+    // Used by services to customized sentry issue routing.
+    const val MDC_SENTRY_ROUTING = "sentry_routing"
 
     val allContextNames = listOf(
       MDC_ACTION,
       MDC_CALLING_PRINCIPAL,
+      MDC_SENTRY_ROUTING
     )
   }
 }

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLogContextInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLogContextInterceptorTest.kt
@@ -51,6 +51,7 @@ internal class RequestLogContextInterceptorTest {
     assertThat(contextFields[RequestLogContextInterceptor.MDC_REQUEST_URI])
       .isEqualTo("/call/me")
     assertThat(contextFields[RequestLogContextInterceptor.MDC_REMOTE_ADDR]).isNotEmpty()
+    assertThat(contextFields[RequestLogContextInterceptor.MDC_SENTRY_ROUTING]).isNull()
   }
 
   fun invoke(asService: String? = null): okhttp3.Response {


### PR DESCRIPTION
Some teams would like to leverage the `sentry_routing` tag to [custom tag-based routing of sentry issues](https://sentry.io/resources/alert-rules/#routing-alerts-to-different-teams). 

This change adds logic to clear the `sentry_routing` log context tag in the RequestLogContextInterceptor, where it makes the most sense, after all misk interceptors have run. This allows teams to route sentry issues from error logs not only the service's code base, but also from Misk interceptors.