### PR TITLE
Add Bad Gateway Exception

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -17,6 +17,12 @@ public final class misk/MiskCaller {
 	public fun toString ()Ljava/lang/String;
 }
 
+public class misk/exceptions/BadGatewayException : misk/exceptions/WebActionException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public class misk/exceptions/BadRequestException : misk/exceptions/WebActionException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -2,6 +2,7 @@ package misk.exceptions
 
 import com.squareup.wire.AnyMessage
 import com.squareup.wire.GrpcStatus
+import java.net.HttpURLConnection.HTTP_BAD_GATEWAY
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 import java.net.HttpURLConnection.HTTP_CONFLICT
 import java.net.HttpURLConnection.HTTP_ENTITY_TOO_LARGE
@@ -98,6 +99,13 @@ open class TooManyRequestsException(message: String = "", cause: Throwable? = nu
 /** This exception is custom to Misk. */
 open class ClientClosedRequestException(message: String = "", cause: Throwable? = null) :
   WebActionException(499, message, message, cause)
+
+/**
+ * Base exception for when a server is acting as a gateway and gets invalid response from upstream.
+ * The message is not exposed to the caller.
+ */
+open class BadGatewayException(message: String = "", cause: Throwable? = null) :
+  WebActionException(HTTP_BAD_GATEWAY, "BAD_GATEWAY", message, cause)
 
 /**
  * Base exception for when a server is acting as a gateway and cannot get a response in time.


### PR DESCRIPTION
This change adds a new status code called BAD_GATEWAY which is a 502 status code meant to be returned when the server acting as a gateway received an invalid response from the upstream server.