### PR TITLE
Revert "Include test fixtures in the bom (#2824)"

### DIFF
--- a/misk-bom/build.gradle.kts
+++ b/misk-bom/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     project.rootProject.subprojects.forEach { subproject ->
       if (subproject.name != "misk-bom") {
         api(subproject)
-        api(testFixtures(subproject))
       }
     }
   }


### PR DESCRIPTION
This reverts commit 6ebbdfc0d702848790e12955a988ec8c0ed9ae93 as it didn't help anything, and caused other issues described in https://cash.slack.com/archives/C915WS04Q/p1687278696769749?thread_ts=1687243149.486839&cid=C915WS04Q (specifically caused downstream consumers to hit the issue at https://github.com/gradle/gradle/issues/20515