### PR TITLE
Web Actions Tab: handle long primitive when building web forms

### DIFF
--- a/misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt
@@ -133,7 +133,7 @@ class MiskWebFormBuilder {
           Int::class.simpleName!!,
           repeated
         )
-        fieldClass == Long::class.javaObjectType -> Field(
+        fieldClass == Long::class.javaObjectType || fieldClass == Long::class.javaPrimitiveType -> Field(
           fieldName,
           Long::class.simpleName!!,
           repeated


### PR DESCRIPTION
In Kotlin, `fieldClass` can be the primitive `long` instead of `Long`. 

When this occurs, the field type comparison on the web actions tab fails:
https://github.com/cashapp/misk/blob/88fe641ccf9a1bbece9818e27250945c6c6c6b7a/misk-admin/web/tabs/web-actions/src/rewrite/WebActionSendRequest.tsx#L84

Resulting in the field being hidden, when it should exist.

For example:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/1646536/156103698-a9af4edf-a602-4b11-9c25-399f876ddafa.png">

Should be:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/1646536/156103800-29454561-e821-47f0-994d-3cd56a2b497c.png">

This fix ensures the field type is passed as `Long` instead of `long` so the frontend interprets it correctly, however an alternative could be patching `WebActionSendRequest` to account for the lowercase type (`long`) instead.
