### PR TITLE
Enable binding both real and fake job queue handler within Misk

### DIFF
--- a/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobHandlerModule.kt
+++ b/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobHandlerModule.kt
@@ -1,6 +1,7 @@
 package misk.jobqueue
 
 import misk.inject.KAbstractModule
+import javax.inject.Qualifier
 import kotlin.reflect.KClass
 
 class FakeJobHandlerModule<T : JobHandler> private constructor(
@@ -9,7 +10,7 @@ class FakeJobHandlerModule<T : JobHandler> private constructor(
 ) : KAbstractModule() {
 
   override fun configure() {
-    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
+    newMapBinder<QueueName, JobHandler>(FakeHandler::class).addBinding(queueName).to(handler.java)
   }
 
   companion object {
@@ -35,3 +36,6 @@ class FakeJobHandlerModule<T : JobHandler> private constructor(
     }
   }
 }
+
+@Qualifier
+internal annotation class FakeHandler

--- a/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue-testing/src/main/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -32,7 +32,7 @@ import javax.inject.Singleton
 @Singleton
 class FakeJobQueue @Inject constructor(
   private val clock: Clock,
-  private val jobHandlers: Provider<Map<QueueName, JobHandler>>,
+  @FakeHandler private val jobHandlers: Provider<Map<QueueName, JobHandler>>,
   private val tokenGenerator: TokenGenerator
 ) : JobQueue, TransactionalJobQueue {
   private val jobQueues = ConcurrentHashMap<QueueName, PriorityBlockingQueue<FakeJob>>()


### PR DESCRIPTION
Currently, we can't bind both fake and real job handlers within Misk because the fake job handlers are treated as real when instantiating the [AwsSqsJobHandlerSubscriptionService](https://github.com/cashapp/misk/blob/master/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt#L75). This change fixes that, enabling Misk to have both fake and real job handlers bound in a single Misk service instance.