### PR TITLE
Provide Redis timeout configuration

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -145,15 +145,17 @@ public final class misk/redis/RedisNodeConfig {
 }
 
 public final class misk/redis/RedisReplicationGroupConfig {
-	public fun <init> (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;)V
+	public fun <init> (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;I)V
 	public final fun component1 ()Lmisk/redis/RedisNodeConfig;
 	public final fun component2 ()Lmisk/redis/RedisNodeConfig;
 	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I;
 	public final fun copy (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;)Lmisk/redis/RedisReplicationGroupConfig;
-	public static synthetic fun copy$default (Lmisk/redis/RedisReplicationGroupConfig;Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/Object;)Lmisk/redis/RedisReplicationGroupConfig;
+	public static synthetic fun copy$default (Lmisk/redis/RedisReplicationGroupConfig;Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;I;ILjava/lang/Object;)Lmisk/redis/RedisReplicationGroupConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReader_endpoint ()Lmisk/redis/RedisNodeConfig;
 	public final fun getRedis_auth_password ()Ljava/lang/String;
+	public final fun getTimeout_ms ()I;
 	public final fun getWriter_endpoint ()Lmisk/redis/RedisNodeConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -146,16 +146,17 @@ public final class misk/redis/RedisNodeConfig {
 
 public final class misk/redis/RedisReplicationGroupConfig {
 	public fun <init> (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;I)V
+	public synthetic fun <init> (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lmisk/redis/RedisNodeConfig;
 	public final fun component2 ()Lmisk/redis/RedisNodeConfig;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()I;
-	public final fun copy (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;)Lmisk/redis/RedisReplicationGroupConfig;
-	public static synthetic fun copy$default (Lmisk/redis/RedisReplicationGroupConfig;Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;I;ILjava/lang/Object;)Lmisk/redis/RedisReplicationGroupConfig;
+	public final fun component4 ()I
+	public final fun copy (Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;I)Lmisk/redis/RedisReplicationGroupConfig;
+	public static synthetic fun copy$default (Lmisk/redis/RedisReplicationGroupConfig;Lmisk/redis/RedisNodeConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;IILjava/lang/Object;)Lmisk/redis/RedisReplicationGroupConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReader_endpoint ()Lmisk/redis/RedisNodeConfig;
 	public final fun getRedis_auth_password ()Ljava/lang/String;
-	public final fun getTimeout_ms ()I;
+	public final fun getTimeout_ms ()I
 	public final fun getWriter_endpoint ()Lmisk/redis/RedisNodeConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
@@ -1,5 +1,6 @@
 package misk.redis
 
+import redis.clients.jedis.Protocol
 import wisp.config.Config
 
 class RedisConfig : java.util.LinkedHashMap<String, RedisReplicationGroupConfig>, Config {
@@ -10,7 +11,8 @@ class RedisConfig : java.util.LinkedHashMap<String, RedisReplicationGroupConfig>
 data class RedisReplicationGroupConfig(
   val writer_endpoint: RedisNodeConfig,
   val reader_endpoint: RedisNodeConfig,
-  val redis_auth_password: String
+  val redis_auth_password: String,
+  val timeout_ms: Int = Protocol.DEFAULT_TIMEOUT
 )
 
 data class RedisNodeConfig(

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -6,7 +6,6 @@ import misk.ServiceModule
 import misk.inject.KAbstractModule
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
-import redis.clients.jedis.Protocol
 
 /**
  * Configures a JedisPool to connect to a Redis instance. The use of a JedisPool ensures thread safety.
@@ -32,7 +31,7 @@ class RedisModule(
         jedisPoolConfig,
         replicationGroup.writer_endpoint.hostname,
         replicationGroup.writer_endpoint.port,
-        Protocol.DEFAULT_TIMEOUT,
+        replicationGroup.timeout_ms,
         replicationGroup.redis_auth_password,
         true
     )


### PR DESCRIPTION
Default of 2 seconds for Redis timeout is too long, and we want to be able to set a smaller timeout so that we can fall back to hit the database if it takes too long.