### PR TITLE
Add menuUrl to DashboardTab, fix MiskWebTabIndexAction to handle slug/sub-path tabs

### DIFF
--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -255,26 +255,28 @@ public final class misk/web/dashboard/DashboardNavbarStatus : misk/web/dashboard
 }
 
 public final class misk/web/dashboard/DashboardTab : misk/web/dashboard/WebTab {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lkotlin/reflect/KClass;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/util/Set;
-	public final fun component8 ()Lkotlin/reflect/KClass;
+	public final fun component8 ()Ljava/util/Set;
 	public final fun component9 ()Lkotlin/reflect/KClass;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/web/dashboard/DashboardTab;
-	public static synthetic fun copy$default (Lmisk/web/dashboard/DashboardTab;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lmisk/web/dashboard/DashboardTab;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/web/dashboard/DashboardTab;
+	public static synthetic fun copy$default (Lmisk/web/dashboard/DashboardTab;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lmisk/web/dashboard/DashboardTab;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccessAnnotationKClass ()Lkotlin/reflect/KClass;
 	public fun getCapabilities ()Ljava/util/Set;
-	public final fun getCategory ()Ljava/lang/String;
 	public final fun getDashboardAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getDashboard_slug ()Ljava/lang/String;
-	public final fun getName ()Ljava/lang/String;
+	public final fun getMenuCategory ()Ljava/lang/String;
+	public final fun getMenuLabel ()Ljava/lang/String;
+	public final fun getMenuUrl ()Ljava/lang/String;
 	public fun getServices ()Ljava/util/Set;
 	public fun getSlug ()Ljava/lang/String;
 	public fun getUrl_path_prefix ()Ljava/lang/String;
@@ -284,17 +286,18 @@ public final class misk/web/dashboard/DashboardTab : misk/web/dashboard/WebTab {
 
 public final class misk/web/dashboard/DashboardTabProvider : javax/inject/Provider {
 	public field accessAnnotationEntries Ljava/util/List;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Lmisk/web/dashboard/DashboardTab;
 	public final fun getAccessAnnotationEntries ()Ljava/util/List;
 	public final fun getAccessAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getCapabilities ()Ljava/util/Set;
-	public final fun getCategory ()Ljava/lang/String;
 	public final fun getDashboardAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getDashboard_slug ()Ljava/lang/String;
-	public final fun getName ()Ljava/lang/String;
+	public final fun getMenuCategory ()Ljava/lang/String;
+	public final fun getMenuLabel ()Ljava/lang/String;
+	public final fun getMenuUrl ()Ljava/lang/String;
 	public final fun getServices ()Ljava/util/Set;
 	public final fun getSlug ()Ljava/lang/String;
 	public final fun getUrl_path_prefix ()Ljava/lang/String;
@@ -366,7 +369,7 @@ public final class misk/web/dashboard/MiskWebTabIndexAction : misk/web/actions/W
 	public static final field Companion Lmisk/web/dashboard/MiskWebTabIndexAction$Companion;
 	public static final field PATH Ljava/lang/String;
 	public fun <init> (Ljava/util/List;)V
-	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+	public final fun get (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class misk/web/dashboard/MiskWebTabIndexAction$Companion {

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/ConfigDashboardTabModule.kt
@@ -26,8 +26,8 @@ class ConfigDashboardTabModule(
       slug = "config",
       urlPathPrefix = "/_admin/config/",
       developmentWebProxyUrl = "http://localhost:3200/",
-      name = "Config",
-      category = "Container Admin"
+      menuLabel = "Config",
+      menuCategory = "Container Admin"
     ))
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
@@ -27,8 +27,9 @@ class DashboardModule(
       val dashboardTabProvider = DashboardTabProvider(
         slug = "menu-link-$url",
         url_path_prefix = url,
-        name = label,
-        category = category,
+        menuLabel = label,
+        menuUrl = url,
+        menuCategory = category,
         dashboard_slug = ValidWebEntry.slugify<DA>(),
         accessAnnotationKClass = AA::class,
         dashboardAnnotationKClass = DA::class,
@@ -44,7 +45,7 @@ class DashboardModule(
      * In local development – when [isDevelopment] is true, the [developmentWebProxyUrl] is used
      * to resolve requests to [resourcePathPrefix]. In real environments,
      * the [classpathResourcePathPrefix] is used to resolve resource requests to files in classpath.
-     * The tab is included in the dashboard navbar menu with [name] and in the menu group [category].
+     * The tab is included in the dashboard navbar menu with [menuLabel] and in the menu group [menuCategory].
      */
     inline fun <reified DA : Annotation, reified AA : Annotation> createMiskWebTab(
       isDevelopment: Boolean,
@@ -53,14 +54,16 @@ class DashboardModule(
       developmentWebProxyUrl: String,
       resourcePathPrefix: String = "/_tab/$slug/",
       classpathResourcePathPrefix: String = "classpath:/web$resourcePathPrefix",
-      name: String,
-      category: String = "Admin",
+      menuLabel: String,
+      menuUrl: String = urlPathPrefix,
+      menuCategory: String = "Admin",
     ): DashboardModule {
       val dashboardTabProvider = DashboardTabProvider(
         slug = slug,
         url_path_prefix = urlPathPrefix,
-        name = name,
-        category = category,
+        menuLabel = menuLabel,
+        menuUrl = menuUrl,
+        menuCategory = menuCategory,
         dashboard_slug = ValidWebEntry.slugify<DA>(),
         accessAnnotationKClass = AA::class,
         dashboardAnnotationKClass = DA::class,

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardTab.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardTab.kt
@@ -14,8 +14,9 @@ import kotlin.reflect.KClass
  * @property [url_path_prefix] A unique url path prefix to namespace tab URLs
  * @property [dashboard_slug] A slug that identifies which dashboard the tab is installed to,
  *  generated from a slugified Dashboard Annotation class simple name
- * @property [name] A title case name used in the dashboard menu for the link to the tab
- * @property [category] A title case category used to group tabs in the dashboard menu
+ * @property [menuLabel] A title case name used in the dashboard menu for the link to the tab
+ * @property [menuCategory] A title case category used to group tabs in the dashboard menu
+ * @property [menuUrl] Url to the tab, by default [url_path_prefix]
  * @property [capabilities] Set to show the tab only for authenticated capabilities, else shows always
  * @property [services] Set to show the tab only for authenticated services, else shows always
  */
@@ -23,8 +24,9 @@ data class DashboardTab(
   override val slug: String,
   override val url_path_prefix: String,
   val dashboard_slug: String,
-  val name: String,
-  val category: String = "",
+  val menuLabel: String,
+  val menuCategory: String = "",
+  val menuUrl: String = url_path_prefix,
   override val capabilities: Set<String> = setOf(),
   override val services: Set<String> = setOf(),
   val accessAnnotationKClass: KClass<out Annotation>? = null,
@@ -37,8 +39,9 @@ data class DashboardTab(
 class DashboardTabProvider(
   val slug: String,
   val url_path_prefix: String,
-  val name: String,
-  val category: String = "Admin",
+  val menuLabel: String,
+  val menuUrl: String = url_path_prefix,
+  val menuCategory: String = "Admin",
   val dashboard_slug: String,
   val capabilities: Set<String> = setOf(),
   val services: Set<String> = setOf(),
@@ -53,8 +56,9 @@ class DashboardTabProvider(
       slug = slug,
       url_path_prefix = url_path_prefix,
       dashboard_slug = dashboard_slug,
-      name = name,
-      category = category,
+      menuLabel = menuLabel,
+      menuUrl = menuUrl,
+      menuCategory = menuCategory,
       capabilities = accessAnnotationEntry?.capabilities?.toSet() ?: capabilities,
       services = accessAnnotationEntry?.services?.toSet() ?: services,
       accessAnnotationKClass = accessAnnotationKClass,
@@ -70,14 +74,16 @@ inline fun <reified DA : Annotation> DashboardTabProvider(
   slug: String,
   url_path_prefix: String,
   name: String,
+  menuUrl: String = url_path_prefix,
   category: String = "Admin",
   capabilities: Set<String> = setOf(),
   services: Set<String> = setOf()
 ) = DashboardTabProvider(
   slug = slug,
   url_path_prefix = url_path_prefix,
-  name = name,
-  category = category,
+  menuLabel = name,
+  menuCategory = category,
+  menuUrl = menuUrl,
   dashboard_slug = slugify<DA>(),
   capabilities = capabilities,
   services = services,
@@ -91,12 +97,14 @@ inline fun <reified DA : Annotation, reified AA : Annotation> DashboardTabProvid
   slug: String,
   url_path_prefix: String,
   name: String,
+  menuUrl: String = url_path_prefix,
   category: String = "Admin",
 ) = DashboardTabProvider(
   slug = slug,
   url_path_prefix = url_path_prefix,
-  name = name,
-  category = category,
+  menuLabel = name,
+  menuCategory = category,
+  menuUrl = menuUrl,
   dashboard_slug = slugify<DA>(),
   accessAnnotationKClass = AA::class,
   dashboardAnnotationKClass = DA::class,

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DatabaseDashboardTabModule.kt
@@ -21,8 +21,8 @@ class DatabaseDashboardTabModule(private val isDevelopment: Boolean): KAbstractM
       slug = "database",
       urlPathPrefix = "/_admin/database/",
       developmentWebProxyUrl = "http://localhost:3202/",
-      name = "Database",
-      category = "Container Admin"
+      menuLabel = "Database",
+      menuCategory = "Container Admin"
     ))
 
     // Default access that doesn't allow any queries for unconfigured DbEntities

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/MiskWebTabIndexAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/MiskWebTabIndexAction.kt
@@ -25,10 +25,10 @@ import javax.inject.Singleton
 class MiskWebTabIndexAction @Inject constructor(
   @AdminDashboard private val dashboardTabs: List<DashboardTab>,
 ) : WebAction {
-  @Get("$PATH/{slug}")
+  @Get("$PATH/{slug}/{rest:.*}")
   @ResponseContentType(MediaTypes.TEXT_HTML)
   @AdminDashboardAccess
-  fun get(@PathParam slug: String?): String {
+  fun get(@PathParam slug: String?, @PathParam rest: String?): String {
     val dashboardTab = dashboardTabs.firstOrNull { slug == it.slug }
       ?: throw NotFoundException("No tab found for slug: $slug")
     // TODO remove this hack when new Web Actions tab lands and old ones removed, v1 and v2 are in the same web-actions tab

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/WebActionsDashboardTabModule.kt
@@ -20,8 +20,8 @@ class WebActionsDashboardTabModule(private val isDevelopment: Boolean): KAbstrac
       slug = "web-actions",
       urlPathPrefix = "/_admin/web-actions/",
       developmentWebProxyUrl = "http://localhost:3201/",
-      name = "Web Actions",
-      category = "Container Admin"
+      menuLabel = "Web Actions",
+      menuCategory = "Container Admin"
     ))
 
     // Web Actions v1
@@ -31,8 +31,8 @@ class WebActionsDashboardTabModule(private val isDevelopment: Boolean): KAbstrac
       urlPathPrefix = "/_admin/web-actions-v1/",
       developmentWebProxyUrl = "http://localhost:3201/",
       classpathResourcePathPrefix = "classpath:/web/_tab/web-actions/",
-      name = "Web Actions v1",
-      category = "Container Admin"
+      menuLabel = "Web Actions v1",
+      menuCategory = "Container Admin"
     ))
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/DashboardMetadataAction.kt
@@ -97,8 +97,8 @@ class DashboardMetadataAction @Inject constructor(
         slug = slug,
         url_path_prefix = url_path_prefix,
         dashboard_slug = dashboard_slug,
-        name = name,
-        category = category,
+        name = menuLabel,
+        category = menuCategory,
         capabilities = capabilities,
         services = services
       )

--- a/misk-admin/src/test/kotlin/misk/web/dashboard/DashboardTabTest.kt
+++ b/misk-admin/src/test/kotlin/misk/web/dashboard/DashboardTabTest.kt
@@ -9,7 +9,7 @@ internal class DashboardTabTest {
     DashboardTab(
       "good-1-slug-test",
       url_path_prefix = "/a/path/",
-      name = "Name",
+      menuLabel = "Name",
       dashboard_slug = "admin"
     )
   }
@@ -20,7 +20,7 @@ internal class DashboardTabTest {
       DashboardTab(
         "bad slug",
         url_path_prefix = "/a/path/",
-        name = "Name",
+        menuLabel = "Name",
         dashboard_slug = "admin"
       )
     }
@@ -29,15 +29,23 @@ internal class DashboardTabTest {
   @Test
   internal fun tabSlugWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
-      DashboardTab("BadSlug", url_path_prefix = "/a/path/", name = "Name", dashboard_slug = "admin")
+      DashboardTab(
+        "BadSlug",
+        url_path_prefix = "/a/path/",
+        menuLabel = "Name",
+        dashboard_slug = "admin"
+      )
     }
   }
 
   @Test
   internal fun tabGoodCategory() {
     DashboardTab(
-      slug = "slug", url_path_prefix = "/a/path/", name = "Name",
-      category = "@tea-pot_418", dashboard_slug = "admin"
+      slug = "slug",
+      url_path_prefix = "/a/path/",
+      menuLabel = "Name",
+      menuCategory = "@tea-pot_418",
+      dashboard_slug = "admin"
     )
   }
 
@@ -45,8 +53,11 @@ internal class DashboardTabTest {
   internal fun tabCategoryWithSpace() {
     assertFailsWith<IllegalArgumentException> {
       DashboardTab(
-        slug = "bad slug", url_path_prefix = "/a/path/", name = "Name",
-        category = "bad icon", dashboard_slug = "admin"
+        slug = "bad slug",
+        url_path_prefix = "/a/path/",
+        menuLabel = "Name",
+        menuCategory = "bad icon",
+        dashboard_slug = "admin"
       )
     }
   }
@@ -55,8 +66,11 @@ internal class DashboardTabTest {
   internal fun tabCategoryWithUpperCase() {
     assertFailsWith<IllegalArgumentException> {
       DashboardTab(
-        slug = "BadSlug", url_path_prefix = "/a/path/", name = "Name",
-        category = "Bad-Icon", dashboard_slug = "admin"
+        slug = "BadSlug",
+        url_path_prefix = "/a/path/",
+        menuLabel = "Name",
+        menuCategory = "Bad-Icon",
+        dashboard_slug = "admin"
       )
     }
   }
@@ -66,7 +80,7 @@ internal class DashboardTabTest {
     DashboardTab(
       slug = "slug",
       url_path_prefix = "/a/path/",
-      name = "Name",
+      menuLabel = "Name",
       dashboard_slug = "admin"
     )
   }
@@ -77,7 +91,7 @@ internal class DashboardTabTest {
       DashboardTab(
         slug = "slug",
         url_path_prefix = "a/path/",
-        name = "Name",
+        menuLabel = "Name",
         dashboard_slug = "admin"
       )
     }
@@ -89,7 +103,7 @@ internal class DashboardTabTest {
       DashboardTab(
         slug = "slug",
         url_path_prefix = "/a/path",
-        name = "Name",
+        menuLabel = "Name",
         dashboard_slug = "admin"
       )
     }

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarDashboardModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarDashboardModule.kt
@@ -9,7 +9,7 @@ import misk.web.dashboard.MiskWebColor
 import misk.web.dashboard.MiskWebTheme
 import misk.web.metadata.config.ConfigMetadataAction
 
-class DashboardModule : KAbstractModule() {
+class ExemplarDashboardModule : KAbstractModule() {
   override fun configure() {
     bind<DashboardTheme>().toInstance(
       DashboardTheme<AdminDashboard>(

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -15,7 +15,7 @@ fun main(args: Array<String>) {
   val config = MiskConfig.load<ExemplarConfig>("exemplar", deployment)
   MiskApplication(
     ConfigModule.create("exemplar", config),
-    DashboardModule(),
+    ExemplarDashboardModule(),
     DeploymentModule(deployment),
     ExemplarAccessModule(),
     ExemplarWebActionsModule(),


### PR DESCRIPTION
Some tabs have a `slug/sub-path` url where `slug/other-path` is served from the same Misk-Web tab. To better support this, an explicit `menuUrl` field will allow binding resources with the `slug` but set the menu to link into the sub path as currently is done.

Similarly, to support `slug/sub-path` tabs, some slight fixes were necessary.