### PR TITLE
Include package name in doc output path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,14 +91,14 @@ subprojects {
   }
 
   tasks.withType<DokkaTask>().configureEach {
-    val dokkaTask = this
+    if (name == "dokkaGfm") {
+      outputDirectory.set(project.file("$rootDir/docs/0.x/${project.name}"))
+    }
+
     dokkaSourceSets.configureEach {
       reportUndocumented.set(false)
       skipDeprecated.set(true)
       jdkVersion.set(8)
-      if (dokkaTask.name == "dokkaGfm") {
-        outputDirectory.set(project.file("$rootDir/docs/0.x"))
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #2489

The output from `dokka` is not playing well with what `mkdocs` is expecting.  Looking at just the `misk` package the docs output was:

```txt
- docs
  - 0.x
    - index.md
    - misk
      - package-list
      - misk
        - index.md
        - <sub packages>
      - <other packages>
 ```

A couple of things to note here.

Firstly, the `index.md` file is not [where the `mkdocs` navigation config](https://github.com/cashapp/misk/blob/master/mkdocs.yml#L48) expects it to be.  You can actually see that [the docs are being generated correctly](https://cashapp.github.io/misk/0.x/misk/misk/), it's just that the navigation links are not pointing the the right location because the entry point isn't being found (it's `https://cashapp.github.io/misk/0.x/misk/index.md` insread of `https://cashapp.github.io/misk/0.x/misk/index.html`.

Secondly, notice the the root level `index.md` for this package is actually a sibling of the the `misk` package's folder.  This means that whichever package generates it's docs last is the solve surviving version of `docs/0.x/index.md`.  This is why [this weirdness](https://cashapp.github.io/misk/0.x/) is occurring when using the breadcrumb navigation in the docs.

This change simply adds the package name to the output directory so that each package can contain the full structure that is being output by `dokka`.  This does output the `index.md` files in the expected locations for `mkdocs` to find and fixes the breadcrumb navigation issue mentioned above.

There is one caveat to this though, which is that all the urls are nested yet another level deeper than they were before (e.g. `https://cashapp.github.io/misk/0.x/misk/misk/` would become `https://cashapp.github.io/misk/0.x/misk/misk/misk/`).  While slightly absurd, I do not know how to avoid this given the configuration options of either `dokka` or `mkdocs`.  I did entertain the idea of processing the output to flatten the directory structure a bit and rewrite the links in the md files accordingly, but that felt quite heavy handed and error prone.

As a side note, I also moved the `outputDirectory` configuration out of the `dokkaSourceSets` configuration as it is actually an [option for the task itself](https://kotlin.github.io/dokka/1.7.10/user_guide/gradle/usage/#configuration-options) so it would simply be setting the same value multiple times for each source set and is ultimately unnecessary, but happy to revert to the previous location if that is preferred for some reason.
