### PR TITLE
Add ability to set max age for prometheus summaries

### DIFF
--- a/misk-metrics-testing/api/misk-metrics-testing.api
+++ b/misk-metrics-testing/api/misk-metrics-testing.api
@@ -4,7 +4,7 @@ public final class misk/metrics/FakeMetrics : misk/metrics/Metrics {
 	public final fun get (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun getSample (Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public static synthetic fun getSample$default (Lmisk/metrics/FakeMetrics;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;ILjava/lang/Object;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
-	public fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lmisk/metrics/Histogram;
+	public fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
 	public final fun histogramCount (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramMean (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramP50 (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
@@ -24,7 +24,7 @@ public final class misk/metrics/v2/FakeMetrics : misk/metrics/v2/Metrics {
 	public final fun getSample (Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public static synthetic fun getSample$default (Lmisk/metrics/v2/FakeMetrics;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;ILjava/lang/Object;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/prometheus/client/Histogram;
-	public fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/prometheus/client/Summary;
+	public fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lio/prometheus/client/Summary;
 	public final fun summaryCount (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun summaryMean (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun summaryP50 (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
@@ -32,7 +32,8 @@ class FakeMetrics @Inject internal constructor(
     name: String,
     help: String,
     labelNames: List<String>,
-    quantiles: Map<Double, Double>
+    quantiles: Map<Double, Double>,
+    maxAgeSeconds: Long?
   ): Histogram {
     val summary = Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
@@ -32,7 +32,7 @@ class FakeMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maybeMaxAgeSeconds: Long?
+    maxAgeSeconds: Long?
   ): Histogram {
     val summary = Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())
@@ -42,8 +42,8 @@ class FakeMetrics @Inject internal constructor(
         }
       }
       .apply {
-        if (maybeMaxAgeSeconds != null) {
-          maxAgeSeconds(maybeMaxAgeSeconds)
+        if (maxAgeSeconds != null) {
+          this.maxAgeSeconds(maxAgeSeconds)
         }
       }
       .register(registry)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
@@ -5,7 +5,6 @@ import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Counter
 import io.prometheus.client.Gauge
 import io.prometheus.client.Summary
-import misk.metrics.Metrics
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,13 +32,18 @@ class FakeMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
+    maybeMaxAgeSeconds: Long?
   ): Histogram {
     val summary = Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())
       .apply {
         quantiles.forEach { (key, value) ->
           quantile(key, value)
+        }
+      }
+      .apply {
+        if (maybeMaxAgeSeconds != null) {
+          maxAgeSeconds(maybeMaxAgeSeconds)
         }
       }
       .register(registry)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -51,13 +51,19 @@ class FakeMetrics @Inject internal constructor(
     name: String,
     help: String,
     labelNames: List<String>,
-    quantiles: Map<Double, Double>
+    quantiles: Map<Double, Double>,
+    maxAgeSeconds: Long?
   ): Summary =
     Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())
       .apply {
         quantiles.forEach { (key, value) ->
           quantile(key, value)
+        }
+      }
+      .apply {
+        if (maxAgeSeconds != null) {
+          maxAgeSeconds(maxAgeSeconds)
         }
       }
       .register(registry)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -52,7 +52,7 @@ class FakeMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
+    maybeMaxAgeSeconds: Long?
   ): Summary =
     Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())
@@ -62,8 +62,8 @@ class FakeMetrics @Inject internal constructor(
         }
       }
       .apply {
-        if (maxAgeSeconds != null) {
-          maxAgeSeconds(maxAgeSeconds)
+        if (maybeMaxAgeSeconds != null) {
+          maxAgeSeconds(maybeMaxAgeSeconds)
         }
       }
       .register(registry)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -52,7 +52,7 @@ class FakeMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maybeMaxAgeSeconds: Long?
+    maxAgeSeconds: Long?
   ): Summary =
     Summary.build(name, help)
       .labelNames(*labelNames.toTypedArray())
@@ -62,8 +62,8 @@ class FakeMetrics @Inject internal constructor(
         }
       }
       .apply {
-        if (maybeMaxAgeSeconds != null) {
-          maxAgeSeconds(maybeMaxAgeSeconds)
+        if (maxAgeSeconds != null) {
+          this.maxAgeSeconds(maxAgeSeconds)
         }
       }
       .register(registry)

--- a/misk-metrics/api/misk-metrics.api
+++ b/misk-metrics/api/misk-metrics.api
@@ -15,13 +15,13 @@ public abstract interface class misk/metrics/HistogramRegistry {
 public abstract interface class misk/metrics/Metrics {
 	public abstract fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
 	public abstract fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
-	public abstract fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lmisk/metrics/Histogram;
+	public abstract fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
 }
 
 public final class misk/metrics/Metrics$DefaultImpls {
 	public static synthetic fun counter$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Counter;
 	public static synthetic fun gauge$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Gauge;
-	public static synthetic fun histogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lmisk/metrics/Histogram;
+	public static synthetic fun histogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/Histogram;
 }
 
 public final class misk/metrics/MetricsKt {
@@ -35,14 +35,14 @@ public abstract interface class misk/metrics/v2/Metrics {
 	public abstract fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
 	public abstract fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
 	public abstract fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/prometheus/client/Histogram;
-	public abstract fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/prometheus/client/Summary;
+	public abstract fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lio/prometheus/client/Summary;
 }
 
 public final class misk/metrics/v2/Metrics$DefaultImpls {
 	public static synthetic fun counter$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Counter;
 	public static synthetic fun gauge$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Gauge;
 	public static synthetic fun histogram$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Histogram;
-	public static synthetic fun summary$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/prometheus/client/Summary;
+	public static synthetic fun summary$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lio/prometheus/client/Summary;
 }
 
 public final class misk/metrics/v2/MetricsKt {

--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -63,7 +63,7 @@ interface Metrics {
     help: String = "",
     labelNames: List<String>,
     quantiles: Map<Double, Double> = defaultQuantiles,
-    maxAgeSeconds: Long?
+    maxAgeSeconds: Long? = null
   ): Histogram
 }
 

--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -62,7 +62,8 @@ interface Metrics {
     name: String,
     help: String = "",
     labelNames: List<String>,
-    quantiles: Map<Double, Double> = defaultQuantiles
+    quantiles: Map<Double, Double> = defaultQuantiles,
+    maxAgeSeconds: Long?
   ): Histogram
 }
 

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -72,7 +72,7 @@ interface Metrics {
     help: String = "",
     labelNames: List<String>,
     buckets: List<Double> = defaultBuckets,
-    maxAgeSeconds: Long?
+    maxAgeSeconds: Long? = null
   ): Histogram
 
   /**

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -71,7 +71,8 @@ interface Metrics {
     name: String,
     help: String = "",
     labelNames: List<String>,
-    buckets: List<Double> = defaultBuckets
+    buckets: List<Double> = defaultBuckets,
+    maxAgeSeconds: Long?
   ): Histogram
 
   /**

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -71,8 +71,7 @@ interface Metrics {
     name: String,
     help: String = "",
     labelNames: List<String>,
-    buckets: List<Double> = defaultBuckets,
-    maxAgeSeconds: Long? = null
+    buckets: List<Double> = defaultBuckets
   ): Histogram
 
   /**
@@ -95,7 +94,8 @@ interface Metrics {
     name: String,
     help: String = "",
     labelNames: List<String>,
-    quantiles: Map<Double, Double> = defaultQuantiles
+    quantiles: Map<Double, Double> = defaultQuantiles,
+    maxAgeSeconds: Long? = null
   ): Summary
 }
 

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -33,7 +33,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long? = null,
+    maxAgeSeconds: Long?,
   ): Histogram = PrometheusHistogram(metricsV2.summary(name, help, labelNames, quantiles, maxAgeSeconds))
 
   companion object {

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -32,8 +32,9 @@ internal class PrometheusMetrics @Inject internal constructor(
     name: String,
     help: String,
     labelNames: List<String>,
-    quantiles: Map<Double, Double>
-  ): Histogram = PrometheusHistogram(metricsV2.summary(name, help, labelNames, quantiles))
+    quantiles: Map<Double, Double>,
+    maxAgeSeconds: Long?
+  ): Histogram = PrometheusHistogram(metricsV2.summary(name, help, labelNames, quantiles, maxAgeSeconds))
 
   companion object {
     /**

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -33,7 +33,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
+    maxAgeSeconds: Long? = null,
   ): Histogram = PrometheusHistogram(metricsV2.summary(name, help, labelNames, quantiles, maxAgeSeconds))
 
   companion object {

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -50,7 +50,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
+    maxAgeSeconds: Long? = null,
   ): Summary = Summary
     .build(name, help)
     .labelNames(*labelNames.toTypedArray())

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -50,7 +50,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maybeMaxAgeSeconds: Long?,
+    maxAgeSeconds: Long?,
   ): Summary = Summary
     .build(name, help)
     .labelNames(*labelNames.toTypedArray())
@@ -60,8 +60,8 @@ internal class PrometheusMetrics @Inject internal constructor(
       }
     }
     .apply {
-      if (maybeMaxAgeSeconds != null) {
-        maxAgeSeconds(maybeMaxAgeSeconds)
+      if (maxAgeSeconds != null) {
+        this.maxAgeSeconds(maxAgeSeconds)
       }
     }
     .register(registry)

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -49,13 +49,19 @@ internal class PrometheusMetrics @Inject internal constructor(
     name: String,
     help: String,
     labelNames: List<String>,
-    quantiles: Map<Double, Double>
+    quantiles: Map<Double, Double>,
+    maxAgeSeconds: Long?
   ): Summary = Summary
     .build(name, help)
     .labelNames(*labelNames.toTypedArray())
     .apply {
       quantiles.forEach { (key, value) ->
         quantile(key, value)
+      }
+    }
+    .apply {
+      if (maxAgeSeconds != null) {
+        maxAgeSeconds(maxAgeSeconds)
       }
     }
     .register(registry)

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -50,7 +50,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long? = null,
+    maxAgeSeconds: Long?,
   ): Summary = Summary
     .build(name, help)
     .labelNames(*labelNames.toTypedArray())

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -50,7 +50,7 @@ internal class PrometheusMetrics @Inject internal constructor(
     help: String,
     labelNames: List<String>,
     quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?,
+    maybeMaxAgeSeconds: Long?,
   ): Summary = Summary
     .build(name, help)
     .labelNames(*labelNames.toTypedArray())
@@ -60,8 +60,8 @@ internal class PrometheusMetrics @Inject internal constructor(
       }
     }
     .apply {
-      if (maxAgeSeconds != null) {
-        maxAgeSeconds(maxAgeSeconds)
+      if (maybeMaxAgeSeconds != null) {
+        maxAgeSeconds(maybeMaxAgeSeconds)
       }
     }
     .register(registry)


### PR DESCRIPTION
R: @r3mariano @chris-ryan-square 

There was a support request to set this option for a specific metrics (http latency). Before the option can be set, it must first be exposed through the wrapping API.