### PR TITLE
Allow POST actions to be considered for handling grpc requests

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1343,6 +1343,7 @@ public final class misk/web/ResponseExtensionsKt {
 	public static final fun readUtf8 (Lmisk/web/Response;)Ljava/lang/String;
 	public static final fun toMisk (Lokhttp3/Response;)Lmisk/web/Response;
 	public static final fun toResponseBody (Ljava/lang/String;)Lmisk/web/ResponseBody;
+	public static final fun toResponseBody (Lokio/ByteString;)Lmisk/web/ResponseBody;
 }
 
 public abstract class misk/web/SocketAddress {

--- a/misk/src/main/kotlin/misk/web/ResponseExtensions.kt
+++ b/misk/src/main/kotlin/misk/web/ResponseExtensions.kt
@@ -2,12 +2,22 @@ package misk.web
 
 import okio.Buffer
 import okio.BufferedSink
+import okio.ByteString
 
 /** Returns a [ResponseBody] that writes this out as UTF-8. */
 fun String.toResponseBody(): ResponseBody {
   return object : ResponseBody {
     override fun writeTo(sink: BufferedSink) {
       sink.writeUtf8(this@toResponseBody)
+    }
+  }
+}
+
+/** Returns a [ResponseBody] that writes this out as bytestring. */
+fun ByteString.toResponseBody(): ResponseBody {
+  return object : ResponseBody {
+    override fun writeTo(sink: BufferedSink) {
+      sink.write(this@toResponseBody)
     }
   }
 }


### PR DESCRIPTION
Some web actions can handle any grpc since they are generic (for example, [WebProxyAction](https://github.com/cashapp/misk/blob/master/misk/src/main/kotlin/misk/web/proxy/WebProxyAction.kt)). However, they are currently not considered for handling content type grpc since the dispatch mechanism is conveyed as grpc (which doesn't match POST).

As a fix for this, we should, as a last resort (before communicating a 404), consider these POST actions if no matching GRPC action was found. 

Thinking about backwards compatibility concerns, for all affected cases today, they currently convey a 404 for these scenarios, so the risk is low of breaking clients. That said, there is some small risk of a webaction in a service today claiming to be able to support GPRC (or all content types) that could start getting hit with traffic.