### PR TITLE
Implement graceful shutdown service dependencies

### DIFF
--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -2,7 +2,6 @@ package misk.dynamodb
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams
@@ -10,16 +9,16 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreamsClientBuilder
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
 import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Provides
+import misk.ReadyService
+import misk.ServiceModule
+import misk.cloud.aws.AwsRegion
+import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
+import misk.healthchecks.HealthCheck
+import misk.inject.KAbstractModule
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
-import misk.ServiceModule
-import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
-import misk.cloud.aws.AwsRegion
-import misk.healthchecks.HealthCheck
-import misk.inject.KAbstractModule
-import java.net.URI
 
 /**
  * Install this module to have access to an AmazonDynamoDB client. This can be
@@ -42,7 +41,7 @@ open class RealDynamoDbModule constructor(
     requireBinding<AwsRegion>()
     multibind<HealthCheck>().to<DynamoDbHealthCheck>()
     bind<DynamoDbService>().to<RealDynamoDbService>()
-    install(ServiceModule<DynamoDbService>())
+    install(ServiceModule<DynamoDbService>().enhancedBy<ReadyService>())
     install(DynamoDbExceptionMapperModule())
   }
 
@@ -78,7 +77,7 @@ open class RealDynamoDbModule constructor(
     configureStreamsClient(builder)
     return builder.build()
   }
-  
+
   open fun configureStreamsClient(builder: AmazonDynamoDBStreamsClientBuilder) {}
 
   /** We don't currently perform any startup work to connect to DynamoDB. */

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -3,6 +3,7 @@ package misk.jobqueue.sqs
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.toKey
@@ -29,10 +30,12 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
       newMapBinder<QueueName, JobHandler>().addBinding(queueName.retryQueue).to(handler.java)
     }
 
-    install(ServiceModule(
-      key = AwsSqsJobHandlerSubscriptionService::class.toKey(),
-      dependsOn = dependsOn
-    ))
+    install(
+      ServiceModule(
+        key = AwsSqsJobHandlerSubscriptionService::class.toKey(),
+        dependsOn = dependsOn
+      ).dependsOn<ReadyService>()
+    )
   }
 
   companion object {

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -2,11 +2,10 @@ package misk.aws2.dynamodb
 
 import com.google.common.util.concurrent.AbstractService
 import com.google.inject.Provides
-import javax.inject.Inject
-import javax.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
-import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
 import misk.cloud.aws.AwsRegion
+import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
 import misk.healthchecks.HealthCheck
 import misk.inject.KAbstractModule
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
@@ -17,6 +16,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClientBuilder
 import java.net.URI
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Install this module to have access to a DynamoDbClient.
@@ -32,7 +33,7 @@ open class RealDynamoDbModule constructor(
     requireBinding<AwsRegion>()
     multibind<HealthCheck>().to<DynamoDbHealthCheck>()
     bind<DynamoDbService>().to<RealDynamoDbService>()
-    install(ServiceModule<DynamoDbService>())
+    install(ServiceModule<DynamoDbService>().enhancedBy<ReadyService>())
     install(DynamoDbExceptionMapperModule())
   }
 
@@ -45,9 +46,9 @@ open class RealDynamoDbModule constructor(
       .region(Region.of(awsRegion.name))
       .credentialsProvider(awsCredentialsProvider)
       .overrideConfiguration(clientOverrideConfig)
-      if (endpointOverride != null) {
-        builder.endpointOverride(endpointOverride)
-      }
+    if (endpointOverride != null) {
+      builder.endpointOverride(endpointOverride)
+    }
     configureClient(builder)
     return builder.build()
   }
@@ -67,7 +68,6 @@ open class RealDynamoDbModule constructor(
     configureClient(builder)
     return builder.build()
   }
-
 
   open fun configureClient(builder: DynamoDbClientBuilder) {}
   open fun configureClient(builder: DynamoDbStreamsClientBuilder) {}

--- a/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseModule.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseModule.kt
@@ -1,6 +1,5 @@
 package misk.clustering.fake.lease
 
-import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.lease.LeaseService
@@ -10,6 +9,6 @@ import wisp.lease.LeaseManager
 class FakeLeaseModule : KAbstractModule() {
   override fun configure() {
     bind<LeaseManager>().to<FakeLeaseManager>()
-    install(ServiceModule<LeaseService>().enhancedBy<ReadyService>())
+    install(ServiceModule<LeaseService>())
   }
 }

--- a/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseModule.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLeaseModule.kt
@@ -1,5 +1,6 @@
 package misk.clustering.fake.lease
 
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.lease.LeaseService
@@ -9,6 +10,6 @@ import wisp.lease.LeaseManager
 class FakeLeaseModule : KAbstractModule() {
   override fun configure() {
     bind<LeaseManager>().to<FakeLeaseManager>()
-    install(ServiceModule<LeaseService>())
+    install(ServiceModule<LeaseService>().enhancedBy<ReadyService>())
   }
 }

--- a/misk-clustering/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
@@ -1,5 +1,6 @@
 package misk.clustering.kubernetes
 
+import misk.ReadyService
 import misk.ServiceModule
 import misk.clustering.Cluster
 import misk.clustering.ClusterService
@@ -17,7 +18,8 @@ class KubernetesClusterModule(private val config: KubernetesConfig) : KAbstractM
     install(
       ServiceModule<KubernetesClusterWatcher>()
         .dependsOn<ClusterService>()
+        .enhancedBy<ReadyService>()
     )
-    install(ServiceModule<ClusterService>())
+    install(ServiceModule<ClusterService>().enhancedBy<ReadyService>())
   }
 }

--- a/misk-clustering/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/kubernetes/KubernetesClusterModule.kt
@@ -20,6 +20,6 @@ class KubernetesClusterModule(private val config: KubernetesConfig) : KAbstractM
         .dependsOn<ClusterService>()
         .enhancedBy<ReadyService>()
     )
-    install(ServiceModule<ClusterService>().enhancedBy<ReadyService>())
+    install(ServiceModule<ClusterService>())
   }
 }

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -51,7 +51,12 @@ class FakeCronModule(
         threadPoolSize
       )
     )
