### PR TITLE
Remove deprecation warning.

### DIFF
--- a/misk-core/src/main/kotlin/misk/config/Config.kt
+++ b/misk-core/src/main/kotlin/misk/config/Config.kt
@@ -1,12 +1,3 @@
 package misk.config
 
-// TODO(chrisryan): soft deprecating...
-// @Deprecated(
-//  message = "Use wisp.config.Config directly",
-//  replaceWith = ReplaceWith(
-//    "Config",
-//    "wisp.config.Config"
-//  )
-// )
-@Deprecated("Use from wisp-config instead")
 interface Config : wisp.config.Config


### PR DESCRIPTION
When consumers try to follow the suggested replacement (eg. https://github.com/squareup/cash-suez/pull/185), they receive [compile errors](https://buildkite.com/cash/suez/builds/791#0188f8ba-0b88-4e15-8f04-c17e1baefc15). We shouldn't mark interfaces as deprecated until it's possible to act on it.