### PR TITLE
Introduces pause detection

### DIFF
--- a/misk-metrics/api/misk-metrics.api
+++ b/misk-metrics/api/misk-metrics.api
@@ -60,6 +60,7 @@ public final class misk/metrics/v2/PeakGauge : io/prometheus/client/SimpleCollec
 	public fun <init> (Lmisk/metrics/v2/PeakGauge$Builder;)V
 	public fun collect ()Ljava/util/List;
 	public synthetic fun newChild ()Ljava/lang/Object;
+	public final fun record (D)V
 }
 
 public final class misk/metrics/v2/PeakGauge$Builder : io/prometheus/client/SimpleCollector$Builder {

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/PeakGauge.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/PeakGauge.kt
@@ -22,6 +22,11 @@ class PeakGauge  : SimpleCollector<PeakGauge.Child> {
     }
   }
 
+  /** Convenience method for recording values without labels */
+  fun record(newValue: Double) {
+    noLabelsChild.record(newValue)
+  }
+
   class Child {
     // For simplicity, using an atomic double with an initial value of 0 here.
     //
@@ -32,8 +37,6 @@ class PeakGauge  : SimpleCollector<PeakGauge.Child> {
 
     /**
      * Updates the stored value if the new value is greater.
-     *
-     *
      */
     fun record(newValue: Double) {
       while (true) {

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -858,6 +858,34 @@ public final class misk/okio/OkioExtensionsKt {
 	public static final fun split (Lokio/BufferedSource;Lokio/ByteString;)Lkotlin/sequences/Sequence;
 }
 
+public final class misk/perf/PauseDetectorConfig {
+	public fun <init> ()V
+	public fun <init> (JJJJJ)V
+	public synthetic fun <init> (JJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun copy (JJJJJ)Lmisk/perf/PauseDetectorConfig;
+	public static synthetic fun copy$default (Lmisk/perf/PauseDetectorConfig;JJJJJILjava/lang/Object;)Lmisk/perf/PauseDetectorConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLogErrorMillis ()J
+	public final fun getLogInfoMillis ()J
+	public final fun getLogWarnMillis ()J
+	public final fun getMetricsUpdateFloor ()J
+	public final fun getResolutionMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/perf/PauseDetectorModule : misk/inject/KAbstractModule {
+	public fun <init> ()V
+	public fun <init> (Lmisk/perf/PauseDetectorConfig;)V
+	public synthetic fun <init> (Lmisk/perf/PauseDetectorConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPauseDetectorConfig ()Lmisk/perf/PauseDetectorConfig;
+}
+
 public final class misk/security/authz/AccessAnnotationEntry {
 	public fun <init> (Lkotlin/reflect/KClass;Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/misk/src/main/kotlin/misk/perf/PauseDetector.kt
+++ b/misk/src/main/kotlin/misk/perf/PauseDetector.kt
@@ -1,0 +1,140 @@
+package misk.perf
+
+import com.google.common.base.Ticker
+import com.google.common.util.concurrent.AbstractExecutionThreadService
+import io.prometheus.client.Summary
+import misk.concurrent.Sleeper
+import misk.metrics.v2.Metrics
+import misk.metrics.v2.PeakGauge
+import org.slf4j.event.Level
+import wisp.logging.getLogger
+import java.time.Duration
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeUnit.NANOSECONDS
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Detects and records pauses experienced by the VM. Garbage collection is a common source of
+ * pauses, but pauses can be caused by many things: CPU throttling, excessive swapping, excessive
+ * active threads, etc.
+ *
+ * Heavily inspired by [jhiccup](https://www.azulsystems.com/jHiccup) which is
+ * [public domain](https://creativecommons.org/publicdomain/zero/1.0/)
+ */
+@Singleton
+internal class PauseDetector @Inject constructor(
+  private val config: PauseDetectorConfig,
+  private val ticker: Ticker,
+  private val sleeper: Sleeper,
+  val metrics: Metrics,
+) : AbstractExecutionThreadService() {
+
+  /** Log levels by pause time sorted by severity descending*/
+  private val logLevels: List<LogLevels> = listOf(
+    LogLevels(config.logErrorMillis, Level.ERROR),
+    LogLevels(config.logWarnMillis, Level.WARN),
+    LogLevels(config.logInfoMillis, Level.INFO)
+  )
+
+  /**
+   * Tracks the distribution and total amount of pause time observed.
+   *
+   * (Using a summary instead of a histogram to prefer more accurate node-local data over
+   * more accurate aggregations)
+   */
+  private val pauseSummary: Summary =
+    metrics.summary("jvm_pause_time_summary_ms", "Summary in ms of pause time", listOf())
+
+  /** Tracks peak pause time. */
+  private val pausePeak: PeakGauge =
+    metrics.peakGauge("jvm_pause_time_peak_ms", "Peak gauge of pause time", listOf())
+
+  // No synchronization is necessary for these variables: they are only ever accessed by the
+  // detector thread itself OR by a test harness thread.
+  //
+  // (They are also initialized in the constructor, but that initialization has a happens-before
+  // relationship to the [Thread.start] that starts the thread).
+  /** Used to prevent generating early noise (for example in the first few seconds of startup) */
+  private var shortestObservedDeltaTimeNsec = Long.MAX_VALUE
+  /** Tracks the start time of the last invocation to [sleep] */
+  private var startTime: Long = 0
+
+  override fun run() {
+    while (isRunning) {
+      // NB: Broken into two different functions so that we can inject time delays for testing
+      // purposes.
+      sleep()
+      check()
+    }
+  }
+
+  /**
+   * Sleeps for the configured resolution
+   *
+   * NB: [sleep] and [check] must always be invoked from the same thread.
+   */
+  internal fun sleep() {
+    startTime = ticker.read()
+    if (config.resolutionMillis != 0L) {
+      sleeper.sleep(Duration.ofMillis(config.resolutionMillis))
+    }
+  }
+
+  /**
+   * Check the elapsed time after an invocation to [sleep]. Elapsed time beyond the configured
+   * resolution and the shortest observed delta is recorded as pause time.
+   *
+   * NB: [sleep] and [check] must always be invoked from the same thread.
+   */
+  internal fun check(): PauseResults {
+    val stopTime: Long = ticker.read()
+    val deltaTimeNsec: Long = (stopTime - startTime)
+
+    // We expect a monotonic ticker that should measure at least the resolution time between
+    // invocations. Guard against a non-monotonic or otherwise "fast" ticker from polluting results.
+    if (deltaTimeNsec < MILLISECONDS.toNanos(config.resolutionMillis)) {
+      val decreaseMs = config.resolutionMillis - NANOSECONDS.toMillis(deltaTimeNsec)
+      logger.info("Observed a negative pause time of ${decreaseMs}ms. Non-monotonic ticker?")
+    } else if (deltaTimeNsec < shortestObservedDeltaTimeNsec) {
+      shortestObservedDeltaTimeNsec = deltaTimeNsec
+    }
+
+    val pauseTimeNsec = deltaTimeNsec - shortestObservedDeltaTimeNsec
+    val pauseMillis = NANOSECONDS.toMillis(pauseTimeNsec)
+    if (pauseMillis >= config.metricsUpdateFloor) {
+      val pauseMillisDouble = pauseMillis.toDouble()
+      pauseSummary.observe(pauseMillisDouble)
+      pausePeak.record(pauseMillisDouble)
+    }
+
+    val level = getLoggingLevel(pauseMillis)
+    if (level != null) {
+      val message = "Detected JVM pause of $pauseMillis ms"
+      when (level) {
+        Level.INFO -> logger.info(message)
+        Level.WARN -> logger.warn(message)
+        Level.ERROR -> logger.error(message)
+        else -> { // NOOP
+        }
+      }
+    }
+
+    return PauseResults(
+      pauseTimeMillis = pauseMillis,
+      shortestObservedDeltaNsec = shortestObservedDeltaTimeNsec
+    )
+  }
+
+  private fun getLoggingLevel(pauseMillis: Long) : Level? {
+    return logLevels.firstOrNull { it.limitMillis in 0..pauseMillis }?.level
+  }
+
+  data class PauseResults(val pauseTimeMillis: Long, val shortestObservedDeltaNsec: Long)
+
+  data class LogLevels(val limitMillis: Long, val level: Level)
+
+  companion object {
+    private val logger = getLogger<PauseDetector>()
+  }
+}

--- a/misk/src/main/kotlin/misk/perf/PauseDetectorConfig.kt
+++ b/misk/src/main/kotlin/misk/perf/PauseDetectorConfig.kt
@@ -1,0 +1,21 @@
+package misk.perf
+
+/**
+ * Configuration for the [PauseDetector]
+ */
+data class PauseDetectorConfig(
+  /** The delay between detector runs. If 0, the detector runs in a spin loop. */
+  val resolutionMillis: Long = 1,
+
+  /** The minimum number of millis paused before logging at info. -1 for never. */
+  val logInfoMillis: Long = 1000,
+
+  /** The minimum number of millis paused before logging at warn. -1 for never. */
+  val logWarnMillis: Long = -1,
+
+  /** The minimum number of millis paused before logging at error. -1 for never. */
+  val logErrorMillis: Long = -1,
+
+  /** The minimum number of millis required to trigger an update of the histogram */
+  val metricsUpdateFloor: Long = 0,
+)

--- a/misk/src/main/kotlin/misk/perf/PauseDetectorModule.kt
+++ b/misk/src/main/kotlin/misk/perf/PauseDetectorModule.kt
@@ -1,0 +1,17 @@
+package misk.perf
+
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+
+/**
+ * Install this module to run the [PauseDetector] in the background.
+ */
+class PauseDetectorModule constructor(
+  val pauseDetectorConfig: PauseDetectorConfig = PauseDetectorConfig(),
+) : KAbstractModule() {
+
+  override fun configure() {
+    install(ServiceModule<PauseDetector>())
+    bind<PauseDetectorConfig>().toInstance(pauseDetectorConfig)
+  }
+}

--- a/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
+++ b/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
@@ -1,0 +1,128 @@
+package misk.perf
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import com.google.common.base.Ticker
+import misk.ServiceManagerModule
+import misk.concurrent.FakeTicker
+import misk.concurrent.Sleeper
+import misk.inject.KAbstractModule
+import misk.logging.LogCollectorModule
+import misk.metrics.v2.FakeMetricsModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wisp.logging.LogCollector
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@MiskTest(startService = true) // NB: only starting services here to get log collection to work.
+class PauseDetectorTest {
+  @MiskTestModule val module = TestModule()
+
+  @Inject lateinit var fakeTicker: FakeTicker
+  @Inject internal lateinit var detector: PauseDetector
+  @Inject lateinit var logCollector: LogCollector
+
+  @BeforeEach fun setup() {
+    // We'll drive the detector from the test thread rather than running a detector thread.
+    assertThat(detector.isRunning()).isFalse()
+
+    // Do one cycle to calibrate shortestObservedDeltaTimeNsec
+    detector.sleep()
+    val (pauseTimeMillis, shortestObservedDeltaNsec) = detector.check()
+    assertThat(pauseTimeMillis).isEqualTo(0)
+    verifyShortestObservedDelta(shortestObservedDeltaNsec)
+    assertThat(takeLogs()).isEmpty()
+  }
+
+  private fun verifyShortestObservedDelta(shortestObservedDeltaNsec: Long) {
+    assertThat(shortestObservedDeltaNsec).isEqualTo(TimeUnit.MILLISECONDS.toNanos(1))
+  }
+
+  @Test fun `no logging`() {
+    detector.sleep()
+    fakeTicker.sleepMs(99)
+    detector.check()
+    takeLogs().isEmpty()
+  }
+
+  @Test fun `log info on a pause`() {
+    detector.sleep()
+    fakeTicker.sleepMs(101)
+    val (pauseTimeMillis, shortestObservedDeltaNsec) = detector.check()
+    assertThat(pauseTimeMillis).isEqualTo(101)
+    verifyShortestObservedDelta(shortestObservedDeltaNsec)
+    val logs = takeLogs()
+    assertThat(logs).hasSize(1)
+    assertThat(logs.first().message).isEqualTo("Detected JVM pause of 101 ms")
+    assertThat(logs.first().level).isEqualTo(Level.INFO)
+  }
+
+  @Test fun `log warn on a pause`() {
+    detector.sleep()
+    fakeTicker.sleepMs(2322)
+    val (pauseTimeMillis, shortestObservedDeltaNsec) = detector.check()
+    assertThat(pauseTimeMillis).isEqualTo(2322)
+    verifyShortestObservedDelta(shortestObservedDeltaNsec)
+    val logs = takeLogs()
+    assertThat(logs).hasSize(1)
+    assertThat(logs.first().message).isEqualTo("Detected JVM pause of 2322 ms")
+    assertThat(logs.first().level).isEqualTo(Level.WARN)
+  }
+
+  @Test fun `log error on a pause`() {
+    detector.sleep()
+    fakeTicker.sleepMs(99999)
+    val (pauseTimeMillis, shortestObservedDeltaNsec) = detector.check()
+    assertThat(pauseTimeMillis).isEqualTo(99999)
+    verifyShortestObservedDelta(shortestObservedDeltaNsec)
+    val logs = takeLogs()
+    assertThat(logs).hasSize(1)
+    assertThat(logs.first().message).isEqualTo("Detected JVM pause of 99999 ms")
+    assertThat(logs.first().level).isEqualTo(Level.ERROR)
+  }
+
+  @Test fun `ticker goes backwards`() {
+    // 1ms of sleep
+    detector.sleep()
+    // Move the ticker back 2020ms
+    fakeTicker.sleepMs(-2020)
+    val (pauseTimeMillis, shortestObservedDeltaNsec) = detector.check()
+    assertThat(pauseTimeMillis).isEqualTo(-2020L)
+    verifyShortestObservedDelta(shortestObservedDeltaNsec)
+    val logs = takeLogs()
+    assertThat(logs).hasSize(1)
+    assertThat(logs.first().message)
+      .isEqualTo("Observed a negative pause time of 2020ms. Non-monotonic ticker?")
+    assertThat(logs.first().level).isEqualTo(Level.INFO)
+  }
+
+  private fun takeLogs(): List<ILoggingEvent> = logCollector.takeEvents(PauseDetector::class)
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      // Wire up the detector
+      val config = PauseDetectorConfig(
+        resolutionMillis = 1,
+        logInfoMillis = 100,
+        logWarnMillis = 1000,
+        logErrorMillis = 10000
+      )
+      // NB: We are intentionally _not_ installing the module
+      // because we want to drive the detector check/sleep cycles from this test harness
+      bind<PauseDetectorConfig>().toInstance(config)
+
+      // And its dependencies with test fakes
+      install(ServiceManagerModule())
+      install(FakeMetricsModule())
+      bind<Ticker>().to<FakeTicker>()
+      bind<Sleeper>().to<FakeTicker>()
+
+      // Test support
+      install(LogCollectorModule())
+    }
+  }
+}


### PR DESCRIPTION
Adds a pause detector thread that sleeps for a defined resolution and records elapsed overage of that sleep time as pause time.

The detector can emit logs with configurable pause time thresholds for INFO/WARN/ERROR

The detector tracks pause time in a `Summary` and a `PeakGauge` so that operators can track total pause time, pause distribution, and the maximum pause time per collection interval.