### PR TITLE
Allow services to configure max_age_in_seconds for Prometheus Summary

### DIFF
--- a/misk-prometheus/api/misk-prometheus.api
+++ b/misk-prometheus/api/misk-prometheus.api
@@ -3,15 +3,17 @@ public final class misk/metrics/MetricsModule : misk/inject/KAbstractModule {
 }
 
 public final class misk/metrics/backends/prometheus/PrometheusConfig : wisp/config/Config {
-	public fun <init> (Ljava/lang/String;I)V
-	public synthetic fun <init> (Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ILjava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
-	public final fun copy (Ljava/lang/String;I)Lmisk/metrics/backends/prometheus/PrometheusConfig;
-	public static synthetic fun copy$default (Lmisk/metrics/backends/prometheus/PrometheusConfig;Ljava/lang/String;IILjava/lang/Object;)Lmisk/metrics/backends/prometheus/PrometheusConfig;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;ILjava/lang/Long;)Lmisk/metrics/backends/prometheus/PrometheusConfig;
+	public static synthetic fun copy$default (Lmisk/metrics/backends/prometheus/PrometheusConfig;Ljava/lang/String;ILjava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/backends/prometheus/PrometheusConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHostname ()Ljava/lang/String;
 	public final fun getHttp_port ()I
+	public final fun getMax_age_in_seconds ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusConfig.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusConfig.kt
@@ -6,5 +6,8 @@ import wisp.config.Config
 data class PrometheusConfig(
   // The hostname on which metrics are exposed; if null uses any addr bound to this host
   val hostname: String? = null,
-  val http_port: Int // The port on metrics are exposed
+  // The port on metrics are exposed
+  val http_port: Int,
+  // How long observations are kept before they are discarded. Only used for Summary.
+  val max_age_in_seconds: Long? = null,
 ) : Config

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsClientModule.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsClientModule.kt
@@ -16,6 +16,7 @@ import javax.inject.Provider
  */
 class PrometheusMetricsClientModule : KAbstractModule() {
   override fun configure() {
+    bind<PrometheusConfig>().toInstance(PrometheusConfig(http_port = 9021))
     bind<HistogramRegistry>().to<PrometheusHistogramRegistry>()
     bind<Metrics>().to<PrometheusMetrics>()
     bind<CollectorRegistry>().toProvider(CollectorRegistryProvider::class.java).asSingleton()

--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -5,6 +5,7 @@ import com.google.common.base.Ticker
 import com.squareup.wire.GrpcMethod
 import io.prometheus.client.Histogram
 import io.prometheus.client.Summary
+import misk.metrics.backends.prometheus.PrometheusConfig
 import misk.metrics.v2.Metrics
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -57,11 +58,15 @@ class ClientMetricsInterceptor private constructor(
   }
 
   @Singleton
-  class Factory @Inject internal constructor(m: Metrics) {
+  class Factory @Inject internal constructor(
+    m: Metrics,
+    config: PrometheusConfig,
+  ) {
     internal val requestDuration = m.summary(
       name = "client_http_request_latency_ms",
       help = "count and duration in ms of outgoing client requests",
-      labelNames = listOf("action", "code")
+      labelNames = listOf("action", "code"),
+      maxAgeSeconds = config.max_age_in_seconds,
     )
     internal val requestDurationHistogram = m.histogram(
       name = "histo_client_http_request_latency_ms",

--- a/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/MetricsInterceptor.kt
@@ -4,6 +4,7 @@ import io.prometheus.client.Histogram
 import io.prometheus.client.Summary
 import misk.Action
 import misk.MiskCaller
+import misk.metrics.backends.prometheus.PrometheusConfig
 import misk.metrics.v2.Metrics
 import misk.scope.ActionScoped
 import misk.time.timed
@@ -41,12 +42,14 @@ internal class MetricsInterceptor internal constructor(
   @Singleton
   class Factory @Inject constructor(
     m: Metrics,
-    private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>
+    private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>,
+    config: PrometheusConfig,
   ) : NetworkInterceptor.Factory {
     internal val requestDuration = m.summary(
       name = "http_request_latency_ms",
       help = "count and duration in ms of incoming web requests",
-      labelNames = listOf("action", "caller", "code")
+      labelNames = listOf("action", "caller", "code"),
+      maxAgeSeconds = config.max_age_in_seconds,
     )
     private val requestDurationHistogram = m.histogram(
       name = "histo_http_request_latency_ms",


### PR DESCRIPTION
This PR builds upon https://github.com/cashapp/misk/pull/2271, exposing `max_age_in_seconds` via `PrometheusConfig` and then using the configured value in the two relevant interceptors.