### PR TITLE
Introduce an annotation for MiskCaller in tests

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -247,6 +247,48 @@ class MyModule : KAbstractModule() {
 }
 ```
 
+### Testing `ActionScoped`
+
+Use `@WithMiskCaller` for `ActionScoped<MiskCaller>`:
+
+```kotlin
+@MiskTest
+@WithMiskCaller
+class MyTest {
+  @MiskTestModule val module = MyModule()
+  @Inject lateinit var action: HelloWebAction
+  @Inject lateinit var miskCaller: ActionScoped<MiskCaller>
+
+  // use action...
+}
+```
+
+Otherwise, use `ActionScope` directly:
+
+```kotlin
+@MiskTest
+class MyTest {
+  @MiskTestModule val module = MyModule()
+  @Inject lateinit var actionScope: ActionScope
+  @Inject lateinit var action: HelloWebAction
+  @Inject lateinit var myScopedObject: ActionScoped<MyScopedObject>
+  
+  @BeforeEach fun setUp() {
+    actionScope.enter(
+      mapOf(
+        keyOf<MyScopedObject>() to MyScopedObject()
+      )
+    )
+  }
+  
+  @AfterEach fun tearDown() {
+    actionScope.provider.get().close()
+  }
+
+  // use action...
+}
+```
+
 ### Integration tests
 
 It's possible to perform tests terminating at the app's HTTP/gRPC interface.

--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -315,6 +315,12 @@ public final class misk/web/FakeWebSocketListener : okhttp3/WebSocketListener {
 	public final fun takeMessage ()Ljava/lang/String;
 }
 
+public final class misk/web/MiskCallerExtension : org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeTestExecutionCallback {
+	public fun <init> ()V
+	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun beforeTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+}
+
 public final class misk/web/WebServerTestingModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/web/WebServerTestingModule$Companion;
 	public fun <init> ()V
@@ -356,6 +362,11 @@ public final class misk/web/WebTestingModule : misk/inject/KAbstractModule {
 
 public final class misk/web/WebTestingModule$Companion {
 	public final fun getTESTING_WEB_CONFIG ()Lmisk/web/WebConfig;
+}
+
+public abstract interface annotation class misk/web/WithMiskCaller : java/lang/annotation/Annotation {
+	public abstract fun service ()Ljava/lang/String;
+	public abstract fun user ()Ljava/lang/String;
 }
 
 public final class org/assertj/core/api/AssertExtensionsKt {

--- a/misk-testing/src/main/kotlin/misk/web/MiskCallerExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/web/MiskCallerExtension.kt
@@ -1,0 +1,51 @@
+package misk.web
+
+import com.google.inject.Injector
+import misk.MiskCaller
+import misk.inject.keyOf
+import misk.scope.ActionScope
+import misk.testing.retrieve
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class MiskCallerExtension : BeforeTestExecutionCallback, AfterTestExecutionCallback {
+  override fun beforeTestExecution(context: ExtensionContext) {
+    val injector = context.retrieve<Injector>("injector")
+    val actionScopeProvider = injector.getBinding(ActionScope::class.java)
+    val actionScope = actionScopeProvider.provider.get()
+    actionScope.enter(
+      mapOf(
+        keyOf<MiskCaller>() to context.getPrincipal()
+      )
+    )
+  }
+
+  override fun afterTestExecution(context: ExtensionContext) {
+    val injector = context.retrieve<Injector>("injector")
+    val actionScope = injector.getBinding(ActionScope::class.java)
+    actionScope.provider.get().close()
+  }
+
+  private fun ExtensionContext.getPrincipal(): MiskCaller {
+    val annotation =
+      requiredTestInstances.allInstances.last().javaClass
+        .getAnnotationsByType(WithMiskCaller::class.java)[0]
+    return when {
+      annotation.user.isNotBlank() -> MiskCaller(user = annotation.user)
+      annotation.service.isNotBlank() -> MiskCaller(service = annotation.service)
+      else -> MiskCaller(user = "default-user")
+    }
+  }
+}
+
+/**
+ * Use this annotation to specify an ActionScoped<MiskCaller> for this class.
+ *
+ * Annotate after [misk.testing.MiskTest].
+ */
+@Target(AnnotationTarget.CLASS)
+@ExtendWith(MiskCallerExtension::class)
+annotation class WithMiskCaller(val user: String = "", val service: String = "")
+

--- a/misk-testing/src/test/kotlin/misk/web/MiskCallerExtensionTest.kt
+++ b/misk-testing/src/test/kotlin/misk/web/MiskCallerExtensionTest.kt
@@ -1,0 +1,45 @@
+package misk.web
+
+import misk.MiskCaller
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.scope.ActionScoped
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest
+class MiskCallerExtensionTest {
+  @MiskTestModule
+  val module = object : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
+    }
+  }
+
+  @Inject lateinit var miskCaller: ActionScoped<MiskCaller>
+
+  open inner class AssertOnActionScoped(private val expectedCaller: MiskCaller) {
+    @Test
+    fun `injects an ActionScoped`() {
+      assertThat(miskCaller.get()).isEqualTo(expectedCaller)
+    }
+  }
+
+  @Nested
+  @WithMiskCaller
+  inner class Default : AssertOnActionScoped(MiskCaller(user = "default-user"))
+
+  @Nested
+  @WithMiskCaller(user = "user")
+  inner class WithUser : AssertOnActionScoped(MiskCaller(user = "user"))
+
+  @Nested
+  @WithMiskCaller(service = "service")
+  inner class WithService : AssertOnActionScoped(MiskCaller(service = "service"))
+
+}


### PR DESCRIPTION
This allows setting up an `ActionScoped<MiskCaller>` in tests conveniently.

Can't do something more generic because annotation classes are limited: https://kotlinlang.org/docs/annotations.html#constructors