### PR TITLE
Check cluster weights in MiskCron leases to support other LeaseManager implementations

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
@@ -23,7 +23,7 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
     var lastRun = clock.instant()
     taskQueue.scheduleWithBackoff(INTERVAL) {
       if (clusterWeight.get() > 0) {
-        Status.OK
+        return@scheduleWithBackoff Status.OK
       }
       val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
 

--- a/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
@@ -1,6 +1,7 @@
 package misk.cron
 
 import com.google.common.util.concurrent.AbstractIdleService
+import misk.clustering.weights.ClusterWeightProvider
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.Status
 import wisp.lease.LeaseManager
@@ -16,14 +17,18 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
   @Inject private lateinit var cronManager: CronManager
   @Inject private lateinit var leaseManager: LeaseManager
   @Inject @ForMiskCron private lateinit var taskQueue: RepeatedTaskQueue
+  @Inject private lateinit var clusterWeight: ClusterWeightProvider
 
   override fun startUp() {
-    val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
     var lastRun = clock.instant()
-
-    logger.info { "Starting CronTask" }
-
     taskQueue.scheduleWithBackoff(INTERVAL) {
+      if (clusterWeight.get() > 0) {
+        Status.OK
+      }
+      val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
+
+      logger.info { "Starting CronTask" }
+
       val now = clock.instant()
       var leaseHeld = lease.checkHeld()
       if (!leaseHeld) {

--- a/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
@@ -20,14 +20,14 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
   @Inject private lateinit var clusterWeight: ClusterWeightProvider
 
   override fun startUp() {
+    logger.info { "Starting CronTask" }
     var lastRun = clock.instant()
     taskQueue.scheduleWithBackoff(INTERVAL) {
-      if (clusterWeight.get() > 0) {
+      if (clusterWeight.get() == 0) {
+        logger.info { "CronTask is running on a passive node. Skipping." }
         return@scheduleWithBackoff Status.OK
       }
       val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
-
-      logger.info { "Starting CronTask" }
 
       val now = clock.instant()
       var leaseHeld = lease.checkHeld()

--- a/misk-cron/src/test/kotlin/misk/cron/CronTestingModule.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronTestingModule.kt
@@ -1,20 +1,46 @@
 package misk.cron
 
+import com.google.inject.Provides
+import com.google.inject.Singleton
 import misk.MiskTestingServiceModule
+import misk.ServiceModule
 import misk.clustering.fake.lease.FakeLeaseModule
+import misk.clustering.weights.FakeClusterWeightModule
+import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.tasks.DelayedTask
+import misk.tasks.RepeatedTaskQueue
+import misk.tasks.RepeatedTaskQueueFactory
 import java.time.ZoneId
 
 class CronTestingModule : KAbstractModule() {
   override fun configure() {
     val applicationModules: List<KAbstractModule> = listOf(
       FakeLeaseModule(),
+      ServiceModule<RepeatedTaskQueue>(ForMiskCron::class),
+      FakeClusterWeightModule(),
       MiskTestingServiceModule(),
 
       // Cron support requires registering the CronJobHandler and the CronRunnerModule.
-      FakeCronModule(ZoneId.of("America/Toronto"))
+      FakeCronModule(ZoneId.of("America/Toronto")),
+      ServiceModule<CronTask>()
+        .dependsOn(keyOf<RepeatedTaskQueue>(ForMiskCron::class)),
     )
 
     applicationModules.forEach { module -> install(module) }
+  }
+
+  @Provides @Singleton
+  fun repeatedTaskQueueBackingStorage(): ExplicitReleaseDelayQueue<DelayedTask> {
+    return ExplicitReleaseDelayQueue()
+  }
+
+  @Provides @Singleton @ForMiskCron
+  fun repeatedTaskQueue(
+    queueFactory: RepeatedTaskQueueFactory,
+    backingStorage: ExplicitReleaseDelayQueue<DelayedTask>
+  ): RepeatedTaskQueue {
+    return queueFactory.forTesting("my-task-queue", backingStorage)
   }
 }


### PR DESCRIPTION
With the changes from zookeeper to SkimDynamoDB leases, cluster weight checks are no longer part of LeaseManager, and needs to be done by the caller. These changes ensure that the cron jobs always run on the active cluster.