### PR TITLE
Disallow setting both url and envoy client configs

### DIFF
--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -154,6 +154,10 @@ data class HttpClientEndpointConfig(
   val envoy: HttpClientEnvoyConfig? = null,
   val clientConfig: HttpClientConfig = HttpClientConfig()
 ) {
+  init {
+    require(url == null || envoy == null) { "Cannot set both url and envoy configs" }
+  }
+  
   @Deprecated(
     "Use clientConfig property",
     replaceWith = ReplaceWith("clientConfig.connectTimeout")

--- a/misk/src/test/kotlin/misk/client/HttpClientsConfigTest.kt
+++ b/misk/src/test/kotlin/misk/client/HttpClientsConfigTest.kt
@@ -1,6 +1,7 @@
 package misk.client
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.net.URL
 import java.time.Duration
@@ -144,5 +145,21 @@ class HttpClientsConfigTest {
           ).withGlobalDefaults()
         )
       )
+  }
+  
+  @Test
+  fun `endpoint settings cannot be given both a URL and envoy config`() {
+    assertThatThrownBy {
+      HttpClientsConfig(
+        endpoints = mapOf(
+          "test" to HttpClientEndpointConfig(
+            url = "http://domain.com",
+            envoy = HttpClientEnvoyConfig("app")
+          )
+        )
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Cannot set both url and envoy configs")
   }
 }


### PR DESCRIPTION
There's no reason to allow `HttpClientEndpointConfig.url` and `HttpClientEndpointConfig.envoy` to both be set; it's nonsensical. If it happens, it's almost certainly due to misconfiguration, such as a bad merge of tiered config files like this:

```
myservice-common.yml

endpoints:
  fooservice:
    url: http://foo.service.com
```
```
myservice-production.yml

endpoints:
  fooservice:
    envoy: { app: "foo" }
```

**Behavior change:** This PR will cause an exception to be thrown early (like in service startup when config objects are built) rather than letting `HttpClientEndpointConfig.url` silently override `HttpClientEndpointConfig.envoy` in places [like this](https://github.com/cashapp/misk/blob/073e9fe0f8d18c1791f18ede9074867aa9ec5833/misk/src/main/kotlin/misk/client/HttpClientConfigUrlProvider.kt#L15-L18). This change will allow the problem to be caught by unit tests, or at least prevent the service from starting and taking traffic, rather than manifesting as surprising behavior after the service starts up.

Wisp equivalent PR: https://github.com/cashapp/wisp/pull/130