### PR TITLE
expose AWS clients to be configurable

### DIFF
--- a/misk-aws-dynamodb/api/misk-aws-dynamodb.api
+++ b/misk-aws-dynamodb/api/misk-aws-dynamodb.api
@@ -23,9 +23,12 @@ public final class misk/dynamodb/DynamoDbHealthCheck$Companion {
 public abstract interface class misk/dynamodb/DynamoDbService : com/google/common/util/concurrent/Service {
 }
 
-public final class misk/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
+public class misk/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
 	public fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;)V
 	public synthetic fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun configure ()V
+	public fun configureClient (Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDBClientBuilder;)V
+	public fun configureStreamsClient (Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDBStreamsClientBuilder;)V
 	public final fun provideRequiredTables ()Ljava/util/List;
 	public final fun providesAmazonDynamoDB (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDB;
 	public final fun providesAmazonDynamoDBStreams (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDBStreams;

--- a/misk-aws/api/misk-aws.api
+++ b/misk-aws/api/misk-aws.api
@@ -69,9 +69,11 @@ public final class misk/jobqueue/sqs/AwsSqsJobQueueConfig : wisp/config/Config {
 	public final fun getTask_queue ()Lmisk/tasks/RepeatedTaskQueueConfig;
 }
 
-public final class misk/jobqueue/sqs/AwsSqsJobQueueModule : misk/inject/KAbstractModule {
+public class misk/jobqueue/sqs/AwsSqsJobQueueModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/jobqueue/sqs/AwsSqsJobQueueModule$Companion;
 	public fun <init> (Lmisk/jobqueue/sqs/AwsSqsJobQueueConfig;)V
+	protected fun configure ()V
+	public fun configureClient (Lcom/amazonaws/client/builder/AwsClientBuilder;)V
 	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;Lmisk/jobqueue/sqs/AwsSqsJobQueueConfig;)Lmisk/tasks/RepeatedTaskQueue;
 	public final fun provideSQSClient (Ljava/lang/String;Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;Lmisk/feature/FeatureFlags;)Lcom/amazonaws/services/sqs/AmazonSQS;
 	public final fun provideSQSClientForReceiving (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/sqs/AmazonSQS;
@@ -173,8 +175,10 @@ public final class misk/jobqueue/sqs/StaticDeadLetterQueueProvider : misk/jobque
 	public fun deadLetterQueueFor (Lmisk/jobqueue/QueueName;)Lmisk/jobqueue/QueueName;
 }
 
-public final class misk/s3/RealS3Module : misk/inject/KAbstractModule {
+public class misk/s3/RealS3Module : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	protected fun configure ()V
+	public fun configureClient (Lcom/amazonaws/services/s3/AmazonS3ClientBuilder;)V
 	public final fun provideS3 (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/s3/AmazonS3;
 }
 

--- a/misk-aws/src/main/kotlin/misk/s3/RealS3Module.kt
+++ b/misk-aws/src/main/kotlin/misk/s3/RealS3Module.kt
@@ -8,7 +8,7 @@ import misk.cloud.aws.AwsRegion
 import misk.inject.KAbstractModule
 import javax.inject.Singleton
 
-class RealS3Module : KAbstractModule() {
+open class RealS3Module : KAbstractModule() {
   override fun configure() {
     requireBinding<AWSCredentialsProvider>()
     requireBinding<AwsRegion>()
@@ -16,10 +16,13 @@ class RealS3Module : KAbstractModule() {
 
   @Provides @Singleton
   fun provideS3(awsRegion: AwsRegion, awsCredentialsProvider: AWSCredentialsProvider): AmazonS3 {
-    return AmazonS3ClientBuilder
+    val builder = AmazonS3ClientBuilder
       .standard()
       .withRegion(awsRegion.name)
       .withCredentials(awsCredentialsProvider)
-      .build()
+    configureClient(builder)
+    return builder.build()
   }
+
+  open fun configureClient(builder: AmazonS3ClientBuilder) {}
 }

--- a/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
+++ b/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
@@ -11,10 +11,11 @@ public final class misk/aws2/dynamodb/DynamoDbHealthCheck$Companion {
 public abstract interface class misk/aws2/dynamodb/DynamoDbService : com/google/common/util/concurrent/Service {
 }
 
-public final class misk/aws2/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
-	public fun <init> ()V
-	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;)V
-	public synthetic fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public class misk/aws2/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
+	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;)V
+	public synthetic fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun configure ()V
+	public fun configureClient (Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClientBuilder;)V
 	public final fun provideRequiredTables ()Ljava/util/List;
 	public final fun providesDynamoDbClient (Lmisk/cloud/aws/AwsRegion;Lsoftware/amazon/awssdk/auth/credentials/AwsCredentialsProvider;)Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClient;
 }

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -13,14 +13,17 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
+import java.net.URI
 
 /**
  * Install this module to have access to a DynamoDbClient.
  */
-class RealDynamoDbModule constructor(
+open class RealDynamoDbModule constructor(
   private val clientOverrideConfig: ClientOverrideConfiguration =
     ClientOverrideConfiguration.builder().build(),
-  private val requiredTables: List<RequiredDynamoDbTable> = listOf()
+  private val requiredTables: List<RequiredDynamoDbTable> = listOf(),
+  private val endpointOverride: URI?
 ) : KAbstractModule() {
   override fun configure() {
     requireBinding<AwsCredentialsProvider>()
@@ -36,12 +39,18 @@ class RealDynamoDbModule constructor(
     awsRegion: AwsRegion,
     awsCredentialsProvider: AwsCredentialsProvider
   ): DynamoDbClient {
-    return DynamoDbClient.builder()
+    val builder = DynamoDbClient.builder()
       .region(Region.of(awsRegion.name))
       .credentialsProvider(awsCredentialsProvider)
       .overrideConfiguration(clientOverrideConfig)
-      .build()
+      if (endpointOverride != null) {
+        builder.endpointOverride(endpointOverride)
+      }
+    configureClient(builder)
+    return builder.build()
   }
+
+  open fun configureClient(builder: DynamoDbClientBuilder) {}
 
   @Provides @Singleton
   fun provideRequiredTables(): List<RequiredDynamoDbTable> = requiredTables


### PR DESCRIPTION
The Dynamodb, SQS, and S3 AWS clients can now be configured in an application by extending the module and implementing the `configureClient` function.