### PR TITLE
Print release version in logs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -30,7 +30,9 @@ jobs:
           miskweb ci-build -e
 
       - name: Set gradle publish version
-        run: sed --in-place -e "s/-SNAPSHOT/-$(date +%Y%m%d.%H%M)-$(git rev-parse --short HEAD)/" gradle.properties
+        run: |
+          sed --in-place -e "s/-SNAPSHOT/-$(date +%Y%m%d.%H%M)-$(git rev-parse --short HEAD)/" gradle.properties
+          cat gradle.properties
 
       - name: Publish the artifacts
         env:


### PR DESCRIPTION
When doing manual releases, seeing the new version in the Github Action log output makes bumping the version downstream easier.