### PR TITLE
Support marking service dependencies for the jetty service.

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1203,7 +1203,8 @@ public final class misk/web/MiskWebFormBuilder$Type {
 }
 
 public final class misk/web/MiskWebModule : misk/inject/KAbstractModule {
-	public fun <init> (Lmisk/web/WebConfig;)V
+	public fun <init> (Lmisk/web/WebConfig;Ljava/util/List;)V
+	public synthetic fun <init> (Lmisk/web/WebConfig;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun provideGzipHandler ()Lorg/eclipse/jetty/server/handler/gzip/GzipHandler;
 	public final fun provideStatisticsHandler ()Lorg/eclipse/jetty/server/handler/StatisticsHandler;
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -1,5 +1,7 @@
 package misk.web
 
+import com.google.common.util.concurrent.Service
+import com.google.inject.Key
 import com.google.inject.Provider
 import com.google.inject.Provides
 import com.google.inject.TypeLiteral
@@ -20,6 +22,7 @@ import misk.ServiceModule
 import misk.exceptions.WebActionException
 import misk.grpc.GrpcFeatureBinding
 import misk.inject.KAbstractModule
+import misk.inject.toKey
 import misk.queuing.TimedBlockingQueue
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
@@ -86,12 +89,15 @@ import org.eclipse.jetty.util.thread.ExecutorThreadPool
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.util.thread.ThreadPool
 
-class MiskWebModule(private val config: WebConfig) : KAbstractModule() {
+class MiskWebModule(
+  private val config: WebConfig,
+  private val jettyDependsOn: List<Key<out Service>> = emptyList(),
+) : KAbstractModule() {
   override fun configure() {
     bind<WebConfig>().toInstance(config)
     bind<ActionExceptionLogLevelConfig>().toInstance(config.action_exception_log_level)
 
-    install(ServiceModule<JettyService>())
+    install(ServiceModule(key = JettyService::class.toKey(), dependsOn = jettyDependsOn))
     install(ServiceModule<JettyThreadPoolMetricsCollector>())
     install(ServiceModule<JettyConnectionMetricsCollector>())
 

--- a/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
+++ b/samples/exemplar/src/main/java/com/squareup/exemplar/ExemplarJavaApp.java
@@ -18,7 +18,7 @@ public class ExemplarJavaApp {
 
     new MiskApplication(
         new MiskRealServiceModule(),
-        new MiskWebModule(config.web),
+        new MiskWebModule(config.web, ImmutableList.of()),
         new ExemplarJavaModule(),
         new ConfigModule<>(ExemplarJavaConfig.class, "exemplar", config),
         new DeploymentModule(deployment)


### PR DESCRIPTION
This change makes it possible to address a long-standing shutdown issue—if a misk application has web action handlers that interact with a database, the misk service coordinator has no idea that the actions depend on the database transacter service being available. During shutdown, this can lead to the DB connection being closed while web actions are still in progress, triggering intermittent errors and risk of data loss.

Because the Jetty service is private to Misk, and the application DB is defined in the application, making the Jetty service aware of this dependency is convoluted. This PR makes it possible for the application to pass down a list of other services that the Jetty service should depend upon, which will enforce a consistent shutdown order.