### PR TITLE
Improve test support for the pause detector

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -926,6 +926,9 @@ public final class misk/okio/OkioExtensionsKt {
 	public static final fun split (Lokio/BufferedSource;Lokio/ByteString;)Lkotlin/sequences/Sequence;
 }
 
+public abstract interface annotation class misk/perf/ForPauseDetector : java/lang/annotation/Annotation {
+}
+
 public final class misk/perf/PauseDetectorConfig {
 	public fun <init> ()V
 	public fun <init> (JJJJJ)V

--- a/misk/src/main/kotlin/misk/perf/ForPauseDetector.kt
+++ b/misk/src/main/kotlin/misk/perf/ForPauseDetector.kt
@@ -1,0 +1,17 @@
+package misk.perf
+
+import com.google.common.base.Ticker
+import misk.concurrent.Sleeper
+import javax.inject.Qualifier
+
+/**
+ * Used to bind a [Sleeper] and [Ticker] that are suitable for usage by the [PauseDetector]
+ */
+@Qualifier
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.TYPE
+)
+annotation class ForPauseDetector

--- a/misk/src/main/kotlin/misk/perf/PauseDetectorModule.kt
+++ b/misk/src/main/kotlin/misk/perf/PauseDetectorModule.kt
@@ -1,17 +1,26 @@
 package misk.perf
 
+import com.google.common.base.Ticker
 import misk.ServiceModule
+import misk.concurrent.Sleeper
 import misk.inject.KAbstractModule
 
 /**
  * Install this module to run the [PauseDetector] in the background.
  */
-class PauseDetectorModule constructor(
+class PauseDetectorModule(
   val pauseDetectorConfig: PauseDetectorConfig = PauseDetectorConfig(),
 ) : KAbstractModule() {
-
   override fun configure() {
     install(ServiceModule<PauseDetector>())
     bind<PauseDetectorConfig>().toInstance(pauseDetectorConfig)
+
+    // Outside of pause detector's own testing harness, we don't want to run with a fake sleeper.
+    // A fake sleeper might never return from `sleep` which will cause service teardown errors.
+    // Another kind of fake sleeper might return immediately from sleep, but that can waste
+    // CPU cycles in CI if the pause detector is pulled into such a test.
+    bind<Sleeper>().annotatedWith<ForPauseDetector>().toInstance(Sleeper.DEFAULT)
+    // For good measure, bind a real ticker with the real sleeper:
+    bind<Ticker>().annotatedWith<ForPauseDetector>().toInstance(Ticker.systemTicker())
   }
 }

--- a/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
+++ b/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
@@ -3,10 +3,12 @@ package misk.perf
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.google.common.base.Ticker
+import com.google.inject.Key
 import misk.ServiceManagerModule
 import misk.concurrent.FakeTicker
 import misk.concurrent.Sleeper
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
 import misk.logging.LogCollectorModule
 import misk.metrics.v2.FakeMetricsModule
 import misk.testing.MiskTest
@@ -22,7 +24,7 @@ import javax.inject.Inject
 class PauseDetectorTest {
   @MiskTestModule val module = TestModule()
 
-  @Inject lateinit var fakeTicker: FakeTicker
+  @Inject @ForPauseDetector lateinit var fakeTicker: FakeTicker
   @Inject internal lateinit var detector: PauseDetector
   @Inject lateinit var logCollector: LogCollector
 
@@ -86,6 +88,9 @@ class PauseDetectorTest {
   }
 
   @Test fun `ticker goes backwards`() {
+    // Move forward 5s so that we can move _backwards_ to a positive value in the test.
+    fakeTicker.sleepMs(5000);
+
     // 1ms of sleep
     detector.sleep()
     // Move the ticker back 2020ms
@@ -112,14 +117,18 @@ class PauseDetectorTest {
         logErrorMillis = 10000
       )
       // NB: We are intentionally _not_ installing the module
-      // because we want to drive the detector check/sleep cycles from this test harness
+      // because we want to drive the detector check/sleep cycles from this test harness and
+      // we want to configure a fake ticker.
       bind<PauseDetectorConfig>().toInstance(config)
+      bind<FakeTicker>().annotatedWith<ForPauseDetector>().toInstance(FakeTicker())
+      bind<Ticker>().annotatedWith<ForPauseDetector>()
+        .to(Key.get(FakeTicker::class.java, ForPauseDetector::class.java))
+      bind<Sleeper>().annotatedWith<ForPauseDetector>()
+        .to(Key.get(FakeTicker::class.java, ForPauseDetector::class.java))
 
       // And its dependencies with test fakes
       install(ServiceManagerModule())
       install(FakeMetricsModule())
-      bind<Ticker>().to<FakeTicker>()
-      bind<Sleeper>().to<FakeTicker>()
 
       // Test support
       install(LogCollectorModule())


### PR DESCRIPTION
My attempt to install the detector module universally in skim revealed a couple of issues with other integration tests.

Misk's default test sleeper is the `FakeSleeper` which doesn't let a sleep terminate unless some other thread manually moves the ticker the appropriate amount. This is a strange default for misk to have, and we should probably consider changing that, but that's beyond the scope of what I want to do here (unclear how many folks might be relying on this default today). This results in test failures utilizing the `ServiceManager` as the detector service will never shut down as it is blocked on a sleep call that will never terminate.

In practice, the only time we care to have a fake ticker or sleeper in the pause detector is in `PauseDetectorTest`. Any integration test that happens to install the pause detector (e.g. via some standard common module) should not have to worry about managing the clock on its behalf.

To address these issues, this change introduces as `@ForPauseDetector` annotation so that we have more direct control over the ticker/sleeper used for the detector.