### PR TITLE
Seed BoundAction initialSeedData with matched Action

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -109,6 +109,7 @@ internal class BoundAction<A : WebAction>(
     val initialSeedData = mapOf<Key<*>, Any?>(
       keyOf<HttpServletRequest>() to request,
       keyOf<HttpCall>() to httpCall,
+      keyOf<Action>() to action,
     )
     val seedData =
       seedDataTransformers.fold(initialSeedData) { seedData, interceptor ->


### PR DESCRIPTION
This will allow users to inject `ActionScoped<Action>`, to get access to things like the current functions annotations inside of an `ActionScopedProvider`, the return type, etc.

No test changes because I think the mechanism of `initialSeedData` is already pretty well tested, but let me know if you disagree and I can look to add one.