### PR TITLE
Deprecate TransactionalJobQueue because it does not guarantee a job will be created if a record is spooled

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsTransactionalJobQueue.kt
@@ -15,6 +15,15 @@ import javax.inject.Singleton
 // development / staging while we build proper job forwarding from the replication stream,
 // but works so long as there is no application failure between the commit and the forward
 @Singleton
+@Deprecated(
+  message = "This implementation is not strictly transactional since jobs are enqueued in a DB "
+    + "post commit hook. If the enqueueing operation fails, the DB record exists but no job is enqueued. "
+    + "Instead, replace with a standard JobQueue and pass an idempotency key to the enqueue() function, "
+    + "persist this value inside the job handler and check if it exists before running the handler.",
+  level = DeprecationLevel.WARNING,
+  replaceWith = ReplaceWith("JobQueue",
+    "misk.jobqueue.JobQueue")
+)
 internal class SqsTransactionalJobQueue @Inject internal constructor(
   private val jobQueue: JobQueue
 ) : TransactionalJobQueue {

--- a/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -15,6 +15,15 @@ import java.util.UUID
  * will typically use tbe second variant, writing jobs to the local shard in the context
  * of a transaction that modifies the contents of an entity group.
  */
+@Deprecated(
+  message = "This implementation is not strictly transactional since jobs are enqueued in a DB "
+    + "post commit hook. If the enqueueing operation fails, the DB record exists but no job is enqueued. "
+    + "Instead, replace with a standard JobQueue and pass an idempotency key to the enqueue() function, "
+    + "persist this value inside the job handler and check if it exists before running the handler.",
+  level = DeprecationLevel.WARNING,
+  replaceWith = ReplaceWith("JobQueue",
+    "misk.jobqueue.JobQueue")
+)
 interface TransactionalJobQueue {
   /**
    * Enqueues a job to the database shard associated with the given entity group. Will

--- a/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -15,15 +15,6 @@ import java.util.UUID
  * will typically use the second variant, writing jobs to the local shard in the context
  * of a transaction that modifies the contents of an entity group.
  */
-@Deprecated(
-  message = "This implementation is not strictly transactional since jobs are enqueued in a DB "
-    + "post commit hook. If the enqueueing operation fails, the DB record exists but no job is enqueued. "
-    + "Instead, replace with a standard JobQueue and pass an idempotency key to the enqueue() function, "
-    + "persist this value inside the job handler and check if it exists before running the handler.",
-  level = DeprecationLevel.WARNING,
-  replaceWith = ReplaceWith("JobQueue",
-    "misk.jobqueue.JobQueue")
-)
 interface TransactionalJobQueue {
   /**
    * Enqueues a job to the database shard associated with the given entity group. Will

--- a/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -12,7 +12,7 @@ import java.util.UUID
  * then forwards the messages asynchronously to the actual queueing system. Two variants
  * of the [enqueue] operation exist - one which writes to the application's main shard, and
  * another which writes to the shard on which a given entity group exists. Applications
- * will typically use tbe second variant, writing jobs to the local shard in the context
+ * will typically use the second variant, writing jobs to the local shard in the context
  * of a transaction that modifies the contents of an entity group.
  */
 @Deprecated(

--- a/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
+++ b/misk-transactional-jobqueue/src/main/kotlin/misk/jobqueue/TransactionalJobQueue.kt
@@ -15,6 +15,15 @@ import java.util.UUID
  * will typically use the second variant, writing jobs to the local shard in the context
  * of a transaction that modifies the contents of an entity group.
  */
+@Deprecated(
+  message = "This implementation is not strictly transactional since jobs are enqueued in a DB "
+    + "post commit hook. If the enqueueing operation fails, the DB record exists but no job is enqueued. "
+    + "Instead, replace with a standard JobQueue and pass an idempotency key to the enqueue() function, "
+    + "persist this value inside the job handler and check if it exists before running the handler.",
+  level = DeprecationLevel.WARNING,
+  replaceWith = ReplaceWith("JobQueue",
+    "misk.jobqueue.JobQueue")
+)
 interface TransactionalJobQueue {
   /**
    * Enqueues a job to the database shard associated with the given entity group. Will


### PR DESCRIPTION
This implementation of TransactionalJobQueue is not fully transactional, in that a failure to enqueue the job (due to AWS outage etc) will not be detected, and no job will be enqueued.

Given it's several years old and the replication-based jobqueue is still not created, this deprecates the existing implementation. 

An alternate implementation would be to pass an [idempotenceKey](https://github.com/cashapp/misk/blob/1e8c0c70f7a75152b12c9f5f41adc41621c7bee6/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobQueue.kt#L41-L41) and in the job handler check if it's in our DB. If not, run enqueue the job and then persist the `idempotenceKey`.

Alternately, an implementation of TransactionalJobQueue could be provided that uses replication logs to guarantee an SQS job is created from a DB record.