### PR TITLE
Disable flaky test that's causing issues

### DIFF
--- a/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
+++ b/misk/src/test/kotlin/misk/web/AbstractRebalancingTest.kt
@@ -20,6 +20,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.closeQuietly
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -47,7 +48,7 @@ abstract class AbstractRebalancingTest(
     test(Protocol.HTTP_1_1)
   }
 
-  @Test
+  @Test @Disabled
   fun http2() {
     test(Protocol.HTTP_2)
   }


### PR DESCRIPTION
The test tests jetty functionality to ensure connections are
being closed by opening several connections to the server and expecting
some of them are being closed. Finally, the test will close all the
connections. However, Jetty still thinks some of the connections are
open after that and will wait for them until the idle time is reached
or the graceful shutdown period is over.

The test is timing out before the graceful period is over, causing the
the flakiness of the test.

This feels like a Jetty issue. I will try to replicate it and send a bug report.