### PR TITLE
Configure VegasLimit with higher initial limit

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -3,6 +3,7 @@ package misk.web.interceptors
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.netflix.concurrency.limits.Limiter
+import com.netflix.concurrency.limits.limit.VegasLimit
 import com.netflix.concurrency.limits.limiter.AbstractLimiter
 import com.netflix.concurrency.limits.limiter.SimpleLimiter
 import java.time.Clock
@@ -15,6 +16,7 @@ import misk.metrics.Metrics
 import misk.web.AvailableWhenDegraded
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
+import misk.web.WebConfig
 import org.slf4j.event.Level
 import wisp.logging.getLogger
 import wisp.logging.log
@@ -131,6 +133,7 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
   class Factory @Inject constructor(
     private val clock: Clock,
     private val limiterFactories: List<ConcurrencyLimiterFactory>,
+    private val config: WebConfig,
     metrics: Metrics,
   ) : NetworkInterceptor.Factory {
     val outcomeCounter = metrics.counter(
@@ -174,6 +177,13 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
         .firstOrNull()
         ?: SimpleLimiter.Builder()
           .clock { clock.millis() }
+          .limit(VegasLimit.newBuilder()
+            // 2 is chosen somewhat arbitrarily here. Most services have one or two endpoints
+            // that receive the majority of traffic (power law, yay!), and those endpoints should
+            // _start up_ without triggering the concurrency limiter at the parallelism that we
+            // configured Jetty to support.
+            .initialLimit(config.jetty_max_thread_pool_size / 2)
+            .build())
           .named(quotaPath ?: action.name)
           .build()
     }


### PR DESCRIPTION
The default initialLimit of the VegasLimit in concurrency-limits-core is 20. Once a service is
up and running under some significant load, VegasLimit will start to tune the limit to the optimal
point. Before then, though, it'll drop any requests after 20 inflight requests get going. This
happens frequently after deploys in some of our services as they're still warming up. Given that the
default Jetty thread pool is _200_, these services should be able to handle a whole lot more than 20
concurrent requests. VegasLimit will eventually figure that out, but not before it drops a bunch of
requests during warm-up. By opening up the initialLimit to a much larger value (200 / 2 = 100), we
should get much less spurious traffic shedding on startup.

The value of `jetty_max_thread_pool_size / 2` was chosen somewhat arbitrarily. I figure that most
services with significant traffic see that traffic only on a couple of endpoints (power law
distribution), so the limits on _each_ of those endpoints should roughly add up to the
`jetty_max_thread_pool_size`. We could make this configurable per-service, but I doubt more than a
couple of teams will go to the effort of configuring it, so I prefer a better default. We could just
double the current default (20 -> 40) and see how that goes, but I feel that basing the initialLimit
on `jetty_max_thread_pool_size` will work better for more teams, because anybody who has bothered to
configure `jetty_max_thread_pool_size` to something reasonable will then benefit from properly tuned
initialLimit.