### PR TITLE
RealPager#nextPage returns null when there is no next page

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/RealPager.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/pagination/RealPager.kt
@@ -19,6 +19,8 @@ internal class RealPager<T : DbEntity<T>, Q : Query<T>>(
   }
 
   override fun nextPage(session: Session): Page<T>? {
+    if (!hasNext) return null
+
     @Suppress("UNCHECKED_CAST")
     val query = query.clone<Q>()
     paginator.applyOffset(query, nextOffset)

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/pagination/RealPagerTest.kt
@@ -124,6 +124,24 @@ class RealPagerTest {
     assertThat(pager.hasNext()).isTrue
   }
 
+  @Test fun `nextPage is null when there are no pages left`() {
+    val pageSize = 4
+    val pageCount = 3
+    val movieId = givenStarWarsMovie()
+    givenStormtrooperCharacters(movieId, count = pageCount * pageSize)
+
+    val pager = queryFactory.newQuery(CharacterQuery::class)
+      .movieId(movieId)
+      .newPager(idDescPaginator(), pageSize = pageSize)
+    // Go through all the pages.
+    repeat(pageCount) {
+      transacter.transaction { session -> pager.nextPage(session) }
+    }
+
+    val nextPage = transacter.transaction { session -> pager.nextPage(session) }
+    assertThat(nextPage).isNull()
+  }
+
   @Test fun `paging does not generate duplicate constraints and order by`() {
     val pageSize = 4
     val pageCount = 3


### PR DESCRIPTION
The docstring of the `Pager#nextPage` interface reads: `Returns null when there are no more pages`. However, the `RealPager` implementation would always return a `Page` when called, potentially resulting in endless iteration if the caller was depending on a `null` result to stop calling for a next page.

This PR changes the behavior to return null when the Pager's `hasNext` is false.