### PR TITLE
[misk-cron] fix: CronManager: log exceptions at ERROR level.

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronManager.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronManager.kt
@@ -84,7 +84,7 @@ class CronManager @Inject constructor() {
             logger.info { "Executing cronjob $name" }
             cronEntry.runnable.run()
           } catch (t: Throwable) {
-            logger.warn { "Exception on cronjob $name: ${t.stackTraceToString()}" }
+            logger.error { "Exception on cronjob $name: ${t.stackTraceToString()}" }
           } finally {
             logger.info { "Executing cronjob $name complete" }
           }


### PR DESCRIPTION
At head, when a CronEntry throws an exception, CronManager logs a WARNING log and swallows the exception. This makes the exception invisible to alerting systems that rely on either ERROR logs or exceptions being thrown. This means that services using Misk cron tasks could be broken without knowing about it.

This PR upgrades the log to an ERROR. This brings the failure mode closer to the "vanilla jvm" case, where exception-throwing code is called from the main thread and produces a stack trace.