### PR TITLE
Specify sql dialect for TiDB datasource in JooqModule

### DIFF
--- a/misk-jooq/src/main/kotlin/misk/jooq/JooqModule.kt
+++ b/misk-jooq/src/main/kotlin/misk/jooq/JooqModule.kt
@@ -140,6 +140,7 @@ class JooqModule(
     DataSourceType.HSQLDB -> SQLDialect.HSQLDB
     DataSourceType.VITESS_MYSQL -> SQLDialect.MYSQL
     DataSourceType.POSTGRESQL -> SQLDialect.POSTGRES
+    DataSourceType.TIDB -> SQLDialect.MYSQL
     else -> throw IllegalArgumentException("no SQLDialect for " + this.name)
   }
 }


### PR DESCRIPTION
Specify sql dialect for TiDB datasource in JooqModule. 
This is to fix an issues discussed here: https://cash.slack.com/archives/C915WS04Q/p1659688168600019