### PR TITLE
Add configurable concurrency limits

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1076,6 +1076,27 @@ public final class misk/tracing/TracerExtKt {
 	public static synthetic fun traceWithSpan$default (Lio/opentracing/Tracer;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class misk/web/ConcurrencyLimiterConfig {
+	public fun <init> ()V
+	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)V
+	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lorg/slf4j/event/Level;
+	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)Lmisk/web/ConcurrencyLimiterConfig;
+	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getInitial_limit ()Ljava/lang/Integer;
+	public final fun getLog_level ()Lorg/slf4j/event/Level;
+	public final fun getMax_concurrency ()Ljava/lang/Integer;
+	public final fun getStrategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class misk/web/CorsConfig {
 	public fun <init> ()V
 	public fun <init> ([Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;ZLjava/lang/String;Z[Ljava/lang/String;)V
@@ -1298,8 +1319,8 @@ public abstract interface class misk/web/WebActionSeedDataTransformerFactory {
 public final class misk/web/WebConfig : wisp/config/Config {
 	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;)V
 	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)V
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()I
@@ -1314,13 +1335,11 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component2 ()J
 	public final fun component20 ()Ljava/util/Map;
 	public final fun component21 ()Z
-	public final fun component22 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
-	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component22 ()Lorg/slf4j/event/Level;
+	public final fun component23 ()Lmisk/web/ConcurrencyLimiterConfig;
 	public final fun component24 ()I
-	public final fun component25 ()Lorg/slf4j/event/Level;
-	public final fun component26 ()I
-	public final fun component27 ()Ljava/lang/Integer;
-	public final fun component28 ()Ljava/lang/Integer;
+	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component26 ()Ljava/lang/Integer;
 	public final fun component3 ()I
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lmisk/web/WebSslConfig;
@@ -1328,17 +1347,15 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/lang/Integer;
-	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
 	public final fun getClose_connection_percent ()D
+	public final fun getConcurrency_limiter ()Lmisk/web/ConcurrencyLimiterConfig;
 	public final fun getConcurrency_limiter_disabled ()Z
-	public final fun getConcurrency_limiter_initial_limit ()I
 	public final fun getConcurrency_limiter_log_level ()Lorg/slf4j/event/Level;
-	public final fun getConcurrency_limiter_max_concurrency ()Ljava/lang/Integer;
-	public final fun getConcurrency_limiter_strategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public final fun getCors ()Ljava/util/Map;
 	public final fun getEnable_thread_pool_queue_metrics ()Z
 	public final fun getGzip ()Z
@@ -1486,7 +1503,7 @@ public final class misk/web/concurrencylimits/ConcurrencyLimiterStrategy : java/
 }
 
 public final class misk/web/concurrencylimits/ConcurrencyLimitsModule : misk/inject/KAbstractModule {
-	public fun <init> (Lmisk/web/WebConfig;)V
+	public fun <init> (Lmisk/web/ConcurrencyLimiterConfig;)V
 	public final fun concurrencyLimiterFactory (Ljavax/inject/Provider;Ljava/time/Clock;)Lmisk/web/concurrencylimits/ConcurrencyLimiterFactory;
 }
 

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1078,17 +1078,19 @@ public final class misk/tracing/TracerExtKt {
 
 public final class misk/web/ConcurrencyLimiterConfig {
 	public fun <init> ()V
-	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;)V
-	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)V
+	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/ConcurrencyLimiterConfig;
-	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
+	public final fun component5 ()Lorg/slf4j/event/Level;
+	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)Lmisk/web/ConcurrencyLimiterConfig;
+	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getEnabled ()Z
+	public final fun getDisabled ()Z
 	public final fun getInitial_limit ()Ljava/lang/Integer;
+	public final fun getLog_level ()Lorg/slf4j/event/Level;
 	public final fun getMax_concurrency ()Ljava/lang/Integer;
 	public final fun getStrategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public fun hashCode ()I

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1298,8 +1298,8 @@ public abstract interface class misk/web/WebActionSeedDataTransformerFactory {
 public final class misk/web/WebConfig : wisp/config/Config {
 	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;)V
 	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)V
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()I
@@ -1314,10 +1314,13 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component2 ()J
 	public final fun component20 ()Ljava/util/Map;
 	public final fun component21 ()Z
-	public final fun component22 ()Lorg/slf4j/event/Level;
-	public final fun component23 ()I
-	public final fun component24 ()Ljava/lang/Integer;
-	public final fun component25 ()Ljava/lang/Integer;
+	public final fun component22 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public final fun component23 ()Ljava/lang/Integer;
+	public final fun component24 ()I
+	public final fun component25 ()Lorg/slf4j/event/Level;
+	public final fun component26 ()I
+	public final fun component27 ()Ljava/lang/Integer;
+	public final fun component28 ()Ljava/lang/Integer;
 	public final fun component3 ()I
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lmisk/web/WebSslConfig;
@@ -1325,14 +1328,17 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/lang/Integer;
-	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;ILorg/slf4j/event/Level;ILjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
 	public final fun getClose_connection_percent ()D
 	public final fun getConcurrency_limiter_disabled ()Z
+	public final fun getConcurrency_limiter_initial_limit ()I
 	public final fun getConcurrency_limiter_log_level ()Lorg/slf4j/event/Level;
+	public final fun getConcurrency_limiter_max_concurrency ()Ljava/lang/Integer;
+	public final fun getConcurrency_limiter_strategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public final fun getCors ()Ljava/util/Map;
 	public final fun getEnable_thread_pool_queue_metrics ()Z
 	public final fun getGzip ()Z
@@ -1464,6 +1470,26 @@ public final class misk/web/actions/WebActionsKt {
 	public static final fun asChain (Lmisk/web/actions/WebAction;Lkotlin/reflect/KFunction;Ljava/util/List;Ljava/util/List;Lmisk/web/HttpCall;)Lmisk/Chain;
 }
 
+public abstract interface class misk/web/concurrencylimits/ConcurrencyLimiterFactory {
+	public abstract fun create (Lmisk/Action;)Lcom/netflix/concurrency/limits/Limiter;
+}
+
+public final class misk/web/concurrencylimits/ConcurrencyLimiterStrategy : java/lang/Enum {
+	public static final field AIMD Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static final field FIXED Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static final field GRADIENT Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static final field GRADIENT2 Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static final field SETTABLE Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static final field VEGAS Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static fun values ()[Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+}
+
+public final class misk/web/concurrencylimits/ConcurrencyLimitsModule : misk/inject/KAbstractModule {
+	public fun <init> (Lmisk/web/WebConfig;)V
+	public final fun concurrencyLimiterFactory (Ljavax/inject/Provider;Ljava/time/Clock;)Lmisk/web/concurrencylimits/ConcurrencyLimiterFactory;
+}
+
 public final class misk/web/exceptions/ActionExceptionLogLevelConfig : wisp/config/Config {
 	public fun <init> ()V
 	public fun <init> (Lorg/slf4j/event/Level;Lorg/slf4j/event/Level;)V
@@ -1572,10 +1598,6 @@ public final class misk/web/formatter/ClassNameFormatter$Companion {
 }
 
 public abstract interface annotation class misk/web/interceptors/BeforeContentEncoding : java/lang/annotation/Annotation {
-}
-
-public abstract interface class misk/web/interceptors/ConcurrencyLimiterFactory {
-	public abstract fun create (Lmisk/Action;)Lcom/netflix/concurrency/limits/Limiter;
 }
 
 public final class misk/web/interceptors/InternalErrorInterceptorFactory : misk/web/NetworkInterceptor$Factory {

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1078,19 +1078,17 @@ public final class misk/tracing/TracerExtKt {
 
 public final class misk/web/ConcurrencyLimiterConfig {
 	public fun <init> ()V
-	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)V
-	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Lorg/slf4j/event/Level;
-	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)Lmisk/web/ConcurrencyLimiterConfig;
-	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
+	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;)Lmisk/web/ConcurrencyLimiterConfig;
+	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnabled ()Z
 	public final fun getInitial_limit ()Ljava/lang/Integer;
-	public final fun getLog_level ()Lorg/slf4j/event/Level;
 	public final fun getMax_concurrency ()Ljava/lang/Integer;
 	public final fun getStrategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public fun hashCode ()I

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -164,7 +164,7 @@ class MiskWebModule(
       .to<MetricsInterceptor.Factory>()
 
     newMultibinder<ConcurrencyLimiterFactory>()
-    if (!config.concurrency_limiter_disabled && config.concurrency_limiter?.enabled != false) {
+    if (!config.concurrency_limiter_disabled && config.concurrency_limiter?.disabled != true) {
       // Shed calls when we're degraded.
       multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<ConcurrencyLimitsInterceptor.Factory>()

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -178,7 +178,6 @@ class MiskWebModule(
         // to support.
         initial_limit = config.concurrency_limiter.initial_limit
           ?: (config.jetty_max_thread_pool_size / 2),
-        log_level = config.concurrency_limiter.log_level ?: config.concurrency_limiter_log_level,
       )
       concurrencyLimiterConfig?.let { install(ConcurrencyLimitsModule(it)) }
     }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -50,7 +50,8 @@ import misk.web.extractors.ResponseBodyFeatureBinding
 import misk.web.extractors.WebSocketFeatureBinding
 import misk.web.extractors.WebSocketListenerFeatureBinding
 import misk.web.interceptors.BeforeContentEncoding
-import misk.web.interceptors.ConcurrencyLimiterFactory
+import misk.web.concurrencylimits.ConcurrencyLimiterFactory
+import misk.web.concurrencylimits.ConcurrencyLimitsModule
 import misk.web.interceptors.ConcurrencyLimitsInterceptor
 import misk.web.interceptors.ForContentEncoding
 import misk.web.interceptors.GunzipRequestBodyInterceptor
@@ -164,6 +165,8 @@ class MiskWebModule(
 
     newMultibinder<ConcurrencyLimiterFactory>()
     if (!config.concurrency_limiter_disabled) {
+      install(ConcurrencyLimitsModule(config))
+
       // Shed calls when we're degraded.
       multibind<NetworkInterceptor.Factory>(MiskDefault::class)
         .to<ConcurrencyLimitsInterceptor.Factory>()

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -230,12 +230,15 @@ data class CorsConfig(
 
 data class ConcurrencyLimiterConfig(
   /** If true, disables automatic load shedding when degraded. */
-  val enabled: Boolean = true,
+  val disabled: Boolean = false,
 
   /** The algorithm to use for determining concurrency limits. */
   val strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
 
-  /** Maximum allowed concurrency limit providing an upper bound failsafe. */
+  /**
+   * Maximum allowed concurrency limit providing an upper bound failsafe. At runtime, this will
+   * default to half of the jetty_max_thread_pool_size if not set.
+   */
   val max_concurrency: Int? = null,
 
   /** Initial limit used by the concurrency limiter. */

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -2,6 +2,7 @@ package misk.web
 
 import misk.security.ssl.CertStoreConfig
 import misk.security.ssl.TrustStoreConfig
+import misk.web.concurrencylimits.ConcurrencyLimiterStrategy
 import misk.web.exceptions.ActionExceptionLogLevelConfig
 import org.slf4j.event.Level
 import wisp.config.Config
@@ -89,6 +90,21 @@ data class WebConfig(
 
   /** If true, disables automatic load shedding when degraded. */
   val concurrency_limiter_disabled: Boolean = false,
+
+  /** The algorithm to use for determining concurrency limits. */
+  val concurrency_limiter_strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
+
+  /** Maximum allowed concurrency limit providing an upper bound failsafe */
+  val concurrency_limiter_max_concurrency: Int? = null,
+
+  /**
+   * Initial limit used by the concurrency limiter
+   *
+   * 2 is chosen somewhat arbitrarily here. Most services have one or two endpoints that receive
+   * the majority of traffic (power law, yay!), and those endpoints should _start up_ without
+   * triggering the concurrency limiter at the parallelism that we configured Jetty to support.
+   */
+  val concurrency_limiter_initial_limit: Int = jetty_max_thread_pool_size / 2,
 
   /** The level of log when concurrency shedding. */
   val concurrency_limiter_log_level: Level = Level.ERROR,

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -91,23 +91,11 @@ data class WebConfig(
   /** If true, disables automatic load shedding when degraded. */
   val concurrency_limiter_disabled: Boolean = false,
 
-  /** The algorithm to use for determining concurrency limits. */
-  val concurrency_limiter_strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
-
-  /** Maximum allowed concurrency limit providing an upper bound failsafe */
-  val concurrency_limiter_max_concurrency: Int? = null,
-
-  /**
-   * Initial limit used by the concurrency limiter
-   *
-   * 2 is chosen somewhat arbitrarily here. Most services have one or two endpoints that receive
-   * the majority of traffic (power law, yay!), and those endpoints should _start up_ without
-   * triggering the concurrency limiter at the parallelism that we configured Jetty to support.
-   */
-  val concurrency_limiter_initial_limit: Int = jetty_max_thread_pool_size / 2,
-
   /** The level of log when concurrency shedding. */
   val concurrency_limiter_log_level: Level = Level.ERROR,
+
+  /* Custom configuration for calculating concurrency limits */
+  val concurrency_limiter: ConcurrencyLimiterConfig? = null,
 
   /** The number of milliseconds to sleep before commencing service shutdown. */
   val shutdown_sleep_ms: Int = 0,
@@ -238,4 +226,23 @@ data class CorsConfig(
   val chainPreflight: Boolean = true,
   /** A comma separated list of HTTP headers that are allowed to be exposed on the client. */
   val exposedHeaders: Array<String> = arrayOf()
+)
+
+data class ConcurrencyLimiterConfig(
+  /** If true, disables automatic load shedding when degraded. */
+  val enabled: Boolean = true,
+
+  /** The algorithm to use for determining concurrency limits. */
+  val strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
+
+  /** Maximum allowed concurrency limit providing an upper bound failsafe */
+  val max_concurrency: Int? = null,
+
+  /**
+   * Initial limit used by the concurrency limiter
+   */
+  val initial_limit: Int? = null,
+
+  /** The level of log when concurrency shedding. */
+  val log_level: Level? = null,
 )

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -235,14 +235,9 @@ data class ConcurrencyLimiterConfig(
   /** The algorithm to use for determining concurrency limits. */
   val strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
 
-  /** Maximum allowed concurrency limit providing an upper bound failsafe */
+  /** Maximum allowed concurrency limit providing an upper bound failsafe. */
   val max_concurrency: Int? = null,
 
-  /**
-   * Initial limit used by the concurrency limiter
-   */
+  /** Initial limit used by the concurrency limiter. */
   val initial_limit: Int? = null,
-
-  /** The level of log when concurrency shedding. */
-  val log_level: Level? = null,
 )

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterFactory.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterFactory.kt
@@ -1,4 +1,4 @@
-package misk.web.interceptors
+package misk.web.concurrencylimits
 
 import com.netflix.concurrency.limits.Limiter
 import misk.Action

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterStrategy.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterStrategy.kt
@@ -1,0 +1,10 @@
+package misk.web.concurrencylimits
+
+enum class ConcurrencyLimiterStrategy {
+  VEGAS,
+  GRADIENT,
+  GRADIENT2,
+  AIMD,
+  SETTABLE,
+  ;
+}

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterStrategy.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimiterStrategy.kt
@@ -1,10 +1,50 @@
 package misk.web.concurrencylimits
 
+/**
+ * Per the [Netflix library](https://github.com/Netflix/concurrency-limits#readme), strategies for
+ * calculating concurrency limits based on existing traffic. For more information, please consult
+ * the [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/package-summary.html).
+ */
 enum class ConcurrencyLimiterStrategy {
+  /**
+   * A limiter based on TCP Vegas where the limit increases by alpha if the queue_use is small
+   * (< alpha) and decreases by alpha if the queue_use is large (> beta). See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/VegasLimit.html)
+   * for more information.
+   */
   VEGAS,
+
+  /**
+   * Concurrency limit algorithm that adjust the limits based on the gradient of change in the
+   * samples minimum RTT and absolute minimum RTT allowing for a queue of square root of the
+   * current limit. See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/GradientLimit.html)
+   * for more information.
+   */
   GRADIENT,
+
+  /**
+   * Concurrency limit algorithm that adjusts the limit based on the gradient of change of the
+   * current average RTT and a long term exponentially smoothed average RTT. See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/Gradient2Limit.html)
+   * for more information.
+   */
   GRADIENT2,
+
+  /**
+   * Loss based dynamic Limit that does an additive increment as long as there are no errors and a
+   * multiplicative decrement when there is an error. See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/AIMDLimit.html)
+   * for more information.
+   */
   AIMD,
+
+  /**
+   * Limit to be used mostly for testing where the limit can be manually adjusted. See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/SettableLimit.html)
+   * for more information.
+   */
   SETTABLE,
+
+  /**
+   * Non dynamic limit with fixed value. See [documentation](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/FixedLimit.html)
+   * for more information.
+   */
+  FIXED,
   ;
 }

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
@@ -5,6 +5,7 @@ import com.google.inject.multibindings.ProvidesIntoSet
 import com.netflix.concurrency.limits.Limit
 import com.netflix.concurrency.limits.Limiter
 import com.netflix.concurrency.limits.limit.AIMDLimit
+import com.netflix.concurrency.limits.limit.FixedLimit
 import com.netflix.concurrency.limits.limit.Gradient2Limit
 import com.netflix.concurrency.limits.limit.GradientLimit
 import com.netflix.concurrency.limits.limit.SettableLimit
@@ -53,12 +54,16 @@ class ConcurrencyLimitsModule(
       }.build()
     ConcurrencyLimiterStrategy.AIMD ->
       AIMDLimit.newBuilder().apply {
-        webConfig.concurrency_limiter_initial_limit?.let { initialLimit(it) }
+        initialLimit(webConfig.concurrency_limiter_initial_limit)
         webConfig.concurrency_limiter_max_concurrency?.let { maxLimit(it) }
       }.build()
     ConcurrencyLimiterStrategy.SETTABLE ->
       webConfig.concurrency_limiter_max_concurrency
         ?.let { SettableLimit.startingAt(it) }
         ?: throw IllegalStateException("SettableLimit algorithm requires 'maxConcurrency'")
+    ConcurrencyLimiterStrategy.FIXED ->
+      webConfig.concurrency_limiter_max_concurrency
+        ?.let { FixedLimit.of(it) }
+        ?: throw IllegalStateException("FixedLimitx algorithm requires 'maxConcurrency'")
   }
 }

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
@@ -74,6 +74,6 @@ class ConcurrencyLimitsModule(
     ConcurrencyLimiterStrategy.FIXED ->
       config.max_concurrency
         ?.let { FixedLimit.of(it) }
-        ?: throw IllegalStateException("FixedLimitx algorithm requires 'maxConcurrency'")
+        ?: throw IllegalStateException("FixedLimit algorithm requires 'maxConcurrency'")
   }
 }

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
@@ -1,0 +1,64 @@
+package misk.web.concurrencylimits
+
+import com.google.inject.Provides
+import com.google.inject.multibindings.ProvidesIntoSet
+import com.netflix.concurrency.limits.Limit
+import com.netflix.concurrency.limits.Limiter
+import com.netflix.concurrency.limits.limit.AIMDLimit
+import com.netflix.concurrency.limits.limit.Gradient2Limit
+import com.netflix.concurrency.limits.limit.GradientLimit
+import com.netflix.concurrency.limits.limit.SettableLimit
+import com.netflix.concurrency.limits.limit.VegasLimit
+import com.netflix.concurrency.limits.limiter.SimpleLimiter
+import misk.Action
+import misk.inject.KAbstractModule
+import misk.web.WebConfig
+import java.time.Clock
+import javax.inject.Provider
+import javax.inject.Singleton
+
+class ConcurrencyLimitsModule(
+  private val webConfig: WebConfig
+) : KAbstractModule() {
+  @ProvidesIntoSet
+  @Singleton
+  fun concurrencyLimiterFactory(
+    limit: Provider<Limit>,
+    clock: Clock
+  ): ConcurrencyLimiterFactory =
+    /**
+     * This will create the SimpleLimiter with the same Limit algorithm
+     * for each every action. This can be configured per action if needed.
+     */
+    object : ConcurrencyLimiterFactory {
+      override fun create(action: Action): Limiter<String>? = SimpleLimiter.Builder()
+        .clock { clock.millis() }
+        .named(action.name)
+        .limit(limit.get())
+        .build()
+    }
+
+  private fun limit() = when (webConfig.concurrency_limiter_strategy) {
+    ConcurrencyLimiterStrategy.VEGAS ->
+      VegasLimit.newBuilder().apply {
+        webConfig.concurrency_limiter_max_concurrency?.let { maxConcurrency(it) }
+      }.build()
+    ConcurrencyLimiterStrategy.GRADIENT ->
+      GradientLimit.newBuilder().apply {
+        webConfig.concurrency_limiter_max_concurrency?.let { maxConcurrency(it) }
+      }.build()
+    ConcurrencyLimiterStrategy.GRADIENT2 ->
+      Gradient2Limit.newBuilder().apply {
+        webConfig.concurrency_limiter_max_concurrency?.let { maxConcurrency(it) }
+      }.build()
+    ConcurrencyLimiterStrategy.AIMD ->
+      AIMDLimit.newBuilder().apply {
+        webConfig.concurrency_limiter_initial_limit?.let { initialLimit(it) }
+        webConfig.concurrency_limiter_max_concurrency?.let { maxLimit(it) }
+      }.build()
+    ConcurrencyLimiterStrategy.SETTABLE ->
+      webConfig.concurrency_limiter_max_concurrency
+        ?.let { SettableLimit.startingAt(it) }
+        ?: throw IllegalStateException("SettableLimit algorithm requires 'maxConcurrency'")
+  }
+}

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -173,7 +173,8 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
         action = action,
         defaultLimiter = createLimiterForAction(action, quotaPath = null),
         clock = clock,
-        logLevel = config.concurrency_limiter_log_level
+        logLevel = config.concurrency_limiter?.log_level
+          ?: config.concurrency_limiter_log_level
       )
     }
 

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -13,7 +13,6 @@ import misk.web.AvailableWhenDegraded
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import misk.web.WebConfig
-import misk.web.concurrencylimits.ConcurrencyLimiterFactory
 import org.slf4j.event.Level
 import wisp.logging.getLogger
 import wisp.logging.log

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -13,6 +13,7 @@ import misk.web.AvailableWhenDegraded
 import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import misk.web.WebConfig
+import misk.web.concurrencylimits.ConcurrencyLimiterFactory
 import org.slf4j.event.Level
 import wisp.logging.getLogger
 import wisp.logging.log

--- a/misk/src/test/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsStrategyTest.kt
+++ b/misk/src/test/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsStrategyTest.kt
@@ -1,0 +1,152 @@
+package misk.web.concurrencylimits
+
+import com.netflix.concurrency.limits.Limit
+import com.netflix.concurrency.limits.limit.AIMDLimit
+import com.netflix.concurrency.limits.limit.FixedLimit
+import com.netflix.concurrency.limits.limit.Gradient2Limit
+import com.netflix.concurrency.limits.limit.GradientLimit
+import com.netflix.concurrency.limits.limit.SettableLimit
+import com.netflix.concurrency.limits.limit.VegasLimit
+import com.netflix.concurrency.limits.limiter.SimpleLimiter
+import misk.MiskTestingServiceModule
+import misk.asAction
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.ConcurrencyLimiterConfig
+import misk.web.DispatchMechanism
+import misk.web.Get
+import misk.web.MiskWebModule
+import misk.web.WebConfig
+import misk.web.actions.WebAction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import wisp.deployment.Deployment
+import wisp.deployment.TESTING
+import javax.inject.Inject
+
+@MiskTest(startService = true)
+class ConcurrencyLimitsStrategyTest {
+  private lateinit var strategy: ConcurrencyLimiterStrategy
+  private var maxConcurrency: Int? = null
+
+  @MiskTestModule
+  val module = object : KAbstractModule() {
+    override fun configure() {
+      bind<Deployment>().toInstance(TESTING)
+
+      install(MiskTestingServiceModule())
+
+      newMultibinder<ConcurrencyLimiterFactory>()
+      install(
+        MiskWebModule(
+          WebConfig(
+            port = 0,
+            concurrency_limiter = ConcurrencyLimiterConfig(
+              strategy = strategy,
+              max_concurrency = maxConcurrency,
+            )
+          )
+        )
+      )
+    }
+  }
+
+  @Inject private lateinit var limiterFactories: List<ConcurrencyLimiterFactory>
+  @Inject private lateinit var limit: Limit
+
+  private class HelloAction : WebAction {
+    @Get("/hello")
+    fun call(): String = "hello"
+  }
+
+  private fun List<ConcurrencyLimiterFactory>.createLimit() =
+    first().create(HelloAction::call.asAction(DispatchMechanism.POST))
+
+  @Nested
+  inner class VegasStrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.VEGAS
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(VegasLimit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+
+  @Nested
+  inner class GradientStrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.GRADIENT
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(GradientLimit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+
+  @Nested
+  inner class Gradient2StrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.GRADIENT2
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(Gradient2Limit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+
+  @Nested
+  inner class AimdStrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.AIMD
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(AIMDLimit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+
+  @Nested
+  inner class SettableStrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.SETTABLE
+      maxConcurrency = 3
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(SettableLimit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+
+  @Nested
+  inner class FixedStrategyTest {
+    init {
+      strategy = ConcurrencyLimiterStrategy.FIXED
+      maxConcurrency = 3
+    }
+
+    @Test
+    fun `limiter factory is bound`() {
+      assertThat(limit).isInstanceOf(FixedLimit::class.java)
+      assertThat(limiterFactories).hasSize(1)
+      assertThat(limiterFactories.createLimit()).isInstanceOf(SimpleLimiter::class.java)
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -25,6 +25,7 @@ import misk.web.actions.LivenessCheckAction
 import misk.web.actions.ReadinessCheckAction
 import misk.web.actions.StatusAction
 import misk.web.actions.WebAction
+import misk.web.concurrencylimits.ConcurrencyLimiterFactory
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
This PR adds support for custom concurrency limit configuration. This will allow developers to configure:
* Limiting strategies (from the ones [defined](https://javadoc.io/static/com.netflix.concurrency-limits/concurrency-limits-core/0.3.6/com/netflix/concurrency/limits/limit/package-summary.html) by the original Netflix library)
* The maximum allowed concurrency limit (providing an upper bound failsafe)
* The initial limit used by the ratelimiter

Developers must opt-in to this new functionality by setting the `WebConfig#concurrency_limiter`. If this is not set, the existing behavior/defaults will be honored.