### PR TITLE
Make Redis.setnx atomic and fail loudly

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -111,9 +111,11 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
   /** Set a ByteArray value if it doesn't already exist with an expiration. Returns true if set and false, otherwise  */
   override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
     return jedisPool.resource.use { jedis ->
-      jedis.setnx(key.toByteArray(charset), value.toByteArray())
-        .also { setResult -> if (setResult == 1L) jedis.expire(key, expiryDuration.seconds) } == 1L
-
+      jedis.set(
+        key.toByteArray(charset),
+        value.toByteArray(),
+        SetParams().nx().px(expiryDuration.toMillis())
+      ) == "OK"
     }
   }
 


### PR DESCRIPTION
As per title. We ran into a problem where keys set using `RealRedis.setnx` were not expiring. I then realized we're not using `SET NX PX` but issuing two commands and discarding the result of the expire command. This only started causing problems after ~1 week when there was some infra issue.  This is pretty dangerous if folks are relying on expiration like we were.

I tested this against local Redis