### PR TITLE
Add a function to snapshot the action scope

### DIFF
--- a/misk-action-scopes/api/misk-action-scopes.api
+++ b/misk-action-scopes/api/misk-action-scopes.api
@@ -24,6 +24,7 @@ public final class misk/scope/ActionScope : java/lang/AutoCloseable {
 	public final fun propagate (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Callable;
 	public final fun propagate (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
 	public final fun propagate (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public final fun snapshotActionScope ()Ljava/util/Map;
 }
 
 public final class misk/scope/ActionScope$Companion {

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -51,6 +51,11 @@ class ActionScope @Inject internal constructor(
     return threadLocalScope.asContextElement(currentScopedData)
   }
 
+  fun snapshotActionScope(): Map<Key<*>, Any?> {
+    check(inScope()) { "not running within an ActionScope" }
+    return threadLocalScope.get().toMap()
+  }
+
   /** Starts the scope on a thread with the provided seed data */
   fun enter(seedData: Map<Key<*>, Any?>): ActionScope {
     check(!inScope()) {

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -5,6 +5,7 @@ import com.google.inject.Key
 import com.google.inject.TypeLiteral
 import com.google.inject.name.Named
 import com.google.inject.name.Names
+import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 import misk.inject.keyOf
 import misk.inject.toKey
@@ -181,6 +182,48 @@ internal class ActionScopedTest {
 
     assertFailsWith<IllegalStateException> {
       scope.asContextElement()
+    }
+  }
+
+  @Test
+  fun `allow getting scope things from another thread`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(
+      keyOf<String>(Names.named("from-seed")) to "seed-value"
+    )
+
+    // exhibit A: trying to access scoped things in a new thread results in exceptions
+    scope.enter(seedData).use { _ ->
+      var thrown: Throwable? = null
+
+      thread {
+        try {
+          assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+        } catch (t: Throwable) {
+          thrown = t
+        }
+      }.join()
+      assertThat(thrown).isNotNull
+    }
+
+    // exhibit B: trying to access scoped things in a new thread can work, if you take
+    // a snapshot of the scope and use it to instantiate a scope in the new thread.
+    scope.enter(seedData).use { actionScope ->
+      var thrown: Throwable? = null
+
+      val snapshot = actionScope.snapshotActionScope()
+      thread {
+        try {
+          actionScope.enter(snapshot).use {
+            assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+          }
+        } catch (t: Throwable) {
+          thrown = t
+        }
+      }.join()
+      assertThat(thrown).isNull()
     }
   }
 }


### PR DESCRIPTION
This will allow using the action scope on threads that are running okhttp async executions. Those threads are not tied to the original action thread in a coroutine-friendly way so we can't use the existing coroutine APIs to propagate the action scope. Instead we need some out-of-band mechanism, and this new function provides that ability.