### PR TITLE
[misk-redis] Add [b]rpoplpush for older Redis clients

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -2,6 +2,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public field clock Ljava/time/Clock;
 	public fun <init> ()V
 	public fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Lokio/ByteString;
+	public fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Lokio/ByteString;
 	public fun del (Ljava/lang/String;)Z
 	public fun del ([Ljava/lang/String;)I
 	public fun expire (Ljava/lang/String;J)Z
@@ -27,6 +28,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public final fun setClock (Ljava/time/Clock;)V
@@ -40,6 +42,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public static final field Companion Lmisk/redis/RealRedis$Companion;
 	public fun <init> (Lredis/clients/jedis/JedisPool;)V
 	public fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Lokio/ByteString;
+	public fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Lokio/ByteString;
 	public final fun close ()V
 	public fun del (Ljava/lang/String;)Z
 	public fun del ([Ljava/lang/String;)I
@@ -65,6 +68,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
@@ -78,6 +82,7 @@ public final class misk/redis/RealRedis$Companion {
 
 public abstract interface class misk/redis/Redis {
 	public abstract fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Lokio/ByteString;
+	public abstract fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Lokio/ByteString;
 	public abstract fun del (Ljava/lang/String;)Z
 	public abstract fun del ([Ljava/lang/String;)I
 	public abstract fun expire (Ljava/lang/String;J)Z
@@ -102,6 +107,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun pExpire (Ljava/lang/String;J)Z
 	public abstract fun pExpireAt (Ljava/lang/String;J)Z
 	public abstract fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public abstract fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public abstract fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public abstract fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -224,6 +224,15 @@ class FakeRedis : Redis {
     return lmove(sourceKey, destinationKey, from, to)
   }
 
+  override fun brpoplpush(sourceKey: String, destinationKey: String, timeoutSeconds: Int) =
+    blmove(
+      sourceKey = sourceKey,
+      destinationKey = destinationKey,
+      from = ListDirection.RIGHT,
+      to = ListDirection.LEFT,
+      timeoutSeconds = timeoutSeconds.toDouble(),
+    )
+
   override fun lmove(
     sourceKey: String,
     destinationKey: String,
@@ -311,6 +320,13 @@ class FakeRedis : Redis {
       return deleteCount
     }
   }
+
+  override fun rpoplpush(sourceKey: String, destinationKey: String) = lmove(
+    sourceKey = sourceKey,
+    destinationKey = destinationKey,
+    from = ListDirection.RIGHT,
+    to = ListDirection.LEFT
+  )
 
   override fun expire(key: String, seconds: Long): Boolean {
     synchronized(lock) {

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -167,6 +167,20 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
+  override fun brpoplpush(
+    sourceKey: String,
+    destinationKey: String,
+    timeoutSeconds: Int
+  ): ByteString? {
+    return jedisPool.resource.use { jedis ->
+      jedis.brpoplpush(
+        sourceKey.toByteArray(charset),
+        destinationKey.toByteArray(charset),
+        timeoutSeconds,
+      )?.toByteString()
+    }
+  }
+
   override fun lmove(
     sourceKey: String,
     destinationKey: String,
@@ -198,6 +212,13 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
   override fun lrem(key: String, count: Long, element: ByteString): Long {
     return jedisPool.resource.use { jedis ->
       jedis.lrem(key.toByteArray(charset), count, element.toByteArray())
+    }
+  }
+
+  override fun rpoplpush(sourceKey: String, destinationKey: String): ByteString? {
+    return jedisPool.resource.use { jedis ->
+      jedis.rpoplpush(sourceKey.toByteArray(charset), destinationKey.toByteArray(charset))
+        ?.toByteString()
     }
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -182,7 +182,7 @@ interface Redis {
    * to it or until timeout (a double value specifying the maximum number of seconds to block) is
    * reached. A timeout of zero can be used to block indefinitely.
    *
-   * This command comes in place of the now deprecated BRPOPLPUSH. Doing BLMOVE RIGHT LEFT is
+   * This command comes in place of the now deprecated [brpoplpush]. Doing BLMOVE RIGHT LEFT is
    * equivalent.
    *
    * See [lmove] for more information.
@@ -194,6 +194,22 @@ interface Redis {
     to: ListDirection,
     timeoutSeconds: Double
   ): ByteString?
+
+  /**
+   * [brpoplpush] is the blocking variant of [rpoplpush]. When source contains elements, this
+   * command behaves exactly like [rpoplpush]. When used inside a MULTI/EXEC block, this command
+   * behaves exactly like [rpoplpush]. When source is empty, Redis will block the connection until
+   * another client pushes to it or until timeout is reached. A timeout of zero can be used to block
+   * indefinitely.
+   *
+   * See [rpoplpush] for more information.
+   *
+   * As of Redis version 6.2.0, this command is regarded as deprecated.
+   *
+   * It can be replaced by [blmove] with the RIGHT and LEFT arguments when migrating or writing new
+   * code.
+   */
+  fun brpoplpush(sourceKey: String, destinationKey: String, timeoutSeconds: Int): ByteString?
 
   /**
    * Atomically returns and removes the first/last element (head/tail depending on the wherefrom
@@ -255,6 +271,25 @@ interface Redis {
    * command will always return 0.
    */
   fun lrem(key: String, count: Long, element: ByteString): Long
+
+  /**
+   * Atomically returns and removes the last element (tail) of the list stored at source, and pushes
+   * the element at the first element (head) of the list stored at destination.
+   *
+   * For example: consider source holding the list a,b,c, and destination holding the list x,y,z.
+   * Executing [rpoplpush] results in source holding a,b and destination holding c,x,y,z.
+   *
+   * If source does not exist, the value nil is returned and no operation is performed. If source
+   * and destination are the same, the operation is equivalent to removing the last element from the
+   * list and pushing it as first element of the list, so it can be considered as a list rotation
+   * command.
+   *
+   * As of Redis version 6.2.0, this command is regarded as deprecated.
+   *
+   * It can be replaced by [lmove] with the RIGHT and LEFT arguments when migrating or writing new
+   * code.
+   */
+  fun rpoplpush(sourceKey: String, destinationKey: String): ByteString?
 
   /**
    * Set a timeout on key. After the timeout has expired, the key will automatically be deleted. A


### PR DESCRIPTION
Add the [Redis List](https://redis.io/commands/?group=list) commands BRPOPLPUSH, RPOPLPUSH to support older Redis clients that don't have BLMOVE & LMOVE.