### PR TITLE
adding getPermitsRemaining()

### DIFF
--- a/misk-admin/web/tabs/admin-dashboard/package-lock.json
+++ b/misk-admin/web/tabs/admin-dashboard/package-lock.json
@@ -12618,9 +12618,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/misk-admin/web/tabs/config/package-lock.json
+++ b/misk-admin/web/tabs/config/package-lock.json
@@ -12618,9 +12618,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/misk-admin/web/tabs/database/package-lock.json
+++ b/misk-admin/web/tabs/database/package-lock.json
@@ -14440,9 +14440,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/misk-admin/web/tabs/web-actions/package-lock.json
+++ b/misk-admin/web/tabs/web-actions/package-lock.json
@@ -12659,9 +12659,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/misk-admin/web/tabs/web-actions/src/rewrite/WebActionSendRequestFormComponents.tsx
+++ b/misk-admin/web/tabs/web-actions/src/rewrite/WebActionSendRequestFormComponents.tsx
@@ -1,0 +1,298 @@
+import React, {useState} from "react"
+import {
+  Button,
+  Collapse,
+  HTMLSelect,
+  Icon,
+  InputGroup,
+  NumericInput,
+  Tooltip
+} from "@blueprintjs/core"
+import _ from "lodash"
+import {ProtoField, WebActionMetadata} from "./types"
+import {IOptionProps} from "@blueprintjs/core/lib/esm/common/props"
+
+export type FormComponentProps<T> = {
+  webActionMetadata: WebActionMetadata
+  field: ProtoField
+  value: T
+  onChange: (value: T) => void
+}
+
+export function FormComponent(props: FormComponentProps<any>) {
+  const { webActionMetadata, field } = props
+
+  let delegate = null
+
+  if (field.repeated) {
+    delegate = <FormRepeatedComponent {...props} />
+  } else if (field.type === "String" || field.type === "ByteString") {
+    delegate = <FormTextComponent {...props} />
+  } else if (field.type === "Int" || field.type === "Long") {
+    delegate = <FormNumberComponent {...props} />
+  } else if (field.type === "Boolean") {
+    delegate = <FormBoolComponent {...props} />
+  } else if (field.type.startsWith("Enum")) {
+    delegate = <FormEnumComponent {...props} />
+  } else if (webActionMetadata.types[field.type]) {
+    delegate = <FormObjectComponent {...props} />
+  }
+
+  return (
+    delegate || (
+      <p style={{ color: "red" }}>Unsupported field type {field.type}.</p>
+    )
+  )
+}
+
+function FormTextComponent({
+  field,
+  value,
+  onChange
+}: FormComponentProps<string>) {
+  return (
+    <FormComponentWrapper
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={field.type}
+    >
+      <InputGroup
+        placeholder={field.type}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange(e.currentTarget.value)
+        }
+        value={value || ""}
+      />
+    </FormComponentWrapper>
+  )
+}
+
+function FormNumberComponent({
+  field,
+  value,
+  onChange
+}: FormComponentProps<number>) {
+  return (
+    <FormComponentWrapper
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={field.type}
+    >
+      <NumericInput
+        buttonPosition="none"
+        placeholder={field.type}
+        defaultValue={null}
+        onValueChange={(_, s: string) => {
+          onChange(s ? Number(s) : null)
+        }}
+        value={value || ""}
+      />
+    </FormComponentWrapper>
+  )
+}
+
+function FormBoolComponent({
+  field,
+  value,
+  onChange
+}: FormComponentProps<boolean>) {
+  return (
+    <FormComponentWrapper
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={field.type}
+    >
+      <HTMLSelect
+        options={["", "True", "False"]}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          const val = e.currentTarget.value
+          onChange(val === "" ? null : val === "True")
+        }}
+        value={value === null ? "" : value ? "True" : "False"}
+      />
+    </FormComponentWrapper>
+  )
+}
+
+function FormEnumComponent({
+  field,
+  value,
+  onChange
+}: FormComponentProps<string>) {
+  const enumValues = field.type
+    .replace(">", "")
+    .substring(5)
+    .split(",")
+  const protoType = enumValues.shift()
+  // Add a blank value to use to not include in the request.
+  const options: IOptionProps[] = [{ label: "", value: null }]
+  enumValues.forEach(val => {
+    options.push({ label: val, value: val })
+  })
+  return (
+    <FormComponentWrapper
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={protoType}
+    >
+      <HTMLSelect
+        options={options}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          onChange(e.currentTarget.value || null)
+        }}
+        value={value || ""}
+      />
+    </FormComponentWrapper>
+  )
+}
+
+function FormRepeatedComponent({
+  webActionMetadata,
+  field,
+  value,
+  onChange
+}: FormComponentProps<any[]>) {
+  const addButton = (
+    <Button
+      text="ADD"
+      intent="primary"
+      small={true}
+      minimal={true}
+      style={{ margin: 0 }}
+      onClick={() => {
+        onChange(value ? [...value, null] : [null])
+      }}
+    />
+  )
+
+  return (
+    <FormComponentWrapper
+      collapsable
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={`${field.type}[]`}
+      buttons={addButton}
+    >
+      {_.isEmpty(value) && (
+        <span style={{ fontStyle: "italic" }}>empty []</span>
+      )}
+      <div style={{ marginLeft: "12px" }}>
+        {value &&
+          value.map((cur, index) => (
+            <FormComponent
+              webActionMetadata={webActionMetadata}
+              field={{
+                ...field,
+                name: `${field.name}[${index}] `,
+                repeated: false
+              }}
+              onChange={newChildVal => {
+                if (newChildVal === null) {
+                  const newVal = [...value]
+                  newVal.splice(index, 1)
+                  onChange(newVal.length === 0 ? null : newVal)
+                } else {
+                  const newListVal = [...value]
+                  newListVal[index] = newChildVal
+                  onChange(newListVal)
+                }
+              }}
+              value={cur}
+            />
+          ))}
+      </div>
+    </FormComponentWrapper>
+  )
+}
+
+function FormObjectComponent({
+  webActionMetadata,
+  field,
+  value,
+  onChange
+}: FormComponentProps<any>) {
+  const complexType = webActionMetadata.types[field.type]
+  return (
+    <FormComponentWrapper
+      collapsable
+      onClear={() => onChange(null)}
+      protoName={field.name}
+      protoType={field.type}
+    >
+      <div style={{ marginLeft: "12px" }}>
+        {complexType.fields.map(subField => {
+          return (
+            <FormComponent
+              webActionMetadata={webActionMetadata}
+              field={subField}
+              onChange={newChildVal => {
+                const newValue = _(_.clone(value) || {})
+                  .set(subField.name, newChildVal)
+                  .omitBy(_.isNull)
+                  .value()
+
+                if (_.isEmpty(newValue)) {
+                  onChange(null)
+                } else {
+                  onChange(newValue)
+                }
+              }}
+              value={_.get(value, subField.name, null)}
+            />
+          )
+        })}
+      </div>
+    </FormComponentWrapper>
+  )
+}
+
+type FormComponentWrapperProps = {
+  protoName: string
+  protoType: string
+  onClear: () => void
+  buttons?: React.ReactNode
+  children: React.ReactNode
+  collapsable?: boolean
+}
+
+function FormComponentWrapper({
+  collapsable = false,
+  protoName,
+  protoType,
+  onClear,
+  buttons,
+  children
+}: FormComponentWrapperProps) {
+  const [isOpen, setOpen] = useState(true)
+
+  const label = (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <span
+        style={{ fontWeight: "bold", flexGrow: 1 }}
+        onClick={() => collapsable && setOpen(!isOpen)}
+      >
+        {protoName} ({protoType.split(".").pop()})
+        {collapsable && <Icon icon={isOpen ? "caret-down" : "caret-right"} />}
+      </span>
+      {buttons}
+      <Tooltip content={`clear ${protoName}`}>
+        <Button
+          tabIndex={-1}
+          intent={"primary"}
+          minimal
+          style={{ margin: "0" }}
+          onClick={onClear}
+          icon={"cross"}
+        />
+      </Tooltip>
+    </div>
+  )
+  return (
+    <div>
+      {label}
+      <Collapse isOpen={isOpen} keepChildrenMounted>
+        {children}
+      </Collapse>
+    </div>
+  )
+}

