### PR TITLE
Provide default endpoint override for dynamo module.

### DIFF
--- a/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
+++ b/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
@@ -12,6 +12,7 @@ public abstract interface class misk/aws2/dynamodb/DynamoDbService : com/google/
 }
 
 public class misk/aws2/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
+	public fun <init> ()V
 	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;)V
 	public synthetic fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun configure ()V

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -23,7 +23,7 @@ open class RealDynamoDbModule constructor(
   private val clientOverrideConfig: ClientOverrideConfiguration =
     ClientOverrideConfiguration.builder().build(),
   private val requiredTables: List<RequiredDynamoDbTable> = listOf(),
-  private val endpointOverride: URI?
+  private val endpointOverride: URI? = null,
 ) : KAbstractModule() {
   override fun configure() {
     requireBinding<AwsCredentialsProvider>()


### PR DESCRIPTION
Followup to #2443 that avoids a breaking change for consumers by maintaining the current behaviour of the module.