### PR TITLE
Add HttpCall.cookies

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -248,8 +248,8 @@ public final class misk/time/FakeTickerModule : misk/inject/KAbstractModule {
 
 public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public fun <init> ()V
-	public fun <init> (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;)V
-	public synthetic fun <init> (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;Ljava/util/List;)V
+	public synthetic fun <init> (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun accepts ()Ljava/util/List;
 	public fun addResponseHeaders (Lokhttp3/Headers;)V
 	public fun asOkHttpRequest ()Lokhttp3/Request;
@@ -258,6 +258,7 @@ public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public final fun component11 ()Lokio/BufferedSink;
 	public final fun component12 ()Lmisk/web/actions/WebSocket;
 	public final fun component13 ()Lmisk/web/actions/WebSocketListener;
+	public final fun component14 ()Ljava/util/List;
 	public final fun component2 ()Lmisk/web/SocketAddress;
 	public final fun component3 ()Lmisk/web/DispatchMechanism;
 	public final fun component4 ()Lokhttp3/Headers;
@@ -268,9 +269,10 @@ public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public final fun component9 ()Lokhttp3/Headers$Builder;
 	public fun computeRequestHeader (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun contentType ()Lokhttp3/MediaType;
-	public final fun copy (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;)Lmisk/web/FakeHttpCall;
-	public static synthetic fun copy$default (Lmisk/web/FakeHttpCall;Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;ILjava/lang/Object;)Lmisk/web/FakeHttpCall;
+	public final fun copy (Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;Ljava/util/List;)Lmisk/web/FakeHttpCall;
+	public static synthetic fun copy$default (Lmisk/web/FakeHttpCall;Lokhttp3/HttpUrl;Lmisk/web/SocketAddress;Lmisk/web/DispatchMechanism;Lokhttp3/Headers;IILokhttp3/Headers$Builder;ZLokhttp3/Headers$Builder;Lokio/BufferedSource;Lokio/BufferedSink;Lmisk/web/actions/WebSocket;Lmisk/web/actions/WebSocketListener;Ljava/util/List;ILjava/lang/Object;)Lmisk/web/FakeHttpCall;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getCookies ()Ljava/util/List;
 	public fun getDispatchMechanism ()Lmisk/web/DispatchMechanism;
 	public final fun getHeadersBuilder ()Lokhttp3/Headers$Builder;
 	public fun getLinkLayerLocalAddress ()Lmisk/web/SocketAddress;
@@ -291,6 +293,7 @@ public final class misk/web/FakeHttpCall : misk/web/HttpCall {
 	public fun putResponseBody (Lokio/BufferedSink;)V
 	public fun putWebSocket (Lmisk/web/actions/WebSocket;)V
 	public fun requireTrailers ()V
+	public fun setCookies (Ljava/util/List;)V
 	public fun setNetworkStatusCode (I)V
 	public final fun setRequestBody (Lokio/BufferedSource;)V
 	public fun setRequestHeaders (Lokhttp3/Headers;)V

--- a/misk-testing/build.gradle.kts
+++ b/misk-testing/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     exclude(group = "junit")
   }
   implementation(Dependencies.javaxInject)
+  api(Dependencies.servletApi)
   api(Dependencies.wispContainersTesting)
   api(Dependencies.wispLogging)
   api(Dependencies.wispLoggingTesting)

--- a/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
+++ b/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
@@ -9,6 +9,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
+import javax.servlet.http.Cookie
 
 data class FakeHttpCall(
   override val url: HttpUrl = "https://example.com/".toHttpUrl(),
@@ -23,7 +24,8 @@ data class FakeHttpCall(
   var requestBody: BufferedSource? = Buffer(),
   var responseBody: BufferedSink? = Buffer(),
   var webSocket: WebSocket? = null,
-  var webSocketListener: WebSocketListener? = null
+  var webSocketListener: WebSocketListener? = null,
+  override var cookies: List<Cookie> = listOf(),
 ) : HttpCall {
 
   override val responseHeaders: Headers

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1136,6 +1136,7 @@ public abstract interface class misk/web/HttpCall {
 	public abstract fun asOkHttpRequest ()Lokhttp3/Request;
 	public abstract fun computeRequestHeader (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun contentType ()Lokhttp3/MediaType;
+	public abstract fun getCookies ()Ljava/util/List;
 	public abstract fun getDispatchMechanism ()Lmisk/web/DispatchMechanism;
 	public abstract fun getLinkLayerLocalAddress ()Lmisk/web/SocketAddress;
 	public abstract fun getNetworkStatusCode ()I
@@ -1148,6 +1149,7 @@ public abstract interface class misk/web/HttpCall {
 	public abstract fun putResponseBody (Lokio/BufferedSink;)V
 	public abstract fun putWebSocket (Lmisk/web/actions/WebSocket;)V
 	public abstract fun requireTrailers ()V
+	public abstract fun setCookies (Ljava/util/List;)V
 	public abstract fun setRequestHeaders (Lokhttp3/Headers;)V
 	public abstract fun setResponseHeader (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setResponseTrailer (Ljava/lang/String;Ljava/lang/String;)V

--- a/misk/src/main/kotlin/misk/web/HttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/HttpCall.kt
@@ -11,6 +11,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.BufferedSink
 import okio.BufferedSource
+import javax.servlet.http.Cookie
 
 /**
  * Information about the socket on which a HTTP call arrived.
@@ -32,6 +33,9 @@ interface HttpCall {
 
   /** HTTP request headers that may be modified via interception. */
   var requestHeaders: Headers
+
+  /** Cookies derived from request's "Cookie" header, if any */
+  var cookies: List<Cookie>
 
   /** Meaningful HTTP status about what actually happened. Not sent over the wire in the case
    * of gRPC, which always returns HTTP 200 even for errors. */

--- a/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
@@ -8,6 +8,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl
 import okio.BufferedSink
 import okio.BufferedSource
+import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 
 internal data class ServletHttpCall(
@@ -23,7 +24,8 @@ internal data class ServletHttpCall(
   var requestBody: BufferedSource? = null,
   val upstreamResponse: UpstreamResponse,
   var responseBody: BufferedSink? = null,
-  var webSocket: WebSocket? = null
+  var webSocket: WebSocket? = null,
+  override var cookies: List<Cookie> = listOf(),
 ) : HttpCall {
   private var _actualStatusCode: Int? = null
 
@@ -131,7 +133,8 @@ internal data class ServletHttpCall(
         upstreamResponse = upstreamResponse,
         requestBody = requestBody,
         responseBody = responseBody,
-        webSocket = webSocket
+        webSocket = webSocket,
+        cookies = request.cookies?.toList() ?: listOf(),
       )
     }
   }


### PR DESCRIPTION
So that users don't have to parse cookies out of the "Cookies" header themselves