### PR TITLE
Add retries to SchemaMigrator.initialize

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigrator.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigrator.kt
@@ -3,8 +3,6 @@ package misk.jdbc
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.base.Stopwatch
 import com.google.common.collect.ImmutableList
-import misk.backoff.FlatBackoff
-import misk.backoff.retry
 import misk.resources.ResourceLoader
 import misk.vitess.Keyspace
 import misk.vitess.Shard
@@ -13,7 +11,6 @@ import misk.vitess.target
 import wisp.logging.getLogger
 import java.sql.Connection
 import java.sql.SQLException
-import java.time.Duration
 import java.util.SortedSet
 import java.util.TreeMap
 import java.util.TreeSet
@@ -148,46 +145,39 @@ internal class SchemaMigrator(
     return migrationMap.navigableKeySet()
   }
 
-  /**
-   * Creates the `schema_version` table if it does not exist. Returns the applied migrations.
-   *
-   * Retry wrapped to handle multiple JDBC modules racing to create the `schema_version` table.
-   */
+  /** Creates the `schema_version` table if it does not exist. Returns the applied migrations. */
   fun initialize(): SortedSet<NamedspacedMigration> {
-    return retry(10, FlatBackoff(Duration.ofMillis(100))) {
-      val noMigrations =
-        shards.get().all { shard -> getMigrationsResources(shard.keyspace).isEmpty() }
-      if (noMigrations) {
-        sortedSetOf()
-      } else {
-        shards.get().flatMapTo(TreeSet()) { shard ->
-          try {
-            val result = appliedMigrations(shard)
-            logger.info {
-              "${qualifier.simpleName} has ${result.size} migrations applied;" +
-                " latest is ${result.lastOrNull()}"
-            }
-            result
-          } catch (e: SQLException) {
-            dataSource.get().connection.use {
-              it.target(shard) { c ->
-                c.createStatement().use { statement ->
-                  statement.execute(
-                    """
+    val noMigrations =
+      shards.get().all { shard -> getMigrationsResources(shard.keyspace).isEmpty() }
+    if (noMigrations) {
+      return sortedSetOf()
+    }
+    return shards.get().flatMapTo(TreeSet()) { shard ->
+      try {
+        val result = appliedMigrations(shard)
+        logger.info {
+          "${qualifier.simpleName} has ${result.size} migrations applied;" +
+            " latest is ${result.lastOrNull()}"
+        }
+        return result
+      } catch (e: SQLException) {
+        dataSource.get().connection.use {
+          it.target(shard) { c ->
+            c.createStatement().use { statement ->
+              statement.execute(
+                """
                 |CREATE TABLE schema_version (
                 |  version varchar(50) PRIMARY KEY,
                 |  installed_by varchar(30) DEFAULT NULL
                 |);
                 |""".trimMargin()
-                  )
-                }
-                c.createStatement().use { statement ->
-                  statement.execute("COMMIT")
-                }
-              }
-              sortedSetOf<NamedspacedMigration>()
+              )
+            }
+            c.createStatement().use { statement ->
+              statement.execute("COMMIT")
             }
           }
+          sortedSetOf<NamedspacedMigration>()
         }
       }
     }

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigratorService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/SchemaMigratorService.kt
@@ -2,9 +2,12 @@ package misk.jdbc
 
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
+import misk.backoff.ExponentialBackoff
+import misk.backoff.retry
 import misk.healthchecks.HealthCheck
 import misk.healthchecks.HealthStatus
 import wisp.deployment.Deployment
+import java.time.Duration
 import javax.inject.Provider
 import kotlin.reflect.KClass
 
@@ -22,7 +25,11 @@ class SchemaMigratorService internal constructor(
     if (deployment.isTest || deployment.isLocalDevelopment) {
       val type = connector.config().type
       if (type != DataSourceType.VITESS_MYSQL) {
-        val appliedMigrations = schemaMigrator.initialize()
+        // Retry wrapped to handle multiple JDBC modules racing to create the `schema_version` table.
+        val appliedMigrations = retry(
+          10,
+          ExponentialBackoff(Duration.ofMillis(100), Duration.ofSeconds(5))
+        ) { schemaMigrator.initialize() }
         migrationState = schemaMigrator.applyAll("SchemaMigratorService", appliedMigrations)
       } else {
         // vttestserver automatically applies migrations

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorServiceTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorServiceTest.kt
@@ -1,0 +1,121 @@
+package misk.jdbc
+
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.config.MiskConfig
+import misk.database.StartDatabaseService
+import misk.environment.DeploymentModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import wisp.config.Config
+import wisp.deployment.TESTING
+import javax.inject.Inject
+
+@MiskTest(startService = false)
+internal class MySQLSchemaMigratorServiceTest : SchemaMigratorServiceTest(DataSourceType.MYSQL)
+
+@Disabled // TODO fix test flake, while not working in Github Actions CI, this does work locally
+@MiskTest(startService = false)
+internal class PostgreSQLSchemaMigratorServiceTest : SchemaMigratorServiceTest(DataSourceType.POSTGRESQL)
+
+@MiskTest(startService = false)
+internal class CockroachdbSchemaMigratorServiceTest : SchemaMigratorServiceTest(DataSourceType.COCKROACHDB)
+
+@MiskTest(startService = false)
+internal class TidbSchemaMigratorServiceTest : SchemaMigratorServiceTest(DataSourceType.TIDB)
+
+internal abstract class SchemaMigratorServiceTest(val type: DataSourceType) {
+  val deploymentModule = DeploymentModule(TESTING)
+
+  val appConfig = MiskConfig.load<RootConfig>("test_schemamigrator_app", TESTING)
+  val config = selectDataSourceConfig(appConfig)
+
+  @MiskTestModule
+  val module = Modules.combine(
+    deploymentModule,
+    MiskTestingServiceModule(),
+    JdbcModule(Movies::class, config),
+    JdbcModule(Movies2::class, config),
+  )
+
+  private fun selectDataSourceConfig(config: RootConfig): DataSourceConfig {
+    return when (type) {
+      DataSourceType.MYSQL -> config.mysql_data_source
+      DataSourceType.COCKROACHDB -> config.cockroachdb_data_source
+      DataSourceType.POSTGRESQL -> config.postgresql_data_source
+      DataSourceType.TIDB -> config.tidb_data_source
+      DataSourceType.HSQLDB -> throw RuntimeException("Not supported (yet?)")
+      else -> throw java.lang.RuntimeException("unexpected data source type $type")
+    }
+  }
+
+  @Inject @Movies lateinit var dataSourceService: DataSourceService
+  @Inject @Movies2 lateinit var dataSourceService2: DataSourceService
+  @Inject @Movies lateinit var schemaMigratorService: SchemaMigratorService
+  @Inject @Movies2 lateinit var schemaMigratorService2: SchemaMigratorService
+  @Inject @Movies lateinit var startDatabaseService: StartDatabaseService
+  @Inject @Movies2 lateinit var startDatabaseService2: StartDatabaseService
+
+  @AfterEach
+  internal fun tearDown() {
+    if (dataSourceService.isRunning) {
+      dropTables()
+      dataSourceService.stopAsync()
+      dataSourceService2.stopAsync()
+      dataSourceService.awaitTerminated()
+      dataSourceService2.awaitTerminated()
+    }
+    if (startDatabaseService.isRunning) {
+      startDatabaseService.stopAsync()
+      startDatabaseService2.stopAsync()
+      startDatabaseService.awaitTerminated()
+      startDatabaseService2.awaitTerminated()
+    }
+  }
+
+  @BeforeEach internal fun setUp() {
+    startDatabaseService.startAsync()
+    startDatabaseService2.startAsync()
+    startDatabaseService.awaitRunning()
+    startDatabaseService2.awaitRunning()
+    dataSourceService.startAsync()
+    dataSourceService2.startAsync()
+    dataSourceService.awaitRunning()
+    dataSourceService2.awaitRunning()
+
+    dropTables()
+  }
+
+  private fun dropTables() {
+    dataSourceService.get().connection.use { connection ->
+      val statement = connection.createStatement()
+      statement.addBatch("DROP TABLE IF EXISTS schema_version")
+      statement.addBatch("DROP TABLE IF EXISTS table_1")
+      statement.addBatch("DROP TABLE IF EXISTS table_2")
+      statement.addBatch("DROP TABLE IF EXISTS table_3")
+      statement.addBatch("DROP TABLE IF EXISTS table_4")
+      statement.addBatch("DROP TABLE IF EXISTS library_table")
+      statement.addBatch("DROP TABLE IF EXISTS merged_library_table")
+      statement.executeBatch()
+      connection.commit()
+    }
+  }
+
+  @Test fun initializeOnMultipleTables() {
+    schemaMigratorService.startAsync()
+    schemaMigratorService2.startAsync()
+    schemaMigratorService.awaitRunning()
+    schemaMigratorService2.awaitRunning()
+  }
+
+  data class RootConfig(
+    val mysql_data_source: DataSourceConfig,
+    val cockroachdb_data_source: DataSourceConfig,
+    val postgresql_data_source: DataSourceConfig,
+    val tidb_data_source: DataSourceConfig
+  ) : Config
+}

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
@@ -42,8 +42,7 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
   val module = Modules.combine(
     deploymentModule,
     MiskTestingServiceModule(),
-    JdbcModule(Movies::class, config),
-    JdbcModule(Movies2::class, config),
+    JdbcModule(Movies::class, config)
   )
 
   private fun selectDataSourceConfig(config: RootConfig): DataSourceConfig {
@@ -59,39 +58,28 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
 
   @Inject lateinit var resourceLoader: ResourceLoader
   @Inject @Movies lateinit var dataSourceService: DataSourceService
-  @Inject @Movies2 lateinit var dataSourceService2: DataSourceService
   @Inject @Movies lateinit var schemaMigrator: SchemaMigrator
   @Inject @Movies lateinit var schemaMigratorService: SchemaMigratorService
-  @Inject @Movies2 lateinit var schemaMigratorService2: SchemaMigratorService
   @Inject @Movies lateinit var startDatabaseService: StartDatabaseService
-  @Inject @Movies2 lateinit var startDatabaseService2: StartDatabaseService
 
   @AfterEach
   internal fun tearDown() {
     if (dataSourceService.isRunning) {
       dropTables()
       dataSourceService.stopAsync()
-      dataSourceService2.stopAsync()
       dataSourceService.awaitTerminated()
-      dataSourceService2.awaitTerminated()
     }
     if (startDatabaseService.isRunning) {
       startDatabaseService.stopAsync()
-      startDatabaseService2.stopAsync()
       startDatabaseService.awaitTerminated()
-      startDatabaseService2.awaitTerminated()
     }
   }
 
   @BeforeEach internal fun setUp() {
     startDatabaseService.startAsync()
-    startDatabaseService2.startAsync()
     startDatabaseService.awaitRunning()
-    startDatabaseService2.awaitRunning()
     dataSourceService.startAsync()
-    dataSourceService2.startAsync()
     dataSourceService.awaitRunning()
-    dataSourceService2.awaitRunning()
 
     dropTables()
   }
@@ -109,13 +97,6 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
       statement.executeBatch()
       connection.commit()
     }
-  }
-
-  @Test fun initializeOnMultipleTables() {
-    schemaMigratorService.startAsync()
-    schemaMigratorService2.startAsync()
-    schemaMigratorService.awaitRunning()
-    schemaMigratorService2.awaitRunning()
   }
 
   @Test fun initializeAndMigrate() {

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorTest.kt
@@ -42,7 +42,8 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
   val module = Modules.combine(
     deploymentModule,
     MiskTestingServiceModule(),
-    JdbcModule(Movies::class, config)
+    JdbcModule(Movies::class, config),
+    JdbcModule(Movies2::class, config),
   )
 
   private fun selectDataSourceConfig(config: RootConfig): DataSourceConfig {
@@ -58,28 +59,39 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
 
   @Inject lateinit var resourceLoader: ResourceLoader
   @Inject @Movies lateinit var dataSourceService: DataSourceService
+  @Inject @Movies2 lateinit var dataSourceService2: DataSourceService
   @Inject @Movies lateinit var schemaMigrator: SchemaMigrator
   @Inject @Movies lateinit var schemaMigratorService: SchemaMigratorService
+  @Inject @Movies2 lateinit var schemaMigratorService2: SchemaMigratorService
   @Inject @Movies lateinit var startDatabaseService: StartDatabaseService
+  @Inject @Movies2 lateinit var startDatabaseService2: StartDatabaseService
 
   @AfterEach
   internal fun tearDown() {
     if (dataSourceService.isRunning) {
       dropTables()
       dataSourceService.stopAsync()
+      dataSourceService2.stopAsync()
       dataSourceService.awaitTerminated()
+      dataSourceService2.awaitTerminated()
     }
     if (startDatabaseService.isRunning) {
       startDatabaseService.stopAsync()
+      startDatabaseService2.stopAsync()
       startDatabaseService.awaitTerminated()
+      startDatabaseService2.awaitTerminated()
     }
   }
 
   @BeforeEach internal fun setUp() {
     startDatabaseService.startAsync()
+    startDatabaseService2.startAsync()
     startDatabaseService.awaitRunning()
+    startDatabaseService2.awaitRunning()
     dataSourceService.startAsync()
+    dataSourceService2.startAsync()
     dataSourceService.awaitRunning()
+    dataSourceService2.awaitRunning()
 
     dropTables()
   }
@@ -97,6 +109,13 @@ internal abstract class SchemaMigratorTest(val type: DataSourceType) {
       statement.executeBatch()
       connection.commit()
     }
+  }
+
+  @Test fun initializeOnMultipleTables() {
+    schemaMigratorService.startAsync()
+    schemaMigratorService2.startAsync()
+    schemaMigratorService.awaitRunning()
+    schemaMigratorService2.awaitRunning()
   }
 
   @Test fun initializeAndMigrate() {

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/VitessSchemaMigratorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/VitessSchemaMigratorTest.kt
@@ -103,6 +103,10 @@ internal class VitessSchemaMigratorTest {
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
 internal annotation class Movies
 
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+internal annotation class Movies2
+
 internal data class MoviesConfig(
   val data_source: DataSourceConfig,
 ) : Config


### PR DESCRIPTION
For cases where multiple JdbcModules are installed, they will race to
create the `schema_version` table in tests and one will fail. Wrapping
initialize with retries will fix this as one will succeed and on retry
the others will succeed.

Motivating use case is where a utility library (say feature flags) is
installed which relies on its own utility table being present in the
database and a separate JDBC module installed for the utility usage.

The test added previously failed without the retries change.
