### PR TITLE
Update setnx to return boolean so caller knows if key was set

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -25,8 +25,8 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public final fun setClock (Ljava/time/Clock;)V
-	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
-	public fun setnx (Ljava/lang/String;Lokio/ByteString;)V
+	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
+	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
 }
@@ -57,8 +57,8 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
-	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
-	public fun setnx (Ljava/lang/String;Lokio/ByteString;)V
+	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
+	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
 }
@@ -89,8 +89,8 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun pipelined ()Lredis/clients/jedis/Pipeline;
 	public abstract fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public abstract fun set (Ljava/lang/String;Lokio/ByteString;)V
-	public abstract fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
-	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;)V
+	public abstract fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
+	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public abstract fun unwatch ([Ljava/lang/String;)V
 	public abstract fun watch ([Ljava/lang/String;)V
 }

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -158,21 +158,21 @@ class FakeRedis : Redis {
     }
   }
 
-  override fun setnx(key: String, value: ByteString) {
-    synchronized(lock) {
+  override fun setnx(key: String, value: ByteString): Boolean {
+    return synchronized(lock) {
       keyValueStore.putIfAbsent(key, Value(
         data = value,
         expiryInstant = Instant.MAX
-      ))
+      )) == null
     }
   }
 
-  override fun setnx(key: String, expiryDuration: Duration, value: ByteString) {
-    synchronized(lock) {
+  override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
+    return synchronized(lock) {
       keyValueStore.putIfAbsent(key, Value(
         data = value,
         expiryInstant = clock.instant().plusSeconds(expiryDuration.seconds)
-      ))
+      )) == null
     }
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -101,14 +101,14 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
-  /** Set a ByteArray value if it doesn't already exist. Returns 1 if set and 0, otherwise */
+  /** Set a ByteArray value if it doesn't already exist. Returns true if set and false, otherwise */
   override fun setnx(key: String, value: ByteString): Boolean {
     return jedisPool.resource.use { jedis ->
       jedis.setnx(key.toByteArray(charset), value.toByteArray()) == 1L
     }
   }
 
-  /** Set a ByteArray value if it doesn't already exist with an expiration. Returns 1 if set and 0, otherwise  */
+  /** Set a ByteArray value if it doesn't already exist with an expiration. Returns true if set and false, otherwise  */
   override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
     return jedisPool.resource.use { jedis ->
       jedis.setnx(key.toByteArray(charset), value.toByteArray())

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -101,18 +101,19 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
-  /** Set a ByteArray value if it doesn't already exist. */
-  override fun setnx(key: String, value: ByteString) {
-    jedisPool.resource.use { jedis ->
-      jedis.setnx(key.toByteArray(charset), value.toByteArray())
+  /** Set a ByteArray value if it doesn't already exist. Returns 1 if set and 0, otherwise */
+  override fun setnx(key: String, value: ByteString): Boolean {
+    return jedisPool.resource.use { jedis ->
+      jedis.setnx(key.toByteArray(charset), value.toByteArray()) == 1L
     }
   }
 
-  /** Set a ByteArray value if it doesn't already exist with an expiration. */
-  override fun setnx(key: String, expiryDuration: Duration, value: ByteString) {
-    val setParams = SetParams.setParams().ex(expiryDuration.seconds).nx()
-    jedisPool.resource.use { jedis ->
-      jedis.set(key.toByteArray(charset), value.toByteArray(), setParams)
+  /** Set a ByteArray value if it doesn't already exist with an expiration. Returns 1 if set and 0, otherwise  */
+  override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
+    return jedisPool.resource.use { jedis ->
+      jedis.setnx(key.toByteArray(charset), value.toByteArray())
+        .also { setResult -> if (setResult == 1L) jedis.expire(key, expiryDuration.seconds) } == 1L
+
     }
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -125,7 +125,7 @@ interface Redis {
    * @param key the key to set
    * @param value the value to set
    */
-  fun setnx(key: String, value: ByteString)
+  fun setnx(key: String, value: ByteString): Boolean
 
   /**
    * Sets the [ByteString] value for the given key if it does not already exist.
@@ -134,7 +134,7 @@ interface Redis {
    * @param expiryDuration the amount of time before the key expires
    * @param value the value to set
    */
-  fun setnx(key: String, expiryDuration: Duration, value: ByteString)
+  fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean
 
   /**
    * Sets the [ByteString] value for the given key and field

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -167,11 +167,11 @@ class FakeRedisTest {
     val value2 = "value2".encodeUtf8()
 
     // Sets value because key does not exist
-    redis.setnx(key, value)
+    assertTrue(redis.setnx(key, value))
     assertEquals(value, redis[key])
 
     // Does not set value because key already exists
-    redis.setnx(key, value2)
+    assertFalse(redis.setnx(key, value2))
     assertEquals(value, redis[key])
   }
 
@@ -182,11 +182,11 @@ class FakeRedisTest {
     val expirySec = 5L
 
     // Sets value because key does not exist
-    redis.setnx(key, Duration.ofSeconds(expirySec), value)
+    assertTrue(redis.setnx(key, Duration.ofSeconds(expirySec), value))
     assertEquals(value, redis[key])
 
     // Does not set value because key already exists
-    redis.setnx(key, Duration.ofSeconds(expirySec), value2)
+    assertFalse(redis.setnx(key, Duration.ofSeconds(expirySec), value2))
     assertEquals(value, redis[key])
 
     // Key should still be there


### PR DESCRIPTION
Set if not exist (setnx) should return a result that can be used to indicate if the key existed or not, before the set call. Redis returns a 1, when the was set, and 0, otherwise. These integers can be coerced into booleans for the caller.