### PR TITLE
chore: remove Guava as dependency injected to all submodules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,6 @@ subprojects {
       // Enforce misk-bom -- it should take priority over external BOMs.
       add("api", enforcedPlatform(project(":misk-bom")))
       add("api", platform(Dependencies.grpcBom))
-      add("api", platform(Dependencies.guava))
       add("api", platform(Dependencies.jacksonBom))
       add("api", platform(Dependencies.jerseyBom))
       add("api", platform(Dependencies.jettyBom))


### PR DESCRIPTION
Guava is not necessarily needed everywhere.
If it is, it should be explicitly added