### PR TITLE
Include stack traces in exceptional gRPC responses

### DIFF
--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
@@ -130,7 +130,7 @@ class MiskClientMiskServerTest {
       val e = assertFailsWith<GrpcException> {
         routeGuide.GetFeature().execute(point)
       }
-      assertThat(e.grpcMessage).isEqualTo("unexpected latitude error!")
+      assertThat(e.grpcMessage).startsWith("unexpected latitude error!")
       assertThat(e.grpcStatus).isEqualTo(GrpcStatus.UNKNOWN)
 
       // Assert that _metrics_ counted a 500 and no 200s, even though an HTTP 200 was returned
@@ -152,7 +152,7 @@ class MiskClientMiskServerTest {
       val e = assertFailsWith<GrpcException> {
         routeGuide.GetFeature().execute(point)
       }
-      assertThat(e.grpcMessage).isEqualTo("unexpected latitude error!")
+      assertThat(e.grpcMessage).startsWith("unexpected latitude error!")
       assertThat(e.grpcStatus).isEqualTo(GrpcStatus.NOT_FOUND)
         .withFailMessage("wrong gRPC status ${e.grpcStatus.name}")
 
@@ -186,7 +186,7 @@ class MiskClientMiskServerTest {
       val e = assertFailsWith<GrpcException> {
         routeGuide.GetFeature().execute(point)
       }
-      assertThat(e.grpcMessage).isEqualTo("invalid coordinates")
+      assertThat(e.grpcMessage).startsWith("invalid coordinates")
       assertThat(e.grpcStatus).isEqualTo(GrpcStatus.INVALID_ARGUMENT)
         .withFailMessage("wrong gRPC status ${e.grpcStatus.name}")
 
@@ -198,4 +198,19 @@ class MiskClientMiskServerTest {
     }
   }
 
+  @Test
+  fun grpcMessageContainsStackTrace() {
+    val point = Point(
+      latitude = -91,
+      longitude = 10,
+    )
+
+    runBlocking {
+      val e = assertFailsWith<GrpcException> {
+        routeGuide.GetFeature().execute(point)
+      }
+      assertThat(e.grpcMessage).contains("GetFeatureGrpcAction.GetFeature")
+    }
+
+  }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -47,11 +47,14 @@ class ExceptionHandlingInterceptor(
     try {
       chain.proceed(chain.httpCall)
     } catch (th: Throwable) {
-      val response = toResponse(th)
       try {
         if (chain.httpCall.dispatchMechanism == DispatchMechanism.GRPC) {
+          // This response object is only used for determining the status code. toGrpcResponse
+          // will provide a more useful log instead.
+          val response = toResponse(th, suppressLog = true)
           sendGrpcFailure(chain.httpCall, response.statusCode, toGrpcResponse(th))
         } else {
+          val response = toResponse(th, suppressLog = false)
           chain.httpCall.statusCode = response.statusCode
           sendHttpFailure(chain.httpCall, response)
         }
@@ -104,13 +107,15 @@ class ExceptionHandlingInterceptor(
     return buffer.readUtf8()
   }
 
-  private fun toResponse(th: Throwable): Response<*> = when (th) {
+  private fun toResponse(th: Throwable, suppressLog: Boolean): Response<*> = when (th) {
     is UnauthenticatedException -> UNAUTHENTICATED_RESPONSE
     is UnauthorizedException -> UNAUTHORIZED_RESPONSE
-    is InvocationTargetException -> toResponse(th.targetException)
-    is UncheckedExecutionException -> toResponse(th.cause!!)
+    is InvocationTargetException -> toResponse(th.targetException, suppressLog = suppressLog)
+    is UncheckedExecutionException -> toResponse(th.cause!!, suppressLog = suppressLog)
     else -> mapperResolver.mapperFor(th)?.let {
-      log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+      if (!suppressLog) {
+        log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+      }
       it.toResponse(th)
     } ?: toInternalServerError(th)
   }
@@ -124,7 +129,7 @@ class ExceptionHandlingInterceptor(
       log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
       val grpcResponse = it.toGrpcResponse(th)
       if (grpcResponse == null) {
-        val httpResponse = toResponse(th)
+        val httpResponse = toResponse(th, suppressLog = true)
         GrpcErrorResponse(toGrpcStatus(httpResponse.statusCode), grpcMessage(httpResponse))
       } else {
         grpcResponse

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -134,7 +134,7 @@ class ExceptionHandlingInterceptor(
       } else {
         grpcResponse
       }
-    } ?: GrpcErrorResponse.INTERNAL_SERVER_ERROR
+    } ?: GrpcErrorResponse.internalServerError(th)
   }
 
   private fun toInternalServerError(th: Throwable): Response<*> {

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -26,6 +26,7 @@ import wisp.logging.log
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 import java.net.HttpURLConnection
+import java.net.URLEncoder
 import java.util.Base64
 import javax.inject.Inject
 
@@ -92,7 +93,9 @@ class ExceptionHandlingInterceptor(
       response.status.code.toString()
     )
     httpCall.setResponseTrailer("grpc-status-details-bin", response.toEncodedStatusProto)
-    httpCall.setResponseTrailer("grpc-message", response.message ?: response.status.name)
+    val message = response.message ?: response.status.name
+    val encoded = message.replace("\n", "%0A")
+    httpCall.setResponseTrailer("grpc-message", encoded)
     httpCall.takeResponseBody()?.use { responseBody: BufferedSink ->
       GrpcMessageSink(responseBody, ProtoAdapter.BYTES, grpcEncoding = "identity")
         .use { messageSink ->

--- a/misk/src/main/kotlin/misk/web/exceptions/GrpcErrorResponse.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/GrpcErrorResponse.kt
@@ -12,7 +12,8 @@ data class GrpcErrorResponse(
   constructor(status: GrpcStatus, message: String?) : this(status, message, listOf())
 
   companion object {
-    val INTERNAL_SERVER_ERROR = GrpcErrorResponse(GrpcStatus.UNKNOWN, "internal server error")
+    fun internalServerError(th: Throwable) =
+      GrpcErrorResponse(GrpcStatus.UNKNOWN, "$th\n${th.stackTraceToString()}")
   }
 
   // backward compatibility

--- a/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/WebActionExceptionMapper.kt
@@ -21,7 +21,7 @@ internal class WebActionExceptionMapper @Inject internal constructor(
   }
 
   override fun toGrpcResponse(th: WebActionException): GrpcErrorResponse {
-    return GrpcErrorResponse(th.grpcStatus ?: toGrpcStatus(th.code), th.responseBody, th.details)
+    return GrpcErrorResponse(th.grpcStatus ?: toGrpcStatus(th.code), "${th.responseBody}\n${th.stackTraceToString()}", th.details)
   }
 
   override fun canHandle(th: Throwable): Boolean = th is WebActionException


### PR DESCRIPTION
Right now, when service A uses gRPC to service B and service B throws an exception, there are two main outcomes:
* service B throws a WebActionException—service A receives a GrpcException with the mapped status code and service B's exception's public message
* service B throws some other exception (e.g. NullPointerException)—service A receives a GrpcException with the code UNKNOWN and the message "internal server error"

Compared to non-gRPC responses, this is very limited information. Services that communicate over HTTP instead often receive a response body that includes a stack trace, which makes it much easier to triage new Sentry reports without having to find the corresponding error report in the callee service.

This PR extends the message provided to the gRPC response when misk intercepts an exception—we now explicitly including the stack trace from the caught exception. Additionally, gRPC messages triggered by the second case now include the exception message, rather than a catch-all "internal server error" string.