### PR TITLE
FakeClockModule install-once

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -248,7 +248,7 @@ public final class misk/time/FakeClock : java/time/Clock {
 	public fun withZone (Ljava/time/ZoneId;)Ljava/time/Clock;
 }
 
-public final class misk/time/FakeClockModule : misk/inject/KAbstractModule {
+public final class misk/time/FakeClockModule : misk/inject/KInstallOnceModule {
 	public fun <init> ()V
 }
 

--- a/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -1,9 +1,9 @@
 package misk.time
 
-import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 import java.time.Clock
 
-class FakeClockModule : KAbstractModule() {
+class FakeClockModule : KInstallOnceModule() {
   override fun configure() {
     bind<Clock>().to<FakeClock>()
     bind<FakeClock>().toInstance(FakeClock())


### PR DESCRIPTION
Use `KInstallOnceModule` with `FakeClockModule` so that multiple testing components can safely install this module to ensure a fake clock is wired up.