### PR TITLE
Guice modularize dashboard tabs

### DIFF
--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -194,6 +194,10 @@ public final class misk/web/dashboard/AdminDashboardTestingModule : misk/inject/
 	public fun <init> ()V
 }
 
+public final class misk/web/dashboard/BaseDashboardModule : misk/inject/KAbstractModule {
+	public fun <init> (Z)V
+}
+
 public final class misk/web/dashboard/ConfigDashboardTabModule : misk/inject/KAbstractModule {
 	public fun <init> (Z)V
 }
@@ -282,6 +286,10 @@ public final class misk/web/dashboard/DashboardTheme {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class misk/web/dashboard/DatabaseDashboardTabModule : misk/inject/KAbstractModule {
+	public fun <init> (Z)V
+}
+
 public final class misk/web/dashboard/EnvironmentToColorLookup {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -356,6 +364,14 @@ public final class misk/web/dashboard/MiskWebTheme {
 
 public final class misk/web/dashboard/MiskWebTheme$Companion {
 	public final fun getDEFAULT_THEME ()Lmisk/web/dashboard/MiskWebTheme;
+}
+
+public final class misk/web/dashboard/WebActionsDashboardTabModule : misk/inject/KAbstractModule {
+	public fun <init> (Z)V
+}
+
+public final class misk/web/dashboard/WebActionsOldDashboardTabModule : misk/inject/KAbstractModule {
+	public fun <init> (Z)V
 }
 
 public abstract class misk/web/dashboard/WebTab : misk/web/dashboard/ValidWebEntry {

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/AdminDashboardModule.kt
@@ -2,13 +2,6 @@ package misk.web.dashboard
 
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessAnnotationEntry
-import misk.web.NetworkInterceptor
-import misk.web.WebActionModule
-import misk.web.interceptors.WideOpenDevelopmentInterceptorFactory
-import misk.web.metadata.database.DatabaseQueryMetadata
-import misk.web.metadata.database.DatabaseQueryMetadataAction
-import misk.web.metadata.database.NoAdminDashboardDatabaseAccess
-import misk.web.metadata.webaction.WebActionMetadataAction
 import javax.inject.Qualifier
 
 /**
@@ -26,90 +19,16 @@ import javax.inject.Qualifier
 class AdminDashboardModule(private val isDevelopment: Boolean) : KAbstractModule() {
 
   override fun configure() {
-    // Install base dashboard support
-    install(DashboardModule())
+    install(BaseDashboardModule(isDevelopment))
+    install(DatabaseDashboardTabModule(isDevelopment))
+    install(WebActionsDashboardTabModule(isDevelopment))
+    install(WebActionsOldDashboardTabModule(isDevelopment))
 
-    // Adds open CORS headers in development to allow through API calls from webpack servers
-    multibind<NetworkInterceptor.Factory>().to<WideOpenDevelopmentInterceptorFactory>()
-
-    // Admin Dashboard Tab
-    multibind<DashboardHomeUrl>().toInstance(
-      DashboardHomeUrl<AdminDashboard>("/_admin/")
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "admin-dashboard",
-        web_proxy_url = "http://localhost:3100/"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "admin-dashboard",
-        web_proxy_url = "http://localhost:3100/",
-        url_path_prefix = "/_admin/",
-        resourcePath = "classpath:/web/_tab/admin-dashboard/"
-      )
-    )
-
-    // @misk packages
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "@misk",
-        web_proxy_url = "http://localhost:3100/",
-        url_path_prefix = "/@misk/",
-        resourcePath = "classpath:/web/_tab/admin-dashboard/@misk/"
-      )
-    )
-
-    // Database Query
-    newMultibinder<DatabaseQueryMetadata>()
-    install(WebActionModule.create<DatabaseQueryMetadataAction>())
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "database",
-        url_path_prefix = "/_admin/database/",
-        name = "Database",
-        category = "Container Admin"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "database",
-        web_proxy_url = "http://localhost:3202/"
-      )
-    )
-    // Default access that doesn't allow any queries for unconfigured DbEntities
-    multibind<AccessAnnotationEntry>().toInstance(
-      AccessAnnotationEntry<NoAdminDashboardDatabaseAccess>(
-        capabilities = listOf("no_admin_dashboard_database_access")
-      )
-    )
+    // Default Menu
     multibind<DashboardNavbarItem>().toInstance(
       DashboardNavbarItem<AdminDashboard>(
         item = "<a href=\"/_admin/database/\">Database</a>",
         order = 100
-      )
-    )
-
-    // Web Actions
-    install(WebActionModule.create<WebActionMetadataAction>())
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "web-actions",
-        url_path_prefix = "/_admin/web-actions/",
-        name = "Web Actions",
-        category = "Container Admin"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "web-actions",
-        web_proxy_url = "http://localhost:3201/"
       )
     )
     multibind<DashboardNavbarItem>().toInstance(
@@ -118,27 +37,10 @@ class AdminDashboardModule(private val isDevelopment: Boolean) : KAbstractModule
         order = 101
       )
     )
-
-    // Web Actions Old
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "web-actions-old",
-        url_path_prefix = "/_admin/web-actions-old/",
-        name = "Web Actions Old",
-        category = "Container Admin"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "web-actions-old",
-        web_proxy_url = "http://localhost:3201/"
-      )
-    )
     multibind<DashboardNavbarItem>().toInstance(
       DashboardNavbarItem<AdminDashboard>(
         item = "<a href=\"/_admin/web-actions-old/\">Web Actions Old</a>",
-        order = 101
+        order = 102
       )
     )
   }

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/BaseDashboardModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/BaseDashboardModule.kt
@@ -1,0 +1,55 @@
+package misk.web.dashboard
+
+import misk.inject.KAbstractModule
+import misk.web.NetworkInterceptor
+import misk.web.interceptors.WideOpenDevelopmentInterceptorFactory
+
+/**
+ * Installs base functionality for the Admin Dashboard including:
+ * - multibindings for menu links and other bound in multiple places resources
+ * - `admin-dashboard` tab which loads all other tabs and provides navbar, menu links, auth
+ * - `@misk` packages used by Misk-Web tabs from window to provide faster tab loads
+ */
+class BaseDashboardModule(
+  private val isDevelopment: Boolean
+): KAbstractModule() {
+  override fun configure() {
+    // Install base dashboard support
+    install(DashboardModule())
+
+    // Adds open CORS headers in development to allow through API calls from webpack servers
+    multibind<NetworkInterceptor.Factory>().to<WideOpenDevelopmentInterceptorFactory>()
+
+    // Admin Dashboard Tab
+    multibind<DashboardHomeUrl>().toInstance(
+      DashboardHomeUrl<AdminDashboard>("/_admin/")
+    )
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "admin-dashboard",
+        web_proxy_url = "http://localhost:3100/"
+      )
+    )
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "admin-dashboard",
+        web_proxy_url = "http://localhost:3100/",
+        url_path_prefix = "/_admin/",
+        resourcePath = "classpath:/web/_tab/admin-dashboard/"
+      )
+    )
+
+    // @misk packages
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "@misk",
+        web_proxy_url = "http://localhost:3100/",
+        url_path_prefix = "/@misk/",
+        resourcePath = "classpath:/web/_tab/admin-dashboard/@misk/"
+      )
+    )
+  }
+}

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
@@ -5,12 +5,11 @@ import misk.web.WebActionModule
 import misk.web.metadata.config.ConfigMetadataAction
 
 /**
- * Installs Config tab for the Misk Admin Dashboard
- *
- * The Config tab shows the raw config inputs and the merged runtime config for a given service
+ * Installs Config dashboard tab which shows the raw config inputs
+ * and the merged runtime config for your Misk service.
  *
  * If you have config parameters that include secrets, you should NOT install this tab because the
- *    secrets will be visible at runtime in the admin dashboard.
+ *    Misk secrets will be visible at runtime in the admin dashboard.
  * TODO There is insufficient secrets redaction that doesn't allow flexibility in secret names when
  *    redaction is run
  */

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
@@ -1,0 +1,40 @@
+package misk.web.dashboard
+
+import misk.inject.KAbstractModule
+import misk.security.authz.AccessAnnotationEntry
+import misk.web.WebActionModule
+import misk.web.metadata.database.DatabaseQueryMetadata
+import misk.web.metadata.database.DatabaseQueryMetadataAction
+import misk.web.metadata.database.NoAdminDashboardDatabaseAccess
+
+/**
+ * Installs Database dashboard tab which allows querying the database from a UI form.
+ */
+class DatabaseDashboardTabModule(private val isDevelopment: Boolean): KAbstractModule() {
+  override fun configure() {
+    // Database Query
+    newMultibinder<DatabaseQueryMetadata>()
+    install(WebActionModule.create<DatabaseQueryMetadataAction>())
+    multibind<DashboardTab>().toProvider(
+      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
+        slug = "database",
+        url_path_prefix = "/_admin/database/",
+        name = "Database",
+        category = "Container Admin"
+      )
+    )
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "database",
+        web_proxy_url = "http://localhost:3202/"
+      )
+    )
+    // Default access that doesn't allow any queries for unconfigured DbEntities
+    multibind<AccessAnnotationEntry>().toInstance(
+      AccessAnnotationEntry<NoAdminDashboardDatabaseAccess>(
+        capabilities = listOf("no_admin_dashboard_database_access")
+      )
+    )
+  }
+}

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
@@ -1,0 +1,33 @@
+package misk.web.dashboard
+
+import misk.inject.KAbstractModule
+import misk.web.NetworkInterceptor
+import misk.web.WebActionModule
+import misk.web.interceptors.WideOpenDevelopmentInterceptorFactory
+import misk.web.metadata.webaction.WebActionMetadataAction
+
+/**
+ * Installs WebActions dashboard tab which allows introspection
+ * and exercising actions from a UI form.
+ */
+class WebActionsDashboardTabModule(private val isDevelopment: Boolean): KAbstractModule() {
+  override fun configure() {
+    // Web Actions
+    install(WebActionModule.create<WebActionMetadataAction>())
+    multibind<DashboardTab>().toProvider(
+      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
+        slug = "web-actions",
+        url_path_prefix = "/_admin/web-actions/",
+        name = "Web Actions",
+        category = "Container Admin"
+      )
+    )
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "web-actions",
+        web_proxy_url = "http://localhost:3201/"
+      )
+    )
+  }
+}

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsOldDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsOldDashboardTabModule.kt
@@ -1,0 +1,35 @@
+package misk.web.dashboard
+
+import misk.inject.KAbstractModule
+import misk.web.NetworkInterceptor
+import misk.web.WebActionModule
+import misk.web.interceptors.WideOpenDevelopmentInterceptorFactory
+import misk.web.metadata.webaction.WebActionMetadataAction
+
+/**
+ * Installs WebActions dashboard tab which allows introspection
+ * and exercising actions from a UI form.
+ *
+ * This installs the first version of the WebActions tab,
+ * the [WebActionsDashboardTabModule] installs a rewrite.
+ */
+class WebActionsOldDashboardTabModule(private val isDevelopment: Boolean): KAbstractModule() {
+  override fun configure() {
+    // Web Actions Old
+    multibind<DashboardTab>().toProvider(
+      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
+        slug = "web-actions-old",
+        url_path_prefix = "/_admin/web-actions-old/",
+        name = "Web Actions Old",
+        category = "Container Admin"
+      )
+    )
+    install(
+      WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = "web-actions-old",
+        web_proxy_url = "http://localhost:3201/"
+      )
+    )
+  }
+}


### PR DESCRIPTION
Modules per tab make it easier to build custom dashboards which only
have certain tabs installed or forgo the provided AdminDashboardModule
for a service specific dashboard module which doesn't include the
default menu links.
