### PR TITLE
Deprecate histogram method and direct users to use summary instead

### DIFF
--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -45,6 +45,8 @@ interface Metrics {
   /**
    * histogram creates and registers a new `Summary` prometheus type.
    *
+   * Deprecated: if you really need a summary metric, use [misk.metrics.v2.Metrics.summary] instead.
+   *
    * For legacy reasons, this function is called `histogram(...)` but it's not backed
    * by a histogram which is confusing.
    *
@@ -58,6 +60,7 @@ interface Metrics {
    *  for the metric. The key of the map is the quantile as a ratio (e.g. 0.99 represents p99) and
    *  the value is the "tolerable error" of the computed quantile.
    */
+  @Deprecated("Use misk.metrics.v2.Metrics.summary instead")
   fun histogram(
     name: String,
     help: String = "",

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -77,9 +77,6 @@ interface Metrics {
   /**
    * summary creates and registers a new `Summary` prometheus type.
    *
-   * This function used to be called `histogram(...)` but was updated because it's not backed
-   * by a histogram which is confusing.
-   *
    * See https://prometheus.github.io/client_java/io/prometheus/client/Summary.html for more info.
    *
    * @param name the name of the metric which will be supplied to prometheus.


### PR DESCRIPTION
`Metrics.histogram` is really a summary metric and not histogram. Deprecating this method to avoid confusion. There is already `v2.Metrics.histogram` and `v2.Metrics.summary` which are correctly named.