### PR TITLE
feat(misk-security): Add @Csp annotation to WebActions.

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -943,6 +943,21 @@ public final class misk/security/cert/X509CertificateExtensionsKt {
 	public static final fun isSignedBy (Ljava/security/cert/X509Certificate;Ljava/security/cert/Certificate;)Z
 }
 
+public abstract interface annotation class misk/security/csp/Csp : java/lang/annotation/Annotation {
+	public abstract fun rules ()[Ljava/lang/String;
+}
+
+public final class misk/security/csp/CspInterceptor : misk/web/NetworkInterceptor {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getRules ()Ljava/util/List;
+	public fun intercept (Lmisk/web/NetworkChain;)V
+}
+
+public final class misk/security/csp/CspInterceptor$Factory : misk/web/NetworkInterceptor$Factory {
+	public fun <init> ()V
+	public fun create (Lmisk/Action;)Lmisk/web/NetworkInterceptor;
+}
+
 public abstract interface class misk/security/keys/KeyService {
 	public abstract fun decrypt (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public abstract fun encrypt (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;

--- a/misk/src/main/kotlin/misk/security/csp/Csp.kt
+++ b/misk/src/main/kotlin/misk/security/csp/Csp.kt
@@ -1,0 +1,15 @@
+package misk.security.csp
+
+// This annotation allows misk endpoints to define their Content-Security-Policy directive.
+// See https://web.archive.org/web/20220906063156/https://content-security-policy.com/
+// for a reference that's up to date when this annotation was added.
+//
+// Production CSPs can be very long so a future contribution should add the ability to define
+// CSP into YAML configs and point the @Csp annotation to the config value.
+//
+// This annotation is currently dumb, it adds the rules passed to a Content-Security-Policy
+// header directive, with no inspection or validation. A future change could parse the policy.
+//
+// Developers using this should check out the various browser extensions to verify the actual
+// CSP on their webpages.
+annotation class Csp(val rules: Array<String>)

--- a/misk/src/main/kotlin/misk/security/csp/CspInterceptor.kt
+++ b/misk/src/main/kotlin/misk/security/csp/CspInterceptor.kt
@@ -1,0 +1,22 @@
+package misk.security.csp
+
+import misk.Action
+import misk.web.NetworkChain
+import misk.web.NetworkInterceptor
+import javax.inject.Inject
+import kotlin.reflect.full.findAnnotation
+
+class CspInterceptor(val rules: List<String>) : NetworkInterceptor {
+  override fun intercept(chain: NetworkChain) {
+    chain.httpCall.setResponseHeader("Content-Security-Policy", rules.joinToString(separator = "; ", postfix = ";"))
+    chain.proceed(chain.httpCall)
+  }
+
+  class Factory @Inject constructor() : NetworkInterceptor.Factory {
+    override fun create(action: Action): NetworkInterceptor? {
+      val cspAnnotation = action.function.findAnnotation<Csp>() ?: return null
+      return CspInterceptor(cspAnnotation.rules.toList())
+    }
+
+  }
+}

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -27,6 +27,7 @@ import misk.queuing.TimedBlockingQueue
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
 import misk.security.authz.MiskCallerAuthenticator
+import misk.security.csp.CspInterceptor
 import misk.security.ssl.CertificatesModule
 import misk.web.actions.LivenessCheckAction
 import misk.web.actions.NotFoundAction
@@ -179,6 +180,10 @@ class MiskWebModule(
     // Optionally log request and response details
     multibind<NetworkInterceptor.Factory>(MiskDefault::class)
       .to<RequestLoggingInterceptor.Factory>()
+
+    // Adds CSP Interceptor
+    multibind<NetworkInterceptor.Factory>(MiskDefault::class)
+      .to<CspInterceptor.Factory>()
 
     // Optionally log request and response body
     multibind<ApplicationInterceptor.Factory>(MiskDefault::class)

--- a/misk/src/test/kotlin/misk/web/actions/CspHeadersTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/CspHeadersTest.kt
@@ -1,0 +1,73 @@
+package misk.web.actions
+
+import com.google.inject.util.Modules
+import misk.client.HttpClientEndpointConfig
+import misk.client.HttpClientFactory
+import misk.inject.KAbstractModule
+import misk.security.authz.Unauthenticated
+import misk.security.csp.Csp
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import misk.web.toResponseBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import kotlin.test.assertEquals
+
+@MiskTest(startService = true)
+class CspHeadersTest {
+  @MiskTestModule
+  val module = Modules.combine(TestWebActionModule(), TestModule())
+  @Inject private lateinit var httpClientFactory: HttpClientFactory
+
+  @Inject private lateinit var jetty: JettyService
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebActionModule.create<CspWebAction>())
+    }
+  }
+
+  @Test
+  fun `check the headers are being added correctly`() {
+    val response = execute()
+
+    val headerValue = response.headers.get("Content-Security-Policy")!!
+    assertEquals("rule1; rule2;", headerValue)
+  }
+
+  private fun execute(): Response {
+    val client = createOkHttpClient()
+
+    val baseUrl = jetty.httpServerUrl
+    val requestBuilder = Request.Builder()
+      .url(baseUrl.resolve("/csp")!!)
+
+    val call = client.newCall(requestBuilder.build())
+    return call.execute()
+  }
+
+  private fun createOkHttpClient(): OkHttpClient {
+    val config = HttpClientEndpointConfig(jetty.httpServerUrl.toString())
+    return httpClientFactory.create(config)
+  }
+
+
+
+
+  class CspWebAction @Inject constructor() : WebAction {
+    @Csp(["rule1", "rule2"])
+    @Get("/csp")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    @Unauthenticated
+    fun get() = "hello world".toResponseBody()
+  }
+
+}


### PR DESCRIPTION
This adds an @Csp annotation so that developers can specify Content-Security-Policy for their endpoints.

This was co-authored by frojas@squareup.com