### PR TITLE
Make FakeFeatureFlag overrides composable with FakeFeatureFlagsOverrideModule

### DIFF
--- a/misk-feature-testing/api/misk-feature-testing.api
+++ b/misk-feature-testing/api/misk-feature-testing.api
@@ -92,7 +92,8 @@ public final class misk/feature/testing/FakeFeatureFlagsModule : misk/inject/KAb
 }
 
 public final class misk/feature/testing/FakeFeatureFlagsOverrideModule : misk/inject/KAbstractModule {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/feature/testing/FakeFeatureFlagsOverrideModule$FakeFeatureFlagsOverride {

--- a/misk-feature-testing/api/misk-feature-testing.api
+++ b/misk-feature-testing/api/misk-feature-testing.api
@@ -91,3 +91,12 @@ public final class misk/feature/testing/FakeFeatureFlagsModule : misk/inject/KAb
 	public final fun withOverrides (Lkotlin/jvm/functions/Function1;)Lmisk/feature/testing/FakeFeatureFlagsModule;
 }
 
+public final class misk/feature/testing/FakeFeatureFlagsOverrideModule : misk/inject/KAbstractModule {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class misk/feature/testing/FakeFeatureFlagsOverrideModule$FakeFeatureFlagsOverride {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun getOverrideLambda ()Lkotlin/jvm/functions/Function1;
+}
+

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -59,8 +59,9 @@ class FakeFeatureFlagsModule(
    *   override(Feature("foo"), true)
    * })
    * ```
+   *
+   * For overriding in many modules see [FakeFeatureFlagsOverrideModule]
    */
-  @Deprecated(message = "replaced by FakeFeatureFlagsOverrideModule")
   fun withOverrides(lambda: FakeFeatureFlags.() -> Unit): FakeFeatureFlagsModule {
     overrides.add(FakeFeatureFlagsOverrideModule(qualifier, lambda))
     return this

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -1,34 +1,48 @@
 package misk.feature.testing
 
+import com.google.inject.Provider
 import com.squareup.moshi.Moshi
 import misk.ServiceModule
 import misk.feature.DynamicConfig
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
+import misk.feature.testing.FakeFeatureFlagsOverrideModule.FakeFeatureFlagsOverride
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 import misk.inject.toKey
+import javax.inject.Inject
 import kotlin.reflect.KClass
 
 /**
  * Binds a [FakeFeatureFlags] that allows tests to override values.
+ *
+ * To define overrides (especially test defaults) use [FakeFeatureFlagsOverrideModule].
+ * In a given misk service's test setup, there is one [FakeFeatureFlagsModule] installed and many
+ * [FakeFeatureFlagsOverrideModule] installed.
  */
 class FakeFeatureFlagsModule(
   private val qualifier: KClass<out Annotation>? = null
 ) : KAbstractModule() {
-  private val overrides = mutableListOf<FakeFeatureFlags.() -> Unit>()
+  private val overrides = mutableListOf<FakeFeatureFlagsOverrideModule>()
 
   override fun configure() {
     requireBinding<Moshi>()
-    val testFeatureFlags = FakeFeatureFlags(getProvider(Moshi::class.java))
+    newMultibinder<FakeFeatureFlagsOverride>()
+    overrides.forEach { install(it) }
     val key = FakeFeatureFlags::class.toKey(qualifier)
-    bind(key).toInstance(testFeatureFlags)
+
+    bind(key).toProvider(object : Provider<FakeFeatureFlags> {
+      @Inject private lateinit var overrides: Set<FakeFeatureFlagsOverride>
+      @Inject private lateinit var moshi: Provider<Moshi>
+      override fun get() = FakeFeatureFlags(moshi).apply {
+        overrides.forEach { it.overrideLambda(this) }
+      }
+    }).asSingleton()
+
     bind(FeatureFlags::class.toKey(qualifier)).to(key)
     bind(FeatureService::class.toKey(qualifier)).to(key)
     bind(DynamicConfig::class.toKey(qualifier)).to(key)
     install(ServiceModule(FeatureService::class.toKey(qualifier)))
-    overrides.forEach {
-      it.invoke(testFeatureFlags)
-    }
   }
 
   /**
@@ -42,8 +56,10 @@ class FakeFeatureFlagsModule(
    * })
    * ```
    */
+  @Deprecated(message = "replaced by FakeFeatureFlagsOverrideModule")
   fun withOverrides(lambda: FakeFeatureFlags.() -> Unit): FakeFeatureFlagsModule {
-    overrides.add(lambda)
+    overrides.add(FakeFeatureFlagsOverrideModule(lambda))
     return this
   }
 }
