### PR TITLE
Avoid deprecated Int versions of redis functions

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -75,7 +75,7 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
   /** Set a ByteArray value with an expiration. */
   override fun set(key: String, expiryDuration: Duration, value: ByteString) {
     jedisPool.resource.use { jedis ->
-      jedis.setex(key.toByteArray(charset), expiryDuration.seconds.toInt(), value.toByteArray())
+      jedis.setex(key.toByteArray(charset), expiryDuration.seconds, value.toByteArray())
     }
   }
 
@@ -88,7 +88,7 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
 
   /** Set a ByteArray value if it doesn't already exist with an expiration. */
   override fun setnx(key: String, expiryDuration: Duration, value: ByteString) {
-    val setParams = SetParams.setParams().ex(expiryDuration.seconds.toInt()).nx()
+    val setParams = SetParams.setParams().ex(expiryDuration.seconds).nx()
     jedisPool.resource.use { jedis ->
       jedis.set(key.toByteArray(charset), value.toByteArray(), setParams)
     }


### PR DESCRIPTION
The versions of these functions that accept `int` are deprecated, they use `long` now.