### PR TITLE
fix `CronTask` service dep

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -7,7 +7,6 @@ import com.google.inject.Singleton
 import misk.ServiceModule
 import misk.concurrent.ExecutorServiceModule
 import misk.inject.KAbstractModule
-import misk.inject.keyOf
 import misk.inject.toKey
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
@@ -19,16 +18,15 @@ class CronModule(
   private val threadPoolSize: Int = 10,
   private val dependencies: List<Key<out Service>> = listOf()
 ) : KAbstractModule() {
-
   override fun configure() {
     install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class))
-    install(ServiceModule<CronTask>().apply {
-      dependsOn(keyOf<RepeatedTaskQueue>(ForMiskCron::class))
-      for (dep in dependencies) {
-        dependsOn(dep)
-      }
-    })
+    install(
+      ServiceModule(
+        key = CronTask::class.toKey(),
+        dependsOn = dependencies,
+      )
+    )
   }
 
   @Provides

--- a/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
@@ -9,7 +9,6 @@ import misk.inject.toKey
 import misk.logging.LogCollectorModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector


### PR DESCRIPTION
Since `ServiceModule.dependsOn` returns a new instance of `ServiceModule` (does not modify the state of the existing instance), `.apply` does not work here because it returns the contextual object, not the result of the lambda.