### PR TITLE
Guice 5.0.1 -> 5.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,7 +31,7 @@ object Dependencies {
   val grpcStub = "io.grpc:grpc-stub:1.41.0"
   val guava = "com.google.guava:guava:30.1.1-jre"
   val guavaTestLib = "com.google.guava:guava-testlib:30.1.1-jre"
-  val guice = "com.google.inject:guice:5.0.1"
+  val guice = "com.google.inject:guice:5.1.0"
   val hibernateCore = "org.hibernate:hibernate-core:5.5.3.Final"
   val hikariCp = "com.zaxxer:HikariCP:4.0.3"
   val hopliteCore = "com.sksamuel.hoplite:hoplite-core:1.4.15"

--- a/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -67,9 +67,7 @@ abstract class KAbstractModule : AbstractModule() {
   ): Multibinder<T> {
     val setOfT = parameterizedType<Set<*>>(type.java).typeLiteral() as TypeLiteral<Set<T>>
     val mutableSetOfTKey = setOfT.toKey(annotation) as Key<MutableSet<T>>
-    val setOfOutT =
-      parameterizedType<Set<*>>(Types.subtypeOf(type.java)).typeLiteral() as TypeLiteral<Set<T>>
-    val setOfOutTKey = setOfOutT.toKey(annotation)
+    // As of Guice 5.1, Set<? out T> is now bound.
     val listOfT = parameterizedType<List<*>>(type.java).typeLiteral() as TypeLiteral<List<T>>
     val listOfOutT =
       parameterizedType<List<*>>(Types.subtypeOf(type.java)).typeLiteral() as TypeLiteral<List<T>>
@@ -78,7 +76,6 @@ abstract class KAbstractModule : AbstractModule() {
     bind(listOfOutTKey).toProvider(
       ListProvider(mutableSetOfTKey, getProvider(mutableSetOfTKey))
     )
-    bind(setOfOutTKey).to(setOfT.toKey(annotation))
     bind(listOfTKey).to(listOfOutTKey)
 
     return when (annotation) {
@@ -103,11 +100,10 @@ abstract class KAbstractModule : AbstractModule() {
     annotation: KClass<out Annotation>? = null
   ): MapBinder<K, V> {
     val mapOfKV = mapOfType(keyType, valueType).toKey(annotation)
-    val mapOfKOutV = mapOfType<K, V>(keyType.type, valueType.subtype()).toKey(annotation)
+    // As of Guice 5.1, Map<K, ? out V> is now bound.
     val mapOfOutKV = mapOfType<K, V>(keyType.subtype(), valueType.type).toKey(annotation)
     val mapOfOutKOutV = mapOfType<K, V>(keyType.subtype(), valueType.subtype()).toKey(annotation)
 
-    bind(mapOfKOutV).to(mapOfKV)
     bind(mapOfOutKV).to(mapOfKV)
     bind(mapOfOutKOutV).to(mapOfKV)
 


### PR DESCRIPTION
Need this for Java 17 support.

Removes bindings to `Set<? out T>` and `Map<K, out V>`, which are now bound by Guice (https://github.com/google/guice/commit/e6ec2a4a9433d64e763093a826eecf49f005aa5d, https://github.com/google/guice/commit/a260458b28b2dad9e2c8cfca2a2783e585784ab6).