### PR TITLE
The Deployment now returns the environment name for staging environments

### DIFF
--- a/wisp-deployment/src/main/kotlin/wisp/deployment/Deployment.kt
+++ b/wisp-deployment/src/main/kotlin/wisp/deployment/Deployment.kt
@@ -53,7 +53,7 @@ data class Deployment(
 
   fun mapToEnvironmentName() = when {
     isProduction -> "production"
-    isStaging -> "staging"
+    isStaging -> name
     isTest -> "testing"
     else -> "development"
   }


### PR DESCRIPTION
This PR updates the Deployment to return the environment name for staging environments as there are staging environments that have names other than "staging".