### PR TITLE
Deprecate DashboardNavbarStatus and PR feedback for MiskWebTabIndexAction

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarStatus.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardNavbarStatus.kt
@@ -6,11 +6,13 @@ import misk.web.dashboard.ValidWebEntry.Companion.slugify
  * Banner text to show below the dashboard navbar
  * 0 or 1 [DashboardNavbarStatus] should be bound per dashboard
  */
+@Deprecated("DashboardNavbarStatus will not be supported in Misk Dashboards v2 and will be deleted shortly. Use custom UI to surface status information.")
 data class DashboardNavbarStatus(
   val dashboard_slug: String,
   val status: String
 ) : ValidWebEntry(valid_slug = dashboard_slug)
 
+@Deprecated("DashboardNavbarStatus will not be supported in Misk Dashboards v2 and will be deleted shortly. Use custom UI to surface status information.")
 inline fun <reified DA : Annotation> DashboardNavbarStatus(
   status: String
 ) = DashboardNavbarStatus(

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/MiskWebTabIndexAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/MiskWebTabIndexAction.kt
@@ -30,21 +30,19 @@ class MiskWebTabIndexAction @Inject constructor(
   @AdminDashboardAccess
   fun get(@PathParam slug: String?): String {
     val dashboardTab = dashboardTabs.firstOrNull { slug == it.slug }
+      ?: throw NotFoundException("No tab found for slug: $slug")
+    // TODO remove this hack when new Web Actions tab lands and old ones removed, v1 and v2 are in the same web-actions tab
+    val normalizedSlug = if (dashboardTab.slug == "web-actions-v1") "web-actions" else dashboardTab.slug
     return buildHtml {
       html {
         head {
-          dashboardTab?.let {
-            link {
-              rel = "stylesheet"
-              type = "text/css"
-              href = "/@misk/common/styles.css"
-            }
+          link {
+            rel = "stylesheet"
+            type = "text/css"
+            href = "/@misk/common/styles.css"
           }
         }
         body {
-          // TODO remove this hack when new Web Actions tab lands and old ones removed, v1 and v2 are in the same web-actions tab
-          val normalizedSlug = if (slug == "web-actions-v1") "web-actions" else slug ?: "null"
-
           div {
             style = "padding: 2rem; margin-bottom: 6rem;"
 
@@ -52,10 +50,6 @@ class MiskWebTabIndexAction @Inject constructor(
             div {
               id = normalizedSlug
             }
-
-            // 404
-            dashboardTab
-              ?: throw NotFoundException("No tab found for slug: $normalizedSlug")
           }
 
           // Common resources


### PR DESCRIPTION
After code search and consultation with Misk customers internal/external, DashboardNavbarStatus appears entirely unused so it will now be deprecated and will be deleted in a follow up PR.

Some PR feedback from https://github.com/cashapp/misk/pull/2807 was also addressed here.