### PR TITLE
Upgrade google-cloud-storage to latest release.

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -19,7 +19,7 @@ object Dependencies {
   val dockerTransport = "com.github.docker-java:docker-java-transport-httpclient5:3.2.13"
   val dokkaGradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
   val gcpCloudCore = "com.google.cloud:google-cloud-core:1.95.4"
-  val gcpCloudStorage = "com.google.cloud:google-cloud-storage:1.117.1"
+  val gcpCloudStorage = "com.google.cloud:google-cloud-storage:2.6.0"
   val gcpDatastore = "com.google.cloud:google-cloud-datastore:1.107.1"
   val gcpKms = "com.google.apis:google-api-services-cloudkms:v1-rev20190626-1.30.1"
   val gcpLogback = "com.google.cloud:google-cloud-logging-logback:0.121.3-alpha"


### PR DESCRIPTION
From an email alert:
```
Hello Google Cloud Storage Customer,

We're writing to let you know that we have identified an issue with older versions of the Java Client Libraries and Object Lifecycle Management. Versions 1.50.0-2.2.3, 4.4.0 - 24.2.0 libraries-bom of this library will fail if buckets have configured any upcoming lifecycle actions. To read/set Google Cloud Storage buckets with any new lifecycle actions, update your Java client library to version 2.3.0 or higher.

What do I need to do?
Update your Java Storage client to version 2.3.0 or higher to read/write Google Cloud Storage buckets with new lifecycle actions by June 20, 2022. You can find more details for the latest version in the [Maven Central Repository](https://notifications.google.com/g/p/AD-FnExlEitirOftY7lT8sL-pNwxn88kYMj_-LrrGMGQk35sMW031-HvIJc7N0lL_wdldEcplDofM7sqImoFKNZBDnhoQViAfM34B_p8d5h3NibKfsIe8gbYpEKDu07yIinEfbWKIwD3jLRlohWsrFPGd0Mg-dxhWxzxkB2EmG5FhXw).
```