### PR TITLE
Plumb through dependencies to CronTask from CronModule

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -22,7 +22,12 @@ class CronModule(
   override fun configure() {
     install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class))
-    install(ServiceModule<CronTask>())
+    install(ServiceModule<CronTask>().apply {
+      dependsOn(RepeatedTaskQueue::class.toKey())
+      for (dep in dependencies) {
+        dependsOn(dep)
+      }
+    })
   }
 
   @Provides

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -23,7 +23,7 @@ class CronModule(
     install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class))
     install(ServiceModule<CronTask>().apply {
-      dependsOn(RepeatedTaskQueue::class.toKey())
+      dependsOn(keyOf<RepeatedTaskQueue>(ForMiskCron::class))
       for (dep in dependencies) {
         dependsOn(dep)
       }

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -7,6 +7,7 @@ import com.google.inject.Singleton
 import misk.ServiceModule
 import misk.concurrent.ExecutorServiceModule
 import misk.inject.KAbstractModule
+import misk.inject.keyOf
 import misk.inject.toKey
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory


### PR DESCRIPTION
This adds the dependencies supplied to CronModule to CronTask to ensure that the modules that CronTask depends on are started up before CronTask starts.