### PR TITLE
Add ability to increment the `FakeClock` by a `java.time.Period` value

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -232,6 +232,7 @@ public final class misk/time/FakeClock : java/time/Clock {
 	public synthetic fun <init> (JLjava/time/ZoneId;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun add (JLjava/util/concurrent/TimeUnit;)J
 	public final fun add (Ljava/time/Duration;)J
+	public final fun add (Ljava/time/Period;)J
 	public fun getZone ()Ljava/time/ZoneId;
 	public fun instant ()Ljava/time/Instant;
 	public final fun setNow (Ljava/time/Instant;)V

--- a/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -25,7 +25,7 @@ class FakeClock(
 
   /**
    * Note that unlike adding a [Duration] the exact amount that is added to the clock will depend on
-   * its current value and timezone. Not all days, months or years have the same length. See the
+   * its current time and timezone. Not all days, months or years have the same length. See the
    * documentation for [Period].
    */
   fun add(p: Period) = millis.getAndUpdate { millis ->

--- a/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -23,6 +23,11 @@ class FakeClock(
 
   fun add(d: Duration) = millis.addAndGet(d.toMillis())
 
+  /**
+   * Note that unlike adding a [Duration] the exact amount that is added to the clock will depend on
+   * its current value and timezone. Not all days, months or years have the same length. See the
+   * documentation for [Period].
+   */
   fun add(p: Period) = millis.getAndUpdate { millis ->
     Instant.ofEpochMilli(millis).atZone(zone).plus(p).toInstant().toEpochMilli()
   }

--- a/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -3,6 +3,7 @@ package misk.time
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.Period
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -21,6 +22,10 @@ class FakeClock(
   override fun instant(): Instant = Instant.ofEpochMilli(millis.get()).atZone(zone).toInstant()
 
   fun add(d: Duration) = millis.addAndGet(d.toMillis())
+
+  fun add(p: Period) = millis.getAndUpdate { millis ->
+    Instant.ofEpochMilli(millis).atZone(zone).plus(p).toInstant().toEpochMilli()
+  }
 
   fun add(n: Long, unit: TimeUnit) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
 

--- a/misk/src/test/kotlin/misk/time/FakeClockTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeClockTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
+import java.time.Period
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
@@ -28,6 +29,9 @@ internal class FakeClockTest {
 
     clock.add(45, TimeUnit.HOURS)
     assertThat(clock.millis()).isEqualTo(162020000L)
+
+    clock.add(Period.ofMonths(2))
+    assertThat(clock.instant()).isEqualTo(Instant.parse("1970-03-02T21:00:20Z"))
   }
 
   @Test

--- a/misk/src/test/kotlin/misk/time/FakeClockTest.kt
+++ b/misk/src/test/kotlin/misk/time/FakeClockTest.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.time.Period
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
 internal class FakeClockTest {
@@ -29,9 +30,6 @@ internal class FakeClockTest {
 
     clock.add(45, TimeUnit.HOURS)
     assertThat(clock.millis()).isEqualTo(162020000L)
-
-    clock.add(Period.ofMonths(2))
-    assertThat(clock.instant()).isEqualTo(Instant.parse("1970-03-02T21:00:20Z"))
   }
 
   @Test
@@ -44,5 +42,21 @@ internal class FakeClockTest {
     val newClock = clock.withZone(ZoneId.of("America/New_York"))
     assertThat(newClock.zone.id).isEqualTo("America/New_York")
     assertThat(newClock.instant()).isEqualTo(Instant.ofEpochMilli(162000000L))
+  }
+
+  @Test
+  fun addPeriod() {
+    val clock = FakeClock(epochMillis = 0L, zone = ZoneId.of("America/Los_Angeles"))
+
+    // Just prior to winding clock forward
+    val startInstant = Instant.parse("1970-04-26T00:00:00Z")
+    clock.setNow(startInstant)
+
+    // This day is only 23 hours long because of the DST transition
+    clock.add(Period.ofDays(1))
+    assertThat(clock.instant()).isEqualTo(startInstant.plus(23L, ChronoUnit.HOURS))
+
+    clock.add(Period.ofMonths(2))
+    assertThat(clock.instant()).isEqualTo(Instant.parse("1970-06-26T23:00:00Z"))
   }
 }


### PR DESCRIPTION
Allows for more fluent expression of things like "adding 6 months" or "3 years" to `FakeClock`.