### PR TITLE
Extend LeaseManager to support Leases as AutoCloseable resources

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLeaseManager.kt
@@ -11,6 +11,7 @@ import misk.tasks.Status
 import misk.zookeeper.SERVICES_NODE
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.state.ConnectionStateListener
+import wisp.lease.AutoCloseableLease
 import wisp.lease.LeaseManager
 import wisp.logging.getLogger
 import java.time.Duration

--- a/wisp-lease/api/wisp-lease.api
+++ b/wisp-lease/api/wisp-lease.api
@@ -1,3 +1,17 @@
+public final class wisp/lease/AutoCloseableLease : java/lang/AutoCloseable, wisp/lease/Lease {
+	public fun <init> (Lwisp/lease/Lease;)V
+	public fun acquire ()Z
+	public fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
+	public fun checkHeld ()Z
+	public fun close ()V
+	public fun getName ()Ljava/lang/String;
+	public fun release ()Z
+}
+
+public final class wisp/lease/ExtensionsKt {
+	public static final fun acquireOrNull (Lwisp/lease/LeaseManager;Ljava/lang/String;)Lwisp/lease/AutoCloseableLease;
+}
+
 public abstract interface class wisp/lease/Lease {
 	public abstract fun acquire ()Z
 	public abstract fun addListener (Lwisp/lease/Lease$StateChangeListener;)V

--- a/wisp-lease/src/main/kotlin/wisp/lease/Extensions.kt
+++ b/wisp-lease/src/main/kotlin/wisp/lease/Extensions.kt
@@ -1,0 +1,24 @@
+package wisp.lease
+
+/** Converts a [lease] into an [AutoCloseable] resource. */
+class AutoCloseableLease(private val lease: Lease): Lease by lease, AutoCloseable {
+  override fun close() {
+    lease.release()
+  }
+}
+
+/**
+ * Attempts to acquire an [AutoCloseableLease].
+ *
+ * Use like
+ *
+ * ```
+ * leaseManager.acquireOrNull("some-lease")?.use { lease ->
+ *   // Do something with the lease.
+ * }
+ * ```
+ */
+fun LeaseManager.acquireOrNull(name: String): AutoCloseableLease? {
+  val lease = requestLease(name)
+  return if (lease.acquire()) AutoCloseableLease(lease) else null
+}


### PR DESCRIPTION
Scratching an itch with the Lease interface.

Here's an implementation independent extension function to make leases auto-closeable.

Intention is to use it like:

```kt
@Inject lateinit val LeaseManager leaseManager

leaseManager.acquireOrNull("some-lease")?.use { lease ->
  /* Do critical stuff that needs the lease */
}
```
