### PR TITLE
Wait to run ready crons until installed services are healthy

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -7,6 +7,7 @@ import misk.concurrent.ExecutorServiceModule
 import misk.inject.KAbstractModule
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
+import wisp.lease.LeaseManager
 import java.time.ZoneId
 import javax.inject.Qualifier
 
@@ -16,6 +17,8 @@ class CronModule(
 ) : KAbstractModule() {
 
   override fun configure() {
+    requireBinding<LeaseManager>()
+
     install(FakeCronModule(zoneId, threadPoolSize))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class))
     install(ServiceModule<CronTask>())


### PR DESCRIPTION
This way, any services that set up a lease manager have been started before we run any cron entries