### PR TITLE
Adds a JVM runtime API

### DIFF
--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -596,6 +596,64 @@ public final class misk/web/metadata/database/DatabaseQueryMetadataAction$Respon
 public abstract interface annotation class misk/web/metadata/database/NoAdminDashboardDatabaseAccess : java/lang/annotation/Annotation {
 }
 
+public final class misk/web/metadata/jvm/JvmMetadataAction : misk/web/actions/WebAction {
+	public fun <init> (Ljava/lang/management/RuntimeMXBean;Lcom/squareup/moshi/Moshi;)V
+	public final fun getRuntime ()Ljava/lang/String;
+}
+
+public final class misk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse {
+	public static final field Companion Lmisk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse$Companion;
+	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Map;)Lmisk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse;
+	public static synthetic fun copy$default (Lmisk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/Map;ILjava/lang/Object;)Lmisk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoot_class_path ()Ljava/lang/String;
+	public final fun getClass_path ()Ljava/lang/String;
+	public final fun getInput_arguments ()Ljava/util/List;
+	public final fun getLibrary_path ()Ljava/lang/String;
+	public final fun getManagement_spec_version ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPid ()Ljava/lang/Long;
+	public final fun getSpec_name ()Ljava/lang/String;
+	public final fun getSpec_vendor ()Ljava/lang/String;
+	public final fun getSpec_version ()Ljava/lang/String;
+	public final fun getStart_time_millis ()Ljava/lang/Long;
+	public final fun getSystem_properties ()Ljava/util/Map;
+	public final fun getUptime_millis ()Ljava/lang/Long;
+	public final fun getVm_name ()Ljava/lang/String;
+	public final fun getVm_vendor ()Ljava/lang/String;
+	public final fun getVm_version ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun is_boot_class_path_supported ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse$Companion {
+	public final fun create (Ljava/lang/management/RuntimeMXBean;)Lmisk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse;
+}
+
+public final class misk/web/metadata/jvm/JvmMetadataModule : misk/inject/KAbstractModule {
+	public fun <init> ()V
+	public final fun provideRuntimeMxBean ()Ljava/lang/management/RuntimeMXBean;
+}
+
 public final class misk/web/metadata/webaction/WebActionMetadataAction : misk/web/actions/WebAction {
 	public fun <init> (Lmisk/web/metadata/webaction/WebActionMetadataList;)V
 	public final fun getAll ()Lmisk/web/metadata/webaction/WebActionMetadataAction$Response;

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
@@ -4,6 +4,7 @@ import misk.inject.KAbstractModule
 import misk.web.WebActionModule
 import misk.web.metadata.DashboardMetadataAction
 import misk.web.metadata.ServiceMetadataAction
+import misk.web.metadata.jvm.JvmMetadataModule
 
 /** Support Misk-Web Dashboards including the Misk [AdminDashboard] and service specific front end apps */
 class DashboardModule : KAbstractModule() {
@@ -18,5 +19,6 @@ class DashboardModule : KAbstractModule() {
     // Add metadata actions to support dashboards
     install(WebActionModule.create<DashboardMetadataAction>())
     install(WebActionModule.create<ServiceMetadataAction>())
+    install(JvmMetadataModule())
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataAction.kt
@@ -1,0 +1,91 @@
+package misk.web.metadata.jvm
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import misk.moshi.adapter
+import misk.web.Get
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.actions.WebAction
+import misk.web.dashboard.AdminDashboardAccess
+import misk.web.mediatype.MediaTypes
+import java.lang.management.RuntimeMXBean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Conveys information about the current JVM
+ */
+@Singleton
+class JvmMetadataAction : WebAction {
+
+  private val runtimeMxBean: RuntimeMXBean
+  private val moshiAdapter: JsonAdapter<JvmRuntimeResponse>
+
+  @Inject constructor(runtimeMxBean: RuntimeMXBean, moshi: Moshi) {
+    this.runtimeMxBean = runtimeMxBean
+    // Indent to make the output more readable since the response can be quite large!
+    this.moshiAdapter = moshi.adapter<JvmRuntimeResponse>().indent("  ")
+  }
+
+  @Get("/api/config/jvm/runtime")
+  @RequestContentType(MediaTypes.APPLICATION_JSON)
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @AdminDashboardAccess
+  fun getRuntime(): String {
+    return moshiAdapter.toJson(JvmRuntimeResponse.create(runtimeMxBean))
+  }
+
+  /**
+   * A data class for serializing information from [java.lang.management.RuntimeMxBean]
+   */
+  data class JvmRuntimeResponse(
+    val pid: Long?,
+    val name: String?,
+    val vm_name: String?,
+    val vm_vendor: String?,
+    val vm_version: String?,
+    val spec_name: String?,
+    val spec_vendor: String?,
+    val spec_version: String?,
+    val management_spec_version: String?,
+    val class_path: String?,
+    val library_path: String?,
+    val is_boot_class_path_supported: Boolean?,
+    val boot_class_path: String?,
+    val input_arguments: List<String>?,
+    val uptime_millis: Long?,
+    val start_time_millis: Long?,
+    val system_properties: Map<String, String>?,
+  ) {
+    companion object {
+      fun create(runtimeMxBean: RuntimeMXBean): JvmRuntimeResponse {
+        return JvmRuntimeResponse(
+          pid = runtimeMxBean.pid,
+          name = runtimeMxBean.name,
+          vm_name = runtimeMxBean.vmName,
+          vm_vendor = runtimeMxBean.vmVendor,
+          vm_version = runtimeMxBean.vmVersion,
+          spec_name = runtimeMxBean.specName,
+          spec_vendor = runtimeMxBean.specVendor,
+          spec_version = runtimeMxBean.specVersion,
+          management_spec_version = runtimeMxBean.managementSpecVersion,
+          class_path = runtimeMxBean.classPath,
+          library_path = runtimeMxBean.libraryPath,
+          is_boot_class_path_supported = runtimeMxBean.isBootClassPathSupported,
+          boot_class_path = {
+            if (runtimeMxBean.isBootClassPathSupported) {
+              runtimeMxBean.bootClassPath
+            } else {
+              null
+            }
+          }(),
+          input_arguments = runtimeMxBean.inputArguments,
+          uptime_millis = runtimeMxBean.uptime,
+          start_time_millis = runtimeMxBean.startTime,
+          system_properties = runtimeMxBean.systemProperties,
+        )
+      }
+    }
+  }
+}

--- a/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataModule.kt
@@ -1,0 +1,19 @@
+package misk.web.metadata.jvm
+
+import com.google.inject.Provides
+import com.squareup.moshi.Moshi
+import misk.inject.KAbstractModule
+import misk.moshi.adapter
+import misk.web.WebActionModule
+import java.lang.management.ManagementFactory
+import java.lang.management.RuntimeMXBean
+
+class JvmMetadataModule : KAbstractModule() {
+  override fun configure() {
+    install(WebActionModule.create<JvmMetadataAction>())
+  }
+
+  @Provides fun provideRuntimeMxBean() : RuntimeMXBean {
+    return ManagementFactory.getRuntimeMXBean()
+  }
+}

--- a/misk-admin/src/test/kotlin/misk/web/metadata/config/JvmMetadataActionTest.kt
+++ b/misk-admin/src/test/kotlin/misk/web/metadata/config/JvmMetadataActionTest.kt
@@ -1,0 +1,81 @@
+package misk.web.metadata.config
+
+import com.squareup.moshi.Moshi
+import misk.inject.KAbstractModule
+import misk.moshi.MoshiModule
+import misk.moshi.adapter
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.metadata.jvm.JvmMetadataAction
+import misk.web.metadata.jvm.JvmMetadataAction.JvmRuntimeResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.management.RuntimeMXBean
+import javax.inject.Inject
+import javax.management.ObjectName
+
+@MiskTest(startService = false)
+class JvmMetadataActionTest {
+  @MiskTestModule
+  val module = JvmMetadataTestingModule()
+
+  @Inject lateinit var moshi: Moshi
+  @Inject lateinit var jvmMetadataAction: JvmMetadataAction
+
+  /** Sanity check that we're able to call the action and spot check the expected data */
+  @Test fun golden() {
+    val rawResponse = jvmMetadataAction.getRuntime();
+    val response = moshi.adapter<JvmRuntimeResponse>().fromJson(rawResponse)!!
+    assertThat(response.vm_name).isEqualTo("FakeRuntimeMxBean - VM Name")
+    assertThat(response).isEqualTo(JvmMetadataAction.JvmRuntimeResponse.create(FakeRuntimeMxBean()))
+  }
+
+  class JvmMetadataTestingModule : KAbstractModule() {
+    override fun configure() {
+      install(MoshiModule())
+      bind<RuntimeMXBean>().to<FakeRuntimeMxBean>()
+    }
+  }
+
+  class FakeRuntimeMxBean @Inject constructor() : RuntimeMXBean {
+    override fun getObjectName(): ObjectName = ObjectName.getInstance("FakeRuntimeMxBean - object name")
+
+    override fun getName(): String = "FakeRuntimeMxBean - Name"
+
+    override fun getVmName(): String = "FakeRuntimeMxBean - VM Name"
+
+    override fun getVmVendor(): String = "FakeRuntimeMxBean - VM Vendor"
+
+    override fun getVmVersion(): String = "FakeRuntimeMxBean - VM Version"
+
+    override fun getSpecName(): String = "FakeRuntimeMxBean - Spec Name"
+
+    override fun getSpecVendor(): String = "FakeRuntimeMxBean - Spec Vendor"
+
+    override fun getSpecVersion(): String = "FakeRuntimeMxBean - Spec Version"
+
+    override fun getManagementSpecVersion(): String = "FakeRuntimeMxBean - Management Spec Version"
+
+    override fun getClassPath(): String = "FakeRuntimeMxBean - Class Path"
+
+    override fun getLibraryPath(): String = "FakeRuntimeMxBean - Library Path"
+
+    override fun isBootClassPathSupported(): Boolean = true
+
+    override fun getBootClassPath(): String = "FakeRuntimeMxBean - Boot Class Path"
+
+    override fun getInputArguments(): MutableList<String> =
+      mutableListOf<String>("FakeRuntimeMxBean - arg 1", "FakeRuntimeMxBean - arg 2")
+
+    override fun getUptime(): Long = 37
+
+    override fun getStartTime(): Long = 17
+
+    override fun getSystemProperties(): MutableMap<String, String> {
+      return mutableMapOf(
+        "FakeRuntimeMxBean prop key 1" to "FakeRuntimeMxBean prop value 1",
+        "FakeRuntimeMxBean prop key 2" to "FakeRuntimeMxBean prop value 2",
+      )
+    }
+  }
+}


### PR DESCRIPTION
My original motivation here was to be able to easily inspect the command line flags passed to the JVM for tuning our production configuration. I went ahead and serialized the rest of the RuntimeMxBean while I was in there since classpath and the like can also be useful.

I'd like to eventually make some nice UI around this, but I've been unable to get miskweb to work locally. However, it's still a useful first step to have an API.