### PR TITLE
Handle empty object in web actions

### DIFF
--- a/misk-admin/web/tabs/web-actions/package.json
+++ b/misk-admin/web/tabs/web-actions/package.json
@@ -30,7 +30,10 @@
     "@misk/prettier": "0.4.0",
     "@misk/tslint": "0.4.0",
     "tslib": "2.3.0",
-    "@misk/cli": "0.4.0"
+    "@misk/cli": "0.4.0",
+    "webpack": "4.43.0",
+    "webpack-cli": "3.3.11",
+    "webpack-dev-server": "3.11.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/misk-admin/web/tabs/web-actions/src/rewrite/WebActionSendRequestFormComponents.tsx
+++ b/misk-admin/web/tabs/web-actions/src/rewrite/WebActionSendRequestFormComponents.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import {
   Button,
+  Checkbox,
   Collapse,
   HTMLSelect,
   Icon,
@@ -220,27 +221,38 @@ function FormObjectComponent({
       protoType={field.type}
     >
       <div style={{ marginLeft: "12px" }}>
-        {complexType.fields.map(subField => {
-          return (
-            <FormComponent
-              webActionMetadata={webActionMetadata}
-              field={subField}
-              onChange={newChildVal => {
-                const newValue = _(_.clone(value) || {})
-                  .set(subField.name, newChildVal)
-                  .omitBy(_.isNull)
-                  .value()
+        {complexType.fields.length > 0 ? (
+          complexType.fields.map(subField => {
+            return (
+              <FormComponent
+                webActionMetadata={webActionMetadata}
+                field={subField}
+                onChange={newChildVal => {
+                  const newValue = _(_.clone(value) || {})
+                    .set(subField.name, newChildVal)
+                    .omitBy(_.isNull)
+                    .value()
 
-                if (_.isEmpty(newValue)) {
-                  onChange(null)
-                } else {
-                  onChange(newValue)
-                }
-              }}
-              value={_.get(value, subField.name, null)}
-            />
-          )
-        })}
+                  if (_.isEmpty(newValue)) {
+                    onChange(null)
+                  } else {
+                    onChange(newValue)
+                  }
+                }}
+                value={_.get(value, subField.name, null)}
+              />
+            )
+          })
+        ) : (
+          <Checkbox
+            onChange={e => {
+              const value = e.currentTarget.checked
+              onChange(value ? {} : undefined)
+            }}
+          >
+            Add as an empty object
+          </Checkbox>
+        )}
       </div>
     </FormComponentWrapper>
   )


### PR DESCRIPTION
**Context**
We have encountered an issue where an empty property couldn't be selected to populate the request body (see [slack1](https://cash.slack.com/archives/C01MK79CCF8/p1683665098147739), [slack2](https://cash.slack.com/archives/C04P0B76LLD/p1683932583193609))

**Fix**
My original plan was to use a dropdown to represent the `oneOf` type and populate the selected empty property to the request body. However, the `oneOfName` value in the `WireField` annotation is not populated in the [misk-web server code](https://github.com/cashapp/misk/blob/77f9a3b9927efb3cb7b369895b296f484a6af9dd/misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt#L210), so there is no way to differentiate the `oneOf` field from the other fields in the web-actions tab. 

Alternatively, I'm adding a checkbox to the empty proto input in the web-actions tab. If the checkbox is checked, add the empty proto to the request body. This has the limitation that it doesn't prevent adding multiple empty protos to the `oneOf` field, which will result in a 500 error on the server side. 

The fix is able to unblock sending a request that contains empty protos from the admin console. I think we can further improve the misk-web server code to populate the "oneOf" type later. 

**Screenshot**
<img width="925" alt="web-action-empty-object" src="https://github.com/cashapp/misk/assets/5472672/76554a4f-9fba-408c-a6cd-c694f09897e2">

**Screen recording**
https://github.com/cashapp/misk/assets/5472672/b825ea17-4015-41cb-bdaa-6ea7490e3bad


