### PR TITLE
add conditional `ServiceModule.dependsOn`

### DIFF
--- a/misk-service/src/main/kotlin/misk/ServiceModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceModule.kt
@@ -116,6 +116,14 @@ class ServiceModule constructor(
     key, dependsOn + upstream, enhancedBy
   )
 
+  /**
+   * Returns the [ServiceModule] with added the upstream dependency if condition is met otherwise
+   * it returns the original [ServiceModule] without changes.
+   */
+  fun dependsOn(upstream: Key<out Service>, condition: Boolean) = if (condition) ServiceModule(
+    key, dependsOn + upstream, enhancedBy
+  ) else this
+
   fun enhancedBy(enhancement: Key<out Service>) =
     ServiceModule(key, dependsOn, enhancedBy + enhancement)
 
@@ -124,6 +132,11 @@ class ServiceModule constructor(
 
   inline fun <reified T : Service> dependsOn(qualifier: KClass<out Annotation>? = null) =
     dependsOn(T::class.toKey(qualifier))
+
+  inline fun <reified T : Service> dependsOn(
+    qualifier: KClass<out Annotation>? = null,
+    condition: Boolean,
+  ) = dependsOn(upstream = T::class.toKey(qualifier), condition = condition)
 
   inline fun <reified T : Service> enhancedBy(qualifier: KClass<out Annotation>? = null) =
     enhancedBy(T::class.toKey(qualifier))

--- a/misk-service/src/test/kotlin/misk/ServiceModuleTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceModuleTest.kt
@@ -1,0 +1,36 @@
+package misk
+
+import com.google.common.util.concurrent.AbstractIdleService
+import misk.inject.toKey
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ServiceModuleTest {
+  class Service1 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class Service2 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  class Service3 : AbstractIdleService() {
+    override fun startUp() {}
+    override fun shutDown() {}
+  }
+
+  @Test fun conditionalDependsOn() {
+    with(
+      ServiceModule<Service1>()
+        .dependsOn<Service2>(condition = false)
+        .dependsOn<Service3>(condition = true)
+    ) {
+      assertThat(this.dependsOn).containsExactly(Service3::class.toKey())
+      assertThat(this.enhancedBy).isEmpty()
+      assertThat(this.enhances).isNull()
+      assertThat(this.key).isEqualTo(Service1::class.toKey())
+    }
+  }
+}


### PR DESCRIPTION
**Overview**

It can be verbose to add service dependencies conditionally especially if these dependencies are chained. 

**Example**
```kotlin
object : KAbstractModule() {
  override fun configure() {
    bind<StringBuilder>().toInstance(log)
    install(ServiceModule<ProducerService>())

    val isACriticalDependencyForSomeReason = true
    install(ServiceModule<ConsumerService>()
      .dependsOn<ProducerService>()
      // Since `dependsOn` returns a new instance of [ServiceModule], a simple `.apply` can't be used here
      .let {
        if (isACriticalDependencyForSomeReason) {
          it.dependsOn<AnotherUpstreamService>()
        } else {
          it
        }
      }
    install(ServiceModule<AnotherUpstreamService>())
  }
}
```

**Post PR changes example**
```kotlin
object : KAbstractModule() {
  override fun configure() {
    bind<StringBuilder>().toInstance(log)
    install(ServiceModule<ProducerService>())

    val isACriticalDependencyForSomeReason = true
    install(ServiceModule<ConsumerService>()
      .dependsOn<ProducerService>()
      // More humanly readable
      .dependsOn<AnotherUpstreamService>(condition = isACriticalDependencyForSomeReason))
    install(ServiceModule<AnotherUpstreamService>())
  }
}
```