### PR TITLE
Adds KInstallOnceModule

### DIFF
--- a/misk-inject/api/misk-inject.api
+++ b/misk-inject/api/misk-inject.api
@@ -49,3 +49,9 @@ protected final class misk/inject/KAbstractModule$KotlinAnnotatedBindingBuilder 
 	public fun toProvider (Ljavax/inject/Provider;)Lcom/google/inject/binder/ScopedBindingBuilder;
 }
 
+public abstract class misk/inject/KInstallOnceModule : misk/inject/KAbstractModule {
+	public fun <init> ()V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun hashCode ()I
+}
+

--- a/misk-inject/src/main/kotlin/misk/inject/KInstallOnceModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KInstallOnceModule.kt
@@ -1,0 +1,18 @@
+package misk.inject
+
+/**
+ * Make it safe to install multiple instances of this module. Guice will only install it once.
+ *
+ * This eases dependency management of library/core dependencies which benefit from multiple
+ * installation sites in varying configurations.
+ */
+abstract class KInstallOnceModule : KAbstractModule() {
+
+  final override fun hashCode(): Int {
+    return javaClass.hashCode()
+  }
+
+  final override fun equals(other: Any?): Boolean {
+    return other != null && javaClass.equals(other.javaClass)
+  }
+}

--- a/misk-inject/src/test/kotlin/misk/inject/KInstallOnceModuleTest.kt
+++ b/misk-inject/src/test/kotlin/misk/inject/KInstallOnceModuleTest.kt
@@ -1,0 +1,32 @@
+package misk.inject
+
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MiskTest
+class KInstallOnceModuleTest {
+  @MiskTestModule
+  val module : KAbstractModule = TestModule()
+
+  @Inject private lateinit var someValue : String
+
+  @Test fun testInstallOnceModule() {
+    assertThat(someValue).isEqualTo("Install once test")
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(TestInstallOnceModule())
+      install(TestInstallOnceModule())
+    }
+  }
+
+  class TestInstallOnceModule : KInstallOnceModule() {
+    override fun configure() {
+      bind<String>().toInstance("Install once test")
+    }
+  }
+}


### PR DESCRIPTION
Allows for de-duped installation of a module from multiple sites. This is useful for core/library dependencies that might need to ensure installation in varying configurations.