### PR TITLE
Allow to specify version for gcr.io/cloud-spanner-emulator/emulator image

### DIFF
--- a/misk-gcp-testing/api/misk-gcp-testing.api
+++ b/misk-gcp-testing/api/misk-gcp-testing.api
@@ -15,19 +15,22 @@ public final class misk/cloud/gcp/datastore/FakeDatastoreModule$FakeDatastoreSer
 public final class misk/cloud/gcp/spanner/GoogleSpannerEmulator : com/google/common/util/concurrent/AbstractIdleService {
 	public static final field CONTAINER_NAME Ljava/lang/String;
 	public static final field Companion Lmisk/cloud/gcp/spanner/GoogleSpannerEmulator$Companion;
-	public static final field IMAGE Ljava/lang/String;
+	public static final field IMAGE_NAME Ljava/lang/String;
 	public fun <init> (Lmisk/cloud/gcp/spanner/SpannerConfig;)V
 	public final fun clearTables ()V
 	public final fun getConfig ()Lmisk/cloud/gcp/spanner/SpannerConfig;
-	public final fun pullImage ()V
+	public final fun pullImage (Ljava/lang/String;)V
+	public static synthetic fun pullImage$default (Lmisk/cloud/gcp/spanner/GoogleSpannerEmulator;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class misk/cloud/gcp/spanner/GoogleSpannerEmulator$Companion {
 	public final fun getDefaultDockerClientConfig ()Lcom/github/dockerjava/core/DefaultDockerClientConfig;
 	public final fun getDocker ()Lcom/github/dockerjava/api/DockerClient;
 	public final fun getHttpClient ()Lcom/github/dockerjava/httpclient5/ApacheDockerHttpClient;
+	public final fun getImage ()Ljava/lang/String;
 	public final fun getLogger ()Lmu/KLogger;
 	public final fun pullImage ()V
+	public final fun setImage (Ljava/lang/String;)V
 }
 
 public final class misk/cloud/gcp/spanner/GoogleSpannerEmulatorModule : misk/inject/KAbstractModule {

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
@@ -126,11 +126,12 @@ class GoogleSpannerEmulator @Inject constructor(
    * Pulls a Docker container containing the Google Spanner emulator.
    */
   fun pullImage(imageVersion: String? = null) {
-    image = "$IMAGE_NAME:${imageVersion ?: "latest"}"
+    setImageVersion(imageVersion)
     Companion.pullImage()
   }
 
-  private fun doStart() {
+  private fun doStart(imageVersion: String? = null) {
+    setImageVersion(imageVersion)
     val spannerGrpcPort = ExposedPort.tcp(server.config.emulator.port)
     val spannerHttpPort = ExposedPort.tcp(server.config.emulator.port + 10)
     val ports = Ports()
@@ -266,6 +267,10 @@ class GoogleSpannerEmulator @Inject constructor(
         }
       )
     }
+  }
+
+  private fun setImageVersion(imageVersion: String?) {
+    image = "$IMAGE_NAME:${imageVersion ?: "latest"}"
   }
 
   private class SpannerServer(

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
@@ -56,7 +56,7 @@ class GoogleSpannerEmulator @Inject constructor(
     if (shouldStartServer()) {
       // We need to do this outside of the service start up because this takes a really long time
       // the first time you do it and can cause service manager to time out.
-      pullImage()
+      pullImage(config.emulator.version)
     }
   }
 
@@ -92,8 +92,9 @@ class GoogleSpannerEmulator @Inject constructor(
       .build()
     val docker: DockerClient =
       DockerClientImpl.getInstance(defaultDockerClientConfig, httpClient)
-    const val IMAGE = "gcr.io/cloud-spanner-emulator/emulator"
+    const val IMAGE_NAME = "gcr.io/cloud-spanner-emulator/emulator"
     const val CONTAINER_NAME = "misk-spanner-testing"
+    var image: String = "$IMAGE_NAME:latest"
 
     fun pullImage() {
       if (imagePulled.get()) {
@@ -102,7 +103,7 @@ class GoogleSpannerEmulator @Inject constructor(
       synchronized(this) {
         if (imagePulled.get()) return
 
-        val process = ProcessBuilder("bash", "-c", "docker pull $IMAGE")
+        val process = ProcessBuilder("bash", "-c", "docker pull $image")
           .redirectOutput(ProcessBuilder.Redirect.INHERIT)
           .redirectError(ProcessBuilder.Redirect.INHERIT)
           .start()
@@ -124,7 +125,8 @@ class GoogleSpannerEmulator @Inject constructor(
   /**
    * Pulls a Docker container containing the Google Spanner emulator.
    */
-  fun pullImage() {
+  fun pullImage(imageVersion: String? = null) {
+    image = "$IMAGE_NAME:${imageVersion ?: "latest"}"
     Companion.pullImage()
   }
 
@@ -148,6 +150,9 @@ class GoogleSpannerEmulator @Inject constructor(
             "state ${runningContainer.state}, force removing and restarting"
         )
         docker.removeContainerCmd(runningContainer.id).withForce(true).exec()
+      } else if (runningContainer.image != image) {
+        logger.info("Docker image does not match expected image. Force removing and restarting Docker container")
+        docker.killContainerCmd(runningContainer.id)
       } else {
         logger.info("Using existing Spanner container named $containerName")
         stopContainerOnExit = false
@@ -157,7 +162,7 @@ class GoogleSpannerEmulator @Inject constructor(
 
     if (containerId == null) {
       logger.info("Starting Spanner with command")
-      containerId = docker.createContainerCmd(IMAGE)
+      containerId = docker.createContainerCmd(image)
         .withExposedPorts(spannerGrpcPort)
         .withExposedPorts(spannerHttpPort)
         .withHostConfig(

--- a/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
+++ b/misk-gcp-testing/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulator.kt
@@ -126,12 +126,16 @@ class GoogleSpannerEmulator @Inject constructor(
    * Pulls a Docker container containing the Google Spanner emulator.
    */
   fun pullImage(imageVersion: String? = null) {
-    setImageVersion(imageVersion)
+    image = fullImageName(imageVersion)
     Companion.pullImage()
   }
 
   private fun doStart(imageVersion: String? = null) {
-    setImageVersion(imageVersion)
+    val image = if (imageVersion != null) {
+      fullImageName(imageVersion)
+    } else {
+      image
+    }
     val spannerGrpcPort = ExposedPort.tcp(server.config.emulator.port)
     val spannerHttpPort = ExposedPort.tcp(server.config.emulator.port + 10)
     val ports = Ports()
@@ -269,8 +273,8 @@ class GoogleSpannerEmulator @Inject constructor(
     }
   }
 
-  private fun setImageVersion(imageVersion: String?) {
-    image = "$IMAGE_NAME:${imageVersion ?: "latest"}"
+  private fun fullImageName(imageVersion: String?): String {
+    return "$IMAGE_NAME:${imageVersion ?: "latest"}"
   }
 
   private class SpannerServer(

--- a/misk-gcp-testing/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorTest.kt
+++ b/misk-gcp-testing/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorTest.kt
@@ -137,7 +137,23 @@ class GoogleSpannerEmulatorTest {
       // Throws a NotFoundError if the image isn't present locally.
       assertDoesNotThrow {
         imageId = dockerClient.inspectImageCmd(
-          GoogleSpannerEmulator.IMAGE
+          GoogleSpannerEmulator.IMAGE_NAME
+        ).exec().id
+      }
+
+      // ID of the image should be present if it's local.
+      assertNotNull(imageId)
+    }
+
+    @Test fun `pulls a Docker image of the emulator with specified version`() {
+      var imageId: String? = null
+
+      emulator.pullImage("1.4.9")
+
+      // Throws a NotFoundError if the image isn't present locally.
+      assertDoesNotThrow {
+        imageId = dockerClient.inspectImageCmd(
+          GoogleSpannerEmulator.IMAGE_NAME
         ).exec().id
       }
 

--- a/misk-gcp/api/misk-gcp.api
+++ b/misk-gcp/api/misk-gcp.api
@@ -136,17 +136,19 @@ public final class misk/cloud/gcp/spanner/SpannerConfig : wisp/config/Config {
 
 public final class misk/cloud/gcp/spanner/SpannerEmulatorConfig {
 	public fun <init> ()V
-	public fun <init> (ZLjava/lang/String;I)V
-	public synthetic fun <init> (ZLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()I
-	public final fun copy (ZLjava/lang/String;I)Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
-	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;ZLjava/lang/String;IILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;ILjava/lang/String;)Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
+	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;ZLjava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnabled ()Z
 	public final fun getHostname ()Ljava/lang/String;
 	public final fun getPort ()I
+	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
@@ -70,4 +70,8 @@ data class SpannerEmulatorConfig(
    * this port "+ 10" as the REST / HTTP port for Docker to bind to.
    */
   val port: Int = 9010,
+
+  // Version of the emulate configuration which will be used. When null will
+  // default to the latest
+  val version: String? = null
 )


### PR DESCRIPTION
Allow for configurations of the version of the image we pull for the spanner emulator