### PR TITLE
fix(misk-policy): Provide hint if the REST API connection fails.

### DIFF
--- a/misk-policy-testing/README.md
+++ b/misk-policy-testing/README.md
@@ -18,7 +18,7 @@ This module should be used alongside the `OpaModule` in the misk-policy package.
 ```kotlin
 install(OpaDevelopmentModule())
 //or
-install(OpaDevelopmentModule(policyDirectory = "some path", withLogging = true))
+install(OpaDevelopmentModule(policyDirectory = "some path", withLogging = true, preferredImageVersion = "0.40.0"))
 ```
 
 The default policy directory is `service/src/policy` and the recommended location to keep policies accessible for local testing.

--- a/misk-policy-testing/api/misk-policy-testing.api
+++ b/misk-policy-testing/api/misk-policy-testing.api
@@ -14,9 +14,9 @@ public final class misk/policy/opa/LocalOpaService : com/google/common/util/conc
 	public static final field Companion Lmisk/policy/opa/LocalOpaService$Companion;
 	public static final field DEFAULT_POLICY_DIRECTORY Ljava/lang/String;
 	public static final field OPA_CONTAINER_NAME Ljava/lang/String;
-	public static final field OPA_DOCKER_IMAGE Ljava/lang/String;
+	public static final field OPA_DOCKER_IMAGE_BASE Ljava/lang/String;
 	public static final field OPA_EXPOSED_PORT I
-	public fun <init> (Ljava/lang/String;Z)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
 }
 
 public final class misk/policy/opa/LocalOpaService$Callback : com/github/dockerjava/core/async/ResultCallbackTemplate {
@@ -30,7 +30,7 @@ public final class misk/policy/opa/LocalOpaService$Companion {
 
 public final class misk/policy/opa/OpaDevelopmentModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/OpaDevelopmentModule.kt
@@ -7,10 +7,11 @@ import misk.policy.opa.LocalOpaService.Companion.DEFAULT_POLICY_DIRECTORY
 
 class OpaDevelopmentModule(
   private val policyDirectory: String = DEFAULT_POLICY_DIRECTORY,
-  private val withLogging: Boolean = false
+  private val withLogging: Boolean = false,
+  private val preferredImageVersion: String = "latest-debug"
 ) : KAbstractModule() {
   override fun configure() {
     install(ServiceModule<LocalOpaService>())
-    bind(keyOf<LocalOpaService>()).toInstance(LocalOpaService(policyDirectory, withLogging))
+    bind(keyOf<LocalOpaService>()).toInstance(LocalOpaService(policyDirectory, withLogging, preferredImageVersion))
   }
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -89,11 +89,18 @@ class RealOpaPolicyEngine @Inject constructor(
       throw IllegalArgumentException("Must specify document")
     }
 
-    val response = opaApi.queryDocument(document, inputString, provenance).execute()
-    if (!response.isSuccessful) {
-      throw PolicyEngineException("[${response.code()}]: ${response.errorBody()?.string()}")
+    try {
+      val response = opaApi.queryDocument(document, inputString, provenance).execute()
+      if (!response.isSuccessful) {
+        throw PolicyEngineException("[${response.code()}]: ${response.errorBody()?.string()}")
+      }
+      return response
+    } catch (e: java.io.IOException) {
+      throw PolicyEngineException(
+        "Underlying IOException, this may indicate an invalid document path",
+        e
+      )
     }
-    return response
   }
 
   private fun <R : OpaResponse> parseResponse(


### PR DESCRIPTION
If the underlying socket connection to the OPA REST API fails, the document
name is likely invalid. This provides that hint to the developer in the
reported exception.
    
Refs: PRODSQUAD-154