### PR TITLE
Add RPUSH, LPOP and RPOP commands to misk-redis client

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -23,6 +23,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun incr (Ljava/lang/String;)J
 	public fun incrBy (Ljava/lang/String;J)J
 	public fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;
+	public fun lpop (Ljava/lang/String;I)Ljava/util/List;
 	public fun lpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public fun lrange (Ljava/lang/String;JJ)Ljava/util/List;
 	public fun lrem (Ljava/lang/String;JLokio/ByteString;)J
@@ -32,7 +33,9 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun rpop (Ljava/lang/String;I)Ljava/util/List;
 	public fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
+	public fun rpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public final fun setClock (Ljava/time/Clock;)V
@@ -69,6 +72,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun incr (Ljava/lang/String;)J
 	public fun incrBy (Ljava/lang/String;J)J
 	public fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;
+	public fun lpop (Ljava/lang/String;I)Ljava/util/List;
 	public fun lpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public fun lrange (Ljava/lang/String;JJ)Ljava/util/List;
 	public fun lrem (Ljava/lang/String;JLokio/ByteString;)J
@@ -78,7 +82,9 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun rpop (Ljava/lang/String;I)Ljava/util/List;
 	public fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
+	public fun rpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
@@ -110,6 +116,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun incr (Ljava/lang/String;)J
 	public abstract fun incrBy (Ljava/lang/String;J)J
 	public abstract fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Lokio/ByteString;
+	public abstract fun lpop (Ljava/lang/String;I)Ljava/util/List;
 	public abstract fun lpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public abstract fun lrange (Ljava/lang/String;JJ)Ljava/util/List;
 	public abstract fun lrem (Ljava/lang/String;JLokio/ByteString;)J
@@ -119,7 +126,9 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun pExpire (Ljava/lang/String;J)Z
 	public abstract fun pExpireAt (Ljava/lang/String;J)Z
 	public abstract fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public abstract fun rpop (Ljava/lang/String;I)Ljava/util/List;
 	public abstract fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
