### PR TITLE
misk-policy-testing: Clarify README.md.

### DIFF
--- a/misk-policy-testing/README.md
+++ b/misk-policy-testing/README.md
@@ -13,7 +13,7 @@ install(FakeOpaModule())
 ```
 
 For an improved local development experience, use the `OpaDevelopmentModule`.
-This module is mutually exclusive with `OpaModule` in the misk-policy package.
+This module should be used alongside the `OpaModule` in the misk-policy package.
 
 ```kotlin
 install(OpaDevelopmentModule())


### PR DESCRIPTION
This clarifies the README.md in misk-policy-testing to point out that the
OpaDevelopmentModule needs to be used with the main OpaModule.