### PR TITLE
Add support for provenance in OPA API

### DIFF
--- a/misk-policy-testing/api/misk-policy-testing.api
+++ b/misk-policy-testing/api/misk-policy-testing.api
@@ -6,8 +6,8 @@ public final class misk/policy/opa/FakeOpaPolicyEngine : misk/policy/opa/OpaPoli
 	public fun <init> ()V
 	public final fun addOverride (Ljava/lang/String;Lmisk/policy/opa/OpaResponse;)V
 	public final fun addOverrideForInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Lmisk/policy/opa/OpaResponse;)V
-	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
-	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
 }
 
 public final class misk/policy/opa/LocalOpaService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-policy-testing/api/misk-policy-testing.api
+++ b/misk-policy-testing/api/misk-policy-testing.api
@@ -6,8 +6,8 @@ public final class misk/policy/opa/FakeOpaPolicyEngine : misk/policy/opa/OpaPoli
 	public fun <init> ()V
 	public final fun addOverride (Ljava/lang/String;Lmisk/policy/opa/OpaResponse;)V
 	public final fun addOverrideForInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Lmisk/policy/opa/OpaResponse;)V
-	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
-	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 
 public final class misk/policy/opa/LocalOpaService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
@@ -9,8 +9,7 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
     document: String,
     input: T,
     inputType: Class<T>,
