### PR TITLE
use PrometheusMeterRegistry for ld metrics and update wisp to 1.4.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,12 @@ dependencyAnalysis {
         exclude(":misk-testing")
       }
     }
+    all {
+      onUnusedDependencies {
+        exclude("com.github.docker-java:docker-java-api:3.3.0")
+        exclude("com.github.docker-java:docker-java-api:3.3.1")
+      }
+    }
     // False positives.
     project(":misk-gcp") {
       onUsedTransitiveDependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -163,7 +163,7 @@ object Dependencies {
   val wireRuntime = "com.squareup.wire:wire-runtime:4.6.2"
   val wireSchema = "com.squareup.wire:wire-schema:4.6.2"
   val wispAwsEnvironment = "app.cash.wisp:wisp-aws-environment"
-  val wispBom = "app.cash.wisp:wisp-bom:1.4.7"
+  val wispBom = "app.cash.wisp:wisp-bom:1.4.10"
   val wispClient = "app.cash.wisp:wisp-client"
   val wispConfig = "app.cash.wisp:wisp-config"
   val wispContainersTesting = "app.cash.wisp:wisp-containers-testing"

--- a/misk-aws/build.gradle.kts
+++ b/misk-aws/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
   implementation(project(":misk-metrics"))
   implementation(project(":misk-service"))
   implementation(project(":misk-transactional-jobqueue"))
-
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.awaitility)
   testImplementation(Dependencies.dockerApi)

--- a/misk-launchdarkly/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsModule.kt
+++ b/misk-launchdarkly/src/main/kotlin/misk/feature/launchdarkly/LaunchDarklyFeatureFlagsModule.kt
@@ -7,6 +7,7 @@ import com.launchdarkly.sdk.server.LDConfig
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface
 import com.squareup.moshi.Moshi
 import misk.ReadyService
+import io.micrometer.core.instrument.MeterRegistry
 import misk.ServiceModule
 import misk.client.HttpClientSSLConfig
 import misk.config.Redact
@@ -41,8 +42,9 @@ class LaunchDarklyModule(
       object : Provider<wisp.launchdarkly.LaunchDarklyFeatureFlags> {
         @Inject private lateinit var ldClient: LDClientInterface
         @Inject private lateinit var moshi: Moshi
+        @Inject private lateinit var meterRegistry: MeterRegistry
         override fun get(): wisp.launchdarkly.LaunchDarklyFeatureFlags =
-          wisp.launchdarkly.LaunchDarklyFeatureFlags(ldClient, moshi)
+          wisp.launchdarkly.LaunchDarklyFeatureFlags(ldClient, moshi, meterRegistry)
       }
     ).asSingleton()
     bind(wisp.feature.FeatureFlags::class.toKey(qualifier)).to(wispLaunchDarklyFeatureFlagsKey)


### PR DESCRIPTION
I added a few metrics for ld library in wisp in this PR: https://github.com/cashapp/wisp/pull/161/files, but they did not show up on DD, I suspect if it is due to we did not pass in PrometheusMeterRegistry from misk, adding it here to see if it works.