### PR TITLE
update addOverrideForInput to correctly handle multiple overrides for the same policy

### DIFF
--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
@@ -33,7 +33,9 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
 
   private val responsesForInput = mutableMapOf<String, MutableMap<OpaRequest,OpaResponse>>()
   fun addOverrideForInput(document: String, key: OpaRequest, obj: OpaResponse) {
-    responsesForInput[document]?.put(key,obj) ?: run {
+    if(responsesForInput.containsKey(document)) {
+      responsesForInput[document]?.put(key,obj)
+    } else {
       responsesForInput[document] = mutableMapOf(Pair(key, obj))
     }
   }

--- a/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
+++ b/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
@@ -43,6 +43,28 @@ internal class FakeOpaPolicyEngineTest {
     assertThat(evaluate).isEqualTo(TestResponse("value"))
   }
 
+  @Test
+  fun `Override document for multiple input`() {
+    fakeOpaPolicyEngine.addOverrideForInput("test", TestRequest("key"), TestResponse("value"))
+    fakeOpaPolicyEngine.addOverrideForInput("test", TestRequest("otherKey"), TestResponse("otherValue"))
+    opaPolicyEngine.evaluate<TestRequest, TestResponse>("test", TestRequest("key")).apply {
+      assertThat(this).isEqualTo(TestResponse("value"))
+    }
+    opaPolicyEngine.evaluate<TestRequest, TestResponse>("test", TestRequest("otherKey")).apply {
+      assertThat(this).isEqualTo(TestResponse("otherValue"))
+    }
+  }
+
+  @Test
+  fun `Override document for the same input`() {
+    fakeOpaPolicyEngine.addOverrideForInput("test", TestRequest("key"), TestResponse("value"))
+    fakeOpaPolicyEngine.addOverrideForInput("test", TestRequest("key"), TestResponse("otherValue"))
+    opaPolicyEngine.evaluate<TestRequest, TestResponse>("test", TestRequest("key")).apply {
+      assertThat(this).isEqualTo(TestResponse("otherValue"))
+    }
+  }
+
+
   data class TestRequest(
     val something: String
   ) : OpaRequest


### PR DESCRIPTION
I think this was the intended behavior, but
```
   responsesForInput[document]?.put(key,obj) ?: run {
      responsesForInput[document] = mutableMapOf(Pair(key, obj))
    }
``` 
would always set `responsesForInput[document]` to the new map since put returns null unless the value was already in the list https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-map/put.html