-    returnType: Class<R>,
-    provenance: Boolean?
+    returnType: Class<R>
   ): R {
     val opaResponse = responsesForInput[document]?.get(input)
       ?: throw IllegalStateException("No override for document '$document' and input '$input'")
@@ -21,8 +20,7 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
 
   override fun <R : OpaResponse> evaluateNoInput(
     document: String,
-    returnType: Class<R>,
-    provenance: Boolean?
+    returnType: Class<R>
   ): R {
     val opaResponse = responses[document]
       ?: throw IllegalStateException("No override for document '$document'")

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
@@ -9,7 +9,8 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
     document: String,
     input: T,
     inputType: Class<T>,
-    returnType: Class<R>
+    returnType: Class<R>,
+    provenance: Boolean?
   ): R {
     val opaResponse = responsesForInput[document]?.get(input)
       ?: throw IllegalStateException("No override for document '$document' and input '$input'")
@@ -18,7 +19,11 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
     return opaResponse as R
   }
 
-  override fun <R : OpaResponse> evaluateNoInput(document: String, returnType: Class<R>): R {
+  override fun <R : OpaResponse> evaluateNoInput(
+    document: String,
+    returnType: Class<R>,
+    provenance: Boolean?
+  ): R {
     val opaResponse = responses[document]
       ?: throw IllegalStateException("No override for document '$document'")
 

--- a/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
+++ b/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
@@ -67,9 +67,9 @@ internal class FakeOpaPolicyEngineTest {
 
   data class TestRequest(
     val something: String
-  ) : OpaRequest
+  ) : OpaRequest()
 
   data class TestResponse(
     val something: String
-  ) : OpaResponse
+  ) : OpaResponse()
 }

--- a/misk-policy/README.md
+++ b/misk-policy/README.md
@@ -37,8 +37,8 @@ In kotlin, this will take the shape of data classes.
 Here is an example:
 
 ```kotlin
-data class BasicResponse(val test: String) : OpaResponse
-data class BasicRequest(val someValue: Int) : OpaRequest
+data class BasicResponse(val test: String) : OpaResponse()
+data class BasicRequest(val someValue: Int) : OpaRequest()
 ```
 
 This defines an input document, which has a single integer value, called someValue in the matching policy.
@@ -66,4 +66,15 @@ Finally to actually perform a query from misk, all we need is to use the extensi
 
 ```kotlin
 val evaluate: BasicResponse = opaPolicyEngine.evaluate("abc", BasicRequest(1))
+```
+
+### Provenance
+
+`misk-policy` is also able to return [provenance information](https://www.openpolicyagent.org/docs/latest/rest-api/#provenance) for each query made to OPA.
+In order to receive provenance information, set the following value in your `yaml` file:
+```yaml
+opa:
+  baseUrl: "http://localhost:8181/"
+  unixSocket: "\u0000authz.sock"
+  provenance: true
 ```

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -21,8 +21,8 @@ public final class misk/policy/opa/OpaModule : misk/inject/KAbstractModule {
 }
 
 public abstract interface class misk/policy/opa/OpaPolicyEngine {
-	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
-	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;LJava/lang/Boolean)Lmisk/policy/opa/OpaResponse;
 }
 
 public abstract interface class misk/policy/opa/OpaRequest {
@@ -37,9 +37,9 @@ public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
 }
 
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
-	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;)V
-	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
-	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;Ljava/lang/Boolean;)V
+	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
 }
 
 public final class misk/policy/opa/Request {

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -1,5 +1,9 @@
 public abstract interface class misk/policy/opa/OpaApi {
-	public abstract fun queryDocument (Ljava/lang/String;Ljava/lang/String;)Lretrofit2/Call;
+	public abstract fun queryDocument (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lretrofit2/Call;
+}
+
+public final class misk/policy/opa/OpaApi$DefaultImpls {
+	public static synthetic fun queryDocument$default (Lmisk/policy/opa/OpaApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lretrofit2/Call;
 }
 
 public final class misk/policy/opa/OpaConfig : misk/config/Config {
@@ -22,7 +26,12 @@ public final class misk/policy/opa/OpaModule : misk/inject/KAbstractModule {
 
 public abstract interface class misk/policy/opa/OpaPolicyEngine {
 	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
-	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;LJava/lang/Boolean)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+}
+
+public final class misk/policy/opa/OpaPolicyEngine$DefaultImpls {
+	public static synthetic fun evaluateNoInput$default (Lmisk/policy/opa/OpaPolicyEngine;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/policy/opa/OpaResponse;
+	public static synthetic fun evaluateWithInput$default (Lmisk/policy/opa/OpaPolicyEngine;Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/policy/opa/OpaResponse;
 }
 
 public abstract interface class misk/policy/opa/OpaRequest {
@@ -37,7 +46,7 @@ public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
 }
 
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
-	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;Ljava/lang/Boolean;)V
+	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;)V
 	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
 	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
 }

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -1,19 +1,24 @@
 public abstract interface class misk/policy/opa/OpaApi {
-	public abstract fun queryDocument (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lretrofit2/Call;
+	public abstract fun getProvenance ()Z
+	public abstract fun queryDocument (Ljava/lang/String;Ljava/lang/String;Z)Lretrofit2/Call;
+	public abstract fun setProvenance (Z)V
 }
 
 public final class misk/policy/opa/OpaApi$DefaultImpls {
-	public static synthetic fun queryDocument$default (Lmisk/policy/opa/OpaApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lretrofit2/Call;
+	public static synthetic fun queryDocument$default (Lmisk/policy/opa/OpaApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lretrofit2/Call;
 }
 
 public final class misk/policy/opa/OpaConfig : misk/config/Config {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lmisk/policy/opa/OpaConfig;
-	public static synthetic fun copy$default (Lmisk/policy/opa/OpaConfig;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/policy/opa/OpaConfig;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lmisk/policy/opa/OpaConfig;
+	public static synthetic fun copy$default (Lmisk/policy/opa/OpaConfig;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lmisk/policy/opa/OpaConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBaseUrl ()Ljava/lang/String;
+	public final fun getProvenance ()Z
 	public final fun getUnixSocket ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -25,19 +30,16 @@ public final class misk/policy/opa/OpaModule : misk/inject/KAbstractModule {
 }
 
 public abstract interface class misk/policy/opa/OpaPolicyEngine {
-	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
-	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
-}
-
-public final class misk/policy/opa/OpaPolicyEngine$DefaultImpls {
-	public static synthetic fun evaluateNoInput$default (Lmisk/policy/opa/OpaPolicyEngine;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/policy/opa/OpaResponse;
-	public static synthetic fun evaluateWithInput$default (Lmisk/policy/opa/OpaPolicyEngine;Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 
 public abstract interface class misk/policy/opa/OpaRequest {
 }
 
 public abstract interface class misk/policy/opa/OpaResponse {
+	public abstract fun getProvenance ()Lmisk/policy/opa/Provenance;
+	public abstract fun setProvenance (Lmisk/policy/opa/Provenance;)V
 }
 
 public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
@@ -45,10 +47,29 @@ public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class misk/policy/opa/Provenance {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lmisk/policy/opa/Provenance;
+	public static synthetic fun copy$default (Lmisk/policy/opa/Provenance;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/policy/opa/Provenance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBuild_commit ()Ljava/lang/String;
+	public final fun getBuild_hostname ()Ljava/lang/String;
+	public final fun getBuild_timestamp ()Ljava/lang/String;
+	public final fun getRevision ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
 	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;)V
-	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
-	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Boolean;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 
 public final class misk/policy/opa/Request {
@@ -63,13 +84,15 @@ public final class misk/policy/opa/Request {
 }
 
 public final class misk/policy/opa/Response {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lmisk/policy/opa/Provenance;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Object;)Lmisk/policy/opa/Response;
-	public static synthetic fun copy$default (Lmisk/policy/opa/Response;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lmisk/policy/opa/Response;
+	public final fun component3 ()Lmisk/policy/opa/Provenance;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Lmisk/policy/opa/Provenance;)Lmisk/policy/opa/Response;
+	public static synthetic fun copy$default (Lmisk/policy/opa/Response;Ljava/lang/String;Ljava/lang/Object;Lmisk/policy/opa/Provenance;ILjava/lang/Object;)Lmisk/policy/opa/Response;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDecision_id ()Ljava/lang/String;
+	public final fun getProvenance ()Lmisk/policy/opa/Provenance;
 	public final fun getResult ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -1,11 +1,5 @@
 public abstract interface class misk/policy/opa/OpaApi {
-	public abstract fun getProvenance ()Z
 	public abstract fun queryDocument (Ljava/lang/String;Ljava/lang/String;Z)Lretrofit2/Call;
-	public abstract fun setProvenance (Z)V
-}
-
-public final class misk/policy/opa/OpaApi$DefaultImpls {
-	public static synthetic fun queryDocument$default (Lmisk/policy/opa/OpaApi;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lretrofit2/Call;
 }
 
 public final class misk/policy/opa/OpaConfig : misk/config/Config {
@@ -34,12 +28,14 @@ public abstract interface class misk/policy/opa/OpaPolicyEngine {
 	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 
-public abstract interface class misk/policy/opa/OpaRequest {
+public abstract class misk/policy/opa/OpaRequest {
+	public fun <init> ()V
 }
 
-public abstract interface class misk/policy/opa/OpaResponse {
-	public abstract fun getProvenance ()Lmisk/policy/opa/Provenance;
-	public abstract fun setProvenance (Lmisk/policy/opa/Provenance;)V
+public abstract class misk/policy/opa/OpaResponse {
+	public fun <init> ()V
+	public final fun getProvenance ()Lmisk/policy/opa/Provenance;
+	public final fun setProvenance (Lmisk/policy/opa/Provenance;)V
 }
 
 public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
@@ -67,7 +63,7 @@ public final class misk/policy/opa/Provenance {
 }
 
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
-	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;)V
+	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;Z)V
 	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
@@ -3,6 +3,7 @@ package misk.policy.opa
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.Query
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -13,6 +14,6 @@ interface OpaApi {
   fun queryDocument(
     @Path(value = "documentPath", encoded = true) documentPath: String,
     @Body input: String,
-    @Query("provenance") provenance: Boolean
+    @Query("provenance") provenance: Boolean?
   ): Call<ResponseBody>
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
@@ -14,6 +14,6 @@ interface OpaApi {
   fun queryDocument(
     @Path(value = "documentPath", encoded = true) documentPath: String,
     @Body input: String,
-    @Query("provenance") provenance: Boolean?
+    @Query("provenance") provenance: Boolean? = false
   ): Call<ResponseBody>
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
@@ -9,13 +9,11 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface OpaApi {
-  var provenance: Boolean
-
   @Headers("Content-Type: application/json")
   @POST("/v1/data/{documentPath}")
   fun queryDocument(
     @Path(value = "documentPath", encoded = true) documentPath: String,
     @Body input: String,
-    @Query("provenance") provenance: Boolean = false
+    @Query("provenance") provenance: Boolean
   ): Call<ResponseBody>
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
@@ -9,11 +9,13 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface OpaApi {
+  var provenance: Boolean
+
   @Headers("Content-Type: application/json")
   @POST("/v1/data/{documentPath}")
   fun queryDocument(
     @Path(value = "documentPath", encoded = true) documentPath: String,
     @Body input: String,
-    @Query("provenance") provenance: Boolean? = false
+    @Query("provenance") provenance: Boolean = false
   ): Call<ResponseBody>
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaApi.kt
@@ -12,6 +12,7 @@ interface OpaApi {
   @POST("/v1/data/{documentPath}")
   fun queryDocument(
     @Path(value = "documentPath", encoded = true) documentPath: String,
-    @Body input: String
+    @Body input: String,
+    @Query("provenance") provenance: Boolean
   ): Call<ResponseBody>
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaConfig.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaConfig.kt
@@ -4,5 +4,6 @@ import misk.config.Config
 
 data class OpaConfig(
   val baseUrl: String,
-  val unixSocket: String?
+  val unixSocket: String?,
+  val provenance: Boolean = false
 ) : Config

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaModule.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaModule.kt
@@ -38,7 +38,9 @@ class OpaModule @Inject constructor(
       builder.client(okHttpClient)
     }
     builder.baseUrl(config.baseUrl)
-    return builder.build().create(OpaApi::class.java)
+    val api = builder.build().create(OpaApi::class.java)
+    api.provenance = config.provenance
+    return api
   }
 
   @Provides @Singleton @Named("opa-moshi")

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaModule.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaModule.kt
@@ -22,6 +22,13 @@ class OpaModule @Inject constructor(
   }
 
   @Provides
+  internal fun opaConfig(
+    config: OpaConfig
+  ): Boolean {
+    return config.provenance
+  }
+
+  @Provides
   internal fun opaApi(
     config: OpaConfig,
     httpClientFactory: HttpClientFactory,
@@ -38,9 +45,7 @@ class OpaModule @Inject constructor(
       builder.client(okHttpClient)
     }
     builder.baseUrl(config.baseUrl)
-    val api = builder.build().create(OpaApi::class.java)
-    api.provenance = config.provenance
-    return api
+    return builder.build().create(OpaApi::class.java)
   }
 
   @Provides @Singleton @Named("opa-moshi")

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -5,10 +5,15 @@ interface OpaPolicyEngine {
     document: String,
     input: T,
     inputType: Class<T>,
-    returnType: Class<R>
+    returnType: Class<R>,
+    provenance: Boolean?
   ): R
 
-  fun <R : OpaResponse> evaluateNoInput(document: String, returnType: Class<R>): R
+  fun <R : OpaResponse> evaluateNoInput(
+    document: String,
+    returnType: Class<R>,
+    provenance: Boolean?
+  ): R
 }
 
 /**
@@ -20,7 +25,10 @@ interface OpaPolicyEngine {
  * @throws IllegalArgumentException if no document path was specified.
  * @return Response shape R from OPA.
  */
-inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(document: String): R {
+inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
+  document: String,
+  provenance: Boolean?
+): R {
   return evaluateNoInput(document, R::class.java)
 }
 
@@ -36,7 +44,8 @@ inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(document: String):
  */
 inline fun <reified T : OpaRequest, reified R : OpaResponse> OpaPolicyEngine.evaluate(
   document: String,
-  input: T
+  input: T,
+  provenance: Boolean?
 ): R {
-  return evaluateWithInput(document, input, T::class.java, R::class.java)
+  return evaluateWithInput(document, input, T::class.java, R::class.java, provenance)
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -5,14 +5,12 @@ interface OpaPolicyEngine {
     document: String,
     input: T,
     inputType: Class<T>,
-    returnType: Class<R>,
-    provenance: Boolean? = false
+    returnType: Class<R>
   ): R
 
   fun <R : OpaResponse> evaluateNoInput(
     document: String,
-    returnType: Class<R>,
-    provenance: Boolean? = false
+    returnType: Class<R>
   ): R
 }
 
@@ -26,10 +24,9 @@ interface OpaPolicyEngine {
  * @return Response shape R from OPA.
  */
 inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
-  document: String,
-  provenance: Boolean? = false
+  document: String
 ): R {
-  return evaluateNoInput(document, R::class.java, provenance)
+  return evaluateNoInput(document, R::class.java)
 }
 
 /**
@@ -44,8 +41,7 @@ inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
  */
 inline fun <reified T : OpaRequest, reified R : OpaResponse> OpaPolicyEngine.evaluate(
   document: String,
-  input: T,
-  provenance: Boolean? = false
+  input: T
 ): R {
-  return evaluateWithInput(document, input, T::class.java, R::class.java, provenance)
+  return evaluateWithInput(document, input, T::class.java, R::class.java)
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -6,13 +6,13 @@ interface OpaPolicyEngine {
     input: T,
     inputType: Class<T>,
     returnType: Class<R>,
-    provenance: Boolean?
+    provenance: Boolean? = false
   ): R
 
   fun <R : OpaResponse> evaluateNoInput(
     document: String,
     returnType: Class<R>,
-    provenance: Boolean?
+    provenance: Boolean? = false
   ): R
 }
 
@@ -27,7 +27,7 @@ interface OpaPolicyEngine {
  */
 inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
   document: String,
-  provenance: Boolean?
+  provenance: Boolean? = false
 ): R {
   return evaluateNoInput(document, R::class.java, provenance)
 }
@@ -45,7 +45,7 @@ inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
 inline fun <reified T : OpaRequest, reified R : OpaResponse> OpaPolicyEngine.evaluate(
   document: String,
   input: T,
-  provenance: Boolean?
+  provenance: Boolean? = false
 ): R {
   return evaluateWithInput(document, input, T::class.java, R::class.java, provenance)
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -29,7 +29,7 @@ inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
   document: String,
   provenance: Boolean?
 ): R {
-  return evaluateNoInput(document, R::class.java)
+  return evaluateNoInput(document, R::class.java, provenance)
 }
 
 /**

--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -80,8 +80,8 @@ class RealOpaPolicyEngine @Inject constructor(
     returnType: Class<R>,
     provenance: Boolean?
   ): R {
-    val response = queryOpa(document)
-    return parseResponse(document, returnType, response, provenance)
+    val response = queryOpa(document, provenance)
+    return parseResponse(document, returnType, response)
   }
 
   private fun queryOpa(

--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -13,7 +13,8 @@ import javax.inject.Named
  */
 class RealOpaPolicyEngine @Inject constructor(
   private val opaApi: OpaApi,
-  @Named("opa-moshi") private val moshi: Moshi
+  @Named("opa-moshi") private val moshi: Moshi,
+  private val provenance: Boolean
 ) : OpaPolicyEngine {
 
   /**
@@ -88,7 +89,7 @@ class RealOpaPolicyEngine @Inject constructor(
       throw IllegalArgumentException("Must specify document")
     }
 
-    val response = opaApi.queryDocument(document, inputString).execute()
+    val response = opaApi.queryDocument(document, inputString, provenance).execute()
     if (!response.isSuccessful) {
       throw PolicyEngineException("[${response.code()}]: ${response.errorBody()?.string()}")
     }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -80,7 +80,7 @@ class RealOpaPolicyEngine @Inject constructor(
     returnType: Class<R>,
     provenance: Boolean?
   ): R {
-    val response = queryOpa(document, provenance)
+    val response = queryOpa(document, "", provenance)
     return parseResponse(document, returnType, response)
   }
 

--- a/misk-policy/src/main/kotlin/misk/policy/opa/Request.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/Request.kt
@@ -7,4 +7,4 @@ data class Request<T>(
   val input: T
 )
 
-interface OpaRequest
+abstract class OpaRequest

--- a/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
@@ -6,7 +6,18 @@ package misk.policy.opa
  */
 data class Response<T>(
   val decision_id: String?,
-  val result: T?
+  val result: T?,
+  val provenance: Provenance?
 )
 
-interface OpaResponse
+data class Provenance(
+  val version: String?,
+  val build_commit: String?,
+  val build_timestamp: String?,
+  val build_hostname: String?,
+  val revision: String?
+)
+
+interface OpaResponse {
+  var provenance: Provenance?
+}

--- a/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
@@ -18,6 +18,6 @@ data class Provenance(
   val revision: String?
 )
 
-interface OpaResponse {
-  var provenance: Provenance?
+abstract class OpaResponse {
+  var provenance: Provenance? = null
 }

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -139,6 +139,6 @@ internal class RealOpaPolicyEngineTest {
   // Weird kotlin workaround for mockito. T must not be nullable.
   private fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()
 
-  data class BasicResponse(val test: String) : OpaResponse
+  data class BasicResponse(val test: String, override var provenance: Provenance? = null) : OpaResponse
   data class BasicRequest(val someValue: Int) : OpaRequest
 }

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.anyString
 import retrofit2.Response
 import retrofit2.mock.Calls
@@ -44,7 +45,7 @@ internal class RealOpaPolicyEngineTest {
 
   @Test
   fun emptyInputQuery() {
-    Mockito.whenever(opaApi.queryDocument(anyString(), anyString())).thenReturn(
+    Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
       Calls.response(
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),
@@ -59,7 +60,7 @@ internal class RealOpaPolicyEngineTest {
   @Test
   fun pojoInputQuery() {
     val requestCaptor = Mockito.captor<String>()
-    Mockito.whenever(opaApi.queryDocument(anyString(), capture(requestCaptor))).thenReturn(
+    Mockito.whenever(opaApi.queryDocument(anyString(), capture(requestCaptor), anyBoolean())).thenReturn(
       Calls.response(
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),
@@ -76,7 +77,7 @@ internal class RealOpaPolicyEngineTest {
 
   @Test
   fun responseIsNotOk() {
-    Mockito.whenever(opaApi.queryDocument(anyString(), anyString())).thenReturn(
+    Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
       Calls.response(
         Response.error(
           403,
@@ -93,7 +94,7 @@ internal class RealOpaPolicyEngineTest {
 
   @Test
   fun unableToParseResponseIntoRequestedShape() {
-    Mockito.whenever(opaApi.queryDocument(anyString(), anyString())).thenReturn(
+    Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
       Calls.response(
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),
@@ -112,7 +113,7 @@ internal class RealOpaPolicyEngineTest {
 
   @Test
   fun unknownPolicyDocument() {
-    Mockito.whenever(opaApi.queryDocument(anyString(), anyString())).thenReturn(
+    Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
       Calls.response(
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),


### PR DESCRIPTION
See https://www.openpolicyagent.org/docs/latest/rest-api/#provenance for more details on how provenance works in OPA.