### PR TITLE
Add min limit configuration for concurrency limiters

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1078,20 +1078,22 @@ public final class misk/tracing/TracerExtKt {
 
 public final class misk/web/ConcurrencyLimiterConfig {
 	public fun <init> ()V
-	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)V
-	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)V
+	public synthetic fun <init> (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Lorg/slf4j/event/Level;
-	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)Lmisk/web/ConcurrencyLimiterConfig;
-	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Lorg/slf4j/event/Level;
+	public final fun copy (ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;)Lmisk/web/ConcurrencyLimiterConfig;
+	public static synthetic fun copy$default (Lmisk/web/ConcurrencyLimiterConfig;ZLmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/slf4j/event/Level;ILjava/lang/Object;)Lmisk/web/ConcurrencyLimiterConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisabled ()Z
 	public final fun getInitial_limit ()Ljava/lang/Integer;
 	public final fun getLog_level ()Lorg/slf4j/event/Level;
 	public final fun getMax_concurrency ()Ljava/lang/Integer;
+	public final fun getMin_limit ()Ljava/lang/Integer;
 	public final fun getStrategy ()Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -245,6 +245,9 @@ data class ConcurrencyLimiterConfig(
   /** The algorithm to use for determining concurrency limits. */
   val strategy: ConcurrencyLimiterStrategy = ConcurrencyLimiterStrategy.VEGAS,
 
+  /** Minimum concurrency limit allowed. */
+  val min_limit: Int? = null,
+
   /**
    * Maximum allowed concurrency limit providing an upper bound failsafe.
    */

--- a/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
+++ b/misk/src/main/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsModule.kt
@@ -14,7 +14,6 @@ import com.netflix.concurrency.limits.limiter.SimpleLimiter
 import misk.Action
 import misk.inject.KAbstractModule
 import misk.web.ConcurrencyLimiterConfig
-import misk.web.WebConfig
 import java.time.Clock
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -52,18 +51,21 @@ class ConcurrencyLimitsModule(
       GradientLimit.newBuilder().apply {
         config.initial_limit?.let { initialLimit(it) }
         config.max_concurrency?.let { maxConcurrency(it) }
+        config.min_limit?.let { minLimit(it) }
       }.build()
 
     ConcurrencyLimiterStrategy.GRADIENT2 ->
       Gradient2Limit.newBuilder().apply {
         config.initial_limit?.let { initialLimit(it) }
         config.max_concurrency?.let { maxConcurrency(it) }
+        config.min_limit?.let { minLimit(it) }
       }.build()
 
     ConcurrencyLimiterStrategy.AIMD ->
       AIMDLimit.newBuilder().apply {
         config.initial_limit?.let { initialLimit(it) }
         config.max_concurrency?.let { maxLimit(it) }
+        config.min_limit?.let { minLimit(it) }
       }.build()
 
     ConcurrencyLimiterStrategy.SETTABLE ->


### PR DESCRIPTION
Follow up for #2678 adding a minimum allowable limit. This is especially important for services that have a lower request volume, as that lower bound might end up being higher than the expected upper bound.