### PR TITLE
Make counter help string not nullable

### DIFF
--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/FakeMetrics.kt
@@ -18,7 +18,7 @@ import javax.inject.Singleton
 class FakeMetrics @Inject internal constructor(
   private val registry: CollectorRegistry
 ) : Metrics {
-  override fun counter(name: String, help: String?, labelNames: List<String>): Counter =
+  override fun counter(name: String, help: String, labelNames: List<String>): Counter =
     Counter.build(name, help)
       .labelNames(*labelNames.toTypedArray())
       .register(registry)

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -20,7 +20,7 @@ class FakeMetrics @Inject internal constructor(
 ) : Metrics {
   override fun counter(
     name: String,
-    help: String?,
+    help: String,
     labelNames: List<String>
   ): Counter =
     Counter.build(name, help)

--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -22,7 +22,7 @@ interface Metrics {
    */
   fun counter(
     name: String,
-    help: String? = "",
+    help: String,
     labelNames: List<String> = listOf()
   ): Counter
 

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -30,7 +30,7 @@ interface Metrics {
    */
   fun counter(
     name: String,
-    help: String? = "",
+    help: String,
     labelNames: List<String> = listOf()
   ): Counter
 

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -18,7 +18,7 @@ internal class PrometheusMetrics @Inject internal constructor(
 ) : Metrics {
   override fun counter(
     name: String,
-    help: String?,
+    help: String,
     labelNames: List<String>
   ): Counter = metricsV2.counter(name, help, labelNames)
 

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -18,7 +18,7 @@ internal class PrometheusMetrics @Inject internal constructor(
 ) : Metrics {
   override fun counter(
     name: String,
-    help: String?,
+    help: String,
     labelNames: List<String>
   ): Counter = Counter
     .build(name, help)


### PR DESCRIPTION
R: @r3mariano @chris-ryan-square 

I was in this code for a different change and I noticed that the help string for counter was nullable, but the help string for all other metric types was not.

I was curious as to whether that was intensional, so I tracked the code and discovered that even though it's marked as nullable, the code actually fails if the value is null or empty.

https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/SimpleCollector.java#L170

This change elevates the failure from a runtime failure to a compile-time failure which is preferable. Strictly speaking, this is not a backward compatible change (because an optional field is now no longer optional) but reading the code, all of those usages that didn't set this parameter should have thrown an `IllegalArguement` exception so I don't think there will be any valid cases that won't work.