### PR TITLE
Respect Accept header when choosing return content type

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -193,7 +193,7 @@ public abstract interface class misk/web/ResponseBody {
 }
 
 public abstract interface annotation class misk/web/ResponseContentType : java/lang/annotation/Annotation {
-	public abstract fun value ()Ljava/lang/String;
+	public abstract fun value ()[Ljava/lang/String;
 }
 
 public final class misk/web/WebActionModule : misk/inject/KAbstractModule {

--- a/misk-actions/src/main/kotlin/misk/web/Http.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Http.kt
@@ -43,7 +43,7 @@ annotation class RequestBody
 annotation class RequestContentType(vararg val value: String)
 
 @Target(AnnotationTarget.FUNCTION)
-annotation class ResponseContentType(val value: String)
+annotation class ResponseContentType(vararg val value: String)
 
 /**
  * When the service is overloaded Misk will intervene and reject calls by returning "HTTP 503

--- a/misk-actions/src/main/kotlin/misk/web/Http.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Http.kt
@@ -42,6 +42,13 @@ annotation class RequestBody
 @Target(AnnotationTarget.FUNCTION)
 annotation class RequestContentType(vararg val value: String)
 
+/**
+ * Indicates what response content types the action can produce.
+ *
+ * Clients can specify what content type they prefer by setting the `Accept` header. If the action
+ * supports multiple content types but no `Accept` header is specified, the first content type is
+ * used.
+ */
 @Target(AnnotationTarget.FUNCTION)
 annotation class ResponseContentType(vararg val value: String)
 

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -271,7 +271,8 @@ public final class misk/Action {
 }
 
 public final class misk/ActionsKt {
-	public static final fun asAction (Lkotlin/reflect/KFunction;Lmisk/web/DispatchMechanism;)Lmisk/Action;
+	public static final fun asAction (Lkotlin/reflect/KFunction;Lmisk/web/DispatchMechanism;Lokhttp3/MediaType;)Lmisk/Action;
+	public static synthetic fun asAction$default (Lkotlin/reflect/KFunction;Lmisk/web/DispatchMechanism;Lokhttp3/MediaType;ILjava/lang/Object;)Lmisk/Action;
 }
 
 public abstract interface class misk/ApplicationInterceptor {

--- a/misk/src/main/kotlin/misk/Actions.kt
+++ b/misk/src/main/kotlin/misk/Actions.kt
@@ -5,6 +5,7 @@ import misk.web.RequestContentType
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
+import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -12,7 +13,8 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.instanceParameter
 
 fun KFunction<*>.asAction(
-  dispatchMechanism: DispatchMechanism
+  dispatchMechanism: DispatchMechanism,
+  responseContentType: MediaType? = singleOrNullResponseMediaType(),
 ): Action {
   val instanceParameter = instanceParameter
     ?: throw IllegalArgumentException("only methods may be actions")
@@ -35,29 +37,31 @@ fun KFunction<*>.asAction(
         }
         listOf(MediaRange.parse(MediaTypes.APPLICATION_GRPC))
       }
+
       else -> findAnnotation<RequestContentType>()?.value?.flatMap {
         MediaRange.parseRanges(it)
       }?.toList() ?: listOf(MediaRange.ALL_MEDIA)
-    }
-
-  val responseContentType =
-    when (dispatchMechanism) {
-      DispatchMechanism.GRPC -> {
-        require(findAnnotation<ResponseContentType>() == null) {
-          "@Grpc cannot be used with @ResponseContentType on $this"
-        }
-        MediaTypes.APPLICATION_GRPC_MEDIA_TYPE
-      }
-      else -> findAnnotation<ResponseContentType>()?.value?.toMediaTypeOrNull()
     }
 
   return Action(
     name = actionName,
     function = this,
     acceptedMediaRanges = acceptedMediaRange,
-    responseContentType = responseContentType,
+    responseContentType = when (dispatchMechanism) {
+      DispatchMechanism.GRPC -> {
+        require(findAnnotation<ResponseContentType>() == null) {
+          "@Grpc cannot be used with @ResponseContentType on $this"
+        }
+        MediaTypes.APPLICATION_GRPC_MEDIA_TYPE
+      }
+
+      else -> responseContentType
+    },
     parameters = actualParameters,
     returnType = returnType,
     dispatchMechanism = dispatchMechanism
   )
 }
+
+private fun KFunction<*>.singleOrNullResponseMediaType() =
+  findAnnotation<ResponseContentType>()?.value?.singleOrNull()?.toMediaTypeOrNull()

--- a/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
@@ -154,6 +154,7 @@ internal class WebActionFactory @Inject constructor(
     val responseContentTypes = function.findAnnotation<ResponseContentType>()
       ?.value
       ?.toList()
+      // We have to have an element in the list to be able to flatMap over it below.
       ?: listOf(null)
 
     val actions = responseContentTypes.flatMap { responseContentType ->
@@ -171,6 +172,9 @@ internal class WebActionFactory @Inject constructor(
       )
     }
 
+    // Because we create a synthetic JSON action for each protobuf action, we need to dedupe the
+    // actions for the case where a user explicitly annotates an endpoint to service both JSON and
+    // Protobuf, to avoid having the synthetic JSON action and the "real" one from the annotation.
     result += actions.distinctBy { it.action }
   }
 

--- a/misk/src/test/kotlin/misk/web/actions/ResponseContentTypeTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ResponseContentTypeTest.kt
@@ -46,7 +46,8 @@ class ResponseContentTypeTest {
 
   @Test
   fun `the Accept header does not allow unsupported types to be returned`() {
-    // Make sure if we don't specify an Accept header, that it defaults to JSON
+    // Make sure if we don't specify an Accept header, that it defaults to only specified response
+    // content type, which in this case is JSON.
     val headerlessRequest = get("/hello-json/jeff")
     val headerlessResponse = httpClient.newCall(headerlessRequest).execute()
     assertThat(headerlessResponse.code).isEqualTo(200)
@@ -60,6 +61,16 @@ class ResponseContentTypeTest {
     val requestForProto = get("/hello-json/jeff", MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE)
     val protoResponse = httpClient.newCall(requestForProto).execute()
     assertThat(protoResponse.code).isEqualTo(415)
+  }
+
+  @Test
+  fun `if no Accept header is specified the first supported content type is preferred`() {
+    // Since we don't specify an Accept header, the first supported content type is used which is
+    // JSON for this particular endpoint.
+    val headerlessRequest = get("/hello/jeff")
+    val headerlessResponse = httpClient.newCall(headerlessRequest).execute()
+    assertThat(headerlessResponse.code).isEqualTo(200)
+    assertThat(headerlessResponse.body!!.string()).isEqualTo("""{"message":"howdy, jeff"}""")
   }
 
   class TestModule : KAbstractModule() {

--- a/misk/src/test/kotlin/misk/web/actions/ResponseContentTypeTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/ResponseContentTypeTest.kt
@@ -1,0 +1,102 @@
+package misk.web.actions
+
+import com.squareup.protos.test.grpc.HelloReply
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.PathParam
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.Charset
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+class ResponseContentTypeTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject private lateinit var jettyService: JettyService
+
+  private val httpClient = OkHttpClient()
+
+  @Test
+  fun `the Accept header can control what response type is returned if the endpoint supports it`() {
+    val requestForJson = get("/hello/jeff", MediaTypes.APPLICATION_JSON_MEDIA_TYPE)
+    val jsonResponse = httpClient.newCall(requestForJson).execute()
+    assertThat(jsonResponse.code).isEqualTo(200)
+    assertThat(jsonResponse.body!!.string()).isEqualTo("""{"message":"howdy, jeff"}""")
+
+    val requestForProto = get("/hello/jeff", MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE)
+    val protoResponse = httpClient.newCall(requestForProto).execute()
+    assertThat(protoResponse.code).isEqualTo(200)
+    assertThat(protoResponse.body!!.string())
+      .isEqualTo(HelloReply("howdy, jeff").encodeByteString().string(Charset.defaultCharset()))
+  }
+
+  @Test
+  fun `the Accept header does not allow unsupported types to be returned`() {
+    // Make sure if we don't specify an Accept header, that it defaults to JSON
+    val headerlessRequest = get("/hello-json/jeff")
+    val headerlessResponse = httpClient.newCall(headerlessRequest).execute()
+    assertThat(headerlessResponse.code).isEqualTo(200)
+    assertThat(headerlessResponse.body!!.string()).isEqualTo("""{"message":"howdy, jeff"}""")
+
+    val requestForJson = get("/hello-json/jeff", MediaTypes.APPLICATION_JSON_MEDIA_TYPE)
+    val jsonResponse = httpClient.newCall(requestForJson).execute()
+    assertThat(jsonResponse.code).isEqualTo(200)
+    assertThat(jsonResponse.body!!.string()).isEqualTo("""{"message":"howdy, jeff"}""")
+
+    val requestForProto = get("/hello-json/jeff", MediaTypes.APPLICATION_PROTOBUF_MEDIA_TYPE)
+    val protoResponse = httpClient.newCall(requestForProto).execute()
+    assertThat(protoResponse.code).isEqualTo(415)
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<HelloAction>())
+    }
+  }
+
+  @Singleton
+  class HelloAction @Inject constructor() : WebAction {
+    @Get("/hello/{name}")
+    @ResponseContentType(
+      MediaTypes.APPLICATION_JSON,
+      MediaTypes.APPLICATION_PROTOBUF,
+    )
+    fun sayHello(@PathParam("name") name: String): HelloReply {
+      return HelloReply.Builder()
+        .message("howdy, $name")
+        .build()
+    }
+
+    @Get("/hello-json/{name}")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun sayHelloJson(@PathParam("name") name: String): HelloReply {
+      return HelloReply.Builder()
+        .message("howdy, $name")
+        .build()
+    }
+  }
+
+  private fun get(path: String, acceptedMediaType: MediaType? = null): Request {
+    return Request.Builder()
+      .get()
+      .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
+      .header("Accept", acceptedMediaType.toString())
+      .build()
+  }
+}


### PR DESCRIPTION
Not sure I'm thrilled with this approach, I tried to keep it as backwards compatible as possible, outside of changing the `value` param of `@ResponseContentType` to be a `vararg`. Tried to follow the same implementation path as how the protobuf endpoints set up JSON variants.

Putting it up to make sure we agree on the high-level implementation first (basically just look at the tests), and then I can rework the internals if there are better suggestions.