--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -237,6 +237,7 @@ public final class misk/sampling/PercentSampler : misk/sampling/Sampler {
 public final class misk/sampling/RateLimiter {
 	public synthetic fun <init> (Lcom/google/common/base/Ticker;Lmisk/concurrent/Sleeper;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPermitsPerSecond ()J
+	public final fun getPermitsRemaining (Ljava/util/concurrent/TimeUnit;J)J
 	public final fun setPermitsPerSecond (J)V
 	public final fun tryAcquire (JJLjava/util/concurrent/TimeUnit;)Z
 }

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -107,9 +107,7 @@ class RateLimiter private constructor(
     }
   }
 
-  private fun getPermitsRemaining(
-    unit: TimeUnit,
-    timeout: Long,
+  fun getPermitsRemaining(
     permitCount: Long
   ): Long {
     val allocatedUntil = atomicAllocatedUntil.get()
@@ -119,7 +117,6 @@ class RateLimiter private constructor(
     if (permitCount > maxRequestSize) return 0L
 
     val now = ticker.read()
-    val timeoutNs = unit.toNanos(timeout)
 
     // If this acquire succeeds, this is the time we're consuming permits through.
     val newAllocatedUntil = maxOf(allocatedUntil, now) +

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -124,11 +124,8 @@ class RateLimiter private constructor(
       // If this acquire succeeds, this is the time we're consuming permits through.
       val newAllocatedUntil = maxOf(allocatedUntil, now) +
         permitCount.permitsToNanos(permitsPerSecond)
-      println(newAllocatedUntil)
 
       val sleepNs = newAllocatedUntil - now - windowSizeNs
-      println("windowSizeNs $windowSizeNs")
-      println("sleepNs $sleepNs")
 
       val timeoutNs = unit.toNanos(timeout)
 

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -6,8 +6,6 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
-import kotlin.math.ceil
-import kotlin.math.floor
 
 /**
  * A deterministic testable rate limiter that uses two variables:
@@ -94,7 +92,8 @@ class RateLimiter private constructor(
       val timeoutNs = unit.toNanos(timeout)
 
       // If this acquire succeeds, this is the time we're consuming permits through.
-      val newAllocatedUntil = maxOf(allocatedUntil, now) + permitCount.permitsToNanos(permitsPerSecond)
+      val newAllocatedUntil =
+        maxOf(allocatedUntil, now) + permitCount.permitsToNanos(permitsPerSecond)
 
       // We only sleep for permits until the beginning of our window.
       val sleepNs = newAllocatedUntil - now - windowSizeNs
@@ -131,7 +130,8 @@ class RateLimiter private constructor(
     //   1. The end of the current [windowSizeNs] bucket minus how much time has already been allocated
     //   2. How long you're willing to wait for more permits to arrive
     // Capped to 1 [windowSizeMs] worth of permits
-    val allocatableTime = (nowNanos + windowSizeNs - allocatedUntil + timeoutNanos).coerceIn(0, windowSizeNs)
+    val allocatableTime =
+      (nowNanos + windowSizeNs - allocatedUntil + timeoutNanos).coerceIn(0, windowSizeNs)
     val timesliceSize = (windowSizeNs / permitsPerSecond)
     val permitsLeft = allocatableTime / timesliceSize
 

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -86,7 +86,6 @@ class RateLimiter private constructor(
 
       val maxRequestSize = windowSizeNs.nanosToPermits(permitsPerSecond)
       if (permitCount > maxRequestSize) return null
-
       val now = ticker.read()
 
       val timeoutNs = unit.toNanos(timeout)
@@ -118,8 +117,6 @@ class RateLimiter private constructor(
     unit: TimeUnit,
     timeout: Long
   ): Long {
-    require(unit.toNanos(timeout) <= windowSizeNs) { return 0L }
-
     val allocatedUntil = atomicAllocatedUntil.get()
     println("getPermitsRemaining.allocatedUntil: $allocatedUntil")
 

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -109,7 +109,9 @@ class RateLimiter private constructor(
   }
 
   /**
-   * Returns the permits remaining, given a time unit and timeout, after tryAcquire() has been invoked.
+   * Returns the maximum number of permits that could have
+   * been acquired by a call to [tryAcquire], assuming the caller
+   * passed the same [timeout] and [unit].
    *
    * @return the permits remaining.
    */

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -91,8 +91,8 @@ class RateLimiter private constructor(
       val timeoutNs = unit.toNanos(timeout)
 
       // If this acquire succeeds, this is the time we're consuming permits through.
-      val newAllocatedUntil =
-        maxOf(allocatedUntil, now) + permitCount.permitsToNanos(permitsPerSecond)
+      val newAllocatedUntil = maxOf(allocatedUntil, now) +
+        permitCount.permitsToNanos(permitsPerSecond)
 
       // We only sleep for permits until the beginning of our window.
       val sleepNs = newAllocatedUntil - now - windowSizeNs
@@ -113,14 +113,12 @@ class RateLimiter private constructor(
    * been acquired by a call to [tryAcquire], assuming the caller
    * passed the same [timeout] and [unit].
    *
-   * @return the permits remaining.
    */
   fun getPermitsRemaining(
     unit: TimeUnit,
     timeout: Long
   ): Long {
     val allocatedUntil = atomicAllocatedUntil.get()
-    println("getPermitsRemaining.allocatedUntil: $allocatedUntil")
 
     val nowNanos = ticker.read()
     val timeoutNanos = unit.toNanos(timeout)

--- a/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
+++ b/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
@@ -156,8 +156,10 @@ class RateLimiterTest {
   fun `permit count exceeds window size`() {
     rateLimiter.permitsPerSecond = 2L
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(0L)
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(3L, 2_000, TimeUnit.MILLISECONDS)).isFalse()
     assertThat(ticker.nowMs).isEqualTo(0L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(2L)
   }
 }

--- a/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
+++ b/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
@@ -35,18 +35,24 @@ class RateLimiterTest {
   @Test
   fun `consume slower than target rate`() {
     rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1_000)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(0L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1L)).isEqualTo(3L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1_000)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(0L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1L)).isEqualTo(2L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1_000)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(500L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1L)).isEqualTo(1L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1_000)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(1_000L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1L)).isEqualTo(0L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 1_000L)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 1_000, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(1_500L)
   }
@@ -54,15 +60,16 @@ class RateLimiterTest {
   @Test
   fun `consume at target rate`() {
     rateLimiter.permitsPerSecond = 2L
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(2L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
+    assertThat(ticker.nowMs).isEqualTo(0L)
+
     assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(2L)
     assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(0L)
 
     assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(1L)
-    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
-    assertThat(ticker.nowMs).isEqualTo(0L)
-
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(0L)
     assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(500L)
 
@@ -70,7 +77,7 @@ class RateLimiterTest {
     assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(1_000L)
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(0L)
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(1L)
     assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(1_500L)
   }
@@ -118,36 +125,38 @@ class RateLimiterTest {
     assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(1L)
     assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(100L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(0L)
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(1L)
   }
 
   @Test
   fun `rate limit decreases`() {
     rateLimiter.permitsPerSecond = 10L
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(1L)
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(10L)
     assertThat(rateLimiter.tryAcquire(10L, 100, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(0L)
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(0L)
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(1L)
     assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(100L)
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(0L)
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(1L)
     assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isTrue()
     assertThat(ticker.nowMs).isEqualTo(200L)
 
     rateLimiter.permitsPerSecond = 2L
 
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(0L)
     assertThat(rateLimiter.tryAcquire(1L, 100, TimeUnit.MILLISECONDS)).isFalse()
     assertThat(ticker.nowMs).isEqualTo(200L)
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 100)).isEqualTo(0L)
   }
 
   @Test
   fun `permit count exceeds window size`() {
     rateLimiter.permitsPerSecond = 2L
 
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(0L)
     assertThat(rateLimiter.tryAcquire(3L, 2_000, TimeUnit.MILLISECONDS)).isFalse()
     assertThat(ticker.nowMs).isEqualTo(0L)
   }


### PR DESCRIPTION
A call to getPermitsRemaining() exposes the permits left to be consumed. For example, if you're rate limiting at 2 permits / sec with a permit count of 1L and a timeout period of 0s, you'd have 1 permit remaining after the first acquisition. If you increase the timeout period to 500ms, you'd have 2 permits remaining after the first acquisition. This functionality is salient for monitoring (ie. setting an alert once getPermitsRemaining() falls below a threshold). 