### PR TITLE
Downgrade a common warning.

### DIFF
--- a/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
+++ b/misk-zookeeper/src/main/kotlin/misk/clustering/zookeeper/ZkLease.kt
@@ -243,7 +243,7 @@ internal class ZkLease(
       status = Status.NOT_HELD
       log.warn { "updating status for lease $name to ${Status.NOT_HELD}; it is held by another process" }
     } else {
-      log.warn { "lease $name is held by another process; skipping acquiring" }
+      log.info { "lease $name is held by another process; skipping acquiring" }
     }
   }
 


### PR DESCRIPTION
To my knowledge, this is a common case that is not actually worthy of warning about. It certainly fills up my service's logs, and has never indicated that something is wrong.