### PR TITLE
Do not warn on unknown LD json fields

### DIFF
--- a/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -132,9 +132,7 @@ class LaunchDarklyFeatureFlags constructor(
       ldClient.jsonValueVariationDetail(name, user, LDValue.ofNull())
     }
     return moshi.adapter(clazz)
-      .fromSafeJson(result.toJsonString()) { exception ->
-        logJsonMigrationWarningOnce(feature, exception)
-      }
+      .fromJson(result.toJsonString())
       ?: throw IllegalArgumentException("null value deserialized from $feature")
   }
 


### PR DESCRIPTION
The warning here is of minimal value. It's normal to update definitions which might have newer fields unknown to older clients. It's not an error state. In cases where someone has fat fingered the definition, it's much more likely that they'll only notice that their definition is wrong when everything explodes anyway.

It is of value when debugging such an explosion, but we should aim for a better way of identifying the issue.

See https://github.com/squareup/cash-franklin/pull/15662