-    install(ServiceModule(key = CronService::class.toKey(), dependsOn = dependencies))
+    install(
+      ServiceModule(
+        key = CronService::class.toKey(),
+        dependsOn = dependencies
+      ).dependsOn<ReadyService>()
+    )
   }
 }
 

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.Service
 import com.google.inject.Key
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.concurrent.ExecutorServiceModule
 import misk.inject.KAbstractModule
@@ -20,12 +21,12 @@ class CronModule(
 ) : KAbstractModule() {
   override fun configure() {
     install(FakeCronModule(zoneId, threadPoolSize, dependencies))
-    install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class))
+    install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class).dependsOn<ReadyService>())
     install(
       ServiceModule(
         key = CronTask::class.toKey(),
         dependsOn = dependencies,
-      )
+      ).dependsOn<ReadyService>()
     )
   }
 

--- a/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
@@ -18,7 +18,6 @@ import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@Suppress("UsePropertyAccessSyntax")
 @MiskTest(startService = true)
 class CronModuleTest {
   @Suppress("unused")
@@ -43,8 +42,13 @@ class CronModuleTest {
   @Inject private lateinit var logCollector: LogCollector
 
   @Test fun dependentServicesStartUpBeforeCron() {
-    assertThat(logCollector.takeMessages()).containsExactly(
+    val messages = logCollector.takeMessages()
+    // Can happen in any order since the relationship isn't specified between the two.
+    assertThat(messages.subList(0, 2)).contains(
+      "Starting ready service",
       "DependentService started",
+    )
+    assertThat(messages.subList(2, 4)).containsExactly(
       "CronService started",
       "Adding cron entry misk.cron.MinuteCron, crontab=* * * * *",
     )

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/GoogleCloudModule.kt
@@ -11,6 +11,7 @@ import com.google.cloud.storage.StorageOptions
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.cloud.gcp.datastore.DatastoreConfig
 import misk.cloud.gcp.storage.LocalStorageRpc
@@ -29,7 +30,7 @@ class GoogleCloudModule(
   override fun configure() {
     bind<DatastoreConfig>().toInstance(datastoreConfig)
     bind<StorageConfig>().toInstance(storageConfig)
-    install(ServiceModule<GoogleCloud>())
+    install(ServiceModule<GoogleCloud>().enhancedBy<ReadyService>())
   }
 
   @Provides

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModule.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/GoogleSpannerModule.kt
@@ -8,6 +8,7 @@ import com.google.cloud.spanner.SpannerOptions
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import wisp.logging.getLogger
@@ -23,7 +24,7 @@ class GoogleSpannerModule(
 ) : KAbstractModule() {
   override fun configure() {
     bind<SpannerConfig>().toInstance(spannerConfig)
-    install(ServiceModule<GoogleSpannerService>())
+    install(ServiceModule<GoogleSpannerService>().enhancedBy<ReadyService>())
   }
 
   @Provides

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -1,6 +1,7 @@
 package misk.hibernate
 
 import com.google.inject.Injector
+import misk.ReadyService
 import misk.ServiceModule
 import misk.concurrent.ExecutorServiceFactory
 import misk.healthchecks.HealthCheck
@@ -219,6 +220,7 @@ class HibernateModule(
       install(
         ServiceModule<TransacterService>(qualifier)
           .enhancedBy<SchemaMigratorService>(qualifier)
+          .enhancedBy<ReadyService>()
           .dependsOn<DataSourceService>(qualifier)
       )
     } else {

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/DevelopmentJobProcessorModule.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/DevelopmentJobProcessorModule.kt
@@ -2,16 +2,16 @@ package misk.jobqueue
 
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.keyOf
-import misk.inject.toKey
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
 
 class DevelopmentJobProcessorModule : KAbstractModule() {
   override fun configure() {
-    install(ServiceModule<DevelopmentJobProcessor>())
+    install(ServiceModule<DevelopmentJobProcessor>().dependsOn<ReadyService>())
     install(ServiceModule(keyOf<RepeatedTaskQueue>(ForDevelopmentHandling::class)))
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisModule.kt
@@ -3,6 +3,7 @@ package misk.redis
 import com.google.common.base.Ticker
 import com.google.inject.Provides
 import com.google.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.metrics.v2.Metrics
@@ -39,7 +40,7 @@ class RedisModule(
 ) : KAbstractModule() {
   override fun configure() {
     bind<RedisConfig>().toInstance(redisConfig)
-    install(ServiceModule<RedisService>())
+    install(ServiceModule<RedisService>().enhancedBy<ReadyService>())
     requireBinding<Metrics>()
   }
 

--- a/misk-service/api/misk-service.api
+++ b/misk-service/api/misk-service.api
@@ -2,6 +2,14 @@ public abstract interface class misk/DelegatingService : com/google/common/util/
 	public abstract fun getService ()Lcom/google/common/util/concurrent/Service;
 }
 
+public final class misk/ReadyService : com/google/common/util/concurrent/AbstractIdleService {
+	public static final field Companion Lmisk/ReadyService$Companion;
+	public fun <init> ()V
+}
+
+public final class misk/ReadyService$Companion {
+}
+
 public final class misk/ServiceManagerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/ServiceManagerModule$Companion;
 	public fun <init> ()V

--- a/misk-service/build.gradle.kts
+++ b/misk-service/build.gradle.kts
@@ -10,9 +10,9 @@ plugins {
 
 dependencies {
   api(Dependencies.guice)
+  api(Dependencies.javaxInject)
   api(project(":misk-inject"))
   implementation(Dependencies.guava)
-  implementation(Dependencies.javaxInject)
   implementation(Dependencies.kotlinLogging)
   implementation(Dependencies.kotlinStdLibJdk8)
   implementation(Dependencies.wispLogging)

--- a/misk-service/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk-service/src/main/kotlin/misk/CoordinatedService.kt
@@ -18,7 +18,6 @@ internal class CoordinatedService(
         created.checkNew("$created must be NEW for it to be coordinated")
         created.addListener(
           object : Listener() {
-
             val outerService = this@CoordinatedService
 
             override fun running() {
@@ -40,20 +39,11 @@ internal class CoordinatedService(
       }
   }
 
-  /** Services that start before this. */
-  private val directDependsOn = mutableSetOf<CoordinatedService>()
+  /** Services that start before this aka enhancements or services who depend on this. */
+  private val upstreamServices = mutableSetOf<CoordinatedService>()
 
-  /** Services this starts before. */
-  private val directDependencies = mutableSetOf<CoordinatedService>()
-
-  /**
-   * Services that enhance this. This starts before them, but they start before
-   * [directDependencies].
-   */
-  private val enhancements = mutableSetOf<CoordinatedService>()
-
-  /** Service that starts up before this, and whose [directDependencies] also depend on this. */
-  private var enhancementTarget: CoordinatedService? = null
+  /** Services this starts before aka dependencies. */
+  private val downstreamServices = mutableSetOf<CoordinatedService>()
 
   /**
    * Used to track internally if this [CoordinatedService] has invoked [startAsync] on the inner
@@ -61,71 +51,14 @@ internal class CoordinatedService(
    * */
   private val innerServiceStarted = AtomicBoolean(false)
 
-  /**
-   * Returns a set of services that are required by this service.
-   *
-   * The set consists of the [enhancementTarget], all direct dependencies and each dependency's
-   * transitive enhancements. It is the set of services that block start-up of this service.
-   */
-  val upstreamServices: Set<CoordinatedService> by lazy {
-    val result = mutableSetOf<CoordinatedService>()
-    if (enhancementTarget != null) {
-      result += enhancementTarget!!
-    }
-    for (provider in directDependsOn) {
-      result += provider
-      provider.getTransitiveEnhancements(result)
-    }
-    result
-  }
-
-  private fun getTransitiveEnhancements(sink: MutableSet<CoordinatedService>) {
-    sink += enhancements
-    for (enhancement in enhancements) {
-      enhancement.getTransitiveEnhancements(sink)
-    }
-  }
-
-  /**
-   * Returns a set of all services which require this service to be started before they can start,
-   * and who must shut down before this service shuts down.
-   *
-   * The set contains this service's enhancements, its dependencies, and the dependencies of
-   * [enhancementTarget] (if it exists) and all transitive targets.
-   */
-  val downstreamServices: Set<CoordinatedService> by lazy {
-    val result = mutableSetOf<CoordinatedService>()
-    result += enhancements
-    var t: CoordinatedService? = this
-    while (t != null) {
-      result += t.directDependencies
-      t = t.enhancementTarget
-    }
-    result
-  }
-
   /** Adds [services] as dependents downstream. */
   fun addDependentServices(vararg services: CoordinatedService) {
     // Check that this service and all dependent services are new before modifying the graph.
     this.checkNew()
     for (service in services) {
       service.checkNew()
-      directDependencies += service
-      service.directDependsOn += this
-    }
-  }
-
-  /**
-   * Adds [services] as enhancements to this service. Enhancements will start after the coordinated
-   * service is running, and stop before it stops.
-   */
-  fun addEnhancements(vararg services: CoordinatedService) {
-    // Check that this service and all dependent services are new before modifying the graph.
-    this.checkNew()
-    for (service in services) {
-      service.checkNew()
-      enhancements += service
-      service.enhancementTarget = this
+      downstreamServices += service
+      service.upstreamServices += this
     }
   }
 
@@ -138,7 +71,7 @@ internal class CoordinatedService(
   }
 
   private fun startIfReady() {
-    val canStartInner = state() == State.STARTING && upstreamServices.all { it.isRunning() }
+    val canStartInner = state() == State.STARTING && upstreamServices.all { it.isRunning }
 
     // startAsync must be called exactly once
     if (canStartInner) {
@@ -166,7 +99,7 @@ internal class CoordinatedService(
   override fun toString() = service.toString()
 
   /**
-   * Traverses the dependency/enhancement graph to detect cycles. If a cycle is found, then a
+   * Traverses the dependency graph to detect cycles. If a cycle is found, then a
    * list of services that forms this cycle is returned.
    *
    * @param validityMap: A map that is used to track traversal of this service's dependency graph.
@@ -179,16 +112,6 @@ internal class CoordinatedService(
       CycleValidity.CHECKING_FOR_CYCLES -> return mutableListOf(this) // We found a cycle!
       else -> {
         validityMap[this] = CycleValidity.CHECKING_FOR_CYCLES
-        // First check there are no cycles in the enhancements that could cause
-        // getDownstreamServices() to get stuck.
-        for (enhancement in enhancements) {
-          val cycle = enhancement.findCycle(validityMap)
-          if (cycle != null) {
-            cycle.add(this)
-            return cycle
-          }
-        }
-        // Now check that there are no mixed enhancement-dependency cycles.
         for (dependency in downstreamServices) {
           val cycle = dependency.findCycle(validityMap)
           if (cycle != null) {

--- a/misk-service/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk-service/src/main/kotlin/misk/CoordinatedService.kt
@@ -39,10 +39,10 @@ internal class CoordinatedService(
       }
   }
 
-  /** Services that start before this aka enhancements or services who depend on this. */
+  /** Services this starts before aka enhancements or services who depend on this. */
   private val upstreamServices = mutableSetOf<CoordinatedService>()
 
-  /** Services this starts before aka dependencies. */
+  /** Services this starts after aka dependencies. */
   private val downstreamServices = mutableSetOf<CoordinatedService>()
 
   /**
@@ -51,7 +51,10 @@ internal class CoordinatedService(
    * */
   private val innerServiceStarted = AtomicBoolean(false)
 
-  /** Adds [services] as dependents downstream. */
+  /**
+   * Marks [services] as dependencies (downstreamServices) and marks itself as upstream services
+   * on each one.
+   * */
   fun addDependentServices(vararg services: CoordinatedService) {
     // Check that this service and all dependent services are new before modifying the graph.
     this.checkNew()

--- a/misk-service/src/main/kotlin/misk/ReadyService.kt
+++ b/misk-service/src/main/kotlin/misk/ReadyService.kt
@@ -1,0 +1,30 @@
+package misk
+
+import com.google.common.util.concurrent.AbstractIdleService
+import wisp.logging.getLogger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * This is a symbolic service that's useful to define the relationship, generally, between
+ * services which process traffic (Jetty, SQS, Kinesis, Cron, Tasks, etc.) and services which
+ * are required to do work (Database, Redis, GCP, Feature Flags).
+ *
+ * By having the former depend on ReadyService and the latter enhance ReadyService we can force,
+ * for example, JettyService to stop _before_ our feature flag service without having to intertwine
+ * our dependency graph.
+ */
+@Singleton
+class ReadyService @Inject constructor() : AbstractIdleService() {
+  override fun startUp() {
+    logger.info { "Starting up" }
+  }
+
+  override fun shutDown() {
+    logger.info { "Shutting down" }
+  }
+
+  companion object {
+    private val logger = getLogger<ReadyService>()
+  }
+}

--- a/misk-service/src/main/kotlin/misk/ReadyService.kt
+++ b/misk-service/src/main/kotlin/misk/ReadyService.kt
@@ -17,11 +17,11 @@ import javax.inject.Singleton
 @Singleton
 class ReadyService @Inject constructor() : AbstractIdleService() {
   override fun startUp() {
-    logger.info { "Starting up" }
+    logger.info { "Starting ready service" }
   }
 
   override fun shutDown() {
-    logger.info { "Shutting down" }
+    logger.info { "Stopping ready service" }
   }
 
   companion object {

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -56,7 +56,7 @@ internal class ServiceGraphBuilder {
    */
   fun enhanceService(toBeEnhanced: Key<*>, enhancement: Key<*>) {
     check(enhancementMap[enhancement] == null) {
-      "Enhancement $enhancement cannot be applied more than once"
+      "Enhancement $enhancement cannot be applied more than once to $toBeEnhanced"
     }
     enhancementMap[enhancement] = toBeEnhanced
   }

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -5,7 +5,6 @@ import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Key
 import misk.CoordinatedService.Companion.CycleValidity
-import wisp.logging.getLogger
 import javax.inject.Provider
 
 /**
@@ -34,7 +33,7 @@ internal class ServiceGraphBuilder {
   }
 
   /**
-   * Registers a dependency pair with the service graph. Specifies that the [dependent] service must
+   * Registers a dependency pair in the service graph. Specifies that the [dependent] must
    * start after [dependsOn], and conversely that [dependent] must stop before [dependsOn].
    */
   fun addDependency(dependent: Key<*>, dependsOn: Key<*>) {
@@ -42,17 +41,10 @@ internal class ServiceGraphBuilder {
   }
 
   /**
-   * Adds a [enhancement] to the service [toBeEnhanced]. The service [toBeEnhanced] depends on its
-   * enhancements.
-   *
-   * Service [enhancement]s will be started after the service [toBeEnhanced] is started, but before
-   * any of its dependents can start. Conversely, the dependents of the service [toBeEnhanced] will
-   * be shut down, followed by all of its [enhancement]s, and finally the service [toBeEnhanced]
-   * itself.
-   *
-   * @param toBeEnhanced The identifier for the service to be enhanced by [enhancement].
-   * @param enhancement The identifier for the service that depends on [toBeEnhanced].
-   * @throws IllegalStateException if the enhancement has already been applied to another service.
+   * This is the opposite of addDependency in that we're specifying that [toBeEnhanced] is a
+   * dependency of [enhancement]. The purpose of this is to avoid having to intertwine
+   * dependencies. For example, misk-service has no dependencies on other misk services but
+   * in the service graph ReadyService depends on many things by using enhancements.
    */
   fun enhanceService(toBeEnhanced: Key<*>, enhancement: Key<*>) {
     dependencyMap.put(toBeEnhanced, enhancement)
@@ -107,9 +99,5 @@ internal class ServiceGraphBuilder {
         "$stringBuilder requires $service but no such service was registered with the builder"
       }
     }
-  }
-
-  companion object {
-    private val logger = getLogger<ServiceGraphBuilder>()
   }
 }

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Key
 import misk.CoordinatedService.Companion.CycleValidity
+import wisp.logging.getLogger
 import javax.inject.Provider
 
 /**
@@ -14,7 +15,6 @@ import javax.inject.Provider
 internal class ServiceGraphBuilder {
   private var serviceMap = mutableMapOf<Key<*>, CoordinatedService>()
   private val dependencyMap = LinkedHashMultimap.create<Key<*>, Key<*>>()
-  private val enhancementMap = LinkedHashMultimap.create<Key<*>, Key<*>>()
 
   /**
    * Registers a [service] with this [ServiceGraphBuilder]
@@ -55,7 +55,7 @@ internal class ServiceGraphBuilder {
    * @throws IllegalStateException if the enhancement has already been applied to another service.
    */
   fun enhanceService(toBeEnhanced: Key<*>, enhancement: Key<*>) {
-    enhancementMap.put(toBeEnhanced, enhancement)
+    dependencyMap.put(toBeEnhanced, enhancement)
   }
 
   /**
@@ -78,8 +78,6 @@ internal class ServiceGraphBuilder {
     for ((key, service) in serviceMap) {
       val dependencies = dependencyMap[key]?.map { serviceMap[it]!! } ?: listOf()
       service.addDependentServices(*dependencies.toTypedArray())
-      val enhancements = enhancementMap[key]?.map { serviceMap[it]!! } ?: listOf()
-      service.addEnhancements(*enhancements.toTypedArray())
     }
   }
 
@@ -109,5 +107,9 @@ internal class ServiceGraphBuilder {
         "$stringBuilder requires $service but no such service was registered with the builder"
       }
     }
+  }
+
+  companion object {
+    private val logger = getLogger<ServiceGraphBuilder>()
   }
 }

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -56,10 +56,10 @@ class ServiceManagerModule : KAbstractModule() {
       builder.addService(entry.key, injector.getProvider(entry.key))
     }
     for (edge in dependencies) {
-      builder.addDependency(service = edge.dependent, dependency = edge.dependsOn)
+      builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
     }
     for (edge in enhancements) {
-      builder.enhanceService(service = edge.toBeEnhanced, enhancement = edge.enhancement)
+      builder.enhanceService(toBeEnhanced = edge.toBeEnhanced, enhancement = edge.enhancement)
     }
 
     // Confirm all services have been registered as singleton. If they aren't singletons,

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -56,10 +56,10 @@ class ServiceManagerModule : KAbstractModule() {
       builder.addService(entry.key, injector.getProvider(entry.key))
     }
     for (edge in dependencies) {
-      builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
+      builder.addDependency(service = edge.dependent, dependency = edge.dependsOn)
     }
     for (edge in enhancements) {
-      builder.enhanceService(toBeEnhanced = edge.toBeEnhanced, enhancement = edge.enhancement)
+      builder.enhanceService(service = edge.toBeEnhanced, enhancement = edge.enhancement)
     }
 
     // Confirm all services have been registered as singleton. If they aren't singletons,

--- a/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -9,7 +9,6 @@ import misk.ServiceGraphBuilderTest.AppendingService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 import kotlin.test.assertFailsWith
 
 class CoordinatedServiceTest {

--- a/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -213,7 +213,12 @@ class ServiceGraphBuilderTest {
       enhanceService(toBeEnhanced = keyA, enhancement = keyB)
       enhanceService(toBeEnhanced = keyC, enhancement = keyB)
     }
-    assertThat(failure).hasMessage("Enhancement $keyB cannot be applied more than once")
+    assertThat(failure).hasMessage(
+      "Enhancement Key[type=com.google.common.util.concurrent.Service, " +
+        "annotation=@com.google.inject.name.Named(\"Service B\")] cannot be applied more than" +
+        " once to Key[type=com.google.common.util.concurrent.Service," +
+        " annotation=@com.google.inject.name.Named(\"Service C\")]"
+    )
   }
 
   @Test fun dependingServiceHasEnhancements() {

--- a/misk-service/src/test/kotlin/misk/ServiceManagerModuleTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceManagerModuleTest.kt
@@ -8,16 +8,16 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import com.google.inject.Scopes
 import com.google.inject.Singleton
-import javax.inject.Inject
-import kotlin.test.assertFailsWith
 import misk.inject.KAbstractModule
 import misk.inject.getInstance
 import misk.inject.keyOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import javax.inject.Inject
+import kotlin.test.assertFailsWith
 
 internal class ServiceManagerModuleTest {
-  @com.google.inject.Singleton
+  @Singleton
   class SingletonService1 : AbstractIdleService() {
     override fun startUp() {}
     override fun shutDown() {}
@@ -117,12 +117,12 @@ internal class ServiceManagerModuleTest {
                 .`in`(Scopes.SINGLETON)
               install(ServiceModule<SingletonAnnotationService>())
               bind(keyOf<SingletonAnnotationService>())
-                .`in`(com.google.inject.Singleton::class.java)
+                .`in`(Singleton::class.java)
               install(
                 ServiceModule<GoogleSingletonAnnotationService>()
               )
               bind(keyOf<GoogleSingletonAnnotationService>())
-                .`in`(com.google.inject.Singleton::class.java)
+                .`in`(Singleton::class.java)
 
               // Should be recognized as non-singletons
               install(ServiceModule<NonSingletonService1>())
@@ -150,6 +150,7 @@ internal class ServiceManagerModuleTest {
     init {
       log.append("ProducerService.init\n")
     }
+
     override fun doStart() {
       log.append("ProducerService.startUp\n")
       notifyStarted()
@@ -168,6 +169,7 @@ internal class ServiceManagerModuleTest {
     init {
       log.append("ConsumerService.init\n")
     }
+
     override fun doStart() {
       log.append("ConsumerService.startUp\n")
       notifyStarted()
@@ -186,6 +188,7 @@ internal class ServiceManagerModuleTest {
     init {
       log.append("AnotherUpstreamService.init\n")
     }
+
     override fun doStart() {
       log.append("AnotherUpstreamService.startUp\n")
       notifyStarted()
@@ -205,9 +208,11 @@ internal class ServiceManagerModuleTest {
         override fun configure() {
           bind<StringBuilder>().toInstance(log)
           install(ServiceModule<ProducerService>())
-          install(ServiceModule<ConsumerService>()
-            .dependsOn<ProducerService>()
-            .dependsOn<AnotherUpstreamService>())
+          install(
+            ServiceModule<ConsumerService>()
+              .dependsOn<ProducerService>()
+              .dependsOn<AnotherUpstreamService>()
+          )
           install(ServiceModule<AnotherUpstreamService>())
         }
       }
@@ -220,7 +225,8 @@ internal class ServiceManagerModuleTest {
     serviceManager.stopAsync()
     serviceManager.awaitStopped()
 
-    assertThat(log.toString()).isEqualTo("""
+    assertThat(log.toString()).isEqualTo(
+      """
       |ProducerService.init
       |ProducerService.startUp
       |AnotherUpstreamService.init
@@ -231,6 +237,7 @@ internal class ServiceManagerModuleTest {
       |ConsumerService.shutDown
       |ProducerService.shutDown
       |AnotherUpstreamService.shutDown
-      |""".trimMargin())
+      |""".trimMargin()
+    )
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -1,6 +1,5 @@
 package misk.logging
 
-import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import wisp.logging.LogCollector
@@ -12,8 +11,6 @@ class LogCollectorModule : KAbstractModule() {
     bind<LogCollector>().to<RealLogCollector>()
     bind<LogCollectorService>().to<RealLogCollector>()
     bind<WispQueuedLogCollector>().toProvider(Provider { WispQueuedLogCollector() })
-    // We have to specify the dependency between LogCollectorService and ReadyService to create
-    // deterministic log collection.
-    install(ServiceModule<LogCollectorService>().enhancedBy<ReadyService>())
+    install(ServiceModule<LogCollectorService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -12,6 +12,6 @@ class LogCollectorModule : KAbstractModule() {
     bind<LogCollector>().to<RealLogCollector>()
     bind<LogCollectorService>().to<RealLogCollector>()
     bind<WispQueuedLogCollector>().toProvider(Provider { WispQueuedLogCollector() })
-    install(ServiceModule<LogCollectorService>().dependsOn<ReadyService>())
+    install(ServiceModule<LogCollectorService>().enhancedBy<ReadyService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -1,5 +1,6 @@
 package misk.logging
 
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import wisp.logging.LogCollector
@@ -11,6 +12,8 @@ class LogCollectorModule : KAbstractModule() {
     bind<LogCollector>().to<RealLogCollector>()
     bind<LogCollectorService>().to<RealLogCollector>()
     bind<WispQueuedLogCollector>().toProvider(Provider { WispQueuedLogCollector() })
-    install(ServiceModule<LogCollectorService>())
+    // We have to specify the dependency between LogCollectorService and ReadyService to create
+    // deterministic log collection.
+    install(ServiceModule<LogCollectorService>().enhancedBy<ReadyService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/LogCollectorModule.kt
@@ -1,5 +1,6 @@
 package misk.logging
 
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import wisp.logging.LogCollector
@@ -11,6 +12,6 @@ class LogCollectorModule : KAbstractModule() {
     bind<LogCollector>().to<RealLogCollector>()
     bind<LogCollectorService>().to<RealLogCollector>()
     bind<WispQueuedLogCollector>().toProvider(Provider { WispQueuedLogCollector() })
-    install(ServiceModule<LogCollectorService>())
+    install(ServiceModule<LogCollectorService>().dependsOn<ReadyService>())
   }
 }

--- a/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
@@ -1,15 +1,20 @@
 package misk.logging
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
 import com.google.common.util.concurrent.AbstractIdleService
 import wisp.logging.LogCollector
 import wisp.logging.WispQueuedLogCollector
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.reflect.KClass
 
 @Singleton
 internal class RealLogCollector @Inject constructor(
   private val wispQueuedLogCollector: WispQueuedLogCollector
-) : AbstractIdleService(), LogCollector by wispQueuedLogCollector, LogCollectorService {
+) : AbstractIdleService(),
+  LogCollector by wispQueuedLogCollector,
+  LogCollectorService {
 
   override fun startUp() {
     wispQueuedLogCollector.startUp()

--- a/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
+++ b/misk-testing/src/main/kotlin/misk/logging/RealLogCollector.kt
@@ -1,20 +1,15 @@
 package misk.logging
 
-import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.spi.ILoggingEvent
 import com.google.common.util.concurrent.AbstractIdleService
 import wisp.logging.LogCollector
 import wisp.logging.WispQueuedLogCollector
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.reflect.KClass
 
 @Singleton
 internal class RealLogCollector @Inject constructor(
   private val wispQueuedLogCollector: WispQueuedLogCollector
-) : AbstractIdleService(),
-  LogCollector by wispQueuedLogCollector,
-  LogCollectorService {
+) : AbstractIdleService(), LogCollector by wispQueuedLogCollector, LogCollectorService {
 
   override fun startUp() {
     wispQueuedLogCollector.startUp()

--- a/misk-testing/src/main/kotlin/misk/testing/LogLevelExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/LogLevelExtension.kt
@@ -2,6 +2,7 @@ package misk.testing
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.slf4j.LoggerFactory
@@ -12,15 +13,16 @@ class LogLevelExtension @Inject constructor() : BeforeEachCallback {
     // Note that the root logger will be a org.slf4j.Logger, but may not
     // be a ch.qos.logback.class.Logger instance. In particular, it can
     // sometimes be a org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger
-    val root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as? Logger
-    root?.let { it.level = level(context) }
+    val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
+    val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+    rootLogger.level = level(context)
   }
 
   private fun level(context: ExtensionContext?): Level {
-    if(context == null || context.element.isEmpty) {
+    if (context == null || context.element.isEmpty) {
       return Level.INFO
     }
-    return  context.element.get().annotations.firstNotNullOfOrNull { it as? LogLevel }
+    return context.element.get().annotations.firstNotNullOfOrNull { it as? LogLevel }
       ?.let { mapLevel(it.level) }
       ?: findParent(context)
       ?: Level.INFO

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -36,6 +36,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
     val module = object : KAbstractModule() {
       override fun configure() {
         binder().requireAtInjectOnConstructors()
+        multibind<BeforeEachCallback>().to<LogLevelExtension>()
 
         if (context.startService()) {
           multibind<BeforeEachCallback>().to<StartServicesBeforeEach>()
@@ -48,7 +49,6 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
         context.requiredTestInstances.allInstances.forEach { install(BoundFieldModule.of(it)) }
 
         multibind<BeforeEachCallback>().to<InjectUninject>()
-        multibind<BeforeEachCallback>().to<LogLevelExtension>()
         multibind<AfterEachCallback>().to<InjectUninject>()
 
         // Initialize empty sets for our multibindings.
@@ -74,8 +74,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
   }
 
   class StartServicesBeforeEach @Inject constructor() : BeforeEachCallback {
-    @Inject
-    lateinit var serviceManager: ServiceManager
+    @Inject lateinit var serviceManager: ServiceManager
 
     override fun beforeEach(context: ExtensionContext) {
       if (context.startService()) {

--- a/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
+++ b/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
@@ -90,8 +90,10 @@ class LogCollectorTest {
       .containsExactly("A thing happened")
     assertThat(logCollector.takeMessages(LogCollectorModule::class, consumeUnmatchedLogs = false))
       .containsExactly("Another thing happened")
-    assertThat(logCollector.takeMessages(consumeUnmatchedLogs = false))
-      .containsExactly("Starting ready service")
+    // Ready service can start before or after logCollector, so it's inconsistent without this.
+    val withoutReadyService = logCollector.takeMessages(consumeUnmatchedLogs = false)
+      .filterNot { it == "Starting ready service" }
+    assertThat(withoutReadyService).isEmpty()
 
     // We can collect messages of different error levels.
     logger.info { "this is a log message!" }

--- a/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
+++ b/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
@@ -90,7 +90,8 @@ class LogCollectorTest {
       .containsExactly("A thing happened")
     assertThat(logCollector.takeMessages(LogCollectorModule::class, consumeUnmatchedLogs = false))
       .containsExactly("Another thing happened")
-    assertThat(logCollector.takeMessages(consumeUnmatchedLogs = false)).isEmpty()
+    assertThat(logCollector.takeMessages(consumeUnmatchedLogs = false))
+      .containsExactly("Starting ready service")
 
     // We can collect messages of different error levels.
     logger.info { "this is a log message!" }
@@ -102,7 +103,7 @@ class LogCollectorTest {
 
     // We can collect messages matching certain patterns.
     logger.info { "hit by pattern match" }
-    logger.info { "missed by pattern match"}
+    logger.info { "missed by pattern match" }
     assertThat(logCollector.takeMessages(pattern = Regex("hit.*"), consumeUnmatchedLogs = false))
       .containsExactly("hit by pattern match")
     assertThat(logCollector.takeMessages(consumeUnmatchedLogs = false))

--- a/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
+++ b/misk-testing/src/test/kotlin/misk/logging/LogCollectorTest.kt
@@ -29,7 +29,10 @@ class LogCollectorTest {
     val logger = getLogger<LogCollectorTest>()
 
     logger.info("this is a log message!")
-    assertThat(logCollector.takeMessages()).containsExactly("this is a log message!")
+    assertThat(logCollector.takeMessages()).containsExactly(
+      "Starting ready service",
+      "this is a log message!"
+    )
 
     logger.info("another log message")
     logger.info("and a third!")
@@ -44,7 +47,7 @@ class LogCollectorTest {
     logger.info("this is INFO.")
     logger.warn("this is WARN!")
     assertThat(logCollector.takeMessages(minLevel = Level.INFO))
-      .containsExactly("this is INFO.", "this is WARN!")
+      .containsExactly("Starting ready service", "this is INFO.", "this is WARN!")
   }
 
   @Test
@@ -114,6 +117,7 @@ class LogCollectorTest {
 
   @Test
   fun takeTimeout() {
+    logCollector.takeEvent()
     val exception = assertFailsWith<IllegalArgumentException> {
       logCollector.takeEvent()
     }
@@ -131,6 +135,7 @@ class LogCollectorTest {
         logger.info("this is a log message!")
       }
     }
+    logCollector.takeMessage()
     thread.start()
 
     assertThat(logCollector.takeMessage()).isEqualTo("this is a log message!")

--- a/misk-testing/src/test/kotlin/misk/testing/LogLevelExtensionTest.kt
+++ b/misk-testing/src/test/kotlin/misk/testing/LogLevelExtensionTest.kt
@@ -27,7 +27,7 @@ class LogLevelExtensionTest {
   @Test fun test() {
     logMessages()
     assertThat(logCollector.takeMessages(minLevel = Level.ALL)).containsExactly(
-      "this is INFO.", "this is WARN.", "this is ERROR."
+      "Starting ready service", "this is INFO.", "this is WARN.", "this is ERROR."
     )
 
   }
@@ -36,7 +36,7 @@ class LogLevelExtensionTest {
   @Test fun levelDebug() {
     logMessages()
     assertThat(logCollector.takeMessages(minLevel = Level.ALL)).containsExactly(
-      "this is DEBUG.", "this is INFO.", "this is WARN.", "this is ERROR."
+      "Starting ready service", "this is DEBUG.", "this is INFO.", "this is WARN.", "this is ERROR."
     )
   }
 
@@ -44,7 +44,7 @@ class LogLevelExtensionTest {
   @Test fun levelInfo() {
     logMessages()
     assertThat(logCollector.takeMessages(minLevel = Level.ALL)).containsExactly(
-      "this is INFO.", "this is WARN.", "this is ERROR."
+      "Starting ready service", "this is INFO.", "this is WARN.", "this is ERROR."
     )
   }
 
@@ -63,7 +63,6 @@ class LogLevelExtensionTest {
       "this is ERROR."
     )
   }
-
 
   @LogLevel(level = LogLevel.Level.ERROR)
   @Nested

--- a/misk-warmup/src/test/kotlin/misk/warmup/WarmupTest.kt
+++ b/misk-warmup/src/test/kotlin/misk/warmup/WarmupTest.kt
@@ -45,6 +45,8 @@ internal class WarmupTest {
     )
 
     assertThat(logCollector.takeMessage(minLevel = Level.INFO))
+      .isEqualTo("Starting ready service")
+    assertThat(logCollector.takeMessage(minLevel = Level.INFO))
       .isEqualTo("Running warmup tasks: [LoggingWarmupTask]")
     assertThat(logCollector.takeMessage(minLevel = Level.INFO))
       .startsWith("Warmup task LoggingWarmupTask completed")
@@ -65,6 +67,8 @@ internal class WarmupTest {
       "LoggingService shutDown",
     )
 
+    assertThat(logCollector.takeMessage(minLevel = Level.INFO))
+      .isEqualTo("Starting ready service")
     assertThat(logCollector.takeMessage(minLevel = Level.INFO))
       .isEqualTo("Running warmup tasks: [ThrowingWarmupTask]")
     assertThat(logCollector.takeMessage(minLevel = Level.ERROR))

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -82,7 +82,6 @@ dependencies {
   testImplementation(Dependencies.wispLoggingTesting)
   testImplementation(Dependencies.wispTimeTesting)
   testImplementation(project(":misk"))
-  testImplementation(project(":misk-metrics-testing"))
   testImplementation(project(":misk-testing"))
 }
 

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -46,5 +46,6 @@ class MiskCommonServiceModule : KAbstractModule() {
     install(JvmManagementFactoryModule())
     // Initialize empty sets for our multibindings.
     newMultibinder<HealthCheck>()
+    install(ServiceModule<ReadyService>())
   }
 }

--- a/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
+++ b/misk/src/test/kotlin/misk/perf/PauseDetectorTest.kt
@@ -4,15 +4,14 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.google.common.base.Ticker
 import com.google.inject.Key
-import misk.ServiceManagerModule
+import misk.MiskTestingServiceModule
 import misk.concurrent.FakeTicker
 import misk.concurrent.Sleeper
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 import misk.logging.LogCollectorModule
-import misk.metrics.v2.FakeMetricsModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import misk.web.WebServerTestingModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,7 +29,7 @@ class PauseDetectorTest {
 
   @BeforeEach fun setup() {
     // We'll drive the detector from the test thread rather than running a detector thread.
-    assertThat(detector.isRunning()).isFalse()
+    assertThat(detector.isRunning).isFalse()
 
     // Do one cycle to calibrate shortestObservedDeltaTimeNsec
     detector.sleep()
@@ -127,8 +126,8 @@ class PauseDetectorTest {
         .to(Key.get(FakeTicker::class.java, ForPauseDetector::class.java))
 
       // And its dependencies with test fakes
-      install(ServiceManagerModule())
-      install(FakeMetricsModule())
+      install(MiskTestingServiceModule())
+      install(WebServerTestingModule())
 
       // Test support
       install(LogCollectorModule())

--- a/misk/src/test/kotlin/misk/web/GracefulShutdownTest.kt
+++ b/misk/src/test/kotlin/misk/web/GracefulShutdownTest.kt
@@ -1,0 +1,131 @@
+package misk.web
+
+import com.google.common.util.concurrent.AbstractIdleService
+import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.util.Modules
+import misk.MiskTestingServiceModule
+import misk.ReadyService
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.time.ClockModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wisp.logging.getLogger
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@MiskTest(startService = true)
+internal class GracefulShutdownTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject lateinit var jettyService: JettyService
+  @Inject lateinit var serviceManager: ServiceManager
+
+  private lateinit var finishedLatch: CountDownLatch
+  private lateinit var httpClient: OkHttpClient
+
+  @BeforeEach
+  internal fun setUp() {
+    httpClient = OkHttpClient().newBuilder()
+      .readTimeout(Duration.ofSeconds(30))
+      .connectTimeout(Duration.ofSeconds(30))
+      .writeTimeout(Duration.ofSeconds(30))
+      .build()
+    finishedLatch = CountDownLatch(1)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    httpClient.dispatcher.executorService.shutdown()
+  }
+
+  /**
+   * This test initiates a long-running HTTP call and makes sure that even if we start the
+   * shutdown process during the call that the client still receives a successful response.
+   *
+   * Additionally, the action itself relies on FakeService, so we verify that by having FakeService
+   * enhancedBy ReadyService that JettyService stops before ReadyService does.
+   */
+  @Test
+  fun basic() {
+    makeHttpCall()
+    Thread.sleep(1000)
+    serviceManager.stopAsync()
+    finishedLatch.await(15, TimeUnit.SECONDS)
+  }
+
+  private fun makeHttpCall() {
+    val url = jettyService.httpServerUrl.resolve("/hello")!!
+    val request = Request.Builder().url(url).build()
+
+    httpClient.newCall(request).enqueue(object : Callback {
+      override fun onFailure(call: Call, e: IOException) {
+      }
+
+      override fun onResponse(call: Call, response: Response) {
+        if (response.code == 200) {
+          finishedLatch.countDown()
+        }
+      }
+    })
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(Modules.override(MiskTestingServiceModule()).with(ClockModule()))
+      install(WebServerTestingModule())
+      install(WebActionModule.create<HelloAction>())
+      install(ServiceModule<FakeService>().enhancedBy<ReadyService>())
+    }
+  }
+}
+
+@Singleton
+internal class HelloAction @Inject constructor(private val fakeService: FakeService) : WebAction {
+  @Get("/hello")
+  fun get(): String {
+    Thread.sleep(Duration.ofSeconds(5).toMillis())
+    fakeService.doWork()
+    return "success"
+  }
+}
+
+@Singleton
+internal class FakeService @Inject constructor() : AbstractIdleService() {
+  private var started = false
+
+  fun doWork() {
+    if (!started) {
+      error("Hey I'm not even running!")
+    }
+  }
+
+  override fun startUp() {
+    logger.info { "Starting up" }
+    started = true
+  }
+
+  override fun shutDown() {
+    logger.info { "Shutting down" }
+    started = false
+  }
+
+  companion object {
+    private val logger = getLogger<FakeService>()
+  }
+}

--- a/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
+++ b/misk/src/test/kotlin/misk/web/InvalidActionsTest.kt
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +22,7 @@ class InvalidActionsTest {
   @Test fun failIdenticalActions() {
     val exception = assertThrows<ProvisionException>("Should throw an exception") {
       Guice.createInjector(IdenticalActionsModule()).getInstance(ServiceManager::class.java)
-        .startAsync().awaitHealthy()
+        .startAsync().awaitHealthy(Duration.ofSeconds(5))
     }
     assertThat(exception.message).contains(
       "Actions [InvalidActionsTest.SomeAction, InvalidActionsTest.IdenticalAction] have identical routing annotations."

--- a/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptorTest.kt
@@ -53,7 +53,7 @@ class ConcurrencyLimitsInterceptorTest {
     val interceptor = factory.create(action)!!
     assertThat(call(action, interceptor, callDuration = Duration.ofMillis(100), statusCode = 200))
       .isEqualTo(CallResult(callWasShed = false, statusCode = 200))
-    assertThat(logCollector.takeMessages()).isEmpty()
+    assertThat(logCollector.takeMessages()).containsExactly("Starting ready service")
     assertThat(callSuccessCount("HelloAction")).isEqualTo(1.0)
   }
 


### PR DESCRIPTION
```13:09:55.223 [JettyService STARTING] INFO misk.web.jetty.JettyService -- Started Jetty in 280.7 ms on port 0/0
13:09:56.265 [JettyService STOPPING] INFO misk.web.jetty.JettyService -- Stopping Jetty
13:09:56.266 [JettyService STOPPING] INFO org.eclipse.jetty.server.Server -- Stopped Server@2175b71{STOPPING}[10.0.14,sto=25000]
13:09:56.267 [JettyService STOPPING] INFO org.eclipse.jetty.server.Server -- Shutdown Server@2175b71{STOPPING}[10.0.14,sto=25000]
13:10:01.346 [JettyService STOPPING] INFO org.eclipse.jetty.server.AbstractConnector -- Stopped health@4be8cb9f{HTTP/1.1, (http/1.1)}{0.0.0.0:0}
13:10:01.347 [JettyService STOPPING] INFO org.eclipse.jetty.server.AbstractConnector -- Stopped http@6156232d{HTTP/1.1, (http/1.1, h2c)}{127.0.0.1:0}
13:10:01.354 [JettyService STOPPING] INFO org.eclipse.jetty.server.AbstractConnector -- Stopped https@56ad378e{SSL, (ssl, alpn, h2, http/1.1)}{127.0.0.1:0}
13:10:01.357 [JettyService STOPPING] INFO org.eclipse.jetty.server.handler.ContextHandler -- Stopped o.e.j.s.ServletContextHandler@2e70ed5f{/,null,STOPPED}
13:10:01.367 [JettyService STOPPING] INFO misk.web.jetty.JettyService -- Stopped Jetty in 5.102 s
13:10:01.368 [ReadyService STOPPING] INFO misk.ReadyService -- Shutting down
13:10:01.368 [FakeService STOPPING] INFO misk.web.FakeService -- Shutting down
```

from the test i added. Note that jetty takes 5 seconds to shutdown since there's an HTTP call in flight 