### PR TITLE
Add envelope encryptor

### DIFF
--- a/misk-gcp/README.md
+++ b/misk-gcp/README.md
@@ -159,3 +159,6 @@ class GoogleSpannerModuleTest {
   }
 }
 ```
+
+## Envelope Encryption (Cloud KMS)
+See [README](src/main/kotlin/misk/cloud/gcp/kms/README.md).

--- a/misk-gcp/build.gradle.kts
+++ b/misk-gcp/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
   implementation(Dependencies.moshiCore)
   implementation(Dependencies.moshiKotlin)
   implementation(Dependencies.moshiAdapters)
+  implementation(Dependencies.tink)
+  implementation(Dependencies.tinkGcpkms)
   implementation(Dependencies.wireGrpcClient)
   implementation(Dependencies.wireRuntime)
   implementation(project(":misk"))

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptionConfig.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptionConfig.kt
@@ -1,0 +1,14 @@
+package misk.cloud.gcp.security.encryption
+
+import misk.config.Secret
+
+data class EnvelopeEncryptionConfig(
+  val project_id: String,
+  val kek: Kek,
+  val credentials: Secret<String>,
+) {
+  val kekUri = "gcp-kms://projects/$project_id/locations/${kek.location}/" +
+    "keyRings/${kek.key_ring}/cryptoKeys/${kek.key_name}"
+}
+
+data class Kek(val location: String, val key_ring: String, val key_name: String)

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptionModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptionModule.kt
@@ -1,0 +1,40 @@
+package misk.cloud.gcp.security.encryption
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.crypto.tink.KmsClients
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.integration.gcpkms.GcpKmsClient
+import java.lang.IllegalArgumentException
+import misk.inject.KAbstractModule
+import wisp.deployment.Deployment
+import wisp.deployment.getDeploymentFromEnvironmentVariable
+
+class EnvelopeEncryptionModule(
+  private val config: EnvelopeEncryptionConfig?,
+  private val deployment: Deployment = getDeploymentFromEnvironmentVariable(),
+) : KAbstractModule() {
+  override fun configure() {
+    AeadConfig.register()
+
+    if (deployment.isReal) {
+      bind<EnvelopeEncryptionConfig>().toInstance(config)
+      registerCloudKmsClient(config!!)
+      bind<EnvelopeEncryptor>().to<RealEnvelopeEncryptor>()
+    } else {
+      bind<EnvelopeEncryptor>().to<FakeEnvelopeEncryptor>()
+    }
+  }
+
+  private fun registerCloudKmsClient(config: EnvelopeEncryptionConfig) {
+    val cloudKmsClient = GcpKmsClient(config.kekUri)
+
+    try {
+      cloudKmsClient.withCredentials(
+        GoogleCredential.fromStream(config.credentials.value.byteInputStream())
+      )
+    } catch (e: IllegalArgumentException) {
+    }
+    KmsClients.add(cloudKmsClient)
+  }
+}
+

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptor.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptor.kt
@@ -1,0 +1,5 @@
+package misk.cloud.gcp.security.encryption
+
+interface EnvelopeEncryptor {
+  fun encrypt(payloadToEncrypt: ByteArray): ByteArray
+}

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/FakeEnvelopeEncryptor.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/FakeEnvelopeEncryptor.kt
@@ -1,0 +1,40 @@
+package misk.cloud.gcp.security.encryption
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.BinaryKeysetWriter
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FakeEnvelopeEncryptor @Inject constructor() : EnvelopeEncryptor {
+  private val kekAead =
+    KeysetHandle.generateNew(KeyTemplates.get(KEY_TEMPLATE)).getPrimitive(Aead::class.java)
+
+  override fun encrypt(payloadToEncrypt: ByteArray): ByteArray {
+    val dekHandle = KeysetHandle.generateNew(KeyTemplates.get(KEY_TEMPLATE))
+    val dekAead = dekHandle.getPrimitive(Aead::class.java)
+
+    val encryptedDek = encryptDek(dekHandle, kekAead)
+    val encryptedPayload = dekAead.encrypt(payloadToEncrypt, byteArrayOf())
+
+    return ByteBuffer.allocate(4 + encryptedDek.size + encryptedPayload.size)
+      .putInt(encryptedDek.size)
+      .put(encryptedDek)
+      .put(encryptedPayload)
+      .array()
+  }
+
+  private fun encryptDek(dek: KeysetHandle, kek: Aead): ByteArray {
+    val encryptedDekStream = ByteArrayOutputStream()
+    dek.write(BinaryKeysetWriter.withOutputStream(encryptedDekStream), kek)
+    return encryptedDekStream.toByteArray()
+  }
+
+  companion object {
+    const val KEY_TEMPLATE = "AES256_GCM"
+  }
+}

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/README.md
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/README.md
@@ -1,0 +1,43 @@
+# Envelope Encryption with Cloud KMS
+
+The `EnvelopeEncryptionModule` provides an `EnvelopeEncryptor` which uses Tink and Cloud KMS to
+encrypt arbitrary data using [envelope encryption](https://cloud.google.com/kms/docs/envelope-encryption).
+
+## Configuring the module
+A typical configuration for the module looks like so:
+```yaml
+envelope_encryptor:
+  project_id: some-gcp-project-id
+  kek:
+    location: some-location
+    key_ring: some-key-ring-name
+    key_name: some-key-name
+  credentials: filesystem:/etc/secrets/service/some-gcp-credentials.json 
+```
+, where `credentials` is a path to a Misk secret.
+
+Configuration is only required for production and staging (i.e. "real") environments.
+Other environments use an in-memory encryption method.
+
+Install the `EnvelopeEncryptionModule` appropriately in your service, like so:
+```kotlin
+install(EnvelopeEncryptionModule(config.envelope_encryptor, serviceBuilder.deployment))
+```
+
+## Using the encryptor
+You need only to inject the `EnvelopeEncryptor` and use its methods.
+Usage is identical in the testing environment.
+```kotlin
+class SomeClass @Inject internal constructor(
+  private val envelopeEncryptor: EnvelopeEncryptor
+) {
+  fun someFunc() {
+    envelopeEncryptor.encrypt(SOME_BYTE_ARRAY)
+  }
+}
+```
+
+## Further notes
+Currently, only encryption is supported and not decryption.
+
+Data encryption keys are only generated using `AES256_GCM`.

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/RealEnvelopeEncryptor.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/security/encryption/RealEnvelopeEncryptor.kt
@@ -1,0 +1,29 @@
+package misk.cloud.gcp.security.encryption
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.aead.KmsEnvelopeAeadKeyManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RealEnvelopeEncryptor @Inject constructor(
+  private val config: EnvelopeEncryptionConfig,
+) : EnvelopeEncryptor {
+  override fun encrypt(payloadToEncrypt: ByteArray): ByteArray {
+    val dekHandle = KeysetHandle.generateNew(
+      KmsEnvelopeAeadKeyManager.createKeyTemplate(
+        config.kekUri,
+        KeyTemplates.get(DEK_TEMPLATE)
+      )
+    )
+    val dekAead = dekHandle.getPrimitive(Aead::class.java)
+
+    return dekAead.encrypt(payloadToEncrypt, byteArrayOf())
+  }
+
+  companion object {
+    const val DEK_TEMPLATE = "AES256_GCM"
+  }
+}

--- a/misk-gcp/src/test/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptorTest.kt
+++ b/misk-gcp/src/test/kotlin/misk/cloud/gcp/security/encryption/EnvelopeEncryptorTest.kt
@@ -1,0 +1,31 @@
+package misk.cloud.gcp.security.encryption
+
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.environment.DeploymentModule
+import javax.inject.Inject
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import wisp.deployment.TESTING
+
+@MiskTest
+class EnvelopeEncryptorTest {
+  @MiskTestModule
+  val module = Modules.combine(
+    MiskTestingServiceModule(),
+    DeploymentModule(TESTING),
+    EnvelopeEncryptionModule(null, TESTING)
+  )
+
+  @Inject lateinit var envelopeEncryptor: EnvelopeEncryptor
+
+  @Test
+  fun `encryption returns envelope encrypted data`() {
+    val plaintextToEncrypt = "to_encrypt"
+    val envelopeEncryptedData = envelopeEncryptor.encrypt(plaintextToEncrypt.toByteArray())
+
+    assertThat(envelopeEncryptedData).isNotEqualTo(plaintextToEncrypt)
+  }
+}


### PR DESCRIPTION
This is a module to use envelope encryption with Tink and Cloud KMS. Currently, only encryption is supported and DEKs are generated using `AES256_GCM`.