### PR TITLE
Set SchemaMigratorService as enhances ReadyService

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
@@ -103,7 +103,7 @@ class JdbcModule @JvmOverloads constructor(
     install(
       ServiceModule<SchemaMigratorService>(qualifier)
         .dependsOn<DataSourceService>(qualifier)
-        .enhancedBy<ReadyService>()
+        .enhances<ReadyService>()
     )
 
     if (installHealthCheck) {


### PR DESCRIPTION
According to ReadyService docs, enhances should be used to set any
services which should be run before the application is considered
"Ready" to take traffic.

In database tests, SchemaMigratorService should be run before being
considered ready, and similarly the TruncateTablesService which enhances
the SchemaMigratorService.