### PR TITLE
Only mark spans as errors for 5xx HTTP status codes

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/TracingInterceptor.kt
@@ -69,7 +69,7 @@ internal class TracingInterceptor internal constructor(private val tracer: Trace
     try {
       chain.proceed(chain.httpCall)
       Tags.HTTP_STATUS.set(span, chain.httpCall.statusCode)
-      if (chain.httpCall.statusCode > 399) {
+      if (chain.httpCall.statusCode >= 500) {
         Tags.ERROR.set(span, true)
         // In case of gRPC errors, [HttpCall.networkStatusCode] is always 200, in which case the
         // parent (likely the root) span won't be able to know about the error.


### PR DESCRIPTION
https://github.com/cashapp/misk/pull/2585 exposed a long-time behaviour in misk, where spans were marked as errors for 4xx responses as well as 5xx responses. When the parent span for the servlet request is left unchanged, Datadog does not expose this by default. Since https://github.com/cashapp/misk/pull/2585 began marking the parent spans as errors as well, Datadog now shows 4xx responses as errors in the service UI.

To avoid this, we should follow industry practices and only mark responses in the 5xx range as errors, which should revert to the expected behaviour for HTTP misk endpoints while retaining the benefits of https://github.com/cashapp/misk/pull/2585 for gRPC endpoints.