### PR TITLE
fix(misk-policy): Provide hint if the REST API connection fails.

### DIFF
--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -89,11 +89,18 @@ class RealOpaPolicyEngine @Inject constructor(
       throw IllegalArgumentException("Must specify document")
     }
 
-    val response = opaApi.queryDocument(document, inputString, provenance).execute()
-    if (!response.isSuccessful) {
-      throw PolicyEngineException("[${response.code()}]: ${response.errorBody()?.string()}")
+    try {
+      val response = opaApi.queryDocument(document, inputString, provenance).execute()
+      if (!response.isSuccessful) {
+        throw PolicyEngineException("[${response.code()}]: ${response.errorBody()?.string()}")
+      }
+      return response
+    } catch (e: java.io.IOException) {
+      throw PolicyEngineException(
+        "Underlying IOException, this may indicate an invalid document path",
+        e
+      )
     }
-    return response
   }
 
   private fun <R : OpaResponse> parseResponse(


### PR DESCRIPTION
If the underlying socket connection to the OPA REST API fails, the document
name is likely invalid. This provides that hint to the developer in the
reported exception.

Refs: PRODSQUAD-154