### PR TITLE
Enable parallel builds 

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         cmd:
-          - gradle testShardHibernate -i --scan
+          - gradle testShardHibernate -i --scan --no-parallel
           - gradle testShardNonHibernate -i --scan --parallel
 
     steps:

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ org.gradle.caching=true
 org.gradle.vfs.watch=true
 org.gradle.configuration-cache=true
 org.gradle.configureondemand=true
+org.gradle.parallel=true
 
 #VERSION_NAME=2023.06.14.101651-421a0ac-SNAPSHOT
-
-org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,5 @@ org.gradle.configuration-cache=true
 org.gradle.configureondemand=true
 
 #VERSION_NAME=2023.06.14.101651-421a0ac-SNAPSHOT
+
+org.gradle.parallel=true


### PR DESCRIPTION
Locally this improves a clean build time for me **from 21 minutes to 6 minutes** (although I'm on old laptop).

~Let's see how much it improves the build time on CI.~ Turns out non-Hibernate tests are [already ran in parallel on CI](testShardNonHibernate) and the Hibernate tests fail on CI when ran in parallel.

The local build time improvement still sounds worthwhile though.