### PR TITLE
Add HRANDFIELD command to misk-redis client

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -1,5 +1,6 @@
 public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public field clock Ljava/time/Clock;
+	public field random Lkotlin/random/Random;
 	public fun <init> ()V
 	public fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Lokio/ByteString;
 	public fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Lokio/ByteString;
@@ -9,11 +10,14 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
 	public final fun getClock ()Ljava/time/Clock;
+	public final fun getRandom ()Lkotlin/random/Random;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
+	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
+	public fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
 	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
 	public fun hset (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incr (Ljava/lang/String;)J
@@ -32,10 +36,14 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public final fun setClock (Ljava/time/Clock;)V
+	public final fun setRandom (Lkotlin/random/Random;)V
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+}
+
+public abstract interface annotation class misk/redis/ForFakeRedis : java/lang/annotation/Annotation {
 }
 
 public final class misk/redis/RealRedis : misk/redis/Redis {
@@ -54,6 +62,8 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
+	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
+	public fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
 	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
 	public fun hset (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incr (Ljava/lang/String;)J
@@ -93,6 +103,8 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public abstract fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
 	public abstract fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
+	public abstract fun hrandField (Ljava/lang/String;J)Ljava/util/List;
+	public abstract fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
 	public abstract fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
 	public abstract fun hset (Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun incr (Ljava/lang/String;)J
@@ -188,5 +200,7 @@ public final class misk/redis/RedisService : com/google/common/util/concurrent/A
 
 public final class misk/redis/RedisTestModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/random/Random;)V
+	public synthetic fun <init> (Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -13,10 +13,12 @@ import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.random.Random
 
 /** Mimics a Redis instance for testing. */
 class FakeRedis : Redis {
   @Inject lateinit var clock: Clock
+  @Inject @ForFakeRedis lateinit var random: Random
 
   private val lock = Any()
 
@@ -143,6 +145,23 @@ class FakeRedis : Redis {
       hset(key, field, value.toString().encode(Charsets.UTF_8))
       return value
     }
+  }
+
+  override fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>? {
+    synchronized(lock) {
+      return randomFields(key, count)?.toMap()
+    }
+  }
+
+  override fun hrandField(key: String, count: Long): List<String> {
+    synchronized(lock) {
+      return randomFields(key, count)?.map { it.first } ?: emptyList()
+    }
+  }
+
+  private fun randomFields(key: String, count: Long): List<Pair<String, ByteString>>? {
+    checkHrandFieldCount(count)
+    return hgetAll(key)?.toList()?.shuffled(random)?.take(count.toInt())
   }
 
   override fun set(key: String, value: ByteString) {

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -10,7 +10,6 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
-import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -88,6 +88,33 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
+  /**
+   * Throws if [count] is negative.
+   *
+   * See [misk.redis.Redis.hrandFieldWithValues].
+   */
+  override fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>? {
+    checkHrandFieldCount(count)
+    return jedisPool.resource.use { jedis ->
+      jedis.hrandfieldWithValues(key.toByteArray(charset), count)
+        ?.mapKeys { (key, _) -> key.toString(charset) }
+        ?.mapValues { (_, value) -> value.toByteString() }
+    }
+  }
+
+  /**
+   * Throws if [count] is negative.
+   *
+   * See [misk.redis.Redis.hrandField].
+   */
+  override fun hrandField(key: String, count: Long): List<String> {
+    checkHrandFieldCount(count)
+    return jedisPool.resource.use { jedis ->
+      jedis.hrandfield(key.toByteArray(charset), count)
+        .map { it.toString(charset) }
+    }
+  }
+
   /** Set a ByteArray value. */
   override fun set(key: String, value: ByteString) {
     jedisPool.resource.use { jedis ->

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -102,6 +102,20 @@ interface Redis {
   fun hincrBy(key: String, field: String, increment: Long): Long
 
   /**
+   * Randomly selects [count] fields and values from the hash stored at [key].
+   *
+   * NB: Implementations using Jedis 4 or seeking to emulate Jedis should use [checkHrandFieldCount]
+   * to avoid surprising behaviour like retrieving a result map which is smaller than requested by a
+   * completely random factor.
+   */
+  fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>?
+
+  /**
+   * Like [hrandFieldWithValues] but only returns the fields of the hash stored at [key].
+   */
+  fun hrandField(key: String, count: Long): List<String>
+
+  /**
    * Sets the [ByteString] value for the given key.
    *
    * @param key the key to set
@@ -372,4 +386,23 @@ interface Redis {
    * Begin a pipeline operation to batch together several updates for optimal performance
    */
   fun pipelined(): Pipeline
+}
+
+/**
+ * Validates [count] is positive and non-zero.
+ * This is to avoid unexpected behaviour due to limitations in Jedis:
+ * https://github.com/redis/jedis/issues/3017
+ *
+ * This check can be removed when Jedis v5.x is released with full support for the behaviours
+ * for negative counts that are specified by Redis.
+ *
+ * https://redis.io/commands/hrandfield/#specification-of-the-behavior-when-count-is-passed
+ */
+internal inline fun checkHrandFieldCount(count: Long) {
+  require(count > -1) {
+    "This Redis client does not support negative field counts for HRANDFIELD."
+  }
+  require(count > 0) {
+    "You must request at least 1 field."
+  }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RedisTestModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisTestModule.kt
@@ -1,9 +1,17 @@
 package misk.redis
 
 import misk.inject.KAbstractModule
+import javax.inject.Qualifier
+import kotlin.random.Random
 
-class RedisTestModule : KAbstractModule() {
+class RedisTestModule(private val random: Random = Random.Default) : KAbstractModule() {
   override fun configure() {
+    bind<Random>().annotatedWith<ForFakeRedis>().toInstance(random)
     bind<Redis>().toInstance(FakeRedis())
   }
 }
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class ForFakeRedis

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -14,6 +14,7 @@ import redis.clients.jedis.args.ListDirection
 import wisp.time.FakeClock
 import java.time.Duration
 import javax.inject.Inject
+import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -24,7 +25,10 @@ import kotlin.test.assertTrue
 class FakeRedisTest {
   @Suppress("unused")
   @MiskTestModule
-  val module: Module = Modules.combine(FakeClockModule(), RedisTestModule())
+  val module: Module = Modules.combine(
+    FakeClockModule(),
+    RedisTestModule(Random(1977)), // Hardcoded random seed for hrandfield* test determinism.
+  )
 
   @Inject lateinit var clock: FakeClock
   @Inject lateinit var redis: Redis
@@ -365,6 +369,61 @@ class FakeRedisTest {
     // Verify
     assertEquals("3", redis.hget("foo", "baz")?.utf8())
     assertEquals("2", redis.hget("foo", "bar")?.utf8())
+  }
+
+  @Test fun hrandField() {
+    // Setup.
+    val map = mapOf(
+      "Luke Skywalker" to "Mark Hamill".encodeUtf8(),
+      "Princess Leah" to "Carrie Fisher".encodeUtf8(),
+      "Han Solo" to "Harrison Ford".encodeUtf8(),
+      "R2-D2" to "Kenny Baker".encodeUtf8()
+    )
+    redis.hset("star wars characters", map)
+
+    // Test hrandfield key [count] with values.
+    assertThat(redis.hrandFieldWithValues("star wars characters", 1))
+      .containsExactlyEntriesOf(mapOf("Luke Skywalker" to "Mark Hamill".encodeUtf8()))
+
+    assertThat(redis.hrandFieldWithValues("star wars characters", 20))
+      .containsExactlyInAnyOrderEntriesOf(map)
+
+    // Test hrandfield key [count].
+    assertThat(redis.hrandField("star wars characters", 1))
+      .containsExactly("Han Solo")
+
+    assertThat(redis.hrandField("star wars characters", 20))
+      .containsExactlyInAnyOrder(*map.keys.toTypedArray())
+  }
+
+  @Test fun hrandFieldUnsupportedCount() {
+    // The Redis HRANDFIELD specification dictates different behaviour when count is negative.
+    // This behaviour cannot be adhered to by our implementation until Jedis fixes this bug:
+    // https://github.com/redis/jedis/issues/3017
+    // We must throw on a negative count in order to avoid surprising behaviour.
+    val ex1 = assertThrows<IllegalArgumentException> {
+      redis.hrandField("doesn't matter", -1)
+    }
+    val ex2 = assertThrows<IllegalArgumentException> {
+      redis.hrandFieldWithValues("doesn't matter", -1)
+    }
+    for (ex in listOf(ex1, ex2)) {
+      assertThat(ex)
+        .hasMessage("This Redis client does not support negative field counts for HRANDFIELD.")
+    }
+
+    // And it doesn't make sense to allow count=0.
+    val z1 = assertThrows<IllegalArgumentException> {
+      redis.hrandField("doesn't matter", 0)
+    }
+    val z2 = assertThrows<IllegalArgumentException> {
+      redis.hrandFieldWithValues("doesn't matter", 0)
+    }
+
+    for (ex in listOf(z1, z2)) {
+      assertThat(ex)
+        .hasMessage("You must request at least 1 field.")
+    }
   }
 
   @Test fun expireImmediately() {

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -101,38 +101,33 @@ class FakeRedisTest {
     // use both single field set and batch field set
     redis.hset(key1, field1, valueKey1Field1)
     redis.hset(key1, field2, valueKey1Field2)
-    redis.hset(key2, mapOf(
-      field1 to valueKey2Field1,
-      field2 to valueKey2Field2,
-    ))
+    redis.hset(
+      key2,
+      mapOf(
+        field1 to valueKey2Field1,
+        field2 to valueKey2Field2,
+      )
+    )
 
     assertThat(redis.hget(key1, field1)).isEqualTo(valueKey1Field1)
     assertThat(redis.hget(key1, field2)).isEqualTo(valueKey1Field2)
     assertThat(redis.hget(key2, field1)).isEqualTo(valueKey2Field1)
     assertThat(redis.hget(key2, field2)).isEqualTo(valueKey2Field2)
 
-    assertThat(redis.hgetAll(key1)).isEqualTo(mapOf(
-      field1 to valueKey1Field1,
-      field2 to valueKey1Field2
-    ))
+    assertThat(redis.hgetAll(key1))
+      .isEqualTo(mapOf(field1 to valueKey1Field1, field2 to valueKey1Field2))
 
-    assertThat(redis.hgetAll(key2)).isEqualTo(mapOf(
-      field1 to valueKey2Field1,
-      field2 to valueKey2Field2
-    ))
+    assertThat(redis.hgetAll(key2))
+      .isEqualTo(mapOf(field1 to valueKey2Field1, field2 to valueKey2Field2))
 
-    assertThat(redis.hmget(key1, field1)).isEqualTo(listOf(
-      valueKey1Field1
-    ))
-    assertThat(redis.hmget(key2, field1, field2)).isEqualTo(listOf(
-      valueKey2Field1,
-      valueKey2Field2
-    ))
+    assertThat(redis.hmget(key1, field1))
+      .isEqualTo(listOf(valueKey1Field1))
+    assertThat(redis.hmget(key2, field1, field2))
+      .isEqualTo(listOf(valueKey2Field1, valueKey2Field2))
 
     redis.hdel(key2, field2)
-    assertThat(redis.hmget(key2, field1, field2)).isEqualTo(listOf(
-      valueKey2Field1
-    ))
+    assertThat(redis.hmget(key2, field1, field2))
+      .isEqualTo(listOf(valueKey2Field1))
   }
 
   @Test
@@ -204,7 +199,6 @@ class FakeRedisTest {
     clock.add(Duration.ofSeconds(1))
     assertNull(redis[key], "Key should be expired")
   }
-
 
   @Test fun overridingResetsExpiry() {
     val key = "key"


### PR DESCRIPTION
This change adds support for Redis' HRANDFIELD command:

```
HRANDFIELD key [count] [WITH VALUES]
```

It comes with caveats based on the underlying Jedis implementation, which _cannot_ support negative counts [as specified](https://redis.io/commands/hrandfield/#specification-of-the-behavior-when-count-is-passed) without potentially surprising behaviour.

Full support for HRANDFIELD in misk-redis is predicated on a Jedis 5 release, which will include this breaking change: https://github.com/redis/jedis/pull/3049