### PR TITLE
fix opa testing policy readme and add bundles to response

### DIFF
--- a/misk-policy-testing/README.md
+++ b/misk-policy-testing/README.md
@@ -53,11 +53,11 @@ internal class FakeOpaPolicyEngineTest {
 
   data class TestRequest(
     val something: String
-  ) : OpaRequest
+  ) : OpaRequest()
 
   data class TestResponse(
     val something: String
-  ) : OpaResponse
+  ) : OpaResponse()
 ```
 
 ## Local development

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -44,18 +44,20 @@ public final class misk/policy/opa/PolicyEngineException : java/lang/Exception {
 }
 
 public final class misk/policy/opa/Provenance {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lmisk/policy/opa/Provenance;
-	public static synthetic fun copy$default (Lmisk/policy/opa/Provenance;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/policy/opa/Provenance;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lmisk/policy/opa/Provenance;
+	public static synthetic fun copy$default (Lmisk/policy/opa/Provenance;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lmisk/policy/opa/Provenance;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBuild_commit ()Ljava/lang/String;
 	public final fun getBuild_hostname ()Ljava/lang/String;
 	public final fun getBuild_timestamp ()Ljava/lang/String;
+	public final fun getBundles ()Ljava/util/Map;
 	public final fun getRevision ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -64,6 +64,17 @@ public final class misk/policy/opa/Provenance {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class misk/policy/opa/ProvenanceBundle {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lmisk/policy/opa/ProvenanceBundle;
+	public static synthetic fun copy$default (Lmisk/policy/opa/ProvenanceBundle;Ljava/lang/String;ILjava/lang/Object;)Lmisk/policy/opa/ProvenanceBundle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRevision ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
 	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;Z)V
 	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;

--- a/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
@@ -16,7 +16,11 @@ data class Provenance(
   val build_timestamp: String?,
   val build_hostname: String?,
   val revision: String?,
-  val bundles: Map<String, String>?
+  val bundles: Map<String, ProvenanceBundle>?
+)
+
+data class ProvenanceBundle(
+  val revision: String?
 )
 
 abstract class OpaResponse {

--- a/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/Response.kt
@@ -15,7 +15,8 @@ data class Provenance(
   val build_commit: String?,
   val build_timestamp: String?,
   val build_hostname: String?,
-  val revision: String?
+  val revision: String?,
+  val bundles: Map<String, String>?
 )
 
 abstract class OpaResponse {

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -141,7 +141,7 @@ internal class RealOpaPolicyEngineTest {
   }
 
   @Test
-  fun returnsProvenanceIfSpecified() {
+  fun returnsProvenanceBundleIfSpecified() {
     Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
       Calls.response(
         ResponseBody.create(
@@ -156,6 +156,24 @@ internal class RealOpaPolicyEngineTest {
     assertThat(evaluate).isEqualTo(BasicResponse("a"))
     assertThat(evaluate.provenance?.bundles).isNotNull
     assertThat(evaluate.provenance?.bundles?.get("xyz")?.revision ?: "").isEqualTo("revision123")
+  }
+
+  @Test
+  fun returnsProvenanceRevisionIfSpecified() {
+    Mockito.whenever(opaApi.queryDocument(anyString(), anyString(), anyBoolean())).thenReturn(
+      Calls.response(
+        ResponseBody.create(
+          APPLICATION_JSON.asMediaType(),
+          "{\"provenance\":{\"version\":\"0.30.1\",\"build_commit\":\"03b0b1f\",\"revision\":" +
+            " \"revision123\"}, \"decision_id\": \"decisionIdString\"," +
+            "\"result\": {\"test\": \"a\"}}"
+        )
+      )
+    )
+    val evaluate: BasicResponse = opaPolicyEngine.evaluate("test", BasicRequest(1))
+    assertThat(evaluate).isEqualTo(BasicResponse("a"))
+    assertThat(evaluate.provenance?.bundles).isNull()
+    assertThat(evaluate.provenance?.revision ?: "").isEqualTo("revision123")
   }
 
   // Weird kotlin workaround for mockito. T must not be nullable.

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -147,7 +147,7 @@ internal class RealOpaPolicyEngineTest {
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),
           "{\"provenance\":{\"version\":\"0.30.1\",\"build_commit\":\"03b0b1f\",\"bundles\"" +
-            ":{\"revision\": \"revision123\"}}, \"decision_id\": \"decisionIdString\"," +
+            ":{\"xyz\":{\"revision\": \"revision123\"}}}, \"decision_id\": \"decisionIdString\"," +
             "\"result\": {\"test\": \"a\"}}"
         )
       )
@@ -155,7 +155,7 @@ internal class RealOpaPolicyEngineTest {
     val evaluate: BasicResponse = opaPolicyEngine.evaluate("test", BasicRequest(1))
     assertThat(evaluate).isEqualTo(BasicResponse("a"))
     assertThat(evaluate.provenance?.bundles).isNotNull
-    assertThat(evaluate.provenance?.bundles?.get("revision") ?: "").isEqualTo("revision123")
+    assertThat(evaluate.provenance?.bundles?.get("xyz")?.revision ?: "").isEqualTo("revision123")
   }
 
   // Weird kotlin workaround for mockito. T must not be nullable.

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -146,14 +146,16 @@ internal class RealOpaPolicyEngineTest {
       Calls.response(
         ResponseBody.create(
           APPLICATION_JSON.asMediaType(),
-          "{\"provenance\":{\"version\":\"0.30.1\",\"build_commit\":\"03b0b1f\",\"revision\"" +
-            ":\"revision123\"}, \"decision_id\": \"decisionIdString\"," +
+          "{\"provenance\":{\"version\":\"0.30.1\",\"build_commit\":\"03b0b1f\",\"bundles\"" +
+            ":{\"revision\": \"revision123\"}}, \"decision_id\": \"decisionIdString\"," +
             "\"result\": {\"test\": \"a\"}}"
         )
       )
     )
     val evaluate: BasicResponse = opaPolicyEngine.evaluate("test", BasicRequest(1))
     assertThat(evaluate).isEqualTo(BasicResponse("a"))
+    assertThat(evaluate.provenance?.bundles).isNotNull
+    assertThat(evaluate.provenance?.bundles?.get("revision") ?: "").isEqualTo("revision123")
   }
 
   // Weird kotlin workaround for mockito. T must not be nullable.


### PR DESCRIPTION
as per https://www.openpolicyagent.org/docs/v0.38.1/rest-api/#provenance, the bundles map is populated when bundles are configured.  This PR adds the bundle field along with the revision field, such that the correct one will get populated when running OPA with bundles or without bundles.