### PR TITLE
Add a config to disable leases in SQS consumers

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueConfig.kt
@@ -57,7 +57,13 @@ class AwsSqsJobQueueConfig(
    */
   val sqs_sending_request_timeout_ms: Int = 5000,
 
-  val aws_sqs_job_receiver_policy: AwsSqsJobReceiverPolicy = AwsSqsJobReceiverPolicy.ONE_FLAG_ONLY
+  val aws_sqs_job_receiver_policy: AwsSqsJobReceiverPolicy = AwsSqsJobReceiverPolicy.ONE_FLAG_ONLY,
+
+  /**
+   * Ignore leases when consuming jobs from SQS. This means that there will be no maximum number
+   * of consumers per pod/cluster, etc.
+   */
+  val ignore_leases: Boolean = false,
 ) : Config
 
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
@@ -13,8 +13,9 @@ import javax.inject.Singleton
  */
 @Singleton
 class SqsConsumerAllocator @Inject constructor(
+  private val config: AwsSqsJobQueueConfig,
   private val leaseManager: LeaseManager,
-  private val featureFlags: FeatureFlags
+  private val featureFlags: FeatureFlags,
 ) {
   fun computeSqsConsumersForPod(
     queueName: QueueName,
@@ -56,6 +57,9 @@ class SqsConsumerAllocator @Inject constructor(
 
   /** Returns true if the lease was acquired false otherwise. */
   private fun maybeAcquireConsumerLease(queueName: QueueName, candidate: Int): Boolean {
+    if (config.ignore_leases) {
+      return false
+    }
     val lease = leaseManager.requestLease(leaseName(queueName, candidate))
     if (lease.checkHeld()) return true
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -18,7 +18,6 @@ import misk.tasks.Status
 import misk.time.timed
 import misk.tracing.traceWithNewRootSpan
 import org.slf4j.MDC
-import wisp.lease.LeaseManager
 import wisp.logging.getLogger
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
@@ -35,7 +34,6 @@ internal class SqsJobConsumer @Inject internal constructor(
   @ForSqsReceiving private val receivingThreads: ExecutorService,
   private val sqsConsumerAllocator: SqsConsumerAllocator,
   private val featureFlags: FeatureFlags,
-  private val leaseManager: LeaseManager,
   private val metrics: SqsMetrics,
   private val moshi: Moshi,
   private val queues: QueueResolver,

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -21,7 +21,7 @@ interface Job {
   /** context attributes associated with the job */
   val attributes: Map<String, String>
 
-  /**
+  /**sqs
    * Acknowledges the job and deletes it from the underlying queue. May perform an RPC, and thus
    * should not be called while holding database transactions or other resources
    */


### PR DESCRIPTION
This will allow SQS consumers to outright ignore leases when consuming from SQS.

Currently just a POC