### PR TITLE
Refactor provisioning of RuntimeMxBean

### DIFF
--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -662,7 +662,6 @@ public final class misk/web/metadata/jvm/JvmMetadataAction$JvmRuntimeResponse$Co
 
 public final class misk/web/metadata/jvm/JvmMetadataModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
-	public final fun provideRuntimeMxBean ()Ljava/lang/management/RuntimeMXBean;
 }
 
 public final class misk/web/metadata/webaction/WebActionMetadataAction : misk/web/actions/WebAction {

--- a/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/jvm/JvmMetadataModule.kt
@@ -2,16 +2,14 @@ package misk.web.metadata.jvm
 
 import com.google.inject.Provides
 import misk.inject.KAbstractModule
+import misk.jvm.JvmManagementFactoryModule
 import misk.web.WebActionModule
 import java.lang.management.ManagementFactory
 import java.lang.management.RuntimeMXBean
 
 class JvmMetadataModule : KAbstractModule() {
   override fun configure() {
+    install(JvmManagementFactoryModule())
     install(WebActionModule.create<JvmMetadataAction>())
-  }
-
-  @Provides fun provideRuntimeMxBean() : RuntimeMXBean {
-    return ManagementFactory.getRuntimeMXBean()
   }
 }

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -867,6 +867,11 @@ public final class misk/io/PathExtensionsKt {
 	public static synthetic fun listRecursively$default (Ljava/nio/file/Path;ZILjava/lang/Object;)Ljava/util/List;
 }
 
+public final class misk/jvm/JvmManagementFactoryModule : misk/inject/KInstallOnceModule {
+	public fun <init> ()V
+	public final fun provideRuntimeMxBean ()Ljava/lang/management/RuntimeMXBean;
+}
+
 public final class misk/monitoring/JvmMetrics {
 	public fun <init> (Ljava/lang/management/RuntimeMXBean;Lmisk/metrics/v2/Metrics;)V
 }

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -5,6 +5,7 @@ import misk.concurrent.SleeperModule
 import misk.environment.RealEnvVarModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
+import misk.jvm.JvmManagementFactoryModule
 import misk.metrics.backends.prometheus.PrometheusMetricsClientModule
 import misk.moshi.MoshiModule
 import misk.resources.ResourceLoaderModule
@@ -42,7 +43,7 @@ class MiskCommonServiceModule : KAbstractModule() {
     install(ServiceManagerModule())
     install(PrometheusMetricsClientModule())
     install(MoshiModule(useWireToRead = true, useWireToWrite = true))
-
+    install(JvmManagementFactoryModule())
     // Initialize empty sets for our multibindings.
     newMultibinder<HealthCheck>()
   }

--- a/misk/src/main/kotlin/misk/jvm/JvmManagementFactoryModule.kt
+++ b/misk/src/main/kotlin/misk/jvm/JvmManagementFactoryModule.kt
@@ -1,0 +1,15 @@
+package misk.jvm
+
+import com.google.inject.Provides
+import misk.inject.KInstallOnceModule
+import java.lang.management.ManagementFactory
+import java.lang.management.RuntimeMXBean
+
+/**
+ * Default providers for the [ManagementFactory] beans that the framework depends on.
+ */
+class JvmManagementFactoryModule : KInstallOnceModule() {
+  @Provides fun provideRuntimeMxBean() : RuntimeMXBean {
+    return ManagementFactory.getRuntimeMXBean()
+  }
+}


### PR DESCRIPTION
Refactor the provider of this to a more common location so that other parts of the framework can rely on an injected `RuntimeMxBean`.

(Immediate use case is plugging the new `MonitoringModule` in to our misk apps by default)