### PR TITLE
Map 404 web action exceptions to NOT_FOUND gRPC status code.

### DIFF
--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
@@ -153,7 +153,7 @@ class MiskClientMiskServerTest {
         routeGuide.GetFeature().execute(point)
       }
       assertThat(e.grpcMessage).isEqualTo("unexpected latitude error!")
-      assertThat(e.grpcStatus).isEqualTo(GrpcStatus.UNIMPLEMENTED)
+      assertThat(e.grpcStatus).isEqualTo(GrpcStatus.NOT_FOUND)
         .withFailMessage("wrong gRPC status ${e.grpcStatus.name}")
 
       // Assert that _metrics_ counted a 404 and no 200s, even though an HTTP 200 was returned

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -172,7 +172,7 @@ fun toGrpcStatus(statusCode: Int): GrpcStatus {
     400 -> GrpcStatus.INTERNAL
     401 -> GrpcStatus.UNAUTHENTICATED
     403 -> GrpcStatus.PERMISSION_DENIED
-    404 -> GrpcStatus.UNIMPLEMENTED
+    404 -> GrpcStatus.NOT_FOUND
     409 -> GrpcStatus.ALREADY_EXISTS
     429 -> GrpcStatus.UNAVAILABLE
     502 -> GrpcStatus.UNAVAILABLE


### PR DESCRIPTION
Right now, if a misk service throws a `NotFoundException` from a gRPC action, the caller receives a `UNIMPLEMENTED` gRPC status code. This is confusing, and we would better serve callers by mapping it to an equivalent status code instead.