### PR TITLE
Revert "Add missing secondary constructor in Misk Response (#2837)"

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -177,9 +177,6 @@ public abstract interface annotation class misk/web/RequestHeaders : java/lang/a
 }
 
 public final class misk/web/Response {
-	public fun <init> (Ljava/lang/Object;)V
-	public fun <init> (Ljava/lang/Object;Lokhttp3/Headers;)V
-	public fun <init> (Ljava/lang/Object;Lokhttp3/Headers;I)V
 	public fun <init> (Ljava/lang/Object;Lokhttp3/Headers;ILkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ljava/lang/Object;Lokhttp3/Headers;ILkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;

--- a/misk-actions/src/main/kotlin/misk/web/Response.kt
+++ b/misk-actions/src/main/kotlin/misk/web/Response.kt
@@ -5,7 +5,7 @@ import okhttp3.Headers.Companion.headersOf
 import okio.BufferedSink
 
 /** An HTTP response body, headers, and status code. */
-data class Response<out T> @JvmOverloads constructor(
+data class Response<out T>(
   val body: T,
   val headers: Headers = headersOf(),
   val statusCode: Int = 200,


### PR DESCRIPTION
This reverts commit 5eaa045814a82f6119a5f52b6613da34a2364d95.