### PR TITLE
Expose annotations for injected network interceptors to handle content encoding

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1546,6 +1546,9 @@ public final class misk/web/formatter/ClassNameFormatter$Companion {
 	public final fun format (Lkotlin/reflect/KClass;)Ljava/lang/String;
 }
 
+public abstract interface annotation class misk/web/interceptors/BeforeContentEncoding : java/lang/annotation/Annotation {
+}
+
 public abstract interface class misk/web/interceptors/ConcurrencyLimiterFactory {
 	public abstract fun create (Lmisk/Action;)Lcom/netflix/concurrency/limits/Limiter;
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -45,8 +45,10 @@ import misk.web.extractors.RequestHeadersFeatureBinding
 import misk.web.extractors.ResponseBodyFeatureBinding
 import misk.web.extractors.WebSocketFeatureBinding
 import misk.web.extractors.WebSocketListenerFeatureBinding
+import misk.web.interceptors.BeforeContentEncoding
 import misk.web.interceptors.ConcurrencyLimiterFactory
 import misk.web.interceptors.ConcurrencyLimitsInterceptor
+import misk.web.interceptors.ForContentEncoding
 import misk.web.interceptors.InternalErrorInterceptorFactory
 import misk.web.interceptors.MetricsInterceptor
 import misk.web.interceptors.RebalancingInterceptor
@@ -130,6 +132,10 @@ class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
 
     // Register built-in interceptors. Interceptors run in the order in which they are
     // installed, and the order of these interceptors is critical.
+
+    newMultibinder<NetworkInterceptor.Factory>(BeforeContentEncoding::class)
+
+    newMultibinder<NetworkInterceptor.Factory>(ForContentEncoding::class)
 
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
       .to<RebalancingInterceptor.Factory>()

--- a/misk/src/main/kotlin/misk/web/interceptors/BeforeContentEncoding.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/BeforeContentEncoding.kt
@@ -1,0 +1,19 @@
+package misk.web.interceptors
+
+import misk.web.NetworkInterceptor
+import javax.inject.Qualifier
+
+/**
+ * Denotes a target to be in the first order of execution before any content decoding happens.
+ * A [NetworkInterceptor] bound with [BeforeContentEncoding] is automatically
+ * installed before interceptors annotated with [ForContentEncoding].
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.TYPE
+)
+annotation class BeforeContentEncoding

--- a/misk/src/main/kotlin/misk/web/interceptors/ForContentEncoding.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ForContentEncoding.kt
@@ -1,0 +1,20 @@
+package misk.web.interceptors
+
+import misk.web.NetworkInterceptor
+import javax.inject.Qualifier
+
+/**
+ * Denotes a target interceptor to handle a message payload represented by a possible list
+ * of encoding found in the "Content-Encoding" header value.
+ * A [NetworkInterceptor] bound with [ForContentEncoding] is automatically installed
+ * after [BeforeContentEncoding] annotated interceptors.
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.TYPE
+)
+internal annotation class ForContentEncoding


### PR DESCRIPTION
## Context
Developers need a way to provision network interceptors ahead of the Misk defaults. 

## This PR
- Exposes a new annotation `@BeforeContentEncoding`
- Add a new annotation `@ForContentEncoding`
- Concatenates network interceptors with said annotations before interceptors annotated by `@MiskDefault`
