### PR TITLE
DontRetryException takes a cause exeception

### DIFF
--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -5,6 +5,7 @@ public abstract interface class misk/backoff/Backoff {
 
 public final class misk/backoff/DontRetryException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Exception;)V
 }
 
 public final class misk/backoff/ExponentialBackoff : misk/backoff/Backoff {

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -35,4 +35,6 @@ fun <A> retry(upTo: Int, withBackoff: Backoff, f: (retryCount: Int) -> A): A {
   throw lastException!!
 }
 
-class DontRetryException(message: String) : Exception(message)
+class DontRetryException(message: String, exception: Exception?) : Exception(message, exception) {
+  constructor(message: String) : this(message, null)
+}


### PR DESCRIPTION
The retry handler will rethrow the DontRetryException and as is loses all context of what the throw exception was