### PR TITLE
Keep prometheus http server running until work has ceased

### DIFF
--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsServiceModule.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetricsServiceModule.kt
@@ -9,6 +9,7 @@ import io.prometheus.client.hotspot.MemoryPoolsExports
 import io.prometheus.client.hotspot.StandardExports
 import io.prometheus.client.hotspot.ThreadExports
 import io.prometheus.client.hotspot.VersionInfoExports
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import javax.inject.Inject
@@ -25,7 +26,10 @@ class PrometheusMetricsServiceModule(private val config: PrometheusConfig) : KAb
     install(PrometheusMetricsClientModule())
 
     bind<PrometheusConfig>().toInstance(config)
-    install(ServiceModule<PrometheusHttpService>())
+    install(
+      ServiceModule<PrometheusHttpService>()
+        .enhancedBy<ReadyService>()
+    )
 
     // For every Collector registered with a multibinding, configure it in the registry when the
     // injector is created.


### PR DESCRIPTION
This should keep both the prometheus http server and the jetty threadpool/connection metrics up until all outstanding requests have been processed 