### PR TITLE
Add opt-in flag for auto MDC injection for datadog tracing

### DIFF
--- a/misk-datadog/api/misk-datadog.api
+++ b/misk-datadog/api/misk-datadog.api
@@ -15,5 +15,6 @@ public final class com/squareup/cash/tracing/datadog/MDCScopeListener$Companion 
 
 public final class misk/tracing/backends/datadog/DatadogTracingBackendModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	public fun <init> (Z)V
 }
 

--- a/misk-datadog/src/main/kotlin/misk/tracing/backends/datadog/DatadogTracingBackendModule.kt
+++ b/misk-datadog/src/main/kotlin/misk/tracing/backends/datadog/DatadogTracingBackendModule.kt
@@ -8,16 +8,28 @@ import misk.inject.KAbstractModule
 /**
  * Binds the datadog tracer to opentracing's [Tracer]
  */
-class DatadogTracingBackendModule : KAbstractModule() {
+
+class DatadogTracingBackendModule() : KAbstractModule() {
+
+  private var useAutoMdcInjection: Boolean = false
+
+  @Deprecated("useAutoMdcInjection is an experimental option that will be removed in a future version")
+  constructor(useAutoMdcInjection: Boolean): this() {
+    this.useAutoMdcInjection = useAutoMdcInjection
+  }
+
   override fun configure() {
     // A DDTracer is installed by the dd-java-agent in TracerInstaller, which runs before the app's main() method.
     // Otherwise, the GlobalTracer in both libraries would return a noop tracer and tracing would be effectively disabled.
     // See https://docs.datadoghq.com/tracing/custom_instrumentation/java/
     // See https://github.com/DataDog/dd-trace-java/tree/v0.65.0/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing
     bind<Tracer>().toInstance(io.opentracing.util.GlobalTracer.get())
-    getInternalTracer()?.apply {
-      val mdcScopeListener = MDCScopeListener()
-      addScopeListener(mdcScopeListener::afterScopeActivated, mdcScopeListener::afterScopeClosed)
+
+    if (!useAutoMdcInjection) {
+      getInternalTracer()?.apply {
+        val mdcScopeListener = MDCScopeListener()
+        addScopeListener(mdcScopeListener::afterScopeActivated, mdcScopeListener::afterScopeClosed)
+      }
     }
   }
 


### PR DESCRIPTION
We have had issues with log correlation when using coroutines and this change is the result of an internal investigation into the issue.

The idea here is that by removing our manual MDC handling we will stop interfering with the [automatic MDC injection](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/java/?tab=slf4jandlogback#automatic-injection) that the DataDog instrumentation is already doing for us, which during the investigation appeared to work as well or better than what we are doing currently in all tested scenarios.

We are first introducing it as an opt-in flag (this PR) but will shortly make this the default and finally remove the flag as we roll through different testing stages.