### PR TITLE
Introduce a Gunzip network interceptor in-place of Jetty's.

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -266,6 +266,7 @@ public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public final fun component7 ()Lokhttp3/Headers$Builder;
 	public final fun component8 ()Z
 	public final fun component9 ()Lokhttp3/Headers$Builder;
+	public fun computeRequestHeader (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun contentType ()Lokhttp3/MediaType;
 	public final fun copy (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;)Lmisk/web/FakeHttpCall;
 	public static synthetic fun copy$default (Lmisk/web/FakeHttpCall;Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;ILjava/lang/Object;)Lmisk/web/FakeHttpCall;
@@ -292,6 +293,7 @@ public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public fun requireTrailers ()V
 	public fun setNetworkStatusCode (I)V
 	public final fun setRequestBody (Lokio/BufferedSource;)V
+	public fun setRequestHeaders (Lokhttp3/Headers;)V
 	public final fun setResponseBody (Lokio/BufferedSink;)V
 	public fun setResponseHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setResponseTrailer (Ljava/lang/String;Ljava/lang/String;)V

--- a/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
+++ b/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
@@ -14,7 +14,7 @@ data class FakeHttpCall(
   override val url: HttpUrl = "https://example.com/".toHttpUrl(),
   override val linkLayerLocalAddress: SocketAddress = SocketAddress.Network("1.2.3.4", 56789),
   override val dispatchMechanism: DispatchMechanism = DispatchMechanism.GET,
-  override val requestHeaders: Headers = headersOf(),
+  override var requestHeaders: Headers = headersOf(),
   override var statusCode: Int = 200,
   override var networkStatusCode: Int = 200,
   val headersBuilder: Headers.Builder = Headers.Builder(),

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1133,6 +1133,7 @@ public abstract interface class misk/web/HttpCall {
 	public abstract fun accepts ()Ljava/util/List;
 	public abstract fun addResponseHeaders (Lokhttp3/Headers;)V
 	public abstract fun asOkHttpRequest ()Lokhttp3/Request;
+	public abstract fun computeRequestHeader (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun contentType ()Lokhttp3/MediaType;
 	public abstract fun getDispatchMechanism ()Lmisk/web/DispatchMechanism;
 	public abstract fun getLinkLayerLocalAddress ()Lmisk/web/SocketAddress;
@@ -1146,6 +1147,7 @@ public abstract interface class misk/web/HttpCall {
 	public abstract fun putResponseBody (Lokio/BufferedSink;)V
 	public abstract fun putWebSocket (Lmisk/web/actions/WebSocket;)V
 	public abstract fun requireTrailers ()V
+	public abstract fun setRequestHeaders (Lokhttp3/Headers;)V
 	public abstract fun setResponseHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setResponseTrailer (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setStatusCode (I)V
@@ -1158,6 +1160,7 @@ public abstract interface class misk/web/HttpCall {
 public final class misk/web/HttpCall$DefaultImpls {
 	public static fun accepts (Lmisk/web/HttpCall;)Ljava/util/List;
 	public static fun asOkHttpRequest (Lmisk/web/HttpCall;)Lokhttp3/Request;
+	public static fun computeRequestHeader (Lmisk/web/HttpCall;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static fun contentType (Lmisk/web/HttpCall;)Lokhttp3/MediaType;
 }
 

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -49,6 +49,7 @@ import misk.web.interceptors.BeforeContentEncoding
 import misk.web.interceptors.ConcurrencyLimiterFactory
 import misk.web.interceptors.ConcurrencyLimitsInterceptor
 import misk.web.interceptors.ForContentEncoding
+import misk.web.interceptors.GunzipRequestBodyInterceptor
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.RebalancingInterceptor
@@ -135,7 +136,9 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
 
     newMultibinder<NetworkInterceptor.Factory>(BeforeContentEncoding::class)
 
-    newMultibinder<NetworkInterceptor.Factory>(ForContentEncoding::class)
+    // Inflates a gzip compressed request
+    multibind<NetworkInterceptor.Factory>(ForContentEncoding::class)
+      .to<GunzipRequestBodyInterceptor.Factory>()
 
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
       .to<RebalancingInterceptor.Factory>()

--- a/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
@@ -19,7 +19,7 @@ internal data class ServletHttpCall(
    */
   override val linkLayerLocalAddress: SocketAddress? = null,
   override val dispatchMechanism: DispatchMechanism,
-  override val requestHeaders: Headers,
+  override var requestHeaders: Headers,
   var requestBody: BufferedSource? = null,
   val upstreamResponse: UpstreamResponse,
   var responseBody: BufferedSink? = null,

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -78,10 +78,15 @@ data class WebConfig(
   val close_connection_percent: Double = 0.01,
 
   /**
-   * If true responses which are larger than the minGzipSize will be compressed. Gzip compression
-   * always enabled for requests and cannot be turned off.
+   * If true responses which are larger than the minGzipSize will be compressed.
    */
   val gzip: Boolean = true,
+
+  /**
+   * If true requests which are gzipped will be inflated by the default Jetty Gzip Handler.
+   * Gzip decompression always enabled for requests unless specified.
+   */
+  val gunzip: Boolean = true,
 
   /** The minimum size in bytes before the response body will be compressed. */
   val minGzipSize: Int = 1024,

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -82,12 +82,6 @@ data class WebConfig(
    */
   val gzip: Boolean = true,
 
-  /**
-   * If true requests which are gzipped will be inflated by the default Jetty Gzip Handler.
-   * Gzip decompression always enabled for requests unless specified.
-   */
-  val gunzip: Boolean = true,
-
   /** The minimum size in bytes before the response body will be compressed. */
   val minGzipSize: Int = 1024,
 

--- a/misk/src/main/kotlin/misk/web/interceptors/GunzipRequestBodyInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/GunzipRequestBodyInterceptor.kt
@@ -1,0 +1,43 @@
+package misk.web.interceptors
+
+import misk.Action
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import misk.web.WebConfig
+import okio.GzipSource
+import okio.buffer
+import org.eclipse.jetty.server.handler.gzip.GzipHandler
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Inflates a gzipped compressed request. The interceptor should be installed if the default
+ * [GzipHandler] for handling such requests was opted out via [WebConfig.gunzip].
+ */
+class GunzipRequestBodyInterceptor private constructor() : NetworkInterceptor {
+  override fun intercept(chain: NetworkChain) {
+    val contentEncoding = chain.httpCall.requestHeaders[CONTENT_ENCODING]
+      ?: return chain.proceed(chain.httpCall)
+    if (contentEncoding.lowercase() == GZIP || COMMA_GZIP.matches(contentEncoding)) {
+      chain.httpCall.takeRequestBody()?.let {
+        chain.httpCall.putRequestBody(GzipSource(it).buffer())
+      }
+    }
+    chain.proceed(chain.httpCall)
+  }
+
+  @Singleton
+  class Factory @Inject internal constructor() : NetworkInterceptor.Factory {
+    override fun create(action: Action) = INTERCEPTOR
+
+    private companion object {
+      private val INTERCEPTOR = GunzipRequestBodyInterceptor()
+    }
+  }
+
+  private companion object {
+    private const val CONTENT_ENCODING = "Content-Encoding"
+    private const val GZIP = "gzip"
+    private val COMMA_GZIP = Regex(".*, *gzip")
+  }
+}

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -3,7 +3,6 @@ package misk.web.jetty
 import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import wisp.logging.getLogger
 import misk.security.ssl.CipherSuites
 import misk.security.ssl.SslLoader
 import misk.security.ssl.TlsProtocols
@@ -33,6 +32,7 @@ import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.eclipse.jetty.unixsocket.UnixSocketConnector
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.ThreadPool
+import wisp.logging.getLogger
 import java.net.InetAddress
 import java.util.EnumSet
 import java.util.concurrent.SynchronousQueue
@@ -258,10 +258,6 @@ class JettyService @Inject internal constructor(
     } else {
       // GET is enabled by default for gzipHandler.
       gzipHandler.addExcludedMethods("GET")
-    }
-    // if true, default jetty gzip handler requires a non-zero buffer size specified.
-    if (webConfig.gunzip) {
-      gzipHandler.inflateBufferSize = 8192
     }
     servletContextHandler.gzipHandler = gzipHandler
 

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -259,7 +259,10 @@ class JettyService @Inject internal constructor(
       // GET is enabled by default for gzipHandler.
       gzipHandler.addExcludedMethods("GET")
     }
-    gzipHandler.inflateBufferSize = 8192
+    // if true, default jetty gzip handler requires a non-zero buffer size specified.
+    if (webConfig.gunzip) {
+      gzipHandler.inflateBufferSize = 8192
+    }
     servletContextHandler.gzipHandler = gzipHandler
 
     server.handler = statisticsHandler

--- a/misk/src/test/kotlin/misk/web/GzipTest.kt
+++ b/misk/src/test/kotlin/misk/web/GzipTest.kt
@@ -1,11 +1,13 @@
 package misk.web
 
 import com.squareup.moshi.Moshi
+import misk.MiskDefault
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.actions.WebAction
+import misk.web.interceptors.GunzipRequestBodyInterceptor
 import misk.web.jetty.JettyService
 import misk.web.mediatype.MediaTypes
 import okhttp3.OkHttpClient
@@ -22,7 +24,7 @@ import javax.inject.Inject
 
 @MiskTest(startService = true)
 internal class GzipTest : AbstractGzipTest() {
-  @MiskTestModule val module = TestModule(true)
+  @MiskTestModule val module = TestModule(gzip = true, installGunzipInterceptor = false)
 
   @Test fun `GET gzip get response body`() {
     get("/miskhype/16").assertGzipEncoding(gzipped = true)
@@ -37,7 +39,37 @@ internal class GzipTest : AbstractGzipTest() {
 
 @MiskTest(startService = true)
 internal class GzipDisabledTest : AbstractGzipTest() {
-  @MiskTestModule val module = TestModule(false)
+  @MiskTestModule val module = TestModule(gzip = false, installGunzipInterceptor = false)
+
+  @Test fun `GET gzip get response body`() {
+    get("/miskhype/16").assertGzipEncoding(gzipped = false)
+    get("/miskhype/8").assertGzipEncoding(gzipped = false)
+  }
+
+  @Test fun `POST gzip response body`() {
+    post("/miskhype/16").assertGzipEncoding(gzipped = false)
+    post("/miskhype/8").assertGzipEncoding(gzipped = false)
+  }
+}
+
+@MiskTest(startService = true)
+internal class GzipWithInterceptorTest : AbstractGzipTest() {
+  @MiskTestModule val module = TestModule(gzip = true, installGunzipInterceptor = true)
+
+  @Test fun `GET gzip get response body`() {
+    get("/miskhype/16").assertGzipEncoding(gzipped = true)
+    get("/miskhype/8").assertGzipEncoding(gzipped = false)
+  }
+
+  @Test fun `POST gzip response body`() {
+    post("/miskhype/16").assertGzipEncoding(gzipped = true)
+    post("/miskhype/8").assertGzipEncoding(gzipped = false)
+  }
+}
+
+@MiskTest(startService = true)
+internal class GzipDisabledWithoutInterceptorTest : AbstractGzipTest() {
+  @MiskTestModule val module = TestModule(gzip = false, installGunzipInterceptor = false)
 
   @Test fun `GET gzip get response body`() {
     get("/miskhype/16").assertGzipEncoding(gzipped = false)
@@ -147,16 +179,21 @@ abstract class AbstractGzipTest {
     return buffer.readByteString().toRequestBody(MediaTypes.APPLICATION_JSON_MEDIA_TYPE)
   }
 
-  class TestModule(val gzip: Boolean) : KAbstractModule() {
+  class TestModule(private val gzip: Boolean, private val installGunzipInterceptor: Boolean) : KAbstractModule() {
     override fun configure() {
       install(
         WebServerTestingModule(
           webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             gzip = gzip,
+            gunzip = !installGunzipInterceptor,
             minGzipSize = 128
           )
         )
       )
+      if (installGunzipInterceptor) {
+        multibind<NetworkInterceptor.Factory>(MiskDefault::class)
+          .to<GunzipRequestBodyInterceptor.Factory>()
+      }
       install(MiskTestingServiceModule())
       install(WebActionModule.create<MiskHypeGetAction>())
       install(WebActionModule.create<MiskHypePostAction>())


### PR DESCRIPTION
## Context
At present, it is not possible to intercept an un-inflated request body that was gzip compressed - the default Jetty service installing the GzipHandler which is preemptively inflates the request when the `Content-Encoding=gzip` header appears in the request. There are use cases where we would like to intercept the request body and by surfacing a `NetworkInterceptor` that implements the gunzip operation, developers may programmatically define the interception chain.

## This PR
- Removes the assignment of `inflateBufferSize` in `JettyService` to disable installation of `GzipHttpInputInterceptor` provisioned by `GzipHandler`
- Make `HttpCall#requestHeaders` mutable in-order to modify incoming request headers
- Binds a new misk default NetworkInterceptor that performs gunzip on an incoming request body buffer and modifies appropriate header values

## Test Plan
GzipTest.kt test suite to use GunzipRequestBodyInterceptor instead GzipHttpInputInterceptor.