+	public abstract fun rpush (Ljava/lang/String;[Lokio/ByteString;)J
 	public abstract fun set (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)V
 	public abstract fun set (Ljava/lang/String;Lokio/ByteString;)V
 	public abstract fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -29,10 +29,10 @@ class FakeRedis : Redis {
 
   /** Acts as the Redis key-value store. */
   private val keyValueStore = ConcurrentHashMap<String, Value<ByteString>>()
-  /** A nested hash map for the hget and hset operations. */
+  /** A nested hash map for hash operations. */
   private val hKeyValueStore =
     ConcurrentHashMap<String, Value<ConcurrentHashMap<String, ByteString>>>()
-  /** A hash map for the l* list operations. */
+  /** A hash map for list operations. */
   private val lKeyValueStore = ConcurrentHashMap<String, Value<List<ByteString>>>()
 
   override fun del(key: String): Boolean {
@@ -283,8 +283,9 @@ class FakeRedis : Redis {
 
   override fun lpush(key: String, vararg elements: ByteString): Long {
     synchronized(lock) {
-      val updated = elements.toMutableList().also {
-        lKeyValueStore[key]?.data?.let { old -> it.addAll(old) }
+      val updated = lKeyValueStore[key]?.data?.toMutableList() ?: mutableListOf()
+      for (element in elements) {
+        updated.add(0, element)
       }
       lKeyValueStore[key] = Value(
         data = updated,

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -294,6 +294,18 @@ class FakeRedis : Redis {
     }
   }
 
+  override fun rpush(key: String, vararg elements: ByteString): Long {
+    synchronized(lock) {
+      val updated = lKeyValueStore[key]?.data?.toMutableList() ?: mutableListOf()
+      updated.addAll(elements)
+      lKeyValueStore[key] = Value(
+        data = updated,
+        expiryInstant = Instant.MAX,
+      )
+      return updated.size.toLong()
+    }
+  }
+
   override fun lpop(key: String, count: Int): List<ByteString?> {
     synchronized(lock) {
       val value = lKeyValueStore[key] ?: Value(emptyList(), clock.instant())

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -230,6 +230,18 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
+  override fun lpop(key: String, count: Int): List<ByteString?> {
+    return jedisPool.resource.use { jedis ->
+      jedis.lpop(key.toByteArray(charset), count).map { it?.toByteString() }
+    }
+  }
+
+  override fun rpop(key: String, count: Int): List<ByteString?> {
+    return jedisPool.resource.use { jedis ->
+      jedis.rpop(key.toByteArray(charset), count).map { it?.toByteString() }
+    }
+  }
+
   override fun lrange(key: String, start: Long, stop: Long): List<ByteString?> {
     return jedisPool.resource.use { jedis ->
       jedis.lrange(key.toByteArray(charset), start, stop).map { it?.toByteString() }

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -230,6 +230,12 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     }
   }
 
+  override fun rpush(key: String, vararg elements: ByteString): Long {
+    return jedisPool.resource.use { jedis ->
+      jedis.rpush(key.toByteArray(charset), *elements.map { it.toByteArray() }.toTypedArray())
+    }
+  }
+
   override fun lpop(key: String, count: Int): List<ByteString?> {
     return jedisPool.resource.use { jedis ->
       jedis.lpop(key.toByteArray(charset), count).map { it?.toByteString() }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -267,6 +267,16 @@ interface Redis {
   fun lpush(key: String, vararg elements: ByteString): Long
 
   /**
+   * Removes and returns the first [count] elements of the list stored at [key].
+   */
+  fun lpop(key: String, count: Int): List<ByteString?>
+
+  /**
+   * Removes and returns the last [count] elements of the list stored at [key].
+   */
+  fun rpop(key: String, count: Int): List<ByteString?>
+
+  /**
    * Returns the specified elements of the list stored at key. The offsets start and stop are
    * zero-based indexes, with 0 being the first element of the list (the head of the list), 1 being
    * the next element and so on.

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -254,17 +254,30 @@ interface Redis {
   ): ByteString?
 
   /**
-   * Insert all the specified values at the head of the list stored at key. If key does not exist,
-   * it is created as empty list before performing the push operations. When key holds a value that
-   * is not a list, an error is returned.
+   * Insert all the specified [elements] at the head of the list stored at [key].
+   * If [key] does not exist, it is created as empty list before performing the push operations.
+   * When [key] holds a value that is not a list, an error is returned.
    *
    * It is possible to push multiple elements using a single command call just specifying multiple
    * arguments at the end of the command. Elements are inserted one after the other to the head of
-   * the list, from the leftmost element to the rightmost element. So for instance the command LPUSH
-   * mylist a b c will result into a list containing c as first element, b as second element and a
-   * as third element.
+   * the list, from the leftmost element to the rightmost element.
+   * So for instance the command `LPUSH mylist a b c` will result into a list containing `c` as
+   * first element, `b` as second element and `a` as third element.
    */
   fun lpush(key: String, vararg elements: ByteString): Long
+
+  /**
+   * Insert all the specified [elements] at the tail of the list stored at [key].
+   * If [key] does not exist, it is created as empty list before performing the push operations.
+   * When [key] holds a value that is not a list, an error is returned.
+   *
+   * It is possible to push multiple elements using a single command call just specifying multiple
+   * arguments at the end of the command. Elements are inserted one after the other to the tail of
+   * the list, from the leftmost element to the rightmost element.
+   * So for instance the command `RPUSH mylist a b c` will result into a list containing `a` as
+   * first element, `b` as second element and `c` as third element.
+   */
+  fun rpush(key: String, vararg elements: ByteString): Long
 
   /**
    * Removes and returns the first [count] elements of the list stored at [key].

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -841,4 +841,16 @@ class FakeRedisTest {
     clock.add(Duration.ofSeconds(1))
     assertThat(redis.rpop("droids", 1)).isEmpty()
   }
+
+  @Test fun lpushAndRpushAreOrderedCorrectly() {
+    // This test is pulled directly from the Redis documentation for LPUSH and RPUSH.
+    val elements = listOf("a", "b", "c").map { it.encodeUtf8() }
+
+    redis.lpush("l", *elements.toTypedArray())
+    assertThat(redis.lrange("l", 0, -1))
+      .containsExactly(*elements.toList().asReversed().toTypedArray())
+
+    redis.rpush("r", *elements.toTypedArray())
+    assertThat(redis.lrange("r", 0, -1)).containsExactly(*elements.toTypedArray())
+  }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -538,8 +538,8 @@ class FakeRedisTest {
     val destinationKey = "oof"
     val destinationElements = listOf("baz".encodeUtf8())
 
-    redis.lpush(sourceKey, *sourceElements.toTypedArray())
-    redis.lpush(destinationKey, *destinationElements.toTypedArray())
+    redis.rpush(sourceKey, *sourceElements.toTypedArray())
+    redis.rpush(destinationKey, *destinationElements.toTypedArray())
 
     // Exercise
     val result = redis.lmove(
@@ -563,7 +563,7 @@ class FakeRedisTest {
     val sourceKey = "foo"
     val sourceElements = listOf("bar", "bat", "baz").map { it.encodeUtf8() }
 
-    redis.lpush(sourceKey, *sourceElements.toTypedArray())
+    redis.rpush(sourceKey, *sourceElements.toTypedArray())
     assertEquals(sourceElements, redis.lrange(sourceKey, 0, -1))
 
     // Exercise
@@ -613,7 +613,7 @@ class FakeRedisTest {
     // Setup
     val key = "foo"
     val elements = listOf("bar", "bat", "bar", "baz").map { it.encodeUtf8() }
-    redis.lpush(key, *elements.toTypedArray())
+    redis.rpush(key, *elements.toTypedArray())
 
     // Exercise
     val result = redis.lrange(key, 0, -1)
@@ -647,7 +647,7 @@ class FakeRedisTest {
     // Setup
     val key = "foo"
     val elements = listOf("bar", "bat", "bar", "baz").map { it.encodeUtf8() }
-    redis.lpush(key, *elements.toTypedArray())
+    redis.rpush(key, *elements.toTypedArray())
 
     // Exercise
     val result = redis.lrange(key, 3, 10)
@@ -660,7 +660,7 @@ class FakeRedisTest {
     // Setup
     val key = "foo"
     val elements = listOf("bar", "bat", "bar", "baz").map { it.encodeUtf8() }
-    redis.lpush(key, *elements.toTypedArray())
+    redis.rpush(key, *elements.toTypedArray())
 
     // Exercise
     val result = redis.lrem(key, 2, "bar".encodeUtf8())
@@ -677,7 +677,7 @@ class FakeRedisTest {
     // Setup
     val key = "foo"
     val elements = listOf("bar", "bat", "bar", "baz").map { it.encodeUtf8() }
-    redis.lpush(key, *elements.toTypedArray())
+    redis.rpush(key, *elements.toTypedArray())
 
     // Exercise
     val result = redis.lrem(key, 1, "bar".encodeUtf8())
@@ -694,7 +694,7 @@ class FakeRedisTest {
     // Setup
     val key = "foo"
     val elements = listOf("bar", "bat", "bar", "baz").map { it.encodeUtf8() }
-    redis.lpush(key, *elements.toTypedArray())
+    redis.rpush(key, *elements.toTypedArray())
 
     // Exercise
     val result = redis.lrem(key, -1, "bar".encodeUtf8())
@@ -722,8 +722,8 @@ class FakeRedisTest {
     val destinationKey = "oof"
     val destinationElements = listOf("baz".encodeUtf8())
 
-    redis.lpush(sourceKey, *sourceElements.toTypedArray())
-    redis.lpush(destinationKey, *destinationElements.toTypedArray())
+    redis.rpush(sourceKey, *sourceElements.toTypedArray())
+    redis.rpush(destinationKey, *destinationElements.toTypedArray())
 
     // Exercise
     val result = redis.rpoplpush(
@@ -745,7 +745,7 @@ class FakeRedisTest {
     val sourceKey = "foo"
     val sourceElements = listOf("bar", "bat", "baz").map { it.encodeUtf8() }
 
-    redis.lpush(sourceKey, *sourceElements.toTypedArray())
+    redis.rpush(sourceKey, *sourceElements.toTypedArray())
     assertEquals(sourceElements, redis.lrange(sourceKey, 0, -1))
 
     // Exercise
@@ -755,9 +755,9 @@ class FakeRedisTest {
     )
 
     // Verify
-    assertEquals("bar".encodeUtf8(), result)
+    assertEquals("baz".encodeUtf8(), result)
     assertEquals(
-      listOf("bar".encodeUtf8(), "baz".encodeUtf8(), "bat".encodeUtf8()),
+      listOf("baz".encodeUtf8(), "bar".encodeUtf8(), "bat".encodeUtf8()),
       redis.lrange(sourceKey, 0, -1)
     )
   }


### PR DESCRIPTION
This PR adds support for the RPUSH, LPOP and RPOP commands for redis lists.

```
RPUSH key element [element...]
```

```
LPOP key [count]
```

```
RPOP key [count]
```

The tests against the FakeRedis for these commands have been verified against a Redis REPL.

---

It also fixes a somewhat subtle bug with the FakeRedis implementation of LPUSH. Previously, FakeRedis would push the entire ordered list of elements to the head of an existing list. This contrasts Redis' actual behaviour for LPUSH, which is to push _each_ element one at a time to the head of the list.

Old behaviour:

```
redis.lpush("mylist", "a", "b", "c")
redis.lrange("mylist", 0, -1) // listOf("a", "b", "c")
```

New correct behaviour:

```
redis.lpush("mylist", "a", "b", "c")
redis.lrange("mylist", 0, -1) // listOf("c", "b", "a")
```

Tests that relied on this (wrong) behaviour have been minimally updated to reflect the behaviour as documented, and tested against a Redis REPL.