### PR TITLE
Add bindConstant to ActionScopedProviderModule

### DIFF
--- a/misk-action-scopes/api/misk-action-scopes.api
+++ b/misk-action-scopes/api/misk-action-scopes.api
@@ -45,6 +45,10 @@ public abstract interface class misk/scope/ActionScopedProvider {
 public abstract class misk/scope/ActionScopedProviderModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/scope/ActionScopedProviderModule$Companion;
 	public fun <init> ()V
+	public final fun bindConstant (Lcom/google/inject/TypeLiteral;Ljava/lang/Object;Ljava/lang/annotation/Annotation;)V
+	public final fun bindConstant (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/annotation/Annotation;)V
+	public static synthetic fun bindConstant$default (Lmisk/scope/ActionScopedProviderModule;Lcom/google/inject/TypeLiteral;Ljava/lang/Object;Ljava/lang/annotation/Annotation;ILjava/lang/Object;)V
+	public static synthetic fun bindConstant$default (Lmisk/scope/ActionScopedProviderModule;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/annotation/Annotation;ILjava/lang/Object;)V
 	public final fun bindProvider (Lcom/google/inject/TypeLiteral;Lkotlin/reflect/KClass;Ljava/lang/Class;)V
 	public final fun bindProvider (Lcom/google/inject/TypeLiteral;Lkotlin/reflect/KClass;Ljava/lang/annotation/Annotation;)V
 	public final fun bindProvider (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Class;)V

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScopedProviderModule.kt
@@ -35,7 +35,12 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   fun <T : Any> bindSeedData(type: TypeLiteral<T>) {
     bindSeedData(
       type.toKey(),
-      Key.get(Types.newParameterizedType(ActionScoped::class.java, type.type)) as Key<ActionScoped<T>>,
+      Key.get(
+        Types.newParameterizedType(
+          ActionScoped::class.java,
+          type.type
+        )
+      ) as Key<ActionScoped<T>>,
     )
   }
 
@@ -48,7 +53,10 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
   fun <T : Any> bindSeedData(type: TypeLiteral<T>, a: Annotation) {
     bindSeedData(
       type.toKey(),
-      Key.get(Types.newParameterizedType(ActionScoped::class.java, type.type), a) as Key<ActionScoped<T>>,
+      Key.get(
+        Types.newParameterizedType(ActionScoped::class.java, type.type),
+        a
+      ) as Key<ActionScoped<T>>,
     )
   }
 
@@ -64,6 +72,51 @@ abstract class ActionScopedProviderModule : KAbstractModule() {
         SeedDataActionScopedProvider(key)
       }
     )
+  }
+
+  /** Binds a provider that returns a constant value on every invocation. */
+  fun <T : Any> bindConstant(
+    kclass: KClass<T>,
+    providedValue: T,
+    annotatedBy: Annotation? = null,
+  ) {
+    val typeKey =
+      if (annotatedBy == null) Key.get(kclass.java)
+      else Key.get(kclass.java, annotatedBy)
+
+    val actionScopedType = actionScopedType(kclass.java)
+    val actionScopedKey =
+      if (annotatedBy == null) Key.get(actionScopedType)
+      else Key.get(actionScopedType, annotatedBy)
+
+    bindProvider(typeKey, actionScopedKey) {
+      object : ActionScopedProvider<T> {
+        override fun get(): T = providedValue
+      }
+    }
+  }
+
+  /** Binds a provider that returns a constant value on every invocation. */
+  fun <T : Any> bindConstant(
+    type: TypeLiteral<T>,
+    providedValue: T,
+    annotatedBy: Annotation? = null,
+  ) {
+    val typeKey =
+      if (annotatedBy == null) Key.get(type)
+      else Key.get(type, annotatedBy)
+
+    @Suppress("UNCHECKED_CAST")
+    val actionScopedType = actionScopedType(type.type) as TypeLiteral<ActionScoped<T>>
+    val actionScopedKey =
+      if (annotatedBy == null) Key.get(actionScopedType)
+      else Key.get(actionScopedType, annotatedBy)
+
+    bindProvider(typeKey, actionScopedKey) {
+      object : ActionScopedProvider<T> {
+        override fun get(): T = providedValue
+      }
+    }
   }
 
   /** Binds an annotation qualified [ActionScoped] along with its provider */

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -32,6 +32,12 @@ internal class ActionScopedTest {
   @Inject @Named("nullable-based-on-foo")
   private lateinit var nullableBasedOnFoo: ActionScoped<String?>
 
+  @Inject @Named("constant")
+  private lateinit var constantString: ActionScoped<String>
+
+  @Inject @Named("constant")
+  private lateinit var optionalConstantString: ActionScoped<Optional<String>>
+
   @Inject private lateinit var scope: ActionScope
 
   @BeforeEach
@@ -90,6 +96,21 @@ internal class ActionScopedTest {
     val seedData: Map<Key<*>, Any> = mapOf(keyOf<String>(Names.named("from-seed")) to "null")
     val result = scope.enter(seedData).use { nullableFoo.get() }
     assertThat(result).isNull()
+  }
+
+  @Test
+  fun supportsReturningConstants() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    scope.enter(mapOf()).use {
+      assertThat(constantString.get()).isEqualTo("constant-value")
+      assertThat(optionalConstantString.get()).isEqualTo(Optional.of("constant-value"))
+
+      // Make sure the same object is returned
+      assertThat(constantString.get()).isSameAs(constantString.get())
+      assertThat(optionalConstantString.get()).isSameAs(optionalConstantString.get())
+    }
   }
 
   @Test

--- a/misk-action-scopes/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -8,6 +8,12 @@ import javax.inject.Inject
 
 internal class TestActionScopedProviderModule : ActionScopedProviderModule() {
   override fun configureProviders() {
+    bindConstant(String::class, "constant-value", Names.named("constant"))
+    bindConstant(
+      object : TypeLiteral<Optional<String>>() {},
+      Optional.of("constant-value"),
+      Names.named("constant"),
+    )
     bindSeedData(String::class, Names.named("from-seed"))
     bindSeedData(object : TypeLiteral<Optional<String>>() {})
     bindProvider(String::class, FooProvider::class, Names.named("foo"))


### PR DESCRIPTION
At Faire we want the ability to have a default binding for a key, with the ability to override it when entering the scope. Generally we're using `Optional` to accomplish this, and the default value is an empty `Optional`. This makes that possible with less boilerplate, avoiding having to create a new class for every `Optional<T>` you want to bind.