### PR TITLE
Improve RequestBodyFeatureBinding Unmarshaller creation

### DIFF
--- a/misk/src/main/kotlin/misk/web/extractors/RequestBodyFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestBodyFeatureBinding.kt
@@ -20,9 +20,9 @@ internal class RequestBodyFeatureBinding(
   private val unmarshallerFactories: List<Unmarshaller.Factory>
 ) : FeatureBinding {
   override fun beforeCall(subject: Subject) {
-    val mediaType = subject.httpCall.requestHeaders["Content-Type"]?.let { it.toMediaTypeOrNull() }
+    val mediaType = subject.httpCall.requestHeaders["Content-Type"]?.toMediaTypeOrNull()
     val unmarshaller = mediaType?.let { type ->
-      unmarshallerFactories.mapNotNull { it.create(type, parameter.type) }.firstOrNull()
+      unmarshallerFactories.firstNotNullOfOrNull { it.create(type, parameter.type) }
     } ?: GenericUnmarshallers.into(parameter)
       ?: throw IllegalArgumentException("no generic unmarshaller for ${parameter.type}")
 


### PR DESCRIPTION
When using `mapNotNull` followed by `first`, we end up calling `create` on all of the `Unmarshaller` factories, only to throw them away and only take the first. This can cause issues if a custom factory conflicts with one of the built-in Misk ones, such as the `JsonUnmarshaller` which uses Moshi and can throw if it can't find a type adapter. This avoids calling `create` eagerly so if an earlier factory is able to create an `Unmarshaller`, the rest of the factories are skipped.