### PR TITLE
feat!: log request and response headers

### DIFF
--- a/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
+++ b/misk-grpc-tests/src/test/kotlin/misk/grpc/MiskClientMiskServerTest.kt
@@ -81,7 +81,9 @@ class MiskClientMiskServerTest {
     assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).containsExactly(
       "GetFeatureGrpcAction principal=unknown time=0.000 ns code=200 " +
         "request=[Point{latitude=43, longitude=-80}] " +
-        "response=Feature{name=maple tree, location=Point{latitude=43, longitude=-80}}"
+        "requestHeaders={accept-encoding=[gzip], content-type=[application/grpc]} " +
+        "response=Feature{name=maple tree, location=Point{latitude=43, longitude=-80}} " +
+        "responseHeaders={}"
     )
     assertThat(callCounter.counter("default.GetFeature").get()).isEqualTo(1)
     assertThat(callCounter.counter("default.RouteChat").get()).isEqualTo(0)
@@ -101,7 +103,10 @@ class MiskClientMiskServerTest {
     // Confirm interceptors were invoked.
     assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).containsExactly(
       "RouteChatGrpcAction principal=unknown time=0.000 ns code=200 " +
-        "request=[GrpcMessageSource, GrpcMessageSink] response=kotlin.Unit"
+        "request=[GrpcMessageSource, GrpcMessageSink] " +
+        "requestHeaders={accept-encoding=[gzip], content-type=[application/grpc]} " +
+        "response=kotlin.Unit " +
+        "responseHeaders={content-type=[application/grpc]}"
     )
     assertThat(callCounter.counter("default.GetFeature").get()).isEqualTo(0)
     assertThat(callCounter.counter("default.RouteChat").get()).isEqualTo(1)

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1760,13 +1760,20 @@ public abstract interface class misk/web/interceptors/RequestLoggingTransformer 
 
 public final class misk/web/interceptors/RequestResponseBody {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
-	public static synthetic fun copy$default (Lmisk/web/interceptors/RequestResponseBody;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
+	public static synthetic fun copy$default (Lmisk/web/interceptors/RequestResponseBody;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lmisk/web/interceptors/RequestResponseBody;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequest ()Ljava/lang/Object;
+	public final fun getRequestHeaders ()Ljava/lang/Object;
 	public final fun getResponse ()Ljava/lang/Object;
+	public final fun getResponseHeaders ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -146,8 +146,14 @@ class RequestLoggingInterceptor internal constructor(
         requestResponseBody.request?.let {
           builder.append(" request=${requestResponseBody.request}")
         }
+        requestResponseBody.requestHeaders?.let {
+          builder.append(" requestHeaders=${requestResponseBody.requestHeaders}")
+        }
         requestResponseBody.response?.let {
           builder.append(" response=${requestResponseBody.response}")
+        }
+        requestResponseBody.responseHeaders?.let {
+          builder.append(" responseHeaders=${requestResponseBody.responseHeaders}")
         }
       }
     }

--- a/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
@@ -46,7 +46,7 @@ internal class WebSocketsTest {
     // Confirm interceptors were invoked.
     assertThat(logCollector.takeMessage(RequestLoggingInterceptor::class)).matches(
       "EchoWebSocket principal=unknown time=0.000 ns code=200 " +
-        "request=\\[JettyWebSocket\\[.* to /echo]] response=EchoListener"
+        "request=\\[JettyWebSocket\\[.* to /echo]] .* response=EchoListener .*"
     )
   }
 

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -61,8 +61,9 @@ internal class RequestLoggingInterceptorTest {
       ).isSuccessful
     ).isTrue()
     assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).containsExactly(
-      "RateLimitingIncludesBodyRequestLoggingAction principal=caller time=100.0 ms " +
-        "code=200 request=[hello] response=echo: hello"
+      "RateLimitingIncludesBodyRequestLoggingAction principal=caller time=100.0 ms code=200 " +
+        "request=[hello] requestHeaders={accept-encoding=[gzip], connection=[keep-alive]} " +
+        "response=echo: hello responseHeaders={}"
     )
 
     // Setting to low value to show that even though it is less than the bodySampling value in the
@@ -88,7 +89,10 @@ internal class RequestLoggingInterceptorTest {
     ).isTrue()
     assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).containsExactly(
       "RateLimitingIncludesBodyRequestLoggingAction principal=caller time=100.0 ms " +
-        "code=200 request=[hello3] response=echo: hello3"
+        "code=200 request=[hello3] " +
+        "requestHeaders={accept-encoding=[gzip], connection=[keep-alive]} " +
+        "response=echo: hello3 " +
+        "responseHeaders={}"
     )
 
     fakeTicker.advance(1, TimeUnit.SECONDS)
