### PR TITLE
Update deprecation message.

### DIFF
--- a/misk-core/src/main/kotlin/misk/config/Config.kt
+++ b/misk-core/src/main/kotlin/misk/config/Config.kt
@@ -8,5 +8,5 @@ package misk.config
 //    "wisp.config.Config"
 //  )
 // )
-@Deprecated("Use from misk-config instead")
+@Deprecated("Use from wisp-config instead")
 interface Config : wisp.config.Config


### PR DESCRIPTION
There is no Config interface in misk-config, so the deprecation message is confusing.