### PR TITLE
Set error on the parent (root) span if it exists

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
@@ -71,6 +71,11 @@ internal class TracingInterceptor internal constructor(private val tracer: Trace
       Tags.HTTP_STATUS.set(span, chain.httpCall.statusCode)
       if (chain.httpCall.statusCode > 399) {
         Tags.ERROR.set(span, true)
+        // In case of gRPC errors, [HttpCall.networkStatusCode] is always 200, in which case the
+        // parent (likely the root) span won't be able to know about the error.
+        if (parentSpan != null) {
+          Tags.ERROR.set(parentSpan, true)
+        }
       }
     } catch (t: Throwable) {
       Tags.ERROR.set(span, true)


### PR DESCRIPTION
For gRPC, the network status code is always 200, so the parent span won't know there's been an error. Help it out by explicitly setting the error tag to true based on the logical status code.