### PR TITLE
Give Limiter a nanosecond clock like it expects

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -19,6 +19,8 @@ import org.slf4j.event.Level
 import wisp.logging.getLogger
 import wisp.logging.log
 import java.net.HttpURLConnection
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Detects degraded behavior and sheds requests accordingly. Internally this uses adaptive limiting
@@ -173,7 +175,7 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
         .mapNotNull { it.create(action) }
         .firstOrNull()
         ?: SimpleLimiter.Builder()
-          .clock { clock.millis() }
+          .clock { Duration.between(Instant.EPOCH, clock.instant()).toNanos() }
           .named(quotaPath ?: action.name)
           .build()
     }

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -1,5 +1,6 @@
 package misk.web.interceptors
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.netflix.concurrency.limits.Limiter
@@ -170,7 +171,8 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
       )
     }
 
-    private fun createLimiterForAction(action: Action, quotaPath: String?): Limiter<String> {
+    @VisibleForTesting
+    internal fun createLimiterForAction(action: Action, quotaPath: String?): Limiter<String> {
       return limiterFactories.asSequence()
         .mapNotNull { it.create(action) }
         .firstOrNull()

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -1,14 +1,11 @@
 package misk.web.interceptors
 
 import ch.qos.logback.classic.Level
+import com.google.inject.util.Modules
 import com.netflix.concurrency.limits.Limiter
 import com.netflix.concurrency.limits.limit.SettableLimit
 import com.netflix.concurrency.limits.limiter.SimpleLimiter
 import io.prometheus.client.CollectorRegistry
-import java.time.Duration
-import java.time.temporal.ChronoUnit
-import javax.inject.Inject
-import javax.inject.Singleton
 import misk.Action
 import misk.MiskTestingServiceModule
 import misk.asAction
@@ -33,6 +30,11 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
+import java.time.Clock
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @MiskTest(startService = true)
 class ConcurrencyLimitsInterceptorTest {
@@ -40,7 +42,7 @@ class ConcurrencyLimitsInterceptorTest {
   val module = TestModule()
 
   @Inject private lateinit var factory: ConcurrencyLimitsInterceptor.Factory
-  @Inject private lateinit var clock: FakeClock
+  @Inject private lateinit var clock: FakeNanoClock
   @Inject lateinit var logCollector: LogCollector
   @Inject lateinit var prometheusRegistry: CollectorRegistry
 
@@ -148,6 +150,33 @@ class ConcurrencyLimitsInterceptorTest {
     assertThat(callSuccessCount("/event_consumer/topic_baz")).isEqualTo(1.0)
   }
 
+  @Test
+  fun limiterResolutionExceedsMicroseconds() {
+    val action = HelloAction::call.asAction(DispatchMechanism.GET)
+    val limiter = factory.createLimiterForAction(action, null)
+    val interceptor = ConcurrencyLimitsInterceptor(factory, action, limiter, clock)
+
+    // load up some inflight requests so we get past "Prevent upward drift if not close to the limit"
+    repeat(10) {
+      limiter.acquire(action.name)
+    }
+    // establish a baseline rtt
+    call(action, interceptor, callDuration = Duration.ofNanos(2400 * 1000))
+    // new request just 0.8ms longer. This should bump the limit up because its rtt implies a
+    // fairly empty queue.
+    call(action, interceptor, callDuration = Duration.ofNanos(3200 * 1000))
+    // metrics updated before, not after, request, so we need another request to trigger an update
+    call(action, interceptor, callDuration = Duration.ofNanos(2500 * 1000))
+
+    val limit = prometheusRegistry.getSampleValue(
+      "concurrency_limits_limit",
+      arrayOf("quota_path"),
+      arrayOf("HelloAction")
+    )
+    // VegasLimit should've bumped _up_ the concurrency limit
+    assertThat(limit).isGreaterThanOrEqualTo(20.0)
+  }
+
   private fun call(
     action: Action,
     interceptor: NetworkInterceptor,
@@ -188,7 +217,12 @@ class ConcurrencyLimitsInterceptorTest {
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(LogCollectorModule())
-      install(MiskTestingServiceModule())
+      install(Modules.override(MiskTestingServiceModule()).with(object : KAbstractModule() {
+        override fun configure() {
+          bind<Clock>().to<FakeNanoClock>()
+          bind<FakeNanoClock>().toInstance(FakeNanoClock())
+        }
+      }))
 
       multibind<ConcurrencyLimiterFactory>().to<CustomLimiterFactory>()
     }

--- a/misk/src/test/kotlin/misk/web/interceptors/FakeNanoClock.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/FakeNanoClock.kt
@@ -1,0 +1,35 @@
+package misk.web.interceptors
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Alternative implementation of FakeClock with nanosecond precision. This implementation is
+ * slower, because it uses synchronization over an AtomicLong, but that's fine.
+ */
+class FakeNanoClock(
+  epochMillis: Long = Instant.parse("2018-01-01T00:00:00Z").toEpochMilli(),
+  private val zone: ZoneId = ZoneId.of("UTC")
+) : Clock() {
+
+  private var now: Instant = Instant.ofEpochMilli(epochMillis)
+
+  override fun getZone(): ZoneId = zone
+
+  override fun withZone(zone: ZoneId): Clock = FakeNanoClock(now.toEpochMilli(), zone)
+
+  @Synchronized
+  override fun instant(): Instant = now.atZone(zone).toInstant()
+
+  @Synchronized
+  fun add(d: Duration) {
+    now = now.plus(d)
+  }
+
+  @Synchronized
+  fun setNow(instant: Instant) {
+    now = instant
+  }
+}


### PR DESCRIPTION
The `Supplier<Long> clock` that AbstractLimiter.Builder.clock() expects is supposed to return a
_nanosecond_ value, not a millisecond value. All of the internal machinery of concurrency-limits
assumes the clock values are in nanoseconds, so we should give it what it expects.

`VegasLimiter` divides the current `rtt` by the minimum RTT it's seen recently (`rtt_noload`),
so as long as they're reasonably large integers (say, >10), then the rounding error introduced
by the lack of timing precision here should be a non-issue. However, for _very fast_ actions
(such as `cash-oauth`'s `AuthenticateClientAction`), the resolution is impaired to the point
of causing problems. If `min_rtt` is 2.54ms, that gets rounded off to 2. Then, if a request
happens to hit a 1ms GC pause, it takes `3.54ms` and gets rounded off to 3. Assuming an
`estimatedLimit` of 20 (the default value), `VegasLimiter` then estimates `queueSize` at 7.
The Vegas algorithm tries to keep the queue size between `alpha` (default 3) and `beta`
(default 6), but with ms resolution we only have a few discrete values for `queueSize`:
[0, 7, 10, 12, ...]. So the algorithm sees `queueSize` fluttering between 0 and 7, instead of
smoothly varying between 0 and 7, and doesn't handle that well.

This is the first (tiny) fruit of [my investigation into ConcurrencyLimitsInterceptor](https://docs.google.com/document/d/1oKsBcNupc7805vE3K5S-g5wALjohbqjDPelYxqWzQ8I/edit) and its impact
on Cash App Pay services.