### PR TITLE
feat(misk-policy): Add API to evaluate raw JSON input.

### DIFF
--- a/misk-policy-testing/api/misk-policy-testing.api
+++ b/misk-policy-testing/api/misk-policy-testing.api
@@ -5,8 +5,10 @@ public final class misk/policy/opa/FakeOpaModule : misk/inject/KAbstractModule {
 public final class misk/policy/opa/FakeOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
 	public fun <init> ()V
 	public final fun addOverride (Ljava/lang/String;Lmisk/policy/opa/OpaResponse;)V
+	public final fun addOverrideForInput (Ljava/lang/String;Ljava/lang/String;Lmisk/policy/opa/OpaResponse;)V
 	public final fun addOverrideForInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Lmisk/policy/opa/OpaResponse;)V
 	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateRawJsonInput (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 

--- a/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
+++ b/misk-policy-testing/src/main/kotlin/misk/policy/opa/FakeOpaPolicyEngine.kt
@@ -18,6 +18,18 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
     return opaResponse as R
   }
 
+  override fun <R: OpaResponse> evaluateRawJsonInput(
+    document: String,
+    input: String,
+    returnType: Class<R>
+  ): R {
+    val opaResponse = responsesForJsonInput[document]?.get(input)
+      ?: throw IllegalStateException("No override for document '$document' and input '$input'")
+
+    @Suppress("UNCHECKED_CAST")
+    return opaResponse as R
+  }
+
   override fun <R : OpaResponse> evaluateNoInput(
     document: String,
     returnType: Class<R>
@@ -32,6 +44,15 @@ class FakeOpaPolicyEngine @Inject constructor(): OpaPolicyEngine {
   private val responses = mutableMapOf<String, OpaResponse>()
   fun addOverride(document: String, obj: OpaResponse) {
     responses[document] = obj
+  }
+
+  private val responsesForJsonInput = mutableMapOf<String, MutableMap<String,OpaResponse>>()
+  fun addOverrideForInput(document: String, key: String, obj: OpaResponse) {
+    if (responsesForJsonInput.containsKey(document)) {
+      responsesForJsonInput[document]?.put(key,obj)
+    } else {
+      responsesForJsonInput[document] = mutableMapOf(Pair(key, obj))
+    }
   }
 
   private val responsesForInput = mutableMapOf<String, MutableMap<OpaRequest,OpaResponse>>()

--- a/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
+++ b/misk-policy-testing/src/test/kotlin/misk/policy/opa/FakeOpaPolicyEngineTest.kt
@@ -64,6 +64,40 @@ internal class FakeOpaPolicyEngineTest {
     }
   }
 
+  @Test
+  fun `Override document with JSON input`() {
+    val jsonInput = "{\"input\":\"foo\"}"
+    fakeOpaPolicyEngine.addOverrideForInput("test", jsonInput, TestResponse("value"))
+    opaPolicyEngine.evaluate<TestResponse>("test", jsonInput).apply {
+      assertThat(this).isEqualTo(TestResponse("value"))
+    }
+  }
+
+  @Test
+  fun `Override document with multiple JSON input`() {
+    val jsonInput = "{\"input\":\"foo\"}"
+    fakeOpaPolicyEngine.addOverrideForInput("test", jsonInput, TestResponse("value"))
+
+    val jsonInput2 = "{\"input\":\"bar\"}"
+    fakeOpaPolicyEngine.addOverrideForInput("test", jsonInput2, TestResponse("otherValue"))
+
+    opaPolicyEngine.evaluate<TestResponse>("test", jsonInput).apply {
+      assertThat(this).isEqualTo(TestResponse("value"))
+    }
+    opaPolicyEngine.evaluate<TestResponse>("test", jsonInput2).apply {
+      assertThat(this).isEqualTo(TestResponse("otherValue"))
+    }
+  }
+
+  @Test
+  fun `Override document with same JSON input`() {
+    val jsonInput = "{\"input\":\"foo\"}"
+    fakeOpaPolicyEngine.addOverrideForInput("test", jsonInput, TestResponse("value"))
+    fakeOpaPolicyEngine.addOverrideForInput("test", jsonInput, TestResponse("otherValue"))
+    opaPolicyEngine.evaluate<TestResponse>("test", jsonInput).apply {
+      assertThat(this).isEqualTo(TestResponse("otherValue"))
+    }
+  }
 
   data class TestRequest(
     val something: String

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -25,6 +25,7 @@ public final class misk/policy/opa/OpaModule : misk/inject/KAbstractModule {
 
 public abstract interface class misk/policy/opa/OpaPolicyEngine {
 	public abstract fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public abstract fun evaluateRawJsonInput (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 	public abstract fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 
@@ -78,6 +79,7 @@ public final class misk/policy/opa/ProvenanceBundle {
 public final class misk/policy/opa/RealOpaPolicyEngine : misk/policy/opa/OpaPolicyEngine {
 	public fun <init> (Lmisk/policy/opa/OpaApi;Lcom/squareup/moshi/Moshi;Z)V
 	public fun evaluateNoInput (Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
+	public fun evaluateRawJsonInput (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 	public fun evaluateWithInput (Ljava/lang/String;Lmisk/policy/opa/OpaRequest;Ljava/lang/Class;Ljava/lang/Class;)Lmisk/policy/opa/OpaResponse;
 }
 

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -54,7 +54,7 @@ inline fun <reified T : OpaRequest, reified R : OpaResponse> OpaPolicyEngine.eva
 /**
  * Evaluate / Query a document with given input of raw JSON.
  * This will connect to OPA via a retrofit interface and perform a /v1/data/{document} POST.
- * This consumes raw JSON for corner cases where developers need to do queries the automatic
+ * This consumes raw JSON for corner cases where developers need to do queries that the automatic
  * JSON serialization doesn't support.
  *
  * @param document Name or Path of the OPA document to query.

--- a/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/OpaPolicyEngine.kt
@@ -12,6 +12,12 @@ interface OpaPolicyEngine {
     document: String,
     returnType: Class<R>
   ): R
+
+  fun <R: OpaResponse> evaluateRawJsonInput(
+    document: String,
+    input: String,
+    returnType: Class<R>
+  ): R
 }
 
 /**
@@ -44,4 +50,22 @@ inline fun <reified T : OpaRequest, reified R : OpaResponse> OpaPolicyEngine.eva
   input: T
 ): R {
   return evaluateWithInput(document, input, T::class.java, R::class.java)
+}
+/**
+ * Evaluate / Query a document with given input of raw JSON.
+ * This will connect to OPA via a retrofit interface and perform a /v1/data/{document} POST.
+ * This consumes raw JSON for corner cases where developers need to do queries the automatic
+ * JSON serialization doesn't support.
+ *
+ * @param document Name or Path of the OPA document to query.
+ * @param input Input data to be supplied to OPA at evaluation time. Must be valid JSON.
+ * @throws PolicyEngineException if the request to OPA failed or the response shape didn't match R.
+ * @throws IllegalArgumentException if no document path was specified.
+ * @return Response shape R from OPA.
+ */
+inline fun <reified R : OpaResponse> OpaPolicyEngine.evaluate(
+  document: String,
+  input: String
+): R {
+  return evaluateRawJsonInput(document, input, R::class.java)
 }

--- a/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/RealOpaPolicyEngine.kt
@@ -57,6 +57,31 @@ class RealOpaPolicyEngine @Inject constructor(
   }
 
   /**
+   * Evaluate / Query a document with given input of raw JSON.
+   * This will connect to OPA via a retrofit interface and perform a /v1/data/{document} POST.
+   * This consumes raw JSON for corner cases where developers need to do queries the automatic
+   * JSON serialization doesn't support.
+   *
+   * @param document Name or Path of the OPA document to query.
+   * @param input Input data to be supplied to OPA at evaluation time. Must be valid JSON.
+   * @param returnType Return shape to be JSONified from OPA.
+   * @throws PolicyEngineException if the request to OPA failed or the response shape didn't match R.
+   * @throws IllegalArgumentException if no document path was specified.
+   * @return Response shape R from OPA.
+   */
+  override fun <R: OpaResponse> evaluateRawJsonInput(
+    document: String,
+    input: String,
+    returnType: Class<R>
+  ): R {
+    if (document.isEmpty()) {
+      throw IllegalArgumentException("Must specify document")
+    }
+    val response = queryOpa(document, input)
+    return parseResponse(document, returnType, response)
+  }
+
+  /**
    * Evaluate / Query a document with no additional input.
    * This will connect to OPA via a retrofit interface and perform a /v1/data/{document} POST.
    *

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -78,6 +78,23 @@ internal class RealOpaPolicyEngineTest {
     assertThat(evaluate).isEqualTo(BasicResponse("a"))
     assertThat(requestCaptor.value).isEqualTo("{\"input\":{\"someValue\":1}}")
   }
+  @Test
+  fun rawJsonInputQuery() {
+    val requestCaptor = Mockito.captor<String>()
+    Mockito.whenever(opaApi.queryDocument(anyString(), capture(requestCaptor), anyBoolean())).thenReturn(
+      Calls.response(
+        ResponseBody.create(
+          APPLICATION_JSON.asMediaType(),
+          "{\"decision_id\": \"decisionIdString\", \"result\": {\"test\": \"a\"}}"
+        )
+      )
+    )
+
+    val evaluate: BasicResponse = opaPolicyEngine.evaluate("test", "{\"input\":\"someValue\"}")
+
+    assertThat(evaluate).isEqualTo(BasicResponse("a"))
+    assertThat(requestCaptor.value).isEqualTo("{\"input\":\"someValue\"}")
+  }
 
   @Test
   fun responseIsNotOk() {

--- a/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
+++ b/misk-policy/src/test/kotlin/misk/policy/opa/RealOpaPolicyEngineTest.kt
@@ -78,6 +78,7 @@ internal class RealOpaPolicyEngineTest {
     assertThat(evaluate).isEqualTo(BasicResponse("a"))
     assertThat(requestCaptor.value).isEqualTo("{\"input\":{\"someValue\":1}}")
   }
+
   @Test
   fun rawJsonInputQuery() {
     val requestCaptor = Mockito.captor<String>()


### PR DESCRIPTION
Sometimes developers hit corner cases with the moshi JSON serialization, so
this API allows a raw JSON string to be passed to OPA.

Refs: PRODSQUAD-78