### PR TITLE
Filter .sql files that don't match the expected file pattern

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigrator.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigrator.kt
@@ -122,7 +122,9 @@ internal class SchemaMigrator(
   fun availableMigrations(keyspace: Keyspace): SortedSet<NamedspacedMigration> {
     val migrations = mutableListOf<NamedspacedMigration>()
     for (migrationsResource in getMigrationsResources(keyspace)) {
-      val migrationsFound = resourceLoader.walk(migrationsResource).filter { it.endsWith(".sql") }
+      val migrationsFound = resourceLoader.walk(migrationsResource)
+        .filter { it.endsWith(".sql") }
+        .filter { NamedspacedMigration.MIGRATION_PATTERN.matcher(it).matches() }
         .map { NamedspacedMigration.fromResourcePath(it, migrationsResource) }
       migrations.addAll(migrationsFound)
     }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
@@ -119,15 +119,20 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
         |CREATE TABLE library_table (name varchar(255))
         |""".trimMargin()
     )
+    resourceLoader.put(
+      "$librarySource/all-migrations.sql", """
+        |CREATE TABLE all_migrations (name varchar(255))
+        |""".trimIndent()
+    )
 
     // Initially the schema_version table is absent.
-    assertThat(tableExists("schema_version")).isFalse()
-    assertThat(tableExists("table_1")).isFalse()
-    assertThat(tableExists("table_2")).isFalse()
-    assertThat(tableExists("table_3")).isFalse()
-    assertThat(tableExists("table_4")).isFalse()
-    assertThat(tableExists("library_table")).isFalse()
-    assertThat(tableExists("merged_library_table")).isFalse()
+    assertThat(tableExists("schema_version")).isFalse
+    assertThat(tableExists("table_1")).isFalse
+    assertThat(tableExists("table_2")).isFalse
+    assertThat(tableExists("table_3")).isFalse
+    assertThat(tableExists("table_4")).isFalse
+    assertThat(tableExists("library_table")).isFalse
+    assertThat(tableExists("merged_library_table")).isFalse
     assertFailsWith<SQLException> {
       schemaMigrator.appliedMigrations(Shard.SINGLE_SHARD)
     }
@@ -135,13 +140,13 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
     // Once we initialize, that table is present but empty.
     schemaMigrator.initialize()
     assertThat(schemaMigrator.appliedMigrations(Shard.SINGLE_SHARD)).isEmpty()
-    assertThat(tableExists("schema_version")).isTrue()
-    assertThat(tableExists("table_1")).isFalse()
-    assertThat(tableExists("table_2")).isFalse()
-    assertThat(tableExists("table_3")).isFalse()
-    assertThat(tableExists("table_4")).isFalse()
-    assertThat(tableExists("library_table")).isFalse()
-    assertThat(tableExists("merged_library_table")).isFalse()
+    assertThat(tableExists("schema_version")).isTrue
+    assertThat(tableExists("table_1")).isFalse
+    assertThat(tableExists("table_2")).isFalse
+    assertThat(tableExists("table_3")).isFalse
+    assertThat(tableExists("table_4")).isFalse
+    assertThat(tableExists("library_table")).isFalse
+    assertThat(tableExists("merged_library_table")).isFalse
 
     // When we apply migrations, the table is present and contains the applied migrations.
     schemaMigrator.applyAll("SchemaMigratorTest", sortedSetOf())
@@ -150,13 +155,14 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
       NamedspacedMigration(1002),
       NamedspacedMigration(1001, "name/space/")
     )
-    assertThat(tableExists("schema_version")).isTrue()
-    assertThat(tableExists("table_1")).isTrue()
-    assertThat(tableExists("table_2")).isTrue()
-    assertThat(tableExists("library_table")).isTrue()
-    assertThat(tableExists("table_3")).isFalse()
-    assertThat(tableExists("table_4")).isFalse()
-    assertThat(tableExists("merged_library_table")).isFalse()
+    assertThat(tableExists("schema_version")).isTrue
+    assertThat(tableExists("table_1")).isTrue
+    assertThat(tableExists("table_2")).isTrue
+    assertThat(tableExists("library_table")).isTrue
+    assertThat(tableExists("table_3")).isFalse
+    assertThat(tableExists("table_4")).isFalse
+    assertThat(tableExists("merged_library_table")).isFalse
+    assertThat(tableExists("all_migrations")).isFalse
     schemaMigrator.requireAll()
 
     // When new migrations are added they can be applied.
@@ -190,13 +196,14 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
       NamedspacedMigration(1001, "name/space/"),
       NamedspacedMigration(1001, "namespace/")
     )
-    assertThat(tableExists("schema_version")).isTrue()
-    assertThat(tableExists("table_1")).isTrue()
-    assertThat(tableExists("table_2")).isTrue()
-    assertThat(tableExists("table_3")).isTrue()
-    assertThat(tableExists("table_4")).isTrue()
-    assertThat(tableExists("library_table")).isTrue()
-    assertThat(tableExists("merged_library_table")).isTrue()
+    assertThat(tableExists("schema_version")).isTrue
+    assertThat(tableExists("table_1")).isTrue
+    assertThat(tableExists("table_2")).isTrue
+    assertThat(tableExists("table_3")).isTrue
+    assertThat(tableExists("table_4")).isTrue
+    assertThat(tableExists("library_table")).isTrue
+    assertThat(tableExists("merged_library_table")).isTrue
+    assertThat(tableExists("all_migrations")).isFalse
     schemaMigrator.requireAll()
   }
 


### PR DESCRIPTION
Instead of throwing an exception if such a file is encountered, filter these files when running the `SchemaMigrationService`. This allows other services like the jooq schema generator to create files in the `resources/migrations` directory and co-exist with `misk.jdbc`.

Here's an example stack trace of the exception being thrown in such cases:
```


java.lang.IllegalArgumentException: unexpected resource: classpath:/migrations/jooq-migrations.sql
--
  | at misk.jdbc.NamedspacedMigration$Companion.fromResourcePath(SchemaMigrator.kt:64)
  | at misk.jdbc.SchemaMigrator.availableMigrations(SchemaMigrator.kt:126)
  | at misk.jdbc.SchemaMigrator.applyAll(SchemaMigrator.kt:218)
  | at misk.jdbc.SchemaMigratorService.startUp(SchemaMigratorService.kt:26)
  | at com.google.common.util.concurrent.AbstractIdleService$DelegateService$1.run(AbstractIdleService.java:62)
  | at com.google.common.util.concurrent.Callables.lambda$threadRenaming$3(Callables.java:103)
  | at java.base/java.lang.Thread.run(Thread.java:833)

```