### PR TITLE
Expose configuration for jetty HTTP header options

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1279,10 +1279,10 @@ public abstract interface class misk/web/WebActionSeedDataTransformerFactory {
 }
 
 public final class misk/web/WebConfig : wisp/config/Config {
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZI)V
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;I)V
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()I
@@ -1299,6 +1299,8 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component21 ()Z
 	public final fun component22 ()Lorg/slf4j/event/Level;
 	public final fun component23 ()I
+	public final fun component24 ()Ljava/lang/Integer;
+	public final fun component25 ()Ljava/lang/Integer;
 	public final fun component3 ()I
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lmisk/web/WebSslConfig;
@@ -1306,8 +1308,8 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/lang/Integer;
-	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;I)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;IILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
@@ -1320,6 +1322,8 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun getHealth_port ()I
 	public final fun getHost ()Ljava/lang/String;
 	public final fun getHttp2 ()Z
+	public final fun getHttp_header_cache_size ()Ljava/lang/Integer;
+	public final fun getHttp_request_header_size ()Ljava/lang/Integer;
 	public final fun getIdle_timeout ()J
 	public final fun getJetty_max_concurrent_streams ()Ljava/lang/Integer;
 	public final fun getJetty_max_thread_pool_queue_size ()I

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -95,6 +95,12 @@ data class WebConfig(
 
   /** The number of milliseconds to sleep before commencing service shutdown. */
   val shutdown_sleep_ms: Int = 0,
+
+  /** The maximum allowed size in bytes for the HTTP request line and HTTP request headers. */
+  val http_request_header_size: Int? = null,
+
+  /** The size of Jetty's header field cache, in terms of unique character branches. */
+  val http_header_cache_size: Int? = null,
 ) : Config {
   @Deprecated(
     message = "obsolete; for binary-compatibility only",
@@ -123,6 +129,8 @@ data class WebConfig(
     cors: Map<String, CorsConfig> = mapOf(),
     concurrency_limiter_disabled: Boolean = false,
     shutdown_sleep_ms: Int = 0,
+    http_request_header_size: Int? = null,
+    http_header_cache_size: Int? = null,
   ) : this(
     port = port,
     idle_timeout = idle_timeout,
@@ -147,6 +155,8 @@ data class WebConfig(
     concurrency_limiter_disabled = concurrency_limiter_disabled,
     concurrency_limiter_log_level = Level.ERROR,
     shutdown_sleep_ms = shutdown_sleep_ms,
+    http_request_header_size = http_request_header_size,
+    http_header_cache_size = http_header_cache_size,
   )
 }
 

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -100,6 +100,12 @@ class JettyService @Inject internal constructor(
     if (webConfig.ssl != null) {
       httpConfig.securePort = webConfig.ssl.port
     }
+    if (webConfig.http_request_header_size != null) {
+      httpConfig.requestHeaderSize = webConfig.http_request_header_size
+    }
+    if (webConfig.http_header_cache_size != null) {
+      httpConfig.headerCacheSize = webConfig.http_header_cache_size
+    }
     httpConnectionFactories += HttpConnectionFactory(httpConfig)
     if (webConfig.http2) {
       val http2 = HTTP2ServerConnectionFactory(httpConfig)


### PR DESCRIPTION
We're dealing with a problem where our request headers have grown larger
than jetty's default will accept. For affected users, this causes this
error:

upstream connect error or disconnect/reset before headers. reset reason:
remote refused stream reset

We're taking other steps to reduce our header size, but it will take a
while. In the meantime, if we expose these jetty configuration options,
we can increase the max allowed header sizes and get things back to a
working state until we can fix the root cause.