### PR TITLE
Proposal to have bounded + balanced sqs receivers

### DIFF
--- a/misk-aws/api/misk-aws.api
+++ b/misk-aws/api/misk-aws.api
@@ -58,8 +58,9 @@ public final class misk/jobqueue/sqs/AwsSqsJobHandlerModule$Companion {
 
 public final class misk/jobqueue/sqs/AwsSqsJobQueueConfig : wisp/config/Config {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;ILmisk/tasks/RepeatedTaskQueueConfig;JIII)V
-	public synthetic fun <init> (Ljava/util/Map;ILmisk/tasks/RepeatedTaskQueueConfig;JIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;ILmisk/tasks/RepeatedTaskQueueConfig;JIIILmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;)V
+	public synthetic fun <init> (Ljava/util/Map;ILmisk/tasks/RepeatedTaskQueueConfig;JIIILmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAws_sqs_job_receiver_policy ()Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
 	public final fun getExternal_queues ()Ljava/util/Map;
 	public final fun getMessage_batch_size ()I
 	public final fun getQueue_attribute_importer_frequency_ms ()J
@@ -84,6 +85,13 @@ public final class misk/jobqueue/sqs/AwsSqsJobQueueModule$Companion {
 
 public final class misk/jobqueue/sqs/AwsSqsJobQueueModuleKt {
 	public static final fun withNoPrefetching (Lcom/amazonaws/services/sqs/buffered/QueueBufferConfig;)Lcom/amazonaws/services/sqs/buffered/QueueBufferConfig;
+}
+
+public final class misk/jobqueue/sqs/AwsSqsJobReceiverPolicy : java/lang/Enum {
+	public static final field BALANCED_MAX Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
+	public static final field ONE_FLAG_ONLY Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
+	public static fun values ()[Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
 }
 
 public final class misk/jobqueue/sqs/AwsSqsQueueConfig {
@@ -168,6 +176,16 @@ public final class misk/jobqueue/sqs/QueueResolverKt {
 	public static final fun getParentQueue (Lmisk/jobqueue/QueueName;)Lmisk/jobqueue/QueueName;
 	public static final fun getRetryQueue (Lmisk/jobqueue/QueueName;)Lmisk/jobqueue/QueueName;
 	public static final fun isRetryQueue (Lmisk/jobqueue/QueueName;)Z
+}
+
+public final class misk/jobqueue/sqs/SqsConsumerAllocator {
+	public static final field Companion Lmisk/jobqueue/sqs/SqsConsumerAllocator$Companion;
+	public fun <init> (Lwisp/lease/LeaseManager;Lmisk/feature/FeatureFlags;)V
+	public final fun computeSqsConsumersForPod (Lmisk/jobqueue/QueueName;Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;)I
+}
+
+public final class misk/jobqueue/sqs/SqsConsumerAllocator$Companion {
+	public final fun leaseName (Lmisk/jobqueue/QueueName;I)Ljava/lang/String;
 }
 
 public final class misk/jobqueue/sqs/StaticDeadLetterQueueProvider : misk/jobqueue/sqs/DeadLetterQueueProvider {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
@@ -1,0 +1,83 @@
+package misk.jobqueue.sqs
+
+import com.google.common.annotations.VisibleForTesting
+import misk.feature.FeatureFlags
+import misk.jobqueue.QueueName
+import wisp.lease.LeaseManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Uses a [LeaseManager] and [FeatureFlags] to calculate the number of sqs consumers a pods should
+ * have. This computation is based off of the [AwsSqsJobReceiverPolicy] specification.
+ */
+@Singleton
+class SqsConsumerAllocator @Inject constructor(
+  private val leaseManager: LeaseManager,
+  private val featureFlags: FeatureFlags
+) {
+  fun computeSqsConsumersForPod(
+    queueName: QueueName,
+    receiverPolicy: AwsSqsJobReceiverPolicy
+  ): Int {
+    return when (receiverPolicy) {
+      AwsSqsJobReceiverPolicy.ONE_FLAG_ONLY -> oneFlagPriorityReceivers(queueName)
+      AwsSqsJobReceiverPolicy.BALANCED_MAX -> balancedMaxReceivers(queueName)
+    }
+  }
+
+  private fun oneFlagPriorityReceivers(queueName: QueueName): Int {
+    val numReceiversPerPodForQueue = receiversPerPodForQueue(queueName)
+    val shouldUsePerPodConfig = numReceiversPerPodForQueue >= 0
+    if (shouldUsePerPodConfig) {
+      return numReceiversPerPodForQueue
+    }
+    val count = (1..receiversForQueue(queueName)).count { maybeAcquireConsumerLease(queueName, it) }
+    return count
+
+  }
+
+  private fun balancedMaxReceivers(queueName: QueueName): Int {
+    // Read the max from the per pod flag.
+    val maxPerPod = podMaxJobQueueConsumers(queueName)
+    // Read the global max from the per queue flag.
+    val maxGlobal = receiversForQueue(queueName)
+
+    var result = 0
+    for (candidate in 1..maxGlobal) {
+      // Don't exceed the per pod max.
+      if (result >= maxPerPod) break
+
+      // Use the lease to enforce global max.
+      if (maybeAcquireConsumerLease(queueName, candidate)) result += 1
+    }
+    return result
+  }
+
+  /** Returns true if the lease was acquired false otherwise. */
+  private fun maybeAcquireConsumerLease(queueName: QueueName, candidate: Int): Boolean {
+    val lease = leaseManager.requestLease(leaseName(queueName, candidate))
+    if (lease.checkHeld()) return true
+
+    return lease.acquire()
+  }
+
+  private fun receiversPerPodForQueue(queueName: QueueName): Int {
+    return featureFlags.getInt(SqsJobConsumer.POD_CONSUMERS_PER_QUEUE, queueName.value)
+  }
+
+  /** Returns a ceiling on # of consumers a pod should have. */
+  private fun podMaxJobQueueConsumers(queueName: QueueName,): Int {
+    return featureFlags.getInt(SqsJobConsumer.POD_MAX_JOBQUEUE_CONSUMERS, queueName.value).coerceAtLeast(0)
+  }
+  private fun receiversForQueue(queueName: QueueName,): Int {
+    return featureFlags.getInt(SqsJobConsumer.CONSUMERS_PER_QUEUE, queueName.value)
+  }
+
+  companion object {
+    @VisibleForTesting
+    fun leaseName(queueName: QueueName, candidate: Int) =
+      "sqs-job-consumer-${queueName.value}-$candidate"
+  }
+
+}

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsConsumerAllocatorTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsConsumerAllocatorTest.kt
@@ -1,0 +1,108 @@
+package misk.jobqueue.sqs
+
+import misk.MiskTestingServiceModule
+import misk.clustering.fake.lease.FakeLeaseManager
+import misk.clustering.fake.lease.FakeLeaseModule
+import misk.feature.testing.FakeFeatureFlags
+import misk.feature.testing.FakeFeatureFlagsModule
+import misk.inject.KAbstractModule
+import misk.jobqueue.QueueName
+import misk.jobqueue.sqs.AwsSqsJobReceiverPolicy.BALANCED_MAX
+import misk.jobqueue.sqs.AwsSqsJobReceiverPolicy.ONE_FLAG_ONLY
+import misk.jobqueue.sqs.SqsJobConsumer.Companion.CONSUMERS_PER_QUEUE
+import misk.jobqueue.sqs.SqsJobConsumer.Companion.POD_CONSUMERS_PER_QUEUE
+import misk.jobqueue.sqs.SqsJobConsumer.Companion.POD_MAX_JOBQUEUE_CONSUMERS
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import kotlin.test.assertEquals
+
+@MiskTest(startService = false)
+class SqsConsumerAllocatorTest {
+
+  @MiskTestModule
+  val module = object : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+      install(FakeLeaseModule())
+      install(FakeFeatureFlagsModule())
+    }
+  }
+
+  @Inject private lateinit var featureFlags: FakeFeatureFlags
+  @Inject private lateinit var leaseManager: FakeLeaseManager
+  @Inject private lateinit var sqsConsumerAllocator: SqsConsumerAllocator
+
+  private val queueName = QueueName("example-queue")
+
+  @Nested
+  inner class OneFlagPolicyTest {
+
+    @Test
+    fun consumersPerQueue() {
+      featureFlags.override(CONSUMERS_PER_QUEUE, 15)
+      featureFlags.override(POD_CONSUMERS_PER_QUEUE, -1)
+      featureFlags.override(POD_MAX_JOBQUEUE_CONSUMERS, 0)
+
+      assertEquals(15, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, ONE_FLAG_ONLY))
+
+      // Take some leases
+      (1..10).forEach {
+        leaseManager.markLeaseHeldElsewhere(SqsConsumerAllocator.leaseName(queueName, it))
+      }
+      assertEquals(5, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, ONE_FLAG_ONLY))
+    }
+
+    @Test
+    fun consumersPerPod() {
+      featureFlags.override(CONSUMERS_PER_QUEUE, 15)
+      featureFlags.override(POD_CONSUMERS_PER_QUEUE, 5)
+      featureFlags.override(POD_MAX_JOBQUEUE_CONSUMERS, 0)
+      // Take some leases.
+      (1..10).forEach {
+        leaseManager.markLeaseHeldElsewhere(SqsConsumerAllocator.leaseName(queueName, it))
+      }
+      // Leases don't matter.. we take all available according to the flag.
+      assertEquals(5, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, ONE_FLAG_ONLY))
+    }
+  }
+
+  @Nested
+  inner class BoundedMaxTest {
+
+    @Test
+    fun `hit global ceiling`() {
+      featureFlags.override(CONSUMERS_PER_QUEUE, 15)
+      featureFlags.override(POD_MAX_JOBQUEUE_CONSUMERS, 10)
+      // Take some leases.
+      (1..10).forEach {
+        leaseManager.markLeaseHeldElsewhere(SqsConsumerAllocator.leaseName(queueName, it))
+      }
+      // Even though this pod can take up to 10 consumers, only 5 are available.
+      assertEquals(5, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, BALANCED_MAX))
+    }
+
+    @Test
+    fun `hit per pod ceiling`() {
+      featureFlags.override(CONSUMERS_PER_QUEUE, 15)
+      featureFlags.override(POD_MAX_JOBQUEUE_CONSUMERS, 5)
+      // Take some leases.
+      (1..2).forEach {
+        leaseManager.markLeaseHeldElsewhere(SqsConsumerAllocator.leaseName(queueName, it))
+      }
+      // Even though there are 13 consumers available globally, this pod is capped at 5.
+      assertEquals(5, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, BALANCED_MAX))
+    }
+
+    @Test
+    fun `noop on negative pod ceiling`() {
+      featureFlags.override(CONSUMERS_PER_QUEUE, 15)
+      featureFlags.override(POD_MAX_JOBQUEUE_CONSUMERS, -1)
+
+      // No pod max specified, do nothing.
+      assertEquals(0, sqsConsumerAllocator.computeSqsConsumersForPod(queueName, BALANCED_MAX))
+    }
+  }
+}


### PR DESCRIPTION
There have been many issues and discussions resulting from the poor tradeoff the sqs feature flags give.

One flag leads to unbalanced pods and the other risks self DOS if the auto scaler kicks in with an sqs backlog

This change proposes a simple way to use both flags to get balanced pods while still having a max upper bound

- [x] todo add test once the idea is ✅ 