### PR TITLE
Explicitly set Java compile target to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
@@ -51,21 +52,14 @@ subprojects {
 
   // Only apply if the project has the kotlin plugin added:
   plugins.withType<KotlinPluginWrapper> {
-    val compileKotlin by tasks.getting(KotlinCompile::class) {
+    tasks.withType<KotlinCompile> {
       kotlinOptions {
         jvmTarget = "11"
-
-        // TODO(alec): Enable again once Environment enum is deleted
-        allWarningsAsErrors = false
       }
     }
-    val compileTestKotlin by tasks.getting(KotlinCompile::class) {
-      kotlinOptions {
-        jvmTarget = "11"
-
-        // TODO(alec): Enable again once Environment enum is deleted
-        allWarningsAsErrors = false
-      }
+    tasks.withType<JavaCompile> {
+      sourceCompatibility = "11"
+      targetCompatibility = "11"
     }
 
     dependencies {


### PR DESCRIPTION
This helps when including misk as an includeBuild in a larger gradle superproject to test changes locally. Otherwise the superproject build can failed with errors about being unable to find the right variant.