### PR TITLE
Add return values to misk-redis HSET

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -18,8 +18,8 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
 	public fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
-	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
-	public fun hset (Ljava/lang/String;Ljava/util/Map;)V
+	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)J
+	public fun hset (Ljava/lang/String;Ljava/util/Map;)J
 	public fun incr (Ljava/lang/String;)J
 	public fun incrBy (Ljava/lang/String;J)J
 	public fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;
@@ -64,8 +64,8 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
 	public fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
-	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
-	public fun hset (Ljava/lang/String;Ljava/util/Map;)V
+	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)J
+	public fun hset (Ljava/lang/String;Ljava/util/Map;)J
 	public fun incr (Ljava/lang/String;)J
 	public fun incrBy (Ljava/lang/String;J)J
 	public fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;
@@ -105,8 +105,8 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public abstract fun hrandField (Ljava/lang/String;J)Ljava/util/List;
 	public abstract fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/Map;
-	public abstract fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)V
-	public abstract fun hset (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)J
+	public abstract fun hset (Ljava/lang/String;Ljava/util/Map;)J
 	public abstract fun incr (Ljava/lang/String;)J
 	public abstract fun incrBy (Ljava/lang/String;J)J
 	public abstract fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -207,15 +207,13 @@ class FakeRedis : Redis {
         expiryInstant = Instant.MAX
       )
     }
-    val newFieldCount = if (hKeyValueStore[key]!!.data[field] != null) { 0L } else 1L
+    val newFieldCount = if (hKeyValueStore[key]!!.data[field] != null) 0L else 1L
     hKeyValueStore[key]!!.data[field] = value
     return newFieldCount
   }
 
   override fun hset(key: String, hash: Map<String, ByteString>): Long {
-    return hash.toList().fold(0L) { newFieldCount, (field, value) ->
-      newFieldCount + hset(key, field, value)
-    }
+    return hash.entries.sumOf { (field, value) -> hset(key, field, value) }
   }
 
   override fun incr(key: String): Long {

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -200,19 +200,21 @@ class FakeRedis : Redis {
     }
   }
 
-  override fun hset(key: String, field: String, value: ByteString) {
+  override fun hset(key: String, field: String, value: ByteString): Long {
     if (!hKeyValueStore.containsKey(key)) {
       hKeyValueStore[key] = Value(
         data = ConcurrentHashMap(),
         expiryInstant = Instant.MAX
       )
     }
+    val newFieldCount = if (hKeyValueStore[key]!!.data[field] != null) { 0L } else 1L
     hKeyValueStore[key]!!.data[field] = value
+    return newFieldCount
   }
 
-  override fun hset(key: String, hash: Map<String, ByteString>) {
-    hash.forEach {
-      hset(key, it.key, it.value)
+  override fun hset(key: String, hash: Map<String, ByteString>): Long {
+    return hash.toList().fold(0L) { newFieldCount, (field, value) ->
+      newFieldCount + hset(key, field, value)
     }
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -148,16 +148,16 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
   }
 
   /** Set a ByteArray value for the given key and field. */
-  override fun hset(key: String, field: String, value: ByteString) {
-    jedisPool.resource.use { jedis ->
+  override fun hset(key: String, field: String, value: ByteString): Long {
+    return jedisPool.resource.use { jedis ->
       jedis.hset(key.toByteArray(charset), field.toByteArray(charset), value.toByteArray())
     }
   }
 
   /** Set ByteArray values for the given key and fields. */
-  override fun hset(key: String, hash: Map<String, ByteString>) {
+  override fun hset(key: String, hash: Map<String, ByteString>): Long {
     val hashBytes = hash.entries.associate { it.key.toByteArray(charset) to it.value.toByteArray() }
-    jedisPool.resource.use { jedis ->
+    return jedisPool.resource.use { jedis ->
       jedis.hset(key.toByteArray(charset), hashBytes)
     }
   }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -155,16 +155,20 @@ interface Redis {
    * @param key the key
    * @param field the field
    * @param value the value to set
+   * @return The number of fields that were added.
+   *         Returns 0 if all fields had their values overwritten.
    */
-  fun hset(key: String, field: String, value: ByteString)
+  fun hset(key: String, field: String, value: ByteString): Long
 
   /**
    * Sets the [ByteString] values for the given key and fields
    *
    * @param key the key
    * @param hash the map of fields to [ByteString] value
+   * @return The number of fields that were added.
+   *         Returns 0 if all fields had their values overwritten.
    */
-  fun hset(key: String, hash: Map<String, ByteString>)
+  fun hset(key: String, hash: Map<String, ByteString>): Long
 
   /**
    * Increments the number stored at key by one. If the key does not exist, it is set to 0 before

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -78,6 +78,31 @@ class FakeRedisTest {
     assertThat(redis[unknownKey]).isNull()
   }
 
+  @Test fun hsetReturnsCorrectValues() {
+    val key = "prehistoric_life"
+    // Add one get one.
+    assertThat(redis.hset(key, "Triassic", """["archosaurs"]""".encodeUtf8()))
+      .isEqualTo(1L)
+    // Add several get several.
+    assertThat(redis.hset(key, mapOf(
+      "Jurassic" to """["dinosaurs"]""".encodeUtf8(),
+      "Cretaceous" to """["feathered birds"]""".encodeUtf8(),
+    )))
+      .isEqualTo(2L)
+    // Replace all, add none.
+    assertThat(redis.hset(key, mapOf(
+      "Jurassic" to """["dinosaurs", "feathered dinosaurs"]""".encodeUtf8(),
+      "Cretaceous" to """["feathered birds", "fish"]""".encodeUtf8(),
+    )))
+      .isEqualTo(0L)
+    // Replace some and add some.
+    assertThat(redis.hset(key, mapOf(
+      "Triassic" to """["archosaurs", "corals"]""".encodeUtf8(), // replaced
+      "Paleogene" to """["primates"]""".encodeUtf8(), // added
+    )))
+      .isEqualTo(1L)
+  }
+
   @Test
   fun hgetAndHset() {
     val key1 = "key1"


### PR DESCRIPTION
`HSET key field value [field value ...]` returns the integer number of the fields that were added by the command invocation.

Previously, misk's Redis interface hid these return values.

This PR exposes them.

You can play with HSET on the doc website: https://redis.io/commands/hset/