+

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsOverrideModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsOverrideModule.kt
@@ -1,6 +1,7 @@
 package misk.feature.testing
 
 import misk.inject.KAbstractModule
+import kotlin.reflect.KClass
 
 /**
  * Install defaults for [FakeFeatureFlags]. This module can be install many times, allowing for
@@ -15,15 +16,20 @@ import misk.inject.KAbstractModule
  * ```
  */
 class FakeFeatureFlagsOverrideModule private constructor(
+  private val qualifier: KClass<out Annotation>? = null,
   private val override: FakeFeatureFlagsOverride,
 ) : KAbstractModule() {
 
-  constructor(overrideLambda: FakeFeatureFlags.() -> Unit) : this(
+  constructor(
+    qualifier: KClass<out Annotation>? = null,
+    overrideLambda: FakeFeatureFlags.() -> Unit,
+  ) : this(
+    qualifier,
     FakeFeatureFlagsOverride(overrideLambda)
   )
 
   override fun configure() {
-    multibind<FakeFeatureFlagsOverride>().toInstance(override)
+    multibind<FakeFeatureFlagsOverride>(qualifier).toInstance(override)
   }
 
   class FakeFeatureFlagsOverride(

--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsOverrideModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsOverrideModule.kt
@@ -1,0 +1,32 @@
+package misk.feature.testing
+
+import misk.inject.KAbstractModule
+
+/**
+ * Install defaults for [FakeFeatureFlags]. This module can be install many times, allowing for
+ * feature flag overrides to be modular and scoped to the module the flag is used in.
+ *
+ * In any module use:
+ * ```
+ * install(FakeFeatureFlagsModuleOverrideModule {
+ *   override(Feature("foo"), true)
+ *   overrideJsonString(Feature("bar"), "{ \"target\": 0.1 }")
+ * })
+ * ```
+ */
+class FakeFeatureFlagsOverrideModule private constructor(
+  private val override: FakeFeatureFlagsOverride,
+) : KAbstractModule() {
+
+  constructor(overrideLambda: FakeFeatureFlags.() -> Unit) : this(
+    FakeFeatureFlagsOverride(overrideLambda)
+  )
+
+  override fun configure() {
+    multibind<FakeFeatureFlagsOverride>().toInstance(override)
+  }
+
+  class FakeFeatureFlagsOverride(
+    val overrideLambda: FakeFeatureFlags.() -> Unit
+  )
+}

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -1,12 +1,15 @@
 package misk.feature.testing
 
 import com.google.inject.Guice
+import com.google.inject.Key
 import misk.feature.Feature
 import misk.feature.FeatureFlags
 import misk.feature.getJson
 import misk.feature.testing.FakeFeatureFlagsTest.JsonFeature
 import misk.inject.KAbstractModule
+import misk.inject.keyOf
 import org.junit.jupiter.api.Test
+import javax.inject.Qualifier
 import kotlin.test.assertEquals
 
 class FakeFeatureFlagsModuleTest {
@@ -37,6 +40,26 @@ class FakeFeatureFlagsModuleTest {
         "key"
       ).value
     )
+  }
+
+  @Test
+  fun `uses overrides from FakeFeatureFlagsOverrideModule with annotation`() {
+    val injector = Guice.createInjector(
+      FakeFeatureFlagsModule(AnotherFeatureFlag::class),
+      FakeFeatureFlagsModule(),
+      MoshiTestingModule(),
+      object : KAbstractModule() {
+        override fun configure() {
+          install(FakeFeatureFlagsOverrideModule { override(Feature("foo"), 24) })
+          install(FakeFeatureFlagsOverrideModule(AnotherFeatureFlag::class) { override(Feature("foo"), 10101) })
+        }
+      }
+    )
+
+    val flags = injector.getInstance(FeatureFlags::class.java)
+    val anotherFeatureFlag = injector.getInstance(Key.get(FeatureFlags::class.java, AnotherFeatureFlag::class.java))
+    assertEquals(24, flags.getInt(Feature("foo"), "bar"))
+    assertEquals(10101, anotherFeatureFlag.getInt(Feature("foo"), "bar"))
   }
 
   @Test
@@ -85,3 +108,7 @@ class FakeFeatureFlagsModuleTest {
     )
   }
 }