@@ -143,7 +147,9 @@ internal class RequestLoggingInterceptorTest {
       .isEqualTo(500)
     val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
     assertThat(messages).containsExactly(
-      "ExceptionThrowingRequestLoggingAction principal=caller time=100.0 ms failed request=[fail]"
+      "ExceptionThrowingRequestLoggingAction principal=caller time=100.0 ms failed " +
+        "request=[fail] " +
+        "requestHeaders={accept-encoding=[gzip], connection=[keep-alive]}"
     )
   }
 
@@ -198,10 +204,11 @@ internal class RequestLoggingInterceptorTest {
       .isTrue()
     val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
     assertThat(messages).containsExactly(
-      "RequestLoggingActionWithHeaders principal=unknown time=100.0 ms " +
-        "code=200 request=[hello, HeadersCapture(headers={accept=[*/*], accept-encoding=[gzip], " +
-        "connection=[keep-alive], content-length=[5], " +
-        "content-type=[application/json;charset=UTF-8]})] response=echo: hello"
+      "RequestLoggingActionWithHeaders principal=unknown time=100.0 ms code=200 " +
+        "request=[hello] " +
+        "requestHeaders={accept=[*/*], accept-encoding=[gzip], connection=[keep-alive], " +
+        "content-length=[5], content-type=[application/json;charset=UTF-8]} " +
+        "response=echo: hello responseHeaders={}"
     )
     assertThat(messages[0]).doesNotContain(headerToNotLog)
     assertThat(messages[0]).doesNotContain(headerToNotLog.toLowerCase())
@@ -221,10 +228,9 @@ internal class RequestLoggingInterceptorTest {
       .isFalse()
     val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
     assertThat(messages).containsExactly(
-      "RequestLoggingActionWithHeaders principal=unknown time=100.0 ms " +
-        "failed request=[fail, HeadersCapture(headers={accept=[*/*], accept-encoding=[gzip], " +
-        "connection=[keep-alive], content-length=[4], " +
-        "content-type=[application/json;charset=UTF-8]})]"
+      "RequestLoggingActionWithHeaders principal=unknown time=100.0 ms failed request=[fail] " +
+        "requestHeaders={accept=[*/*], accept-encoding=[gzip], connection=[keep-alive], " +
+        "content-length=[4], content-type=[application/json;charset=UTF-8]}"
     )
     assertThat(messages[0]).doesNotContain(headerToNotLog)
     assertThat(messages[0]).doesNotContain(headerToNotLog.toLowerCase())
@@ -240,7 +246,9 @@ internal class RequestLoggingInterceptorTest {
       // Even though this endpoint is configured with low rate limiting and body sampling in its annotation,
       // the RequestLoggingConfig injected will override it to no rate limiting and 1.0 sampling
       assertThat(messages).containsExactly(
-        "ConfigOverrideAction principal=caller time=100.0 ms code=200 request=[foo] response=echo: foo"
+        "ConfigOverrideAction principal=caller time=100.0 ms code=200 request=[foo] " +
+          "requestHeaders={accept-encoding=[gzip], connection=[keep-alive]} " +
+          "response=echo: foo responseHeaders={}"
       )
     }
   }
@@ -253,7 +261,9 @@ internal class RequestLoggingInterceptorTest {
     // Note that the [DontSayDumbTransformer] is registered earlier and thus ran _before_ the
     // [EvanHatingTransformer] which added "dumb" to the response, so it doesn't get applied here.
     assertThat(messages).containsExactly(
-      "LogEverythingAction principal=caller time=100.0 ms code=200 request=[Quokka] response=echo: Quokka (the happiest, most bestest animal)"
+      "LogEverythingAction principal=caller time=100.0 ms code=200 request=[Quokka] " +
+        "requestHeaders={accept-encoding=[gzip], connection=[keep-alive]} " +
+        "response=echo: Quokka (the happiest, most bestest animal) responseHeaders={}"
     )
   }
 
@@ -271,7 +281,10 @@ internal class RequestLoggingInterceptorTest {
       .filter { it.loggerName == RequestLoggingInterceptor::class.qualifiedName }
       .map { it.message }
     assertThat(interceptorLogs).containsExactly(
-      "LogEverythingAction principal=caller time=100.0 ms code=200 request=[Oppenheimer-the-bestest] response=echo: Oppenheimer-the-most bestest"
+      "LogEverythingAction principal=caller time=100.0 ms code=200 " +
+        "request=[Oppenheimer-the-bestest] " +
+        "requestHeaders={accept-encoding=[gzip], connection=[keep-alive]} " +
+        "response=echo: Oppenheimer-the-most bestest responseHeaders={}"
     )
   }
 


### PR DESCRIPTION
Previously it would only be logged if the request included Headers as one of its args. It should just log headers, using the same redaction logic we had previously added.

Binary-incompatible change in `RequestResponseBody`.