### PR TITLE
Allow service dependencies for misk-cron

### DIFF
--- a/misk-cron/api/misk-cron.api
+++ b/misk-cron/api/misk-cron.api
@@ -35,8 +35,8 @@ public final class misk/cron/CronManager$CronEntry {
 }
 
 public final class misk/cron/CronModule : misk/inject/KAbstractModule {
-	public fun <init> (Ljava/time/ZoneId;I)V
-	public synthetic fun <init> (Ljava/time/ZoneId;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V
+	public synthetic fun <init> (Ljava/time/ZoneId;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun provideTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;)Lmisk/tasks/RepeatedTaskQueue;
 }
 
@@ -45,7 +45,7 @@ public abstract interface annotation class misk/cron/CronPattern : java/lang/ann
 }
 
 public final class misk/cron/FakeCronModule : misk/inject/KAbstractModule {
-	public fun <init> (Ljava/time/ZoneId;I)V
-	public synthetic fun <init> (Ljava/time/ZoneId;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V
+	public synthetic fun <init> (Ljava/time/ZoneId;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
@@ -1,0 +1,67 @@
+package misk.cron
+
+import com.google.common.util.concurrent.AbstractIdleService
+import misk.MiskTestingServiceModule
+import misk.ServiceModule
+import misk.clustering.fake.lease.FakeLeaseModule
+import misk.inject.KAbstractModule
+import misk.inject.toKey
+import misk.logging.LogCollectorModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import wisp.logging.LogCollector
+import wisp.logging.getLogger
+import java.lang.Thread.sleep
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Suppress("UsePropertyAccessSyntax")
+@MiskTest(startService = true)
+class CronModuleTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module = object : KAbstractModule() {
+    override fun configure() {
+      install(FakeLeaseModule())
+      install(MiskTestingServiceModule())
+      install(LogCollectorModule())
+
+      install(ServiceModule<DependentService>())
+      install(
+        FakeCronModule(
+          ZoneId.of("America/Toronto"),
+          dependencies = listOf(DependentService::class.toKey())
+        )
+      )
+      install(CronEntryModule.create<MinuteCron>())
+    }
+  }
+
+  @Inject private lateinit var logCollector: LogCollector
+
+  @Test fun dependentServicesStartUpBeforeCron() {
+    assertThat(logCollector.takeMessages()).containsExactly(
+      "DependentService started",
+      "CronService started",
+      "Adding cron entry misk.cron.MinuteCron, crontab=* * * * *",
+    )
+  }
+
+  @Singleton
+  private class DependentService @Inject constructor() : AbstractIdleService() {
+    override fun startUp() {
+      logger.info { "DependentService started" }
+      sleep(1000)
+    }
+
+    override fun shutDown() {}
+
+    companion object {
+      val logger = getLogger<DependentService>()
+    }
+  }
+}


### PR DESCRIPTION
Presently, misk-cron doesn't allow specifying service dependencies. This patch plumbs service dependency keys through the `CronModule`, so that you can (for example) wait until your service's database has started before your cron jobs start running.

Paired with @iwismer on this.