+
+@Qualifier
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD)
+annotation class AnotherFeatureFlag

--- a/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
+++ b/misk-feature-testing/src/test/kotlin/misk/feature/testing/FakeFeatureFlagsModuleTest.kt
@@ -1,16 +1,71 @@
 package misk.feature.testing
 
 import com.google.inject.Guice
-import misk.feature.testing.FakeFeatureFlagsTest.JsonFeature
-import org.junit.jupiter.api.Test
 import misk.feature.Feature
 import misk.feature.FeatureFlags
 import misk.feature.getJson
+import misk.feature.testing.FakeFeatureFlagsTest.JsonFeature
+import misk.inject.KAbstractModule
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class FakeFeatureFlagsModuleTest {
   @Test
-  fun testModule() {
+  fun `uses overrides from FakeFeatureFlagsOverrideModule`() {
+    val injector = Guice.createInjector(
+      FakeFeatureFlagsModule(),
+      MoshiTestingModule(),
+      object : KAbstractModule() {
+        override fun configure() {
+          install(FakeFeatureFlagsOverrideModule { override(Feature("foo"), 24) })
+          install(FakeFeatureFlagsOverrideModule {
+            overrideJson(
+              Feature("jsonFeature"),
+              JsonFeature("testValue")
+            )
+          })
+        }
+      }
+    )
+
+    val flags = injector.getInstance(FeatureFlags::class.java)
+    assertEquals(24, flags.getInt(Feature("foo"), "bar"))
+    assertEquals(
+      "testValue",
+      flags.getJson<JsonFeature>(
+        Feature("jsonFeature"),
+        "key"
+      ).value
+    )
+  }
+
+  @Test
+  fun `withOverrides method and FakeFeatureFlagsOverrideModule both work`() {
+    val injector = Guice.createInjector(
+      FakeFeatureFlagsModule().withOverrides {
+        overrideJson(Feature("jsonFeature"), JsonFeature("testValue"))
+      },
+      MoshiTestingModule(),
+      object : KAbstractModule() {
+        override fun configure() {
+          install(FakeFeatureFlagsOverrideModule { override(Feature("foo"), 24) })
+        }
+      }
+    )
+
+    val flags = injector.getInstance(FeatureFlags::class.java)
+    assertEquals(24, flags.getInt(Feature("foo"), "bar"))
+    assertEquals(
+      "testValue",
+      flags.getJson<JsonFeature>(
+        Feature("jsonFeature"),
+        "key"
+      ).value
+    )
+  }
+
+  @Test
+  fun `deprecated withOverrides method`() {
     val injector = Guice.createInjector(
       FakeFeatureFlagsModule().withOverrides {
         override(Feature("foo"), 24)


### PR DESCRIPTION
In the current setup, all test feature flag overrides have to live in the same guice module. For large services we end up duplicating feature flag overrides in many places. 

This change allows us to have one `FakeFeatureFlagsModule` and many `FakeFeatureFlagsOverrideModule`. Modules at any level can install their own overrides independently using the familiar api of `FakeFeatureFlagsModule#withOverride`