### PR TITLE
Add client metrics to misk-redis

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -55,7 +55,7 @@ public abstract interface annotation class misk/redis/ForFakeRedis : java/lang/a
 
 public final class misk/redis/RealRedis : misk/redis/Redis {
 	public static final field Companion Lmisk/redis/RealRedis$Companion;
-	public fun <init> (Lredis/clients/jedis/JedisPool;)V
+	public fun <init> (Lredis/clients/jedis/JedisPool;Lmisk/redis/RedisClientMetrics;)V
 	public fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Lokio/ByteString;
 	public fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Lokio/ByteString;
 	public fun close ()V
@@ -146,6 +146,14 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public abstract fun unwatch ([Ljava/lang/String;)V
 	public abstract fun watch ([Ljava/lang/String;)V
+}
+
+public final class misk/redis/RedisClientMetrics {
+	public static final field Companion Lmisk/redis/RedisClientMetrics$Companion;
+	public fun <init> (Lmisk/metrics/v2/Metrics;)V
+}
+
+public final class misk/redis/RedisClientMetrics$Companion {
 }
 
 public final class misk/redis/RedisConfig : java/util/LinkedHashMap, wisp/config/Config {

--- a/misk-redis/build.gradle.kts
+++ b/misk-redis/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   implementation(project(":misk-service"))
 
   testImplementation(Dependencies.assertj)
+  testImplementation(project(":misk-metrics-testing"))
   testImplementation(project(":misk-redis-testing"))
   testImplementation(project(":misk-testing"))
 }

--- a/misk-redis/build.gradle.kts
+++ b/misk-redis/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 }
 
 dependencies {
+  api(Dependencies.wispConfig)
+
   implementation(Dependencies.guava)
   implementation(Dependencies.guice)
   implementation(Dependencies.jedis)
@@ -11,8 +13,8 @@ dependencies {
   implementation(project(":misk"))
   implementation(project(":misk-core"))
   implementation(project(":misk-inject"))
+  implementation(project(":misk-metrics"))
   implementation(project(":misk-service"))
-  api(Dependencies.wispConfig)
 
   testImplementation(Dependencies.assertj)
   testImplementation(project(":misk-redis-testing"))

--- a/misk-redis/src/main/kotlin/misk/redis/JedisPoolWithMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPoolWithMetrics.kt
@@ -1,0 +1,60 @@
+package misk.redis
+
+import org.apache.commons.pool2.PooledObject
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisFactory
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.JedisPoolConfig
+import redis.clients.jedis.Protocol
+
+internal class JedisPoolWithMetrics(
+  private val metrics: RedisClientMetrics,
+  poolConfig: JedisPoolConfig,
+  replicationGroupConfig: RedisReplicationGroupConfig,
+  ssl: Boolean = true,
+  requiresPassword: Boolean = true,
+) : JedisPool(
+  poolConfig,
+  JedisFactoryWithMetrics(metrics, replicationGroupConfig, ssl, requiresPassword)
+) {
+  init {
+    metrics.maxTotalConnectionsGauge.set(this.maxTotal.toDouble())
+    metrics.maxIdleConnectionsGauge.set(this.maxIdle.toDouble())
+  }
+
+  override fun getResource(): Jedis {
+    metrics.activeConnectionsGauge.set(this.numActive.toDouble())
+    metrics.idleConnectionsGauge.set(this.numIdle.toDouble())
+    return super.getResource()
+  }
+
+  private class JedisFactoryWithMetrics(
+    private val metrics: RedisClientMetrics,
+    replicationGroupConfig: RedisReplicationGroupConfig,
+    ssl: Boolean = true,
+    requiresPassword: Boolean = true,
+  ) : JedisFactory(
+    /* host = */ replicationGroupConfig.writer_endpoint.hostname,
+    /* port = */ replicationGroupConfig.writer_endpoint.port,
+    /* connectionTimeout = */ replicationGroupConfig.timeout_ms,
+    /* soTimeout = */ replicationGroupConfig.timeout_ms,
+    /* password = */ replicationGroupConfig.redis_auth_password
+    .ifEmpty {
+      check(!requiresPassword) {
+        "This Redis client is configured to require an auth password, but none was provided!"
+      }
+      null
+    },
+    /* database = */ Protocol.DEFAULT_DATABASE,
+    /* clientName = */ null,
+    /* ssl = */ ssl,
+    /* sslSocketFactory = */ null,
+    /* sslParameters = */ null,
+    /* hostnameVerifier = */ null
+  ) {
+    override fun destroyObject(pooledJedis: PooledObject<Jedis>) {
+      metrics.destroyedConnectionsCounter.inc()
+      super.destroyObject(pooledJedis)
+    }
+  }
+}

--- a/misk-redis/src/main/kotlin/misk/redis/JedisPoolWithMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPoolWithMetrics.kt
@@ -20,12 +20,30 @@ internal class JedisPoolWithMetrics(
   init {
     metrics.maxTotalConnectionsGauge.set(this.maxTotal.toDouble())
     metrics.maxIdleConnectionsGauge.set(this.maxIdle.toDouble())
+    setActiveIdleConnectionMetrics()
   }
 
   override fun getResource(): Jedis {
+    return super.getResource().also {
+      setActiveIdleConnectionMetrics()
+    }
+  }
+
+  override fun returnBrokenResource(resource: Jedis?) {
+    super.returnBrokenResource(resource).also {
+      setActiveIdleConnectionMetrics()
+    }
+  }
+
+  override fun returnResource(resource: Jedis?) {
+    super.returnResource(resource).also {
+      setActiveIdleConnectionMetrics()
+    }
+  }
+
+  private fun setActiveIdleConnectionMetrics() {
     metrics.activeConnectionsGauge.set(this.numActive.toDouble())
     metrics.idleConnectionsGauge.set(this.numIdle.toDouble())
-    return super.getResource()
   }
 
   private class JedisFactoryWithMetrics(

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -6,88 +6,84 @@ import redis.clients.jedis.JedisPool
 import redis.clients.jedis.Pipeline
 import redis.clients.jedis.Transaction
 import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.commands.JedisBinaryCommands
 import redis.clients.jedis.params.SetParams
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 import java.time.Duration
+import kotlin.reflect.cast
 
 /**
  * For each command, a Jedis instance is retrieved from the pool and returned once the command has
  * been issued.
  */
-class RealRedis(private val jedisPool: JedisPool) : Redis {
+class RealRedis(
+  private val jedisPool: JedisPool,
+  private val clientMetrics: RedisClientMetrics,
+) : Redis {
   override fun del(key: String): Boolean {
-    jedisPool.resource.use { jedis ->
-      return (jedis.del(key) == 1L)
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { del(keyBytes) == 1L }
   }
 
   override fun del(vararg keys: String): Int {
-    jedisPool.resource.use { jedis ->
-      return jedis.del(*keys).toInt()
-    }
+    val keysAsBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+    return jedis { del(*keysAsBytes) }.toInt()
   }
 
   override fun mget(vararg keys: String): List<ByteString?> {
-    val byteArrays = keys.map { it.toByteArray(charset) }.toTypedArray()
-    jedisPool.resource.use { jedis ->
-      return jedis.mget(*byteArrays).map { it?.toByteString() }
-    }
+    val keysAsBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+    return jedis { mget(*keysAsBytes) }
+      .map { it?.toByteString() }
   }
 
   override fun mset(vararg keyValues: ByteString) {
     require(keyValues.size % 2 == 0) { "Wrong number of arguments to mset" }
-
     val byteArrays = keyValues.map { it.toByteArray() }.toTypedArray()
-    jedisPool.resource.use { jedis ->
-      jedis.mset(*byteArrays)
-    }
+    jedis { mset(*byteArrays) }
   }
 
   override fun get(key: String): ByteString? {
-    jedisPool.resource.use { jedis ->
-      return jedis.get(key.toByteArray(charset))?.toByteString()
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { get(keyBytes) }?.toByteString()
   }
 
   override fun hdel(key: String, vararg fields: String): Long {
-    jedisPool.resource.use { jedis ->
-      val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
-      return jedis.hdel(key.toByteArray(charset), *fieldsAsByteArrays)
-    }
+    val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hdel(keyBytes, *fieldsAsByteArrays) }
   }
 
   override fun hgetAll(key: String): Map<String, ByteString>? {
-    jedisPool.resource.use { jedis ->
-      return jedis.hgetAll(key.toByteArray(charset))?.mapKeys {
-        it.key.toString(charset)
-      }?.mapValues {
-        it.value.toByteString()
-      }
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hgetAll(keyBytes) }
+      ?.mapKeys { it.key.toString(charset) }
+      ?.mapValues { it.value.toByteString() }
   }
 
   override fun hlen(key: String): Long {
-    jedisPool.resource.use { jedis ->
-      return jedis.hlen(key.toByteArray(charset))
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hlen(keyBytes) }
   }
 
   override fun hmget(key: String, vararg fields: String): List<ByteString?> {
-    jedisPool.resource.use { jedis ->
-      val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
-      return jedis.hmget(key.toByteArray(charset), *fieldsAsByteArrays).map { it?.toByteString() }
-    }
+    val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hmget(keyBytes, *fieldsAsByteArrays) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
   override fun hget(key: String, field: String): ByteString? {
-    jedisPool.resource.use { jedis ->
-      return jedis.hget(key.toByteArray(charset), field.toByteArray(charset))?.toByteString()
-    }
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    return jedis { hget(keyBytes, fieldBytes) }?.toByteString()
   }
 
   override fun hincrBy(key: String, field: String, increment: Long): Long {
-    jedisPool.resource.use { jedis ->
-      return jedis.hincrBy(key, field, increment)
-    }
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    return jedis { hincrBy(keyBytes, fieldBytes, increment) }
   }
 
   /**
@@ -97,11 +93,10 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
    */
   override fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>? {
     checkHrandFieldCount(count)
-    return jedisPool.resource.use { jedis ->
-      jedis.hrandfieldWithValues(key.toByteArray(charset), count)
-        ?.mapKeys { (key, _) -> key.toString(charset) }
-        ?.mapValues { (_, value) -> value.toByteString() }
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hrandfieldWithValues(keyBytes, count) }
+      ?.mapKeys { (key, _) -> key.toString(charset) }
+      ?.mapValues { (_, value) -> value.toByteString() }
   }
 
   /**
@@ -111,63 +106,57 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
    */
   override fun hrandField(key: String, count: Long): List<String> {
     checkHrandFieldCount(count)
-    return jedisPool.resource.use { jedis ->
-      jedis.hrandfield(key.toByteArray(charset), count)
-        .map { it.toString(charset) }
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hrandfield(keyBytes, count) }
+      .map { it.toString(charset) }
   }
 
   override fun set(key: String, value: ByteString) {
-    jedisPool.resource.use { jedis ->
-      jedis.set(key.toByteArray(charset), value.toByteArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    jedis { set(keyBytes, valueBytes) }
   }
 
   override fun set(key: String, expiryDuration: Duration, value: ByteString) {
-    jedisPool.resource.use { jedis ->
-      jedis.setex(key.toByteArray(charset), expiryDuration.seconds, value.toByteArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    jedis { setex(keyBytes, expiryDuration.seconds, valueBytes) }
   }
 
   override fun setnx(key: String, value: ByteString): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.setnx(key.toByteArray(charset), value.toByteArray()) == 1L
-    }
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    return jedis { setnx(keyBytes, valueBytes) == 1L }
   }
 
   override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.set(
-        key.toByteArray(charset),
-        value.toByteArray(),
-        SetParams().nx().px(expiryDuration.toMillis())
-      ) == "OK"
-    }
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().nx().px(expiryDuration.toMillis())
+    return jedis { set(keyBytes, valueBytes, params) == "OK" }
   }
 
   override fun hset(key: String, field: String, value: ByteString): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.hset(key.toByteArray(charset), field.toByteArray(charset), value.toByteArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    return jedis { hset(keyBytes, fieldBytes, valueBytes) }
   }
 
   override fun hset(key: String, hash: Map<String, ByteString>): Long {
     val hashBytes = hash.entries.associate { it.key.toByteArray(charset) to it.value.toByteArray() }
-    return jedisPool.resource.use { jedis ->
-      jedis.hset(key.toByteArray(charset), hashBytes)
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hset(keyBytes, hashBytes) }
   }
 
   override fun incr(key: String): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.incr(key.toByteArray(charset))
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { incr(keyBytes) }
   }
 
   override fun incrBy(key: String, increment: Long): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.incrBy(key.toByteArray(charset), increment)
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { incrBy(keyBytes, increment) }
   }
 
   override fun blmove(
@@ -177,15 +166,9 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     to: ListDirection,
     timeoutSeconds: Double
   ): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.blmove(
-        sourceKey.toByteArray(charset),
-        destinationKey.toByteArray(charset),
-        from,
-        to,
-        timeoutSeconds
-      )?.toByteString()
-    }
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { blmove(sourceKeyBytes, destKeyBytes, from, to, timeoutSeconds) }?.toByteString()
   }
 
   override fun brpoplpush(
@@ -193,13 +176,9 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     destinationKey: String,
     timeoutSeconds: Int
   ): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.brpoplpush(
-        sourceKey.toByteArray(charset),
-        destinationKey.toByteArray(charset),
-        timeoutSeconds,
-      )?.toByteString()
-    }
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { brpoplpush(sourceKeyBytes, destinationKeyBytes, timeoutSeconds) }?.toByteString()
   }
 
   override fun lmove(
@@ -208,122 +187,124 @@ class RealRedis(private val jedisPool: JedisPool) : Redis {
     from: ListDirection,
     to: ListDirection
   ): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.lmove(
-        sourceKey.toByteArray(charset),
-        destinationKey.toByteArray(charset),
-        from,
-        to
-      )?.toByteString()
-    }
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { lmove(sourceKeyBytes, destKeyBytes, from, to) }?.toByteString()
   }
 
   override fun lpush(key: String, vararg elements: ByteString): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.lpush(key.toByteArray(charset), *elements.map { it.toByteArray() }.toTypedArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    return jedis { lpush(keyBytes, *byteArrays) }
   }
 
   override fun rpush(key: String, vararg elements: ByteString): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.rpush(key.toByteArray(charset), *elements.map { it.toByteArray() }.toTypedArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    return jedis { rpush(keyBytes, *byteArrays) }
   }
 
   override fun lpop(key: String, count: Int): List<ByteString?> {
-    return jedisPool.resource.use { jedis ->
-      jedis.lpop(key.toByteArray(charset), count)?.map { it?.toByteString() } ?: emptyList()
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lpop(keyBytes, count) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
   override fun lpop(key: String): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.lpop(key.toByteArray(charset))?.toByteString()
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lpop(keyBytes) }?.toByteString()
   }
 
   override fun rpop(key: String, count: Int): List<ByteString?> {
-    return jedisPool.resource.use { jedis ->
-      jedis.rpop(key.toByteArray(charset), count)?.map { it?.toByteString() } ?: emptyList()
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { rpop(keyBytes, count) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
   override fun rpop(key: String): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.rpop(key.toByteArray(charset))?.toByteString()
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { rpop(keyBytes) }?.toByteString()
   }
 
   override fun lrange(key: String, start: Long, stop: Long): List<ByteString?> {
-    return jedisPool.resource.use { jedis ->
-      jedis.lrange(key.toByteArray(charset), start, stop).map { it?.toByteString() }
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lrange(keyBytes, start, stop) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
   override fun lrem(key: String, count: Long, element: ByteString): Long {
-    return jedisPool.resource.use { jedis ->
-      jedis.lrem(key.toByteArray(charset), count, element.toByteArray())
-    }
+    val keyBytes = key.toByteArray(charset)
+    val elementBytes = element.toByteArray()
+    return jedis { lrem(keyBytes, count, elementBytes) }
   }
 
   override fun rpoplpush(sourceKey: String, destinationKey: String): ByteString? {
-    return jedisPool.resource.use { jedis ->
-      jedis.rpoplpush(sourceKey.toByteArray(charset), destinationKey.toByteArray(charset))
-        ?.toByteString()
-    }
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { rpoplpush(sourceKeyBytes, destinationKeyBytes) }?.toByteString()
   }
 
   override fun expire(key: String, seconds: Long): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.expire(key, seconds) == 1L
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { expire(keyBytes, seconds) == 1L }
   }
 
   override fun expireAt(key: String, timestampSeconds: Long): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.expireAt(key, timestampSeconds) == 1L
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { expireAt(keyBytes, timestampSeconds) == 1L }
   }
 
   override fun pExpire(key: String, milliseconds: Long): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.pexpire(key, milliseconds) == 1L
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { pexpire(keyBytes, milliseconds) == 1L }
   }
 
   override fun pExpireAt(key: String, timestampMilliseconds: Long): Boolean {
-    return jedisPool.resource.use { jedis ->
-      jedis.pexpireAt(key, timestampMilliseconds) == 1L
-    }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { pexpireAt(keyBytes, timestampMilliseconds) == 1L }
   }
 
   override fun watch(vararg keys: String) {
-    jedisPool.resource.use { jedis ->
-      jedis.watch(*keys)
-    }
+    val keysAsBytes = keys.map { it.toByteArray() }.toTypedArray()
+    jedisPool.resource.use { jedis -> jedis.watch(*keysAsBytes) }
   }
 
   override fun unwatch(vararg keys: String) {
-    jedisPool.resource.use { jedis ->
-      jedis.unwatch()
-    }
+    jedisPool.resource.use { jedis -> jedis.unwatch() }
   }
 
-  override fun multi(): Transaction {
-    jedisPool.resource.use { jedis ->
-      return jedis.multi()
-    }
-  }
+  override fun multi(): Transaction = jedisPool.resource.use { multi() }
 
-  override fun pipelined(): Pipeline {
-    jedisPool.resource.use { jedis ->
-      return jedis.pipelined()
-    }
-  }
+  override fun pipelined(): Pipeline = jedisPool.resource.use { pipelined() }
+
 
   /** Closes the connection to Redis. */
   override fun close() {
     return jedisPool.close()
+  }
+
+  private fun <T> jedis(op: JedisBinaryCommands.() -> T): T {
+    return jedisPool.resource.use { jedisResource ->
+      val invocationHandler = JedisTimedInvocationHandler(jedisResource, clientMetrics)
+      val timedProxy = JedisBinaryCommands::class.cast(
+        Proxy.newProxyInstance(
+          ClassLoader.getSystemClassLoader(),
+          arrayOf(JedisBinaryCommands::class.java),
+          invocationHandler
+        )
+      )
+      timedProxy.op()
+    }
+  }
+
+  private class JedisTimedInvocationHandler(
+    private val jedis: JedisBinaryCommands,
+    private val clientMetrics: RedisClientMetrics,
+  ) : InvocationHandler {
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any =
+      clientMetrics.timed(method.name) {
+        method.invoke(jedis, *args ?: arrayOf())
+      }
   }
 
   companion object {

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -39,6 +39,7 @@ interface Redis {
    *
    * @param keyValues the list of keys and values in alternating order.
    */
+  // Consider deprecating in favour of a list of pairs?
   fun mset(vararg keyValues: ByteString)
 
   /**

--- a/misk-redis/src/main/kotlin/misk/redis/RedisClientMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisClientMetrics.kt
@@ -32,6 +32,15 @@ class RedisClientMetrics(metrics: Metrics) {
            Connections are dropped when they fail validation, and may be in an inconsistent state.
            """.trimIndent(),
   )
+  private val operationTime = metrics.histogram(
+    name = OPERATION_TIME,
+    help = "The time it took in seconds, as reported by the client, to complete an operation.",
+    labelNames = listOf("command"),
+  )
+
+  internal fun <T> timed(commandName: String, block: () -> T): T {
+    return operationTime.labels(commandName).time(block)
+  }
 
   companion object {
     internal const val MAX_TOTAL_CONNECTIONS = "redis_client_max_total_connections"
@@ -39,5 +48,6 @@ class RedisClientMetrics(metrics: Metrics) {
     internal const val IDLE_CONNECTIONS = "redis_client_idle_connections"
     internal const val ACTIVE_CONNECTIONS = "redis_client_active_connections"
     internal const val DESTROYED_CONNECTIONS_TOTAL = "redis_client_pool_destroyed_connections_total"
+    internal const val OPERATION_TIME = "redis_client_operation_time_seconds"
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RedisClientMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisClientMetrics.kt
@@ -1,0 +1,43 @@
+package misk.redis
+
+import misk.metrics.v2.Metrics
+
+class RedisClientMetrics(metrics: Metrics) {
+  internal val maxTotalConnectionsGauge = metrics.gauge(
+    name = MAX_TOTAL_CONNECTIONS,
+    help = """
+           Max number of connections for the misk-redis client connection pool.
+           This is configured on app startup.
+           """.trimIndent(),
+  )
+  internal val maxIdleConnectionsGauge = metrics.gauge(
+    name = MAX_IDLE_CONNECTIONS,
+    help = """
+           Max number of idle connections for the misk-redis client connection pool.
+           This is configured on app startup.
+           """.trimIndent(),
+  )
+  internal val activeConnectionsGauge = metrics.gauge(
+    name = ACTIVE_CONNECTIONS,
+    help = "Current number of active connections for the misk-redis client connection pool.",
+  )
+  internal val idleConnectionsGauge = metrics.gauge(
+    name = IDLE_CONNECTIONS,
+    help = "Current number of idle connections for the misk-redis client connection pool.",
+  )
+  internal val destroyedConnectionsCounter = metrics.counter(
+    name = DESTROYED_CONNECTIONS_TOTAL,
+    help = """
+           The total count of connections dropped from the pool.
+           Connections are dropped when they fail validation, and may be in an inconsistent state.
+           """.trimIndent(),
+  )
+
+  companion object {
+    internal const val MAX_TOTAL_CONNECTIONS = "redis_client_max_total_connections"
+    internal const val MAX_IDLE_CONNECTIONS = "redis_client_max_idle_connections"
+    internal const val IDLE_CONNECTIONS = "redis_client_idle_connections"
+    internal const val ACTIVE_CONNECTIONS = "redis_client_active_connections"
+    internal const val DESTROYED_CONNECTIONS_TOTAL = "redis_client_pool_destroyed_connections_total"
+  }
+}

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -53,14 +53,15 @@ class RedisModule(
       ?: throw RuntimeException("At least 1 replication group must be specified")
 
     // Create our jedis pool with client-side metrics.
+    val clientMetrics = RedisClientMetrics(metrics)
     val jedisPoolWithMetrics = JedisPoolWithMetrics(
-      metrics = RedisClientMetrics(metrics),
+      metrics = clientMetrics,
       poolConfig = jedisPoolConfig,
       replicationGroupConfig = replicationGroup,
       ssl = useSsl,
       requiresPassword = deployment.isReal
     )
 
-    return RealRedis(jedisPoolWithMetrics)
+    return RealRedis(jedisPoolWithMetrics, clientMetrics)
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -4,12 +4,31 @@ import com.google.inject.Provides
 import com.google.inject.Singleton
 import misk.ServiceModule
 import misk.inject.KAbstractModule
+import misk.metrics.v2.Metrics
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
 import wisp.deployment.Deployment
 
 /**
- * Configures a JedisPool to connect to a Redis instance. The use of a JedisPool ensures thread safety.
+ * Configures a [Redis] client with metrics, this also installs a [ServiceModule] for [RedisService].
+ * If other services require a working client connection to Redis before they can be used, specify a
+ * dependency like:
+ *
+ * ```
+ * install(ServiceModule<MyService>()
+ *     .dependsOn(keyOf<RedisService>())
+ * )
+ * ```
+ *
+ * You must pass in configuration for your Redis client.
+ *
+ * [redisConfig]: Only one replication group config is supported; this module will use the first
+ * configuration it finds. An empty [RedisReplicationGroupConfig.redis_auth_password] is only
+ * permitted in fake environments. See [Deployment].
+ *
+ * [jedisPoolConfig]: Misk-redis is backed by a [JedisPool], you may not want to use the
+ * [JedisPoolConfig] defaults! Be sure to understand them!
+ *
  * See: https://github.com/xetorthio/jedis/wiki/Getting-started#using-jedis-in-a-multithreaded-environment
  */
 class RedisModule(
@@ -20,27 +39,28 @@ class RedisModule(
   override fun configure() {
     bind<RedisConfig>().toInstance(redisConfig)
     install(ServiceModule<RedisService>())
+    requireBinding<Metrics>()
   }
 
   @Provides @Singleton
-  internal fun provideRedisClient(config: RedisConfig, deployment: Deployment): Redis {
+  internal fun provideRedisClient(
+    config: RedisConfig,
+    deployment: Deployment,
+    metrics: Metrics
+  ): Redis {
     // Get the first replication group, we only support 1 replication group per service.
     val replicationGroup = config[config.keys.first()]
       ?: throw RuntimeException("At least 1 replication group must be specified")
 
-    // Create our jedis pool
-    val jedisPool = JedisPool(
-      jedisPoolConfig,
-      replicationGroup.writer_endpoint.hostname,
-      replicationGroup.writer_endpoint.port,
-      replicationGroup.timeout_ms,
-      replicationGroup.redis_auth_password.ifEmpty {
-        check(deployment.isFake) { "Redis auth password cannot be empty in a real environment!" }
-        null
-      },
-      useSsl,
+    // Create our jedis pool with client-side metrics.
+    val jedisPoolWithMetrics = JedisPoolWithMetrics(
+      metrics = RedisClientMetrics(metrics),
+      poolConfig = jedisPoolConfig,
+      replicationGroupConfig = replicationGroup,
+      ssl = useSsl,
+      requiresPassword = deployment.isReal
     )
 
-    return RealRedis(jedisPool)
+    return RealRedis(jedisPoolWithMetrics)
   }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/RedisAuthPasswordEnvTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RedisAuthPasswordEnvTest.kt
@@ -38,7 +38,8 @@ class RedisAuthPasswordEnvTest {
     val injector = createInjector(realEnv, realRedisModule)
     val ex = assertThrows<ProvisionException> { injector.getInstance(keyOf<RedisConsumer>()) }
     assertThat(ex).hasCauseInstanceOf(IllegalStateException::class.java)
-    assertThat(ex.cause).hasMessage("Redis auth password cannot be empty in a real environment!")
+    assertThat(ex.cause)
+      .hasMessage("This Redis client is configured to require an auth password, but none was provided!")
   }
 
   private class RedisConsumer @Inject constructor(val redis: Redis)

--- a/misk-redis/src/test/kotlin/misk/redis/RedisClientMetricsTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RedisClientMetricsTest.kt
@@ -1,0 +1,69 @@
+package misk.redis
+
+import io.prometheus.client.CollectorRegistry
+import misk.MiskTestingServiceModule
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.redis.RedisClientMetrics.Companion.ACTIVE_CONNECTIONS
+import misk.redis.RedisClientMetrics.Companion.DESTROYED_CONNECTIONS_TOTAL
+import misk.redis.RedisClientMetrics.Companion.IDLE_CONNECTIONS
+import misk.redis.RedisClientMetrics.Companion.MAX_IDLE_CONNECTIONS
+import misk.redis.RedisClientMetrics.Companion.MAX_TOTAL_CONNECTIONS
+import misk.redis.RedisClientMetrics.Companion.OPERATION_TIME
+import misk.redis.testing.DockerRedis
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import redis.clients.jedis.JedisPoolConfig
+import wisp.deployment.TESTING
+import javax.inject.Inject
+
+@Suppress("UsePropertyAccessSyntax")
+@MiskTest
+class RedisClientMetricsTest {
+  @Suppress("unused")
+  @MiskExternalDependency private val dockerRedis = DockerRedis
+
+  @Suppress("unused")
+  @MiskTestModule private val module = object : KAbstractModule() {
+    override fun configure() {
+      install(DeploymentModule(TESTING))
+      install(MiskTestingServiceModule())
+      install(RedisModule(DockerRedis.config, JedisPoolConfig(), useSsl = false))
+    }
+  }
+
+  @Inject private lateinit var collectorRegistry: CollectorRegistry
+  @Inject private lateinit var redis: Redis
+
+  @Test fun `connections are counted`() {
+    // No connections are created or used yet.
+    assertThat(collectorRegistry[ACTIVE_CONNECTIONS]).isEqualTo(0.0)
+    assertThat(collectorRegistry[IDLE_CONNECTIONS]).isEqualTo(0.0)
+    assertThat(collectorRegistry[MAX_TOTAL_CONNECTIONS]).isEqualTo(8.0)
+    assertThat(collectorRegistry[MAX_IDLE_CONNECTIONS]).isEqualTo(8.0)
+
+    // Take a connection. The connection should be counted as active while it is held.
+    // FIXME: Testing active connection count in a single-threaded testing environment is impossible
+    //   without proper Transaction or Pipeline support. Presently misk-redis will return a jedis
+    //   that yields a transaction to the pool, which will result in wrong metrics.
+    assertThat(redis["hello"]).isNull()
+
+    // The connection is returned to idle, once it is used.
+    assertThat(collectorRegistry[ACTIVE_CONNECTIONS]).isEqualTo(0.0)
+    assertThat(collectorRegistry[IDLE_CONNECTIONS]).isEqualTo(1.0)
+
+    // No connections are destroyed, because this is exceptional unless we close the client.
+    assertThat(collectorRegistry[DESTROYED_CONNECTIONS_TOTAL]).isZero()
+
+    // Close the client to destroy all idle connections.
+    redis.close()
+    assertThat(collectorRegistry[DESTROYED_CONNECTIONS_TOTAL]).isEqualTo(1.0)
+  }
+
+  private operator fun CollectorRegistry.get(metric: String): Double? =
+    getSampleValue(metric)
+}


### PR DESCRIPTION
This PR adds client-side metrics to misk-redis.

1. Connection metrics:
   - `redis_client_max_connections` (gauge) (tracks configuration, serves a baseline to track pool usage)
   - `redis_client_max_idle_connections` (gauge) (tracks configuration, serves a baseline to track pool usage)
   - `redis_client_active_connections` (gauge) (tracks connections in use, helps track pool usage)
   - `redis_client_idle_connections` (gauge) (tracks connections not in use, helps track pool usage)
   - `redis_client_pool_destroyed_connections_total` (counter) (destroyed connections outside of host restarts are indicative of anomalies, but generally Jedis will do the right thing to replace destroyed connections)
  
   These metrics are exposed by plugging into the relevant lifecycle methods of the JedisPool.
   
2. Performance/latency metrics:
   - `redis_client_operation_time_seconds` (histogram) (tagged by command, e.g. command=hset)
      
   This works by dynamic proxy, so every Redis method call gets timed and recorded to a histogram

---

Notes: 

- Jedis connection pool metrics _can_ be exposed via JMX, as they use Apache common pool 2; this PR opts to add custom metrics for consistent prometheus style naming conventions, and to be robust in case the backing redis implementation ever changes.
- Misk-redis is a bit of a leaky abstraction, as it exposes Jedis types (Pipeline and Transaction); metrics are _not_ supported on pipeline or transaction calls right now. They will likely be added in a follow-up, but we'll need to add new APIs for better contained (and testable) transactions and pipelines.