### PR TITLE
Refactor dashboard tab install with new DashboardTabModule

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -217,7 +217,15 @@ public abstract interface class misk/web/actions/WebAction {
 
 public final class misk/web/actions/WebActionEntry : misk/web/dashboard/ValidWebEntry {
 	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;)V
+	public final fun component1 ()Lkotlin/reflect/KClass;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lkotlin/reflect/KClass;Ljava/lang/String;)Lmisk/web/actions/WebActionEntry;
+	public static synthetic fun copy$default (Lmisk/web/actions/WebActionEntry;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lmisk/web/actions/WebActionEntry;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActionClass ()Lkotlin/reflect/KClass;
+	public final fun getUrl_path_prefix ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class misk/web/actions/WebSocket {
@@ -237,13 +245,13 @@ public class misk/web/actions/WebSocketListener {
 	public fun onMessage (Lmisk/web/actions/WebSocket;Lokio/ByteString;)V
 }
 
-public abstract class misk/web/dashboard/ValidWebEntry {
+public class misk/web/dashboard/ValidWebEntry {
 	public static final field Companion Lmisk/web/dashboard/ValidWebEntry$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getSlug ()Ljava/lang/String;
-	public final fun getUrl_path_prefix ()Ljava/lang/String;
+	public final fun getValid_slug ()Ljava/lang/String;
+	public final fun getValid_url_path_prefix ()Ljava/lang/String;
 }
 
 public final class misk/web/dashboard/ValidWebEntry$Companion {

--- a/misk-actions/src/main/kotlin/misk/web/actions/WebActionEntry.kt
+++ b/misk-actions/src/main/kotlin/misk/web/actions/WebActionEntry.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
  *   - any number of non-whitespace characters (including additional path segments or "/")
  *   - must terminate with a non-"/" because rest of path will start with "/"
  */
-class WebActionEntry(
+data class WebActionEntry(
   val actionClass: KClass<out WebAction>,
-  url_path_prefix: String
-) : ValidWebEntry(url_path_prefix = url_path_prefix)
+  val url_path_prefix: String
+) : ValidWebEntry(valid_url_path_prefix = url_path_prefix)

--- a/misk-actions/src/main/kotlin/misk/web/dashboard/ValidWebEntry.kt
+++ b/misk-actions/src/main/kotlin/misk/web/dashboard/ValidWebEntry.kt
@@ -4,19 +4,19 @@ import com.google.common.base.CharMatcher
 
 private val BlockedUrlPathPrefixes = listOf("/api/")
 
-abstract class ValidWebEntry(val slug: String = "", val url_path_prefix: String = "/") {
+open class ValidWebEntry(val valid_slug: String = "", val valid_url_path_prefix: String = "/") {
   init {
     // internal link url_path_prefix must start and end with '/'
-    require(url_path_prefix.startsWith("http") || url_path_prefix.matches(Regex("(/[^/]+)*/"))) {
-      "Invalid or unexpected url path prefix: '$url_path_prefix'. " +
+    require(valid_url_path_prefix.startsWith("http") || valid_url_path_prefix.matches(Regex("(/[^/]+)*/"))) {
+      "Invalid or unexpected url path prefix: '$valid_url_path_prefix'. " +
         "Must start with 'http' OR start and end with '/'."
     }
 
     // url_path_prefix must not be in the blocked list of prefixes to prevent forwarding conflicts with webactions
-    require(BlockedUrlPathPrefixes.all { !url_path_prefix.startsWith(it) }) {
+    require(BlockedUrlPathPrefixes.all { !valid_url_path_prefix.startsWith(it) }) {
       "Url path prefix begins with a blocked prefix: ${
       BlockedUrlPathPrefixes.filter {
-        url_path_prefix.startsWith(
+        valid_url_path_prefix.startsWith(
           it
         )
       }
@@ -27,7 +27,7 @@ abstract class ValidWebEntry(val slug: String = "", val url_path_prefix: String 
     require(
       CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9')).or(
         CharMatcher.`is`('-')
-      ).matchesAllOf(slug)
+      ).matchesAllOf(valid_slug)
     ) {
       "Slug contains invalid characters. Can only contain characters in ranges [a-z], [0-9] or '-'."
     }

--- a/misk-actions/src/test/kotlin/misk/web/dashboard/ValidWebEntryTest.kt
+++ b/misk-actions/src/test/kotlin/misk/web/dashboard/ValidWebEntryTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertFailsWith
 
 class ValidWebEntryTest {
   @Test fun `happy path`() {
-    class TestWebEntry : ValidWebEntry(slug = "test-slug", url_path_prefix = "/test-path/")
+    class TestWebEntry : ValidWebEntry(valid_slug = "test-slug", valid_url_path_prefix = "/test-path/")
     TestWebEntry()
   }
 
@@ -17,7 +17,7 @@ class ValidWebEntryTest {
 
   @Test fun `fails on bad url path prefix missing trailing slash`() {
     val errMsg = assertFailsWith<IllegalArgumentException> {
-      class TestWebEntry : ValidWebEntry(slug = "test-slug", url_path_prefix = "/test-path")
+      class TestWebEntry : ValidWebEntry(valid_slug = "test-slug", valid_url_path_prefix = "/test-path")
       TestWebEntry()
     }
     assertEquals(
@@ -29,7 +29,7 @@ class ValidWebEntryTest {
 
   @Test fun `fails on bad url path prefix missing starting slash`() {
     val errMsg = assertFailsWith<IllegalArgumentException> {
-      class TestWebEntry : ValidWebEntry(slug = "test-slug", url_path_prefix = "test-path/")
+      class TestWebEntry : ValidWebEntry(valid_slug = "test-slug", valid_url_path_prefix = "test-path/")
       TestWebEntry()
     }
     assertEquals(
@@ -42,8 +42,8 @@ class ValidWebEntryTest {
   @Test fun `fails on bad url path prefix not starting with http if absolute path`() {
     val errMsg = assertFailsWith<IllegalArgumentException> {
       class TestWebEntry : ValidWebEntry(
-        slug = "test-slug",
-        url_path_prefix = "www.cash.app/test-path"
+        valid_slug = "test-slug",
+        valid_url_path_prefix = "www.cash.app/test-path"
       )
       TestWebEntry()
     }
@@ -56,7 +56,7 @@ class ValidWebEntryTest {
 
   @Test fun `fails on blocked prefix`() {
     val errMsg = assertFailsWith<IllegalArgumentException> {
-      class TestWebEntry : ValidWebEntry(slug = "test-slug", url_path_prefix = "/api/test-path/")
+      class TestWebEntry : ValidWebEntry(valid_slug = "test-slug", valid_url_path_prefix = "/api/test-path/")
       TestWebEntry()
     }
     assertEquals("Url path prefix begins with a blocked prefix: [/api/].", errMsg.message)
@@ -64,7 +64,7 @@ class ValidWebEntryTest {
 
   @Test fun `fails on invalid slug characters`() {
     val errMsg = assertFailsWith<IllegalArgumentException> {
-      class TestWebEntry : ValidWebEntry(slug = "!test-slug", url_path_prefix = "/test-path/")
+      class TestWebEntry : ValidWebEntry(valid_slug = "!test-slug", valid_url_path_prefix = "/test-path/")
       TestWebEntry()
     }
     assertEquals(

--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -250,23 +250,53 @@ public final class misk/web/dashboard/DashboardNavbarStatus : misk/web/dashboard
 }
 
 public final class misk/web/dashboard/DashboardTab : misk/web/dashboard/WebTab {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun component7 ()Ljava/util/Set;
+	public final fun component8 ()Lkotlin/reflect/KClass;
+	public final fun component9 ()Lkotlin/reflect/KClass;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/web/dashboard/DashboardTab;
+	public static synthetic fun copy$default (Lmisk/web/dashboard/DashboardTab;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lmisk/web/dashboard/DashboardTab;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessAnnotationKClass ()Lkotlin/reflect/KClass;
+	public fun getCapabilities ()Ljava/util/Set;
 	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDashboardAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getDashboard_slug ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
+	public fun getServices ()Ljava/util/Set;
+	public fun getSlug ()Ljava/lang/String;
+	public fun getUrl_path_prefix ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/web/dashboard/DashboardTabModule : misk/inject/KAbstractModule {
+	public static final field Companion Lmisk/web/dashboard/DashboardTabModule$Companion;
+	public fun <init> (Lmisk/web/dashboard/DashboardTabProvider;Lmisk/web/dashboard/WebTabResourceModule;)V
+	public synthetic fun <init> (Lmisk/web/dashboard/DashboardTabProvider;Lmisk/web/dashboard/WebTabResourceModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class misk/web/dashboard/DashboardTabModule$Companion {
 }
 
 public final class misk/web/dashboard/DashboardTabProvider : javax/inject/Provider {
 	public field accessAnnotationEntries Ljava/util/List;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;Ljava/util/Set;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Lmisk/web/dashboard/DashboardTab;
-	public final fun getAccessAnnotation ()Lkotlin/reflect/KClass;
 	public final fun getAccessAnnotationEntries ()Ljava/util/List;
+	public final fun getAccessAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getCapabilities ()Ljava/util/Set;
 	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDashboardAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getDashboard_slug ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getServices ()Ljava/util/Set;
@@ -372,11 +402,13 @@ public final class misk/web/dashboard/WebActionsDashboardTabModule : misk/inject
 	public fun <init> (Z)V
 }
 
-public abstract class misk/web/dashboard/WebTab : misk/web/dashboard/ValidWebEntry {
+public class misk/web/dashboard/WebTab : misk/web/dashboard/ValidWebEntry {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCapabilities ()Ljava/util/Set;
-	public final fun getServices ()Ljava/util/Set;
+	public fun getCapabilities ()Ljava/util/Set;
+	public fun getServices ()Ljava/util/Set;
+	public fun getSlug ()Ljava/lang/String;
+	public fun getUrl_path_prefix ()Ljava/lang/String;
 }
 
 public final class misk/web/dashboard/WebTabResourceModule : misk/inject/KAbstractModule {
@@ -393,6 +425,7 @@ public final class misk/web/dashboard/WebTabResourceModule : misk/inject/KAbstra
 public final class misk/web/metadata/DashboardMetadataAction : misk/web/actions/WebAction {
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lmisk/scope/ActionScoped;)V
 	public final fun getAll (Ljava/lang/String;)Lmisk/web/metadata/DashboardMetadataAction$Response;
+	public final fun getDashboardMetadata (Lmisk/MiskCaller;Ljava/lang/String;)Lmisk/web/metadata/DashboardMetadataAction$DashboardMetadata;
 }
 
 public final class misk/web/metadata/DashboardMetadataAction$DashboardMetadata {
@@ -414,6 +447,35 @@ public final class misk/web/metadata/DashboardMetadataAction$DashboardMetadata {
 	public final fun getTheme ()Lmisk/web/dashboard/MiskWebTheme;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/web/metadata/DashboardMetadataAction$DashboardTabMetadata {
+	public static final field Companion Lmisk/web/metadata/DashboardMetadataAction$DashboardTabMetadata$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun component7 ()Ljava/util/Set;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)Lmisk/web/metadata/DashboardMetadataAction$DashboardTabMetadata;
+	public static synthetic fun copy$default (Lmisk/web/metadata/DashboardMetadataAction$DashboardTabMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lmisk/web/metadata/DashboardMetadataAction$DashboardTabMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Ljava/util/Set;
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDashboard_slug ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getServices ()Ljava/util/Set;
+	public final fun getSlug ()Ljava/lang/String;
+	public final fun getUrl_path_prefix ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/web/metadata/DashboardMetadataAction$DashboardTabMetadata$Companion {
+	public final fun toMetadata (Lmisk/web/dashboard/DashboardTab;)Lmisk/web/metadata/DashboardMetadataAction$DashboardTabMetadata;
 }
 
 public final class misk/web/metadata/DashboardMetadataAction$Response {

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/AdminDashboardAccess.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/AdminDashboardAccess.kt
@@ -1,5 +1,16 @@
 package misk.web.dashboard
 
+/**
+ * Bind to set access for the Misk Admin Dashboard.
+ *
+ * ```kotlin
+ * // Give engineers access to the admin dashboard for Exemplar service
+ * multibind<AccessAnnotationEntry>().toInstance(
+ *   AccessAnnotationEntry<AdminDashboardAccess>(
+ *   capabilities = listOf("admin_console"))
+ * )
+ * ```
+ */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class AdminDashboardAccess

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
@@ -20,20 +20,14 @@ class ConfigDashboardTabModule(
   override fun configure() {
     bind<ConfigMetadataAction.ConfigTabMode>().toInstance(mode)
     install(WebActionModule.create<ConfigMetadataAction>())
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "config",
-        url_path_prefix = "/_admin/config/",
-        name = "Config",
-        category = "Container Admin"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "config",
-        web_proxy_url = "http://localhost:3200/"
-      )
-    )
+
+    install(DashboardTabModule.createMiskWeb<AdminDashboard, AdminDashboardAccess>(
+      isDevelopment = isDevelopment,
+      slug = "config",
+      urlPathPrefix = "/_admin/config/",
+      developmentWebProxyUrl = "http://localhost:3200/",
+      name = "Config",
+      category = "Container Admin"
+    ))
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardHomeUrl.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardHomeUrl.kt
@@ -9,7 +9,7 @@ import misk.web.dashboard.ValidWebEntry.Companion.slugify
 data class DashboardHomeUrl(
   val dashboard_slug: String,
   val url: String
-) : ValidWebEntry(slug = dashboard_slug, url_path_prefix = url)
+) : ValidWebEntry(valid_slug = dashboard_slug, valid_url_path_prefix = url)
 
 inline fun <reified DA : Annotation> DashboardHomeUrl(
   urlPathPrefix: String

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarItem.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarItem.kt
@@ -11,7 +11,7 @@ data class DashboardNavbarItem(
   val dashboard_slug: String,
   val item: String,
   val order: Int
-) : ValidWebEntry(slug = dashboard_slug)
+) : ValidWebEntry(valid_slug = dashboard_slug)
 
 inline fun <reified DA : Annotation> DashboardNavbarItem(
   item: String,

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarStatus.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarStatus.kt
@@ -9,7 +9,7 @@ import misk.web.dashboard.ValidWebEntry.Companion.slugify
 data class DashboardNavbarStatus(
   val dashboard_slug: String,
   val status: String
-) : ValidWebEntry(slug = dashboard_slug)
+) : ValidWebEntry(valid_slug = dashboard_slug)
 
 inline fun <reified DA : Annotation> DashboardNavbarStatus(
   status: String

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardTabModule.kt
@@ -1,0 +1,56 @@
+package misk.web.dashboard
+
+import misk.inject.KAbstractModule
+
+/** Handles complete installation of a new DashboardTab for use in AdminDashboard or another. */
+class DashboardTabModule(
+  private val dashboardTabProvider: DashboardTabProvider,
+  private val webTabResourceModule: WebTabResourceModule? = null
+) : KAbstractModule() {
+  override fun configure() {
+    multibind<DashboardTab>().toProvider(dashboardTabProvider)
+    webTabResourceModule?.let { install(it) }
+  }
+
+  companion object {
+    /**
+     * Installs a Misk-Web tab for a dashboard [DA] with access [AA].
+     * The tab is identified by a unique [slug] and is routed to by match on [urlPathPrefix].
+     * In local development – when [isDevelopment] is true, the [developmentWebProxyUrl] is used
+     * to resolve requests to [resourcePathPrefix]. In real environments,
+     * the [classpathResourcePathPrefix] is used to resolve resource requests to files in classpath.
+     * The tab is included in the dashboard navbar menu with [name] and in the menu group [category].
+     */
+    inline fun <reified DA : Annotation, reified AA : Annotation> createMiskWeb(
+      isDevelopment: Boolean,
+      slug: String,
+      urlPathPrefix: String,
+      developmentWebProxyUrl: String,
+      resourcePathPrefix: String = "/_tab/$slug/",
+      classpathResourcePathPrefix: String = "classpath:/web$resourcePathPrefix",
+      name: String,
+      category: String = "Admin",
+    ): DashboardTabModule {
+      val dashboardTabProvider = DashboardTabProvider(
+        slug = slug,
+        url_path_prefix = urlPathPrefix,
+        name = name,
+        category = category,
+        dashboard_slug = ValidWebEntry.slugify<DA>(),
+        accessAnnotationKClass = AA::class,
+        dashboardAnnotationKClass = DA::class,
+      )
+      val webTabResourceModule = WebTabResourceModule(
+        isDevelopment = isDevelopment,
+        slug = slug,
+        url_path_prefix = resourcePathPrefix,
+        resourcePath = classpathResourcePathPrefix,
+        web_proxy_url = developmentWebProxyUrl
+      )
+      return DashboardTabModule(
+        dashboardTabProvider = dashboardTabProvider,
+        webTabResourceModule = webTabResourceModule
+      )
+    }
+  }
+}

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
@@ -15,21 +15,16 @@ class DatabaseDashboardTabModule(private val isDevelopment: Boolean): KAbstractM
     // Database Query
     newMultibinder<DatabaseQueryMetadata>()
     install(WebActionModule.create<DatabaseQueryMetadataAction>())
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "database",
-        url_path_prefix = "/_admin/database/",
-        name = "Database",
-        category = "Container Admin"
-      )
-    )
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "database",
-        web_proxy_url = "http://localhost:3202/"
-      )
-    )
+
+    install(DashboardTabModule.createMiskWeb<AdminDashboard, AdminDashboardAccess>(
+      isDevelopment = isDevelopment,
+      slug = "database",
+      urlPathPrefix = "/_admin/database/",
+      developmentWebProxyUrl = "http://localhost:3202/",
+      name = "Database",
+      category = "Container Admin"
+    ))
+
     // Default access that doesn't allow any queries for unconfigured DbEntities
     multibind<AccessAnnotationEntry>().toInstance(
       AccessAnnotationEntry<NoAdminDashboardDatabaseAccess>(

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
@@ -12,34 +12,27 @@ import misk.web.metadata.webaction.WebActionMetadataAction
  */
 class WebActionsDashboardTabModule(private val isDevelopment: Boolean): KAbstractModule() {
   override fun configure() {
-    // Web Actions v2
     install(WebActionModule.create<WebActionMetadataAction>())
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "web-actions",
-        url_path_prefix = "/_admin/web-actions/",
-        name = "Web Actions",
-        category = "Container Admin"
-      )
-    )
+
+    // Web Actions v2
+    install(DashboardTabModule.createMiskWeb<AdminDashboard, AdminDashboardAccess>(
+      isDevelopment = isDevelopment,
+      slug = "web-actions",
+      urlPathPrefix = "/_admin/web-actions/",
+      developmentWebProxyUrl = "http://localhost:3201/",
+      name = "Web Actions",
+      category = "Container Admin"
+    ))
 
     // Web Actions v1
-    multibind<DashboardTab>().toProvider(
-      DashboardTabProvider<AdminDashboard, AdminDashboardAccess>(
-        slug = "web-actions",
-        url_path_prefix = "/_admin/web-actions-v1/",
-        name = "Web Actions V1",
-        category = "Container Admin"
-      )
-    )
-
-    // Both v1 and v2 live in the same tab code so only one resource module is installed
-    install(
-      WebTabResourceModule(
-        isDevelopment = isDevelopment,
-        slug = "web-actions",
-        web_proxy_url = "http://localhost:3201/"
-      )
-    )
+    install(DashboardTabModule.createMiskWeb<AdminDashboard, AdminDashboardAccess>(
+      isDevelopment = isDevelopment,
+      slug = "web-actions-v1",
+      urlPathPrefix = "/_admin/web-actions-v1/",
+      developmentWebProxyUrl = "http://localhost:3201/",
+      classpathResourcePathPrefix = "classpath:/web/_tab/web-actions/",
+      name = "Web Actions v1",
+      category = "Container Admin"
+    ))
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebTab.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebTab.kt
@@ -1,10 +1,10 @@
 package misk.web.dashboard
 
-abstract class WebTab(
-  slug: String,
-  url_path_prefix: String,
+open class WebTab(
+  open val slug: String,
+  open val url_path_prefix: String,
   // capabilities, services permissions control visibility of tab to misk web application user
   // it does not deal with any other permissions such as static resource access or otherwise
-  val capabilities: Set<String> = setOf(),
-  val services: Set<String> = setOf()
-) : ValidWebEntry(slug = slug, url_path_prefix = url_path_prefix)
+  open val capabilities: Set<String> = setOf(),
+  open val services: Set<String> = setOf()
+) : ValidWebEntry(valid_slug = slug, valid_url_path_prefix = url_path_prefix)

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebTabResourceModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebTabResourceModule.kt
@@ -26,9 +26,9 @@ import wisp.deployment.Deployment
  * @property resourcePath JVM path for non-Development environment static resources (includes `classpath:/` prefix)
  */
 class WebTabResourceModule(
-  private val isDevelopment: Boolean,
+  private val isDevelopment: Boolean = false,
   val slug: String,
-  val web_proxy_url: String,
+  val web_proxy_url: String? = null,
   val url_path_prefix: String = "/_tab/$slug/",
   val resourcePath: String = "classpath:/web/_tab/$slug/"
 ) : KAbstractModule() {
@@ -47,12 +47,13 @@ class WebTabResourceModule(
       .toInstance(
         StaticResourceEntry(url_path_prefix = url_path_prefix, resourcePath = resourcePath)
       )
-
     if (isDevelopment) {
-      install(WebActionModule.createWithPrefix<WebProxyAction>(url_path_prefix = url_path_prefix))
-      multibind<WebProxyEntry>().toInstance(
-        WebProxyEntry(url_path_prefix = url_path_prefix, web_proxy_url = web_proxy_url)
-      )
+      web_proxy_url?.let {
+        install(WebActionModule.createWithPrefix<WebProxyAction>(url_path_prefix = url_path_prefix))
+        multibind<WebProxyEntry>().toInstance(
+          WebProxyEntry(url_path_prefix = url_path_prefix, web_proxy_url = it)
+        )
+      }
     } else {
       install(
         WebActionModule.createWithPrefix<StaticResourceAction>(url_path_prefix = url_path_prefix)

--- a/misk-admin/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
@@ -15,6 +15,7 @@ import misk.web.dashboard.DashboardTab
 import misk.web.dashboard.DashboardTheme
 import misk.web.dashboard.MiskWebTheme
 import misk.web.mediatype.MediaTypes
+import misk.web.metadata.DashboardMetadataAction.DashboardTabMetadata.Companion.toMetadata
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -46,43 +47,69 @@ class DashboardMetadataAction @Inject constructor(
   fun getAll(
     @PathParam dashboard_slug: String
   ): Response {
-    val caller = callerProvider.get() ?: return Response()
+    return Response(getDashboardMetadata(callerProvider.get(), dashboard_slug))
+  }
+
+  fun getDashboardMetadata(
+    caller: MiskCaller?,
+    dashboardSlug: String
+  ): DashboardMetadata {
+    if (caller == null) return DashboardMetadata()
 
     val authorizedDashboardTabs = allTabs
-      .filter { it.dashboard_slug == dashboard_slug }
+      .filter { it.dashboard_slug == dashboardSlug }
       .filter { caller.isAllowed(it.capabilities, it.services) }
 
     val homeUrl = allHomeUrls
-      .find { it.dashboard_slug == dashboard_slug }?.url ?: ""
+      .find { it.dashboard_slug == dashboardSlug }?.url ?: ""
 
     val navbarItems = allNavbarItems
-      .filter { it.dashboard_slug == dashboard_slug }
+      .filter { it.dashboard_slug == dashboardSlug }
       .sortedBy { it.order }
       .map { it.item }
 
     val navbarStatus = allNavbarStatus
-      .find { it.dashboard_slug == dashboard_slug }?.status ?: ""
+      .find { it.dashboard_slug == dashboardSlug }?.status ?: ""
 
     val theme = allThemes
-      .find { it.dashboard_slug == dashboard_slug }?.theme
+      .find { it.dashboard_slug == dashboardSlug }?.theme
 
-    val dashboardMetadata = DashboardMetadata(
+    return DashboardMetadata(
       home_url = homeUrl,
       navbar_items = navbarItems,
       navbar_status = navbarStatus,
-      tabs = authorizedDashboardTabs,
+      tabs = authorizedDashboardTabs.map { it.toMetadata() },
       theme = theme,
     )
-    return Response(
-      dashboardMetadata = dashboardMetadata
-    )
+  }
+
+  data class DashboardTabMetadata(
+    val slug: String,
+    val url_path_prefix: String,
+    val dashboard_slug: String,
+    val name: String,
+    val category: String = "",
+    val capabilities: Set<String> = setOf(),
+    val services: Set<String> = setOf(),
+  ) {
+    companion object {
+      fun DashboardTab.toMetadata() = DashboardTabMetadata(
+        slug = slug,
+        url_path_prefix = url_path_prefix,
+        dashboard_slug = dashboard_slug,
+        name = name,
+        category = category,
+        capabilities = capabilities,
+        services = services
+      )
+    }
   }
 
   data class DashboardMetadata(
     val home_url: String = "",
     val navbar_items: List<String> = listOf(),
     val navbar_status: String = "",
-    val tabs: List<DashboardTab> = listOf(),
+    val tabs: List<DashboardTabMetadata> = listOf(),
     /** If null, uses default theme that ships with Misk-Web */
     val theme: MiskWebTheme? = null,
   )

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -2018,7 +2018,15 @@ public final class misk/web/proxy/WebProxyAction : misk/web/actions/WebAction {
 public final class misk/web/proxy/WebProxyEntry : misk/web/dashboard/ValidWebEntry {
 	public fun <init> (Ljava/lang/String;Lokhttp3/HttpUrl;)V
 	public synthetic fun <init> (Ljava/lang/String;Lokhttp3/HttpUrl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lokhttp3/HttpUrl;
+	public final fun copy (Ljava/lang/String;Lokhttp3/HttpUrl;)Lmisk/web/proxy/WebProxyEntry;
+	public static synthetic fun copy$default (Lmisk/web/proxy/WebProxyEntry;Ljava/lang/String;Lokhttp3/HttpUrl;ILjava/lang/Object;)Lmisk/web/proxy/WebProxyEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl_path_prefix ()Ljava/lang/String;
 	public final fun getWeb_proxy_url ()Lokhttp3/HttpUrl;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class misk/web/proxy/WebProxyEntryKt {
@@ -2041,6 +2049,13 @@ public final class misk/web/resources/StaticResourceAction : misk/web/actions/We
 public final class misk/web/resources/StaticResourceEntry : misk/web/dashboard/ValidWebEntry {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lmisk/web/resources/StaticResourceEntry;
+	public static synthetic fun copy$default (Lmisk/web/resources/StaticResourceEntry;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/web/resources/StaticResourceEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl_path_prefix ()Ljava/lang/String;
+	public fun hashCode ()I
 	public final fun resourcePath (Ljava/lang/String;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/misk/src/main/kotlin/misk/web/proxy/WebProxyEntry.kt
+++ b/misk/src/main/kotlin/misk/web/proxy/WebProxyEntry.kt
@@ -21,10 +21,10 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
  * multibind<WebProxyEntry>().toInstance(WebProxyEntry(...))
  * ```
  */
-class WebProxyEntry(
-  url_path_prefix: String = "/",
+data class WebProxyEntry(
+  val url_path_prefix: String = "/",
   val web_proxy_url: HttpUrl
-) : ValidWebEntry(url_path_prefix = url_path_prefix) {
+) : ValidWebEntry(valid_url_path_prefix = url_path_prefix) {
   init {
     require(
       web_proxy_url.encodedPath.endsWith("/") &&

--- a/misk/src/main/kotlin/misk/web/resources/ResourceEntryFinder.kt
+++ b/misk/src/main/kotlin/misk/web/resources/ResourceEntryFinder.kt
@@ -26,10 +26,10 @@ class ResourceEntryFinder @Inject constructor(
     urlPath: String
   ): ValidWebEntry? {
     val results = entries
-      .filter { urlPath.startsWith(it.url_path_prefix) }
-      .sortedByDescending { it.url_path_prefix.length }
+      .filter { urlPath.startsWith(it.valid_url_path_prefix) }
+      .sortedByDescending { it.valid_url_path_prefix.length }
     // Error if there are overlapping identical matched prefixes https://github.com/square/misk/issues/303
-    require(results.size <= 1 || results[0].url_path_prefix != results[1].url_path_prefix)
+    require(results.size <= 1 || results[0].valid_url_path_prefix != results[1].valid_url_path_prefix)
     return results.firstOrNull()
   }
 }

--- a/misk/src/main/kotlin/misk/web/resources/StaticResourceEntry.kt
+++ b/misk/src/main/kotlin/misk/web/resources/StaticResourceEntry.kt
@@ -10,10 +10,10 @@ import misk.web.dashboard.ValidWebEntry
  * multibind<StaticResourceEntry>().toInstance(StaticResourceEntry(...))
  * ```
  */
-class StaticResourceEntry(
-  url_path_prefix: String = "/",
+data class StaticResourceEntry(
+  val url_path_prefix: String = "/",
   private val resourcePath: String
-) : ValidWebEntry(url_path_prefix = url_path_prefix) {
+) : ValidWebEntry(valid_url_path_prefix = url_path_prefix) {
 
   fun resourcePath(urlPath: String): String {
     val normalizedResourcePath = if (!resourcePath.endsWith("/")) "$resourcePath/" else resourcePath


### PR DESCRIPTION
Split out from https://github.com/cashapp/misk/pull/2800, the new DashboardTabModule provides an encapsulated way to install dashboard tabs. In future PRs it will be extended to provide support for installing IFrame and Hotwire tabs instead of only Misk-Web.