### PR TITLE
Return a 415 to help decrease developer debugging time

### DIFF
--- a/misk-jdbc-testing/src/main/kotlin/misk/vitess/VitessScaleSafetyChecks.kt
+++ b/misk-jdbc-testing/src/main/kotlin/misk/vitess/VitessScaleSafetyChecks.kt
@@ -17,7 +17,6 @@ import net.ttddyy.dsproxy.support.ProxyDataSource
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import wisp.containers.ContainerUtil
-import java.io.File
 import java.sql.Connection
 import java.sql.Timestamp
 import java.util.ArrayDeque

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1428,7 +1428,6 @@ public final class misk/web/actions/LivenessCheckAction : misk/web/actions/WebAc
 
 public final class misk/web/actions/NotFoundAction : misk/web/actions/WebAction {
 	public static final field Companion Lmisk/web/actions/NotFoundAction$Companion;
-	public fun <init> (Lmisk/scope/ActionScoped;)V
 	public final fun notFound (Ljava/lang/String;)Lmisk/web/Response;
 }
 

--- a/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/NotFoundAction.kt
@@ -2,6 +2,7 @@ package misk.web.actions
 
 import misk.scope.ActionScoped
 import misk.security.authz.Unauthenticated
+import misk.web.BoundActionMatch
 import misk.web.Get
 import misk.web.HttpCall
 import misk.web.PathParam
@@ -20,22 +21,69 @@ import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
-class NotFoundAction @Inject constructor(
-  @JvmSuppressWildcards private val clientHttpCall: ActionScoped<HttpCall>
+class NotFoundAction @Inject internal constructor(
+  @JvmSuppressWildcards private val clientHttpCall: ActionScoped<HttpCall>,
+  private val servletProvider: Provider<WebActionsServlet>
 ) : WebAction {
-  @Inject internal lateinit var servletProvider: Provider<WebActionsServlet>
-
   @Get("/{path:.*}")
   @Post("/{path:.*}")
   @RequestContentType(MediaTypes.ALL)
   @ResponseContentType(MediaTypes.ALL)
   @Unauthenticated
   fun notFound(@PathParam path: String): Response<ResponseBody> {
+    val httpCall = clientHttpCall.get()
+    val httpMethod = httpCall.dispatchMechanism.method
+    val alternativeActions = urlOnlyMatches(httpCall)
+    // If there are any actions that match on URL the client is likely using the wrong
+    // content type or the wrong method, so we'll return a 405 (wrong method) or
+    // 415 (wrong media type).
+    val statusCode = when {
+      alternativeActions.isEmpty() -> 404
+      alternativeActions.none { it.action.metadata.httpMethod == httpMethod } -> 405
+      else -> 415
+    }
+
     return Response(
-      body = notFoundMessage(path, clientHttpCall.get()).toResponseBody(),
+      body = notFoundMessage(path, alternativeActions, httpCall).toResponseBody(),
       headers = headersOf("Content-Type", MediaTypes.TEXT_PLAIN_UTF8),
-      statusCode = 404
+      statusCode = statusCode
     )
+  }
+
+  /** Generates a message for a client that hints what may have been wrong with their request. */
+  private fun notFoundMessage(
+    path: String,
+    alternativeActions: List<BoundActionMatch>,
+    httpCall: HttpCall
+  ) = buildString {
+    append("Nothing found at /$path.\n\n")
+    append("Received:\n")
+    append("${httpCall.dispatchMechanism.method} /$path\n")
+    for (accept in httpCall.accepts()) {
+      append("Accept: $accept\n")
+    }
+    val contentType = httpCall.contentType()
+    if (contentType != null) {
+      append("Content-Type: $contentType\n")
+    }
+
+    for (element in alternativeActions) {
+      append("\n")
+      val metadata = element.action.metadata
+      append("Alternative:\n")
+      append("${metadata.httpMethod} ${metadata.pathPattern}\n")
+      append("Accept: ${metadata.responseMediaType}\n")
+      for (requestContentType in metadata.requestMediaTypes) {
+        append("Content-Type: $requestContentType\n")
+      }
+    }
+  }
+
+  private fun urlOnlyMatches(httpCall: HttpCall): List<BoundActionMatch> {
+    val boundActions = servletProvider.get().boundActions
+    return boundActions.mapNotNull {
+      it.matchByUrl(httpCall.url)
+    }.filterNot { it.action.pathPattern.matchesWildcardPath }
   }
 
   companion object {
@@ -48,37 +96,6 @@ class NotFoundAction @Inject constructor(
         headers = headersOf("Content-Type", MediaTypes.TEXT_PLAIN_UTF8),
         statusCode = 404
       )
-    }
-  }
-
-  /** Generates a message for a client that hints what may have been wrong with their request. */
-  private fun notFoundMessage(path: String, httpCall: HttpCall) = buildString {
-    val boundActions = servletProvider.get().boundActions
-    val alternativeActions = boundActions.mapNotNull {
-      it.matchByUrl(httpCall.url)
-    }.filterNot { it.action.pathPattern.matchesWildcardPath }
-
-    append("Nothing found at /$path.\n\n")
-    append("Received:\n")
-    append("${httpCall.dispatchMechanism.method} /$path\n")
-    for (accept in httpCall.accepts()) {
-      append("Accept: $accept\n")
-    }
-    val contentType = httpCall.contentType()
-    if (contentType != null) {
-      append("Content-Type: ${httpCall.contentType()}\n")
-    }
-
-    for (i in 0 until alternativeActions.size) {
-      append("\n")
-      val alternative = alternativeActions[i]
-      val metadata = alternative.action.metadata
-      append("Alternative:\n")
-      append("${metadata.httpMethod} ${metadata.pathPattern}\n")
-      append("Accept: ${metadata.responseMediaType}\n")
-      for (requestContentType in metadata.requestMediaTypes) {
-        append("Content-Type: $requestContentType\n")
-      }
     }
   }
 }

--- a/misk/src/main/kotlin/misk/web/proxy/WebProxyAction.kt
+++ b/misk/src/main/kotlin/misk/web/proxy/WebProxyAction.kt
@@ -13,16 +13,12 @@ import misk.web.ResponseContentType
 import misk.web.actions.NotFoundAction
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
-import misk.web.mediatype.asMediaType
 import misk.web.resources.ResourceEntryFinder
 import misk.web.resources.StaticResourceAction
 import misk.web.toMisk
-import misk.web.toResponseBody
-import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import java.io.IOException
-import java.net.HttpURLConnection
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -52,7 +48,6 @@ class WebProxyAction @Inject constructor(
   private val staticResourceAction: StaticResourceAction,
   private val resourceEntryFinder: ResourceEntryFinder
 ) : WebAction {
-
   @Get("/{path:.*}")
   @Post("/{path:.*}")
   @RequestContentType(MediaTypes.ALL)
@@ -79,24 +74,16 @@ class WebProxyAction @Inject constructor(
     }
   }
 
-  private fun fetchFailResponse(clientRequestUrl: HttpUrl): Response<ResponseBody> {
-    return Response(
-      "Failed to fetch upstream URL $clientRequestUrl".toResponseBody(),
-      headersOf("Content-Type", MediaTypes.TEXT_PLAIN_UTF8.asMediaType().toString()),
-      HttpURLConnection.HTTP_UNAVAILABLE
-    )
-  }
-
   private fun okhttp3.Request.forwardedWithUrl(newUrl: HttpUrl): okhttp3.Request {
     // TODO(adrw) include the client URL/IP as the for= field for Forwarded
     return newBuilder()
       .addHeader(
         "Forwarded",
         "for=; by=${
-        HttpUrl.Builder()
-          .scheme(this.url.scheme)
-          .host(this.url.host)
-          .port(this.url.port)
+          HttpUrl.Builder()
+            .scheme(this.url.scheme)
+            .host(this.url.host)
+            .port(this.url.port)
         }"
       )
       .url(newUrl)

--- a/misk/src/main/kotlin/misk/web/resources/StaticResourceAction.kt
+++ b/misk/src/main/kotlin/misk/web/resources/StaticResourceAction.kt
@@ -36,7 +36,6 @@ class StaticResourceAction @Inject constructor(
   private val resourceLoader: ResourceLoader,
   private val resourceEntryFinder: ResourceEntryFinder
 ) : WebAction {
-
   @Get("/{path:.*}")
   @Post("/{path:.*}")
   @RequestContentType(MediaTypes.ALL)
@@ -48,12 +47,10 @@ class StaticResourceAction @Inject constructor(
   }
 
   fun getResponse(httpCall: HttpCall): Response<ResponseBody> {
-    val entry =
-      (
-        resourceEntryFinder.staticResource(httpCall.url) as StaticResourceEntry?
-          ?: return NotFoundAction.response(httpCall.url.encodedPath.drop(1))
-        )
-    return MatchedResource(entry).getResponse(httpCall)
+    val staticResourceEntry =
+      resourceEntryFinder.staticResource(httpCall.url) as StaticResourceEntry?
+        ?: return NotFoundAction.response(httpCall.url.encodedPath.drop(1))
+    return MatchedResource(staticResourceEntry).getResponse(httpCall)
   }
 
   private enum class Kind {
@@ -72,8 +69,10 @@ class StaticResourceAction @Inject constructor(
           urlPath.endsWith("/") -> resourceResponse(
             normalizePath(matchedEntry.url_path_prefix)
           )
+
           else -> null
         }
+
         Kind.RESOURCE -> resourceResponse(urlPath)
         Kind.RESOURCE_DIRECTORY -> resourceResponse(normalizePathWithQuery(httpCall.url))
       } ?: NotFoundAction.response(httpCall.url.encodedPath.drop(1))
@@ -133,6 +132,7 @@ class StaticResourceAction @Inject constructor(
             )
           )
         }
+
         else -> null
       }
     }

--- a/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/NotFoundActionTest.kt
@@ -93,7 +93,7 @@ class NotFoundActionTest {
   @Test fun responseMessageSuggestsAlternativeMethod() {
     val wrongMethod = get("/echo", plainTextMediaType)
     val response = httpClient.newCall(wrongMethod).execute()
-    assertThat(response.code).isEqualTo(404)
+    assertThat(response.code).isEqualTo(405)
     assertThat(response.body!!.source().readUtf8()).isEqualTo(
       """
       |Nothing found at /echo.
@@ -113,7 +113,7 @@ class NotFoundActionTest {
   @Test fun responseMessageSuggestsContentType() {
     val wrongContentType = post("/echo", weirdMediaType, "hello")
     val response = httpClient.newCall(wrongContentType).execute()
-    assertThat(response.code).isEqualTo(404)
+    assertThat(response.code).isEqualTo(415)
     assertThat(response.body!!.source().readUtf8()).isEqualTo(
       """
       |Nothing found at /echo.
@@ -134,7 +134,7 @@ class NotFoundActionTest {
   @Test fun responseMessageSuggestsAcceptType() {
     val wrongAccept = post("/echo", plainTextMediaType, "hello", weirdMediaType)
     val response = httpClient.newCall(wrongAccept).execute()
-    assertThat(response.code).isEqualTo(404)
+    assertThat(response.code).isEqualTo(415)
     assertThat(response.body!!.source().readUtf8()).isEqualTo(
       """
       |Nothing found at /echo.


### PR DESCRIPTION
This commit changes the behavior of misk action matching to return a 415 rather than a 404 when a request matches a URL but not the content type. For example, if there's an action defined as a `POST /hello application/json` and we make a request to `POST /hello text/plain` we will now return a 415 as it's likely the caller is simply using the wrong media types.