### PR TITLE
Make DelayedTask's task visible for testing

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1169,6 +1169,7 @@ public final class misk/tasks/DelayedTask : java/util/concurrent/Delayed {
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Ljava/util/concurrent/Delayed;)I
 	public fun getDelay (Ljava/util/concurrent/TimeUnit;)J
+	public final fun getTask ()Lkotlin/jvm/functions/Function0;
 }
 
 public final class misk/tasks/RepeatedTaskQueue : com/google/common/util/concurrent/AbstractExecutionThreadService {

--- a/misk/src/main/kotlin/misk/tasks/DelayedTask.kt
+++ b/misk/src/main/kotlin/misk/tasks/DelayedTask.kt
@@ -1,5 +1,6 @@
 package misk.tasks
 
+import com.google.common.annotations.VisibleForTesting
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -10,7 +11,7 @@ import java.util.concurrent.TimeUnit
 class DelayedTask(
   internal val clock: Clock,
   internal val executionTime: Instant,
-  internal val task: () -> Result
+  @VisibleForTesting val task: () -> Result
 ) : Delayed {
   override fun compareTo(other: Delayed): Int {
     return getDelay(TimeUnit.MILLISECONDS).compareTo(other.getDelay(TimeUnit.MILLISECONDS))


### PR DESCRIPTION
As a user of the RepeatedTaskQueue library, I would like to be able to verify interactions of my service with the different bound task queues. Making the DelayedTask's task visible enable a devs to pulls validate behaviour of delayed tasks in the blocking queue within a RepeatedTaskQueue.