### PR TITLE
Remove constraint on prometheus client dependency

### DIFF
--- a/misk-bom/build.gradle.kts
+++ b/misk-bom/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
 
 dependencies {
   constraints {
-    // Prometheus 0.10+ enforce _total in counters. Opt out of this version (but we should update
-    // and deal with this breaking change).
-    // See: https://github.com/prometheus/client_java/releases/tag/parent-0.10.0
-    api(Dependencies.prometheusClient)
-
     project.rootProject.subprojects.forEach { subproject ->
       if (subproject.name != "misk-bom") {
         api(subproject)


### PR DESCRIPTION
This is not the right place for such a constraint, because non-cash users of misk (if any such mythical creatures exist) may not want to be forced into using a particular prometheus client.