### PR TITLE
Bring back the ServiceModule secondary constructor

### DIFF
--- a/misk-service/api/misk-service.api
+++ b/misk-service/api/misk-service.api
@@ -19,9 +19,8 @@ public final class misk/ServiceManagerModule$Companion {
 }
 
 public final class misk/ServiceModule : misk/inject/KAbstractModule {
-	public fun <init> (Lcom/google/inject/Key;)V
-	public fun <init> (Lcom/google/inject/Key;Ljava/util/List;)V
 	public fun <init> (Lcom/google/inject/Key;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/google/inject/Key;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/google/inject/Key;Ljava/util/List;Ljava/util/List;Lcom/google/inject/Key;)V
 	public synthetic fun <init> (Lcom/google/inject/Key;Ljava/util/List;Ljava/util/List;Lcom/google/inject/Key;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final synthetic fun dependsOn ()Lmisk/ServiceModule;

--- a/misk-service/src/main/kotlin/misk/ServiceModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceModule.kt
@@ -74,13 +74,25 @@ import misk.inject.toKey
  * This service will stall in the `STARTING` state until all upstream services are `RUNNING`.
  * Symmetrically it stalls in the `STOPPING` state until all dependent services are `TERMINATED`.
  */
-class ServiceModule @JvmOverloads constructor(
+@Suppress("AnnotatePublicApisWithJvmOverloads")
+class ServiceModule constructor(
   val key: Key<out Service>,
   val dependsOn: List<Key<out Service>> = listOf(),
   val enhancedBy: List<Key<out Service>> = listOf(),
   val enhances: Key<out Service>? = null
 ) : KAbstractModule() {
 
+  // This constructor exists for binary-compatibility with older callers.
+  constructor(
+    key: Key<out Service>,
+    dependsOn: List<Key<out Service>> = listOf(),
+    enhancedBy: List<Key<out Service>> = listOf()
+  ) : this(
+    key = key,
+    dependsOn = dependsOn,
+    enhancedBy = enhancedBy,
+    enhances = null
+  )
   override fun configure() {
     multibind<ServiceEntry>().toInstance(ServiceEntry(key))
 


### PR DESCRIPTION
Revering the change to `ServiceModule` in [this PR](https://github.com/cashapp/misk/pull/2858), which had ironically led to a NoSuchMethodError. 
