### PR TITLE
Makes RequestBodyLoggingInterceptor public

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1736,12 +1736,37 @@ public final class misk/web/interceptors/RequestBodyLoggingInterceptor$Factory :
 }
 
 public final class misk/web/interceptors/RequestLoggingInterceptor : misk/web/NetworkInterceptor {
+	public fun <init> (Lmisk/Action;Lmisk/scope/ActionScoped;Lcom/google/common/base/Ticker;Lmisk/random/ThreadLocalRandom;Lmisk/web/interceptors/LogRateLimiter;JJDDLmisk/web/interceptors/RequestResponseCapture;)V
 	public fun intercept (Lmisk/web/NetworkChain;)V
 	public final fun maybeLog (Lmisk/web/HttpCall;Lcom/google/common/base/Stopwatch;Ljava/lang/Throwable;)V
 }
 
 public final class misk/web/interceptors/RequestLoggingInterceptor$Factory : misk/web/NetworkInterceptor$Factory {
 	public fun create (Lmisk/Action;)Lmisk/web/NetworkInterceptor;
+}
+
+public final class misk/web/interceptors/RequestResponseBody {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
+	public static synthetic fun copy$default (Lmisk/web/interceptors/RequestResponseBody;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequest ()Ljava/lang/Object;
+	public final fun getResponse ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/web/interceptors/RequestResponseCapture {
+	public static final field Companion Lmisk/web/interceptors/RequestResponseCapture$Companion;
+	public fun <init> ()V
+	public final fun clear ()V
+	public final fun get ()Lmisk/web/interceptors/RequestResponseBody;
+	public final fun set (Lmisk/web/interceptors/RequestResponseBody;)V
+}
+
+public final class misk/web/interceptors/RequestResponseCapture$Companion {
 }
 
 public final class misk/web/interceptors/ResponseBodyMarshallerFactory {

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
@@ -85,7 +85,7 @@ internal data class HeadersCapture(
   )
 }
 
-internal class RequestResponseCapture @Inject constructor() {
+class RequestResponseCapture @Inject constructor() {
   companion object {
     private val capture = ThreadLocal<RequestResponseBody>()
   }
@@ -101,4 +101,4 @@ internal class RequestResponseCapture @Inject constructor() {
   }
 }
 
-internal data class RequestResponseBody(val request: Any?, val response: Any?)
+data class RequestResponseBody(val request: Any?, val response: Any?)

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -24,7 +24,7 @@ private val logger = getLogger<RequestLoggingInterceptor>()
  * Logs request and response information for an action.
  * Timing information doesn't count time writing the response to the remote client.
  */
-class RequestLoggingInterceptor internal constructor(
+class RequestLoggingInterceptor(
   private val action: Action,
   private val caller: ActionScoped<MiskCaller?>,
   private val ticker: Ticker,


### PR DESCRIPTION
And, by necessity, makes a couple child classes public as well.

The rationale for this change is so that services can opt in to request logging through a mechanism other than Misk's `@LogRequestResponse`.

Example use case: a library that sets up web actions, where the user of the library may or may not want request logging. This change will allow the library to take in request logging parameters and set them at runtime rather than relying on values set in the annotation when the library was compiled.

See also an alternative approach: https://github.com/cashapp/misk/pull/2726