### PR TITLE
Resolving divide by 0 error 

### DIFF
--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -118,7 +118,7 @@ class RateLimiter private constructor(
     unit: TimeUnit,
     timeout: Long
   ): Long {
-    if (permitsPerSecond == 0L) return 0L
+    if (permitsPerSecond <= 0L) return 0L
     val allocatedUntil = atomicAllocatedUntil.get()
 
     val nowNanos = ticker.read()

--- a/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/RateLimiter.kt
@@ -118,6 +118,7 @@ class RateLimiter private constructor(
     unit: TimeUnit,
     timeout: Long
   ): Long {
+    if (permitsPerSecond == 0L) return 0L
     val allocatedUntil = atomicAllocatedUntil.get()
 
     val nowNanos = ticker.read()

--- a/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
+++ b/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
@@ -165,7 +165,14 @@ class RateLimiterTest {
   @Test fun `QPS is set to 0`(){
     rateLimiter.permitsPerSecond = 0L
 
-    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(0L)
-    assertThat(rateLimiter.tryAcquire(1L, 0, TimeUnit.MILLISECONDS)).isFalse()
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isFalse()
+  }
+
+  @Test fun `QPS is set to a negative value`(){
+    rateLimiter.permitsPerSecond = -1L
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 500)).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 500, TimeUnit.MILLISECONDS)).isFalse()
   }
 }

--- a/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
+++ b/misk-core/src/test/kotlin/misk/sampling/RateLimiterTest.kt
@@ -152,8 +152,7 @@ class RateLimiterTest {
     assertThat(ticker.nowMs).isEqualTo(200L)
   }
 
-  @Test
-  fun `permit count exceeds window size`() {
+  @Test fun `permit count exceeds window size`() {
     rateLimiter.permitsPerSecond = 2L
 
     assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(2L)
@@ -161,5 +160,12 @@ class RateLimiterTest {
     assertThat(ticker.nowMs).isEqualTo(0L)
 
     assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(2L)
+  }
+
+  @Test fun `QPS is set to 0`(){
+    rateLimiter.permitsPerSecond = 0L
+
+    assertThat(rateLimiter.getPermitsRemaining(TimeUnit.MILLISECONDS, 2_000)).isEqualTo(0L)
+    assertThat(rateLimiter.tryAcquire(1L, 0, TimeUnit.MILLISECONDS)).isFalse()
   }
 }


### PR DESCRIPTION
Adding in error handling to `getPermitsRemaining()` in the case that a user sets the allowed `qps` to 0. 