### PR TITLE
Fix Redis#hdel docs

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -50,12 +50,11 @@ interface Redis {
   operator fun get(key: String): ByteString?
 
   /**
-   * Delete one or more hash fields
+   * Delete one or more hash [fields] stored at [key].
+   * Specified fields that do not exist are ignored.
    *
-   * @param key the key for which to delete fields
-   * @param fields the specific fields to delete
-   * @return If the field was present in the hash it is deleted and 1 is returned, otherwise 0 is
-   * returned and no operation is performed.
+   * @return The number of fields that were removed from the hash. If the key does not exist,
+   *         it is treated as an empty hash and 0 is returned.
    */
   fun hdel(key: String, vararg fields: String): Long
 

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -156,6 +156,24 @@ class FakeRedisTest {
   }
 
   @Test
+  fun hdelReturnsTheRightNumbers() {
+    redis.hset(
+      key = "movie_years",
+      hash = mapOf(
+        "Star Wars" to "1977".encodeUtf8(),
+        "Rogue One" to "2016".encodeUtf8(),
+        "Jurassic Park" to "1993".encodeUtf8(),
+        "Jurassic World" to "2015".encodeUtf8()
+      )
+    )
+
+    assertThat(redis.hdel("dne", "dne")).isEqualTo(0L)
+    assertThat(redis.hdel("movie_years", "dne")).isEqualTo(0L)
+    assertThat(redis.hdel("movie_years", "Star Wars")).isEqualTo(1L)
+    assertThat(redis.hdel("movie_years", "Rogue One", "Jurassic World", "dne")).isEqualTo(2)
+  }
+
+  @Test
   fun badArgumentsToBatchSet() {
     assertThatThrownBy {
       redis.mset("key".encodeUtf8())


### PR DESCRIPTION
misk-redis inherited documentation from Jedis, which incorrectly describes the return values of Redis' HDEL command.

Fortunately, our FakeRedis implementation actually matches the behaviour from Redis, despite the documentation descrepancy on our interface. I've added a test to make sure it doesn't regress.

This PR updates the docs to reflect the [offical docs](https://redis.io/commands/hdel/).

I've also submitted a PR upstream to Jedis to fix their docs: https://github.com/redis/jedis/pull/3290