### PR TITLE
Make Misk FakeClock wrap Wisp FakeClock

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -128,7 +128,7 @@ object Dependencies {
   val wireRuntime = "com.squareup.wire:wire-runtime:4.4.0"
   val wireSchema = "com.squareup.wire:wire-schema:4.4.0"
   val wispAwsEnvironment = "app.cash.wisp:wisp-aws-environment"
-  val wispBom = "app.cash.wisp:wisp-bom:1.2.2"
+  val wispBom = "app.cash.wisp:wisp-bom:1.2.4"
   val wispClient = "app.cash.wisp:wisp-client"
   val wispConfig = "app.cash.wisp:wisp-config"
   val wispContainersTesting = "app.cash.wisp:wisp-containers-testing"
@@ -145,5 +145,6 @@ object Dependencies {
   val wispResourceLoader = "app.cash.wisp:wisp-resource-loader"
   val wispResourceLoaderTesting = "app.cash.wisp:wisp-resource-loader-testing"
   val wispSsl = "app.cash.wisp:wisp-ssl"
+  val wispTimeTesting = "app.cash.wisp:wisp-time-testing"
   val zookeeper = "org.apache.zookeeper:zookeeper:3.7.0"
 }

--- a/misk-aws/build.gradle.kts
+++ b/misk-aws/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
   testImplementation(project(":misk-feature-testing"))
   testImplementation(Dependencies.mockitoCore)
   testImplementation(Dependencies.wispFeatureTesting)
+  testImplementation(Dependencies.wispTimeTesting)
 }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobTest.kt
@@ -9,10 +9,10 @@ import misk.jobqueue.QueueName
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import javax.inject.Inject
 
 @MiskTest(startService = true)

--- a/misk-cron/build.gradle.kts
+++ b/misk-cron/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
   api(Dependencies.wispLogging)
 
   testImplementation(Dependencies.assertj)
+  testImplementation(Dependencies.wispTimeTesting)
   testImplementation(project(":misk-testing"))
 }

--- a/misk-cron/src/test/kotlin/misk/cron/CronTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronTest.kt
@@ -8,9 +8,9 @@ import misk.inject.KAbstractModule
 import misk.tasks.DelayedTask
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant

--- a/misk-hibernate/build.gradle.kts
+++ b/misk-hibernate/build.gradle.kts
@@ -53,4 +53,5 @@ dependencies {
   testImplementation(project(":misk-testing"))
   testImplementation(project(":misk-hibernate-testing"))
   testImplementation(Dependencies.wispConfig)
+  testImplementation(Dependencies.wispTimeTesting)
 }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/HealthCheckTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/HealthCheckTest.kt
@@ -7,12 +7,12 @@ import misk.mockito.Mockito.whenever
 import misk.services.FakeService
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.HibernateException
 import org.hibernate.SessionFactory
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Provider

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -5,13 +5,13 @@ import com.google.common.collect.Iterables.getOnlyElement
 import misk.hibernate.Operator.LT
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThat
 import org.hibernate.LazyInitializationException
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
+import wisp.time.FakeClock
 import java.time.Duration.ofSeconds
 import java.time.LocalDate
 import javax.inject.Inject

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/TimestampListenerTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/TimestampListenerTest.kt
@@ -3,9 +3,9 @@ package misk.hibernate
 import misk.jdbc.DataSourceType
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/misk-jobqueue-testing/build.gradle.kts
+++ b/misk-jobqueue-testing/build.gradle.kts
@@ -17,13 +17,14 @@ dependencies {
   api(project(":misk-jobqueue"))
   api(project(":misk-transactional-jobqueue"))
 
-  testImplementation(Dependencies.wispConfig)
   testImplementation(project(":misk-hibernate"))
   testImplementation(project(":misk-hibernate-testing"))
-  testImplementation(Dependencies.wispLogging)
-  testImplementation(Dependencies.junitApi)
-  testImplementation(Dependencies.loggingApi)
   testImplementation(Dependencies.assertj)
+  testImplementation(Dependencies.junitApi)
   testImplementation(Dependencies.kotlinTest)
   testImplementation(Dependencies.logbackClassic)
+  testImplementation(Dependencies.loggingApi)
+  testImplementation(Dependencies.wispConfig)
+  testImplementation(Dependencies.wispLogging)
+  testImplementation(Dependencies.wispTimeTesting)
 }

--- a/misk-jobqueue-testing/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
+++ b/misk-jobqueue-testing/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
@@ -7,11 +7,11 @@ import misk.logging.LogCollectorModule
 import misk.moshi.adapter
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
 import wisp.logging.getLogger
+import wisp.time.FakeClock
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ConcurrentHashMap

--- a/misk-jooq/build.gradle.kts
+++ b/misk-jooq/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
   api(Dependencies.wispLogging)
 
   testImplementation(Dependencies.assertj)
+  testImplementation(Dependencies.wispTimeTesting)
   testApi(project(":misk-testing"))
   testApi(project(":misk-jdbc-testing"))
 

--- a/misk-jooq/src/test/kotlin/misk/jooq/JooqTransacterTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/JooqTransacterTest.kt
@@ -11,13 +11,13 @@ import misk.jooq.model.Genre
 import misk.jooq.testgen.tables.references.MOVIE
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/misk-metrics-digester/build.gradle.kts
+++ b/misk-metrics-digester/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(Dependencies.moshiAdapters)
   implementation(project(":misk"))
 
-  testImplementation(project(":misk-testing"))
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.kotlinTest)
+  testImplementation(Dependencies.wispTimeTesting)
 }

--- a/misk-metrics-digester/src/test/kotlin/misk/metrics/digester/SlidingWindowDigestTest.kt
+++ b/misk-metrics-digester/src/test/kotlin/misk/metrics/digester/SlidingWindowDigestTest.kt
@@ -1,8 +1,8 @@
 package misk.metrics.digester
 
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.SortedMap

--- a/misk-redis/build.gradle.kts
+++ b/misk-redis/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
   testImplementation(project(":misk-testing"))
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.kotlinTest)
+  testImplementation(Dependencies.wispTimeTesting)
 }

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -2,10 +2,8 @@ package misk.redis
 
 import com.google.inject.Module
 import com.google.inject.util.Modules
-import com.squareup.wire.durationOfSeconds
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import misk.time.FakeClockModule
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
@@ -13,9 +11,9 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import redis.clients.jedis.args.ListDirection
+import wisp.time.FakeClock
 import java.time.Duration
 import javax.inject.Inject
-import kotlin.IllegalArgumentException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull

--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -239,6 +239,8 @@ public final class misk/time/FakeClock : java/time/Clock {
 	public fun <init> ()V
 	public fun <init> (JLjava/time/ZoneId;)V
 	public synthetic fun <init> (JLjava/time/ZoneId;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lwisp/time/FakeClock;)V
+	public synthetic fun <init> (Lwisp/time/FakeClock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun add (JLjava/util/concurrent/TimeUnit;)J
 	public final fun add (Ljava/time/Duration;)J
 	public final fun add (Ljava/time/Period;)J

--- a/misk-testing/build.gradle.kts
+++ b/misk-testing/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     exclude(group = "junit")
   }
   implementation(Dependencies.javaxInject)
+  implementation(Dependencies.wispTimeTesting)
   api(Dependencies.servletApi)
   api(Dependencies.wispContainersTesting)
   api(Dependencies.wispLogging)

--- a/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClock.kt
@@ -6,33 +6,32 @@ import java.time.Instant
 import java.time.Period
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
+import wisp.time.FakeClock as WispFakeClock
 
 class FakeClock(
-  epochMillis: Long = Instant.parse("2018-01-01T00:00:00Z").toEpochMilli(),
-  private val zone: ZoneId = ZoneId.of("UTC")
+  private val wispFakeClock: WispFakeClock = WispFakeClock()
 ) : Clock() {
+  constructor(
+    epochMillis: Long = Instant.parse("2018-01-01T00:00:00Z").toEpochMilli(),
+    zone: ZoneId = ZoneId.of("UTC")
+  ) : this(WispFakeClock(epochMillis = epochMillis, zone = zone))
 
-  private val millis: AtomicLong = AtomicLong(epochMillis)
+  override fun getZone(): ZoneId = wispFakeClock.zone
 
-  override fun getZone(): ZoneId = zone
+  override fun withZone(zone: ZoneId): Clock = wispFakeClock.withZone(zone = zone)
 
-  override fun withZone(zone: ZoneId): Clock = FakeClock(millis.get(), zone)
+  override fun instant(): Instant = wispFakeClock.instant()
 
-  override fun instant(): Instant = Instant.ofEpochMilli(millis.get()).atZone(zone).toInstant()
-
-  fun add(d: Duration) = millis.addAndGet(d.toMillis())
+  fun add(d: Duration) = wispFakeClock.add(d = d)
 
   /**
    * Note that unlike adding a [Duration] the exact amount that is added to the clock will depend on
    * its current time and timezone. Not all days, months or years have the same length. See the
    * documentation for [Period].
    */
-  fun add(p: Period) = millis.getAndUpdate { millis ->
-    Instant.ofEpochMilli(millis).atZone(zone).plus(p).toInstant().toEpochMilli()
-  }
+  fun add(p: Period) = wispFakeClock.add(p = p)
 
-  fun add(n: Long, unit: TimeUnit) = millis.addAndGet(TimeUnit.MILLISECONDS.convert(n, unit))
+  fun add(n: Long, unit: TimeUnit) = wispFakeClock.add(n = n, unit = unit)
 
-  fun setNow(instant: Instant) = millis.set(instant.toEpochMilli())
+  fun setNow(instant: Instant) = wispFakeClock.setNow(instant = instant)
 }

--- a/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
+++ b/misk-testing/src/main/kotlin/misk/time/FakeClockModule.kt
@@ -2,10 +2,13 @@ package misk.time
 
 import misk.inject.KInstallOnceModule
 import java.time.Clock
+import wisp.time.FakeClock as WispFakeClock
 
 class FakeClockModule : KInstallOnceModule() {
   override fun configure() {
-    bind<Clock>().to<FakeClock>()
-    bind<FakeClock>().toInstance(FakeClock())
+    bind<Clock>().to<WispFakeClock>()
+    val wispFakeClock = WispFakeClock()
+    bind<WispFakeClock>().toInstance(wispFakeClock)
+    bind<FakeClock>().toInstance(FakeClock(wispFakeClock = wispFakeClock))
   }
 }

--- a/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
+++ b/misk-testing/src/test/kotlin/misk/concurrent/FakeScheduledExecutorServiceTest.kt
@@ -1,8 +1,8 @@
 package misk.concurrent
 
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/misk-testing/src/test/kotlin/misk/concurrent/FakeSleeperTest.kt
+++ b/misk-testing/src/test/kotlin/misk/concurrent/FakeSleeperTest.kt
@@ -1,8 +1,8 @@
 package misk.concurrent
 
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/misk-testing/src/test/kotlin/misk/time/FakeClockTest.kt
+++ b/misk-testing/src/test/kotlin/misk/time/FakeClockTest.kt
@@ -25,10 +25,10 @@ internal class FakeClockTest {
     val clock = FakeClock(epochMillis = 0L)
     assertThat(clock.millis()).isEqualTo(0L)
 
-    clock.add(Duration.ofSeconds(20))
+    assertThat(clock.add(Duration.ofSeconds(20))).isEqualTo(20000L)
     assertThat(clock.millis()).isEqualTo(20000L)
 
-    clock.add(45, TimeUnit.HOURS)
+    assertThat(clock.add(45, TimeUnit.HOURS)).isEqualTo(162020000L)
     assertThat(clock.millis()).isEqualTo(162020000L)
   }
 
@@ -53,10 +53,10 @@ internal class FakeClockTest {
     clock.setNow(startInstant)
 
     // This day is only 23 hours long because of the DST transition
-    clock.add(Period.ofDays(1))
+    assertThat(clock.add(Period.ofDays(1))).isEqualTo(startInstant.plus(23L, ChronoUnit.HOURS).toEpochMilli())
     assertThat(clock.instant()).isEqualTo(startInstant.plus(23L, ChronoUnit.HOURS))
 
-    clock.add(Period.ofMonths(2))
+    assertThat(clock.add(Period.ofMonths(2))).isEqualTo(Instant.parse("1970-06-26T23:00:00Z").toEpochMilli())
     assertThat(clock.instant()).isEqualTo(Instant.parse("1970-06-26T23:00:00Z"))
   }
 }

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
   }
   testImplementation(Dependencies.openTracingMock)
   testImplementation(Dependencies.guavaTestLib)
+  testImplementation(Dependencies.wispTimeTesting)
 }
 
 val generatedSourceDir = "$buildDir/generated/source/wire-test"

--- a/misk/src/test/kotlin/misk/concurrent/RealExecutorServiceFactoryTest.kt
+++ b/misk/src/test/kotlin/misk/concurrent/RealExecutorServiceFactoryTest.kt
@@ -1,9 +1,9 @@
 package misk.concurrent
 
 import io.opentracing.mock.MockTracer
-import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException

--- a/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
+++ b/misk/src/test/kotlin/misk/tasks/RepeatedTaskQueueTest.kt
@@ -12,11 +12,11 @@ import misk.concurrent.ExplicitReleaseDelayQueue
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import misk.time.FakeClock
 import misk.time.FakeClockModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import wisp.time.FakeClock
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.PriorityBlockingQueue


### PR DESCRIPTION
Changes Misk's `FakeClock` to delegate to Wisp's `FakeClock` with the intent to eventually deprecate Misk's in the future.

Also changes all the usages of FakeClock internally in Misk to use Wisp's directly instead.