### PR TITLE
feat(misk-testing): Introduce injection at the method level

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -174,6 +174,15 @@ public final class misk/testing/ExternalDependency$DefaultImpls {
 	public static fun getId (Lmisk/testing/ExternalDependency;)Ljava/lang/String;
 }
 
+public abstract interface annotation class misk/testing/InjectTest : java/lang/annotation/Annotation {
+}
+
+public final class misk/testing/InjectingParameterResolver : org/junit/jupiter/api/extension/ParameterResolver {
+	public fun <init> ()V
+	public fun resolveParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object;
+	public fun supportsParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Z
+}
+
 public abstract interface annotation class misk/testing/LogLevel : java/lang/annotation/Annotation {
 	public abstract fun level ()Lmisk/testing/LogLevel$Level;
 }

--- a/misk-testing/src/main/kotlin/misk/testing/InjectTest.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/InjectTest.kt
@@ -1,0 +1,9 @@
+package misk.testing
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@Target(AnnotationTarget.FUNCTION)
+@Test
+@ExtendWith(InjectingParameterResolver::class)
+annotation class InjectTest

--- a/misk-testing/src/main/kotlin/misk/testing/InjectingParameterResolver.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/InjectingParameterResolver.kt
@@ -4,15 +4,13 @@ import com.google.inject.Injector
 import com.google.inject.Key
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
-import org.junit.jupiter.api.extension.ParameterResolutionException
 import org.junit.jupiter.api.extension.ParameterResolver
-import kotlin.reflect.KClass
 
 class InjectingParameterResolver : ParameterResolver {
   override fun supportsParameter(
     parameterContext: ParameterContext,
     extensionContext: ExtensionContext
-  ): Boolean = methodHasInjectAnnotation(extensionContext)
+  ): Boolean = true
 
   override fun resolveParameter(
     parameterContext: ParameterContext,
@@ -20,33 +18,15 @@ class InjectingParameterResolver : ParameterResolver {
   ): Any {
     val injector = extensionContext.retrieve<Injector>("injector")
 
-    if (methodHasInjectAnnotation(extensionContext)) {
-      return if (parameterContext.parameter.annotations.isNotEmpty()) {
-        injector.getInstance(
-          Key.get(
-            parameterContext.parameter.parameterizedType,
-            parameterContext.parameter.annotations.first()
-          )
+    return if (parameterContext.parameter.annotations.isNotEmpty()) {
+      injector.getInstance(
+        Key.get(
+          parameterContext.parameter.parameterizedType,
+          parameterContext.parameter.annotations.first()
         )
-      } else {
-        injector.getInstance(Key.get(parameterContext.parameter.parameterizedType))
-      }
+      )
+    } else {
+      injector.getInstance(Key.get(parameterContext.parameter.parameterizedType))
     }
-
-    throw ParameterResolutionException("Unexpected state")
-  }
-
-  private fun methodHasInjectAnnotation(extensionContext: ExtensionContext) = INJECT_CLASSES
-    .union(extensionContext.testMethod.orElse(null)
-      ?.annotations?.map { it::class }
-      ?: emptyList()
-    )
-    .isNotEmpty()
-
-  companion object {
-    val INJECT_CLASSES: List<KClass<out Annotation>> = listOf(
-      javax.inject.Inject::class,
-      com.google.inject.Inject::class
-    )
   }
 }

--- a/misk-testing/src/main/kotlin/misk/testing/InjectingParameterResolver.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/InjectingParameterResolver.kt
@@ -1,0 +1,52 @@
+package misk.testing
+
+import com.google.inject.Injector
+import com.google.inject.Key
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolutionException
+import org.junit.jupiter.api.extension.ParameterResolver
+import kotlin.reflect.KClass
+
+class InjectingParameterResolver : ParameterResolver {
+  override fun supportsParameter(
+    parameterContext: ParameterContext,
+    extensionContext: ExtensionContext
+  ): Boolean = methodHasInjectAnnotation(extensionContext)
+
+  override fun resolveParameter(
+    parameterContext: ParameterContext,
+    extensionContext: ExtensionContext
+  ): Any {
+    val injector = extensionContext.retrieve<Injector>("injector")
+
+    if (methodHasInjectAnnotation(extensionContext)) {
+      return if (parameterContext.parameter.annotations.isNotEmpty()) {
+        injector.getInstance(
+          Key.get(
+            parameterContext.parameter.parameterizedType,
+            parameterContext.parameter.annotations.first()
+          )
+        )
+      } else {
+        injector.getInstance(Key.get(parameterContext.parameter.parameterizedType))
+      }
+    }
+
+    throw ParameterResolutionException("Unexpected state")
+  }
+
+  private fun methodHasInjectAnnotation(extensionContext: ExtensionContext) = INJECT_CLASSES
+    .union(extensionContext.testMethod.orElse(null)
+      ?.annotations?.map { it::class }
+      ?: emptyList()
+    )
+    .isNotEmpty()
+
+  companion object {
+    val INJECT_CLASSES: List<KClass<out Annotation>> = listOf(
+      javax.inject.Inject::class,
+      com.google.inject.Inject::class
+    )
+  }
+}

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @Target(AnnotationTarget.CLASS)
 @ExtendWith(MiskTestExtension::class)
+@ExtendWith(InjectingParameterResolver::class)
 
 /**
  * Annotate your test classes with `@MiskTest` to have fields annotated with `@Inject` initialized.

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @Target(AnnotationTarget.CLASS)
 @ExtendWith(MiskTestExtension::class)
-@ExtendWith(InjectingParameterResolver::class)
 
 /**
  * Annotate your test classes with `@MiskTest` to have fields annotated with `@Inject` initialized.

--- a/misk/src/test/kotlin/misk/testing/InjectingParameterResolverTest.kt
+++ b/misk/src/test/kotlin/misk/testing/InjectingParameterResolverTest.kt
@@ -1,0 +1,29 @@
+package misk.testing
+
+import com.google.inject.BindingAnnotation
+import com.google.inject.Provides
+import misk.inject.KAbstractModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest
+internal class InjectingParameterResolverTest {
+  @MiskTestModule val module = object : KAbstractModule() {
+    @Provides fun myString(): String = "a string"
+
+    @Provides @TestAnnotation fun myAnnotatedList(): List<String> = listOf("strings?")
+  }
+
+  @BindingAnnotation
+  annotation class TestAnnotation
+
+  @Test @Inject fun `retrieves all parameters if the method is annotated`(
+    myString: String,
+    @TestAnnotation myList: List<String>
+  ) {
+    assertThat(myString).isEqualTo("a string")
+
+    assertThat(myList).containsExactly("strings?")
+  }
+}

--- a/misk/src/test/kotlin/misk/testing/InjectingParameterResolverTest.kt
+++ b/misk/src/test/kotlin/misk/testing/InjectingParameterResolverTest.kt
@@ -4,8 +4,6 @@ import com.google.inject.BindingAnnotation
 import com.google.inject.Provides
 import misk.inject.KAbstractModule
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
-import javax.inject.Inject
 
 @MiskTest
 internal class InjectingParameterResolverTest {
@@ -18,7 +16,7 @@ internal class InjectingParameterResolverTest {
   @BindingAnnotation
   annotation class TestAnnotation
 
-  @Test @Inject fun `retrieves all parameters if the method is annotated`(
+  @InjectTest fun `retrieves all parameters if the method is annotated`(
     myString: String,
     @TestAnnotation myList: List<String>
   ) {


### PR DESCRIPTION
Sample usage in `InjectingParameterResolverTest`.

This might be useful to parallelise tests.