### PR TITLE
Add allow_public_key_retrieval to DataSourceConfig for MySQL8

### DIFF
--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -281,8 +281,8 @@ public final class misk/jdbc/DataSourceClustersConfig : java/util/LinkedHashMap,
 }
 
 public final class misk/jdbc/DataSourceConfig {
-	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZ)V
-	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;)V
+	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asReplica ()Lmisk/jdbc/DataSourceConfig;
 	public final fun buildJdbcUrl (Lwisp/deployment/Deployment;)Ljava/lang/String;
 	public final fun canRecoverOnReplica ()Z
@@ -305,6 +305,7 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component24 ()Ljava/lang/Integer;
 	public final fun component25 ()Z
 	public final fun component26 ()Z
+	public final fun component27 ()Ljava/util/Map;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -312,8 +313,8 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component7 ()I
 	public final fun component8 ()Ljava/time/Duration;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZ)Lmisk/jdbc/DataSourceConfig;
-	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
+	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;)Lmisk/jdbc/DataSourceConfig;
+	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllow_public_key_retrieval ()Z
 	public final fun getClient_certificate_key_store_password ()Ljava/lang/String;
@@ -326,6 +327,7 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun getFixed_pool_size ()I
 	public final fun getHost ()Ljava/lang/String;
 	public final fun getJdbc_statement_batch_size ()Ljava/lang/Integer;
+	public final fun getJdbc_url_query_parameters ()Ljava/util/Map;
 	public final fun getMigrations_resource ()Ljava/lang/String;
 	public final fun getMigrations_resources ()Ljava/util/List;
 	public final fun getPassword ()Ljava/lang/String;

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -281,8 +281,8 @@ public final class misk/jdbc/DataSourceClustersConfig : java/util/LinkedHashMap,
 }
 
 public final class misk/jdbc/DataSourceConfig {
-	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Z)V
-	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZ)V
+	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asReplica ()Lmisk/jdbc/DataSourceConfig;
 	public final fun buildJdbcUrl (Lwisp/deployment/Deployment;)Ljava/lang/String;
 	public final fun canRecoverOnReplica ()Z
@@ -304,6 +304,7 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component23 ()Ljava/lang/String;
 	public final fun component24 ()Ljava/lang/Integer;
 	public final fun component25 ()Z
+	public final fun component26 ()Z
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -311,9 +312,10 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component7 ()I
 	public final fun component8 ()Ljava/time/Duration;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;Z)Lmisk/jdbc/DataSourceConfig;
-	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
+	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZ)Lmisk/jdbc/DataSourceConfig;
+	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Integer;ZZILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllow_public_key_retrieval ()Z
 	public final fun getClient_certificate_key_store_password ()Ljava/lang/String;
 	public final fun getClient_certificate_key_store_path ()Ljava/lang/String;
 	public final fun getClient_certificate_key_store_url ()Ljava/lang/String;

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -80,7 +80,9 @@ data class DataSourceConfig(
   // MySQL 8+ by default requires authentication via RSA keys if TLS is unavailable.
   // Within secured subnets, overriding to true can be acceptable.
   // See https://mysqlconnector.net/troubleshooting/retrieval-public-key/
-  val allow_public_key_retrieval: Boolean = false
+  val allow_public_key_retrieval: Boolean = false,
+  // Allow setting additional JDBC url parameters for advanced configuration
+  val jdbc_url_query_parameters: Map<String, Any> = mapOf()
 ) {
   fun withDefaults(): DataSourceConfig {
     val isRunningInDocker = File("/proc/1/cgroup")
@@ -223,6 +225,10 @@ data class DataSourceConfig(
 
         if (allow_public_key_retrieval) {
           queryParams += "&allowPublicKeyRetrieval=true"
+        }
+
+        jdbc_url_query_parameters.entries.forEach { (key, value) ->
+          queryParams += "&$key=$value"
         }
 
         "jdbc:tracing:mysql://${config.host}:${config.port}/${config.database}$queryParams"

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -76,7 +76,10 @@ data class DataSourceConfig(
   val show_sql: String? = "false",
   // Consider using this if you want Hibernate to automagically batch inserts/updates when it can.
   val jdbc_statement_batch_size: Int? = null,
-  val use_fixed_pool_size: Boolean = false
+  val use_fixed_pool_size: Boolean = false,
+  // MySQL 8+ by default requires authentication via RSA keys if TLS is unavailable.
+  // Within secured subnets, overriding to true can be acceptable.
+  val allow_public_key_retrieval: Boolean = false
 ) {
   fun withDefaults(): DataSourceConfig {
     val isRunningInDocker = File("/proc/1/cgroup")
@@ -215,6 +218,10 @@ data class DataSourceConfig(
 
         if (enabledTlsProtocols.isNotEmpty()) {
           queryParams += "&enabledTLSProtocols=${enabledTlsProtocols.joinToString(",")}"
+        }
+
+        if (allow_public_key_retrieval) {
+          queryParams += "&allowPublicKeyRetrieval=true"
         }
 
         "jdbc:tracing:mysql://${config.host}:${config.port}/${config.database}$queryParams"

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -186,6 +186,17 @@ class DataSourceConfigTest {
   }
 
   @Test
+  fun buildMysqlJDBCUrlWithNoTlsAllowPublicKeyRetrieval() {
+    val config = DataSourceConfig(DataSourceType.MYSQL, allow_public_key_retrieval = true)
+    assertEquals(
+      "jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&sslMode=PREFERRED&" +
+        "enabledTLSProtocols=TLSv1.2,TLSv1.3&allowPublicKeyRetrieval=true",
+      config.buildJdbcUrl(TESTING)
+    )
+  }
+
+  @Test
   fun buildMysqlJDBCUrlWithEnabledTlsProtocols() {
     val config = DataSourceConfig(
       DataSourceType.MYSQL,

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -1,8 +1,8 @@
 package misk.jdbc
 
 import org.junit.jupiter.api.Test
-import wisp.deployment.TESTING
 import wisp.containers.ContainerUtil
+import wisp.deployment.TESTING
 import kotlin.test.assertEquals
 
 class DataSourceConfigTest {
@@ -192,6 +192,20 @@ class DataSourceConfigTest {
       "jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&sslMode=PREFERRED&" +
         "enabledTLSProtocols=TLSv1.2,TLSv1.3&allowPublicKeyRetrieval=true",
+      config.buildJdbcUrl(TESTING)
+    )
+  }
+
+  @Test
+  fun buildMysqlJDBCUrlWithNoTlsCustomJdbcUrlParameters() {
+    val config = DataSourceConfig(
+      DataSourceType.MYSQL,
+      jdbc_url_query_parameters = mapOf("alpha" to "true", "bravo" to "false")
+    )
+    assertEquals(
+      "jdbc:tracing:mysql://127.0.0.1:3306/?useLegacyDatetimeCode=false&" +
+        "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&sslMode=PREFERRED&" +
+        "enabledTLSProtocols=TLSv1.2,TLSv1.3&alpha=true&bravo=false",
       config.buildJdbcUrl(TESTING)
     )
   }


### PR DESCRIPTION
For MySQL8 and above, when TLS is unavailable then an RSA key pair exchange is attempted to provide secure communication of authentication details instead of as plaintext in the JDBC url. Within secured subnetworks, the added `allow_public_key_retrieval` config parameter gives service owners the flexibility to disable the restrictive default RSA fallback functionality.

See the description in these docs for more information: https://mysqlconnector.net/troubleshooting/retrieval-public-key/

I also added a generic parameters section to config to provide easier advanced configuration without waiting for Misk changes, I'm open to dropping the `allow_public_key_retrieval` section in favour of the more flexible `jdbc_url_query_parameters` field if that is preferred.