### PR TITLE
Introduces `PeakGauge`

### DIFF
--- a/misk-metrics-testing/api/misk-metrics-testing.api
+++ b/misk-metrics-testing/api/misk-metrics-testing.api
@@ -26,6 +26,7 @@ public final class misk/metrics/v2/FakeMetrics : misk/metrics/v2/Metrics {
 	public final fun getSample (Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public static synthetic fun getSample$default (Lmisk/metrics/v2/FakeMetrics;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;ILjava/lang/Object;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/prometheus/client/Histogram;
+	public fun peakGauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lmisk/metrics/v2/PeakGauge;
 	public fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lio/prometheus/client/Summary;
 	public final fun summaryCount (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun summaryMean (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -37,6 +37,11 @@ class FakeMetrics @Inject internal constructor(
       .labelNames(*labelNames.toTypedArray())
       .register(registry)
 
+  override fun peakGauge(name: String, help: String, labelNames: List<String>): PeakGauge =
+    PeakGauge.builder(name, help)
+      .labelNames(*labelNames.toTypedArray())
+      .register(registry)
+
   override fun histogram(
     name: String,
     help: String,

--- a/misk-metrics-testing/src/test/kotlin/misk/metrics/v2/FakeMetricsTest.kt
+++ b/misk-metrics-testing/src/test/kotlin/misk/metrics/v2/FakeMetricsTest.kt
@@ -36,6 +36,23 @@ class FakeMetricsTest {
   }
 
   @Test
+  internal fun `peakGauge happy path`() {
+    assertThat(metrics.get("thread_count", "state" to "running")).isNull()
+    val peakGauge = metrics.peakGauge("thread_count", "-", labelNames = listOf("state"))
+      .labels("running")
+    peakGauge.record(10.0)
+    peakGauge.record(20.0)
+    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(20.0)
+    // Another get without a set should result in seeing the initial value (0)
+    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(0.0)
+    peakGauge.record(30.0)
+    peakGauge.record(20.0)
+    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(30.0)
+    // Another get without a set should result in seeing the initial value (0)
+    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(0.0)
+  }
+
+  @Test
   internal fun `summary happy path`() {
     assertThat(metrics.get("call_times", "status" to "200")).isNull()
     val summary = metrics.summary("call_times", "-", labelNames = listOf("status"))

--- a/misk-metrics/api/misk-metrics.api
+++ b/misk-metrics/api/misk-metrics.api
@@ -35,6 +35,7 @@ public abstract interface class misk/metrics/v2/Metrics {
 	public abstract fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
 	public abstract fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
 	public abstract fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/prometheus/client/Histogram;
+	public abstract fun peakGauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lmisk/metrics/v2/PeakGauge;
 	public abstract fun summary (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lio/prometheus/client/Summary;
 }
 
@@ -42,6 +43,7 @@ public final class misk/metrics/v2/Metrics$DefaultImpls {
 	public static synthetic fun counter$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Counter;
 	public static synthetic fun gauge$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Gauge;
 	public static synthetic fun histogram$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Histogram;
+	public static synthetic fun peakGauge$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lmisk/metrics/v2/PeakGauge;
 	public static synthetic fun summary$default (Lmisk/metrics/v2/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lio/prometheus/client/Summary;
 }
 
@@ -51,5 +53,28 @@ public final class misk/metrics/v2/MetricsKt {
 	public static final fun getDefaultQuantiles ()Ljava/util/Map;
 	public static final fun getDefaultSparseBuckets ()Ljava/util/List;
 	public static final fun linearBuckets (DDI)Ljava/util/List;
+}
+
+public final class misk/metrics/v2/PeakGauge : io/prometheus/client/SimpleCollector {
+	public static final field Companion Lmisk/metrics/v2/PeakGauge$Companion;
+	public fun <init> (Lmisk/metrics/v2/PeakGauge$Builder;)V
+	public fun collect ()Ljava/util/List;
+	public synthetic fun newChild ()Ljava/lang/Object;
+}
+
+public final class misk/metrics/v2/PeakGauge$Builder : io/prometheus/client/SimpleCollector$Builder {
+	public fun <init> ()V
+	public synthetic fun create ()Lio/prometheus/client/SimpleCollector;
+	public fun create ()Lmisk/metrics/v2/PeakGauge;
+}
+
+public final class misk/metrics/v2/PeakGauge$Child {
+	public fun <init> ()V
+	public final fun getAndClear ()D
+	public final fun record (D)V
+}
+
+public final class misk/metrics/v2/PeakGauge$Companion {
+	public final fun builder (Ljava/lang/String;Ljava/lang/String;)Lmisk/metrics/v2/PeakGauge$Builder;
 }
 

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -51,6 +51,21 @@ interface Metrics {
   ): Gauge
 
   /**
+   * peakGauge creates and registers a new `Gauge` prometheus type that resets to its
+   * initial value after each metrics collection.
+   *
+   * @param name the name of the metric which will be supplied to prometheus.
+   *  Must be unique across all metric types.
+   * @param help human-readable help text that will be supplied to prometheus.
+   * @param labelNames the names (a.k.a. keys) of all the labels that will be used for this metric.
+   */
+  fun peakGauge(
+    name: String,
+    help: String = "",
+    labelNames: List<String> = listOf()
+  ): PeakGauge
+
+  /**
    * histogram creates a new `Histogram` prometheus type with the supplied parameters.
    *
    * NOTE: `misk.metrics.v2.Metrics` is NOT backward compatible with `misk.metrics.Metrics`.

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/PeakGauge.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/PeakGauge.kt
@@ -1,0 +1,74 @@
+package misk.metrics.v2
+
+import com.google.common.util.concurrent.AtomicDouble
+import io.prometheus.client.SimpleCollector
+import javax.annotation.concurrent.ThreadSafe
+
+/**
+ * A peak gauge is a variant of a [io.prometheus.client.Gauge] that resets to an initial value of 0
+ * after a metric collection.
+ *
+ * This is useful for accurately capturing maximum observed values over time. In contrast to the
+ * histogram maximum which tracks the maximum value in its sampling window. That sampling window
+ * typically covers multiple metric collections.
+ */
+@ThreadSafe
+class PeakGauge  : SimpleCollector<PeakGauge.Child> {
+  constructor(builder: Builder) : super(builder)
+
+  class Builder : SimpleCollector.Builder<Builder, PeakGauge>() {
+    override fun create(): PeakGauge {
+      return PeakGauge(this)
+    }
+  }
+
+  class Child {
+    // For simplicity, using an atomic double with an initial value of 0 here.
+    //
+    // If we cared to differentiate between the initial value due to no samples vs having
+    // samples that are equal or less than 0, then we would need to also track whether we
+    // have received an update since the last reset.
+    private val value = AtomicDouble()
+
+    /**
+     * Updates the stored value if the new value is greater.
+     *
+     *
+     */
+    fun record(newValue: Double) {
+      while (true) {
+        val previous = value.get()
+        if (newValue > previous) {
+          value.compareAndSet(previous, newValue)
+        } else {
+          return
+        }
+      }
+    }
+
+    /**
+     * Reset to the initial value and return previously held value.
+     */
+    fun getAndClear(): Double {
+      return value.getAndSet(0.0)
+    }
+  }
+
+  override fun collect(): MutableList<MetricFamilySamples> {
+    val samples = ArrayList<MetricFamilySamples.Sample>(children.size)
+    for ((labels, value) in children.entries) {
+      samples.add(MetricFamilySamples.Sample(fullname, labelNames, labels, value.getAndClear()))
+    }
+    return familySamplesList(Type.GAUGE, samples)
+  }
+
+  override fun newChild(): Child {
+    return Child()
+  }
+
+  companion object {
+    fun builder(name: String, help: String) : Builder {
+      return Builder().name(name).help(help)
+    }
+  }
+}

--- a/misk-metrics/src/test/kotlin/misk/metrics/v2/PeakGaugeTest.kt
+++ b/misk-metrics/src/test/kotlin/misk/metrics/v2/PeakGaugeTest.kt
@@ -1,0 +1,85 @@
+package misk.metrics.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PeakGaugeTest {
+
+  /**
+   * Verifies that a peak gauge records the correct maximum value and resets to the initial value
+   * after [PeakGauge.Child.getAndClear]
+   */
+  @Test fun `records maximum and resets on getAndClear`() {
+    val builder =
+      PeakGauge.builder("some_name", "some help text").labelNames("some_label_name").create();
+    val gauge = builder.labels("some_label_value")
+
+    // 0 is our implicit initial value
+    assertThat(gauge.getAndClear()).isEqualTo(0.0)
+
+    // We can read a value after setting it
+    gauge.record(37.0)
+    assertThat(gauge.getAndClear()).isEqualTo(37.0)
+
+    // Clearing the value should reset it to the initial value
+    assertThat(gauge.getAndClear()).isEqualTo(0.0)
+
+    // A read after multiple sets returns the peak value
+    gauge.record(10.0)
+    gauge.record(5.0)
+    gauge.record(15.0)
+    gauge.record(20.0)
+    gauge.record(1.0)
+
+    assertThat(gauge.getAndClear()).isEqualTo(20.0)
+  }
+
+  /**
+   * Verifies that [PeakGauge.collect] returns correct information and from and resets each
+   * [PeakGauge.Child].
+   */
+  @Test fun `collection returns correct information and resets each child`() {
+    val builder =
+      PeakGauge.builder("some_name", "some help text")
+        .labelNames("some_label_name", "another_label_name").create();
+    val gauge1 = builder.labels("some_label_value", "another_label_value")
+    gauge1.record(36.0)
+    gauge1.record(37.0)
+
+    val gauge2 = builder.labels("different_label_value", "another_different_label_value")
+    gauge2.record(31.0)
+    gauge2.record(30.0)
+
+    // Perform a collection. This will reset the gauges.
+    val collection = builder.collect()
+
+    // Verify they have been reset.
+    assertThat(gauge1.getAndClear()).isEqualTo(0.0)
+    assertThat(gauge2.getAndClear()).isEqualTo(0.0)
+
+    // We have one set of label names
+    assertThat(collection).hasSize(1);
+
+    // We have 2 gauges with distinct label values: gauge1 and gauge2
+    val byValue = collection[0].samples.groupBy { it.value }
+    assertThat(byValue).hasSize(2)
+
+    // The first gauge should have peak of 37
+    assertThat(byValue.get(37.0)).hasSize(1)
+    assertThat(byValue.get(37.0)!!.get(0).labelValues).isEqualTo(
+      listOf(
+        "some_label_value",
+        "another_label_value"
+      )
+    )
+
+    // The second gauge should have a peak of 31
+    assertThat(byValue.get(31.0)).hasSize(1)
+    assertThat(byValue.get(31.0)!!.get(0).labelValues).isEqualTo(
+      listOf(
+        "different_label_value",
+        "another_different_label_value"
+      )
+    )
+  }
+}

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -5,6 +5,7 @@ import io.prometheus.client.Counter
 import io.prometheus.client.Gauge
 import misk.metrics.Histogram
 import misk.metrics.Metrics
+import misk.metrics.v2.PeakGauge
 import misk.metrics.v2.Metrics as MetricsV2
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/v2/PrometheusMetrics.kt
@@ -6,6 +6,7 @@ import io.prometheus.client.Histogram
 import io.prometheus.client.Gauge
 import io.prometheus.client.Summary
 import misk.metrics.v2.Metrics
+import misk.metrics.v2.PeakGauge
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +32,14 @@ internal class PrometheusMetrics @Inject internal constructor(
     labelNames: List<String>
   ): Gauge = Gauge
     .build(name, help)
+    .labelNames(*labelNames.toTypedArray())
+    .register(registry)
+
+  override fun peakGauge(name: String,
+    help: String,
+    labelNames: List<String>
+  ): PeakGauge = PeakGauge
+    .builder(name, help)
     .labelNames(*labelNames.toTypedArray())
     .register(registry)
 


### PR DESCRIPTION
A `PeakGauge` is a variant of a regular gauge that resets to an initial value of 0 after a metric collection.

This is useful for accurately capturing maximum observed values over time. In contrast to the histogram maximum which tracks the maximum value in its sampling window. That sampling window typically covers multiple metric collections.