### PR TITLE
Report gRPC exceptions as errors.

### DIFF
--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -6,6 +6,7 @@ import com.google.inject.Provider
 import com.google.inject.Provides
 import com.google.inject.TypeLiteral
 import com.google.inject.multibindings.MapBinder
+import com.squareup.wire.GrpcException
 import misk.ApplicationInterceptor
 import misk.MiskCaller
 import misk.MiskDefault
@@ -31,6 +32,7 @@ import misk.web.exceptions.ActionExceptionLogLevelConfig
 import misk.web.exceptions.EofExceptionMapper
 import misk.web.exceptions.ExceptionHandlingInterceptor
 import misk.web.exceptions.ExceptionMapperModule
+import misk.web.exceptions.GrpcExceptionMapper
 import misk.web.exceptions.IOExceptionMapper
 import misk.web.exceptions.RequestBodyExceptionMapper
 import misk.web.exceptions.WebActionExceptionMapper
@@ -222,6 +224,7 @@ class MiskWebModule @JvmOverloads constructor(
     newMultibinder<WebActionSeedDataTransformerFactory>()
 
     install(ExceptionMapperModule.create<WebActionException, WebActionExceptionMapper>())
+    install(ExceptionMapperModule.create<GrpcException, GrpcExceptionMapper>())
     install(ExceptionMapperModule.create<IOException, IOExceptionMapper>())
     install(ExceptionMapperModule.create<EofException, EofExceptionMapper>())
     install(ExceptionMapperModule.create<RequestBodyException, RequestBodyExceptionMapper>())

--- a/misk/src/main/kotlin/misk/web/exceptions/GrpcExceptionMapper.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/GrpcExceptionMapper.kt
@@ -1,0 +1,11 @@
+package misk.web.exceptions
+
+import com.squareup.wire.GrpcException
+import org.slf4j.event.Level
+import javax.inject.Inject
+
+internal class GrpcExceptionMapper @Inject internal constructor() : ExceptionMapper<GrpcException> {
+  override fun toResponse(th: GrpcException) = IOExceptionMapper.INTERNAL_SERVER_ERROR_RESPONSE
+
+  override fun loggingLevel(th: GrpcException): Level = Level.ERROR
+}


### PR DESCRIPTION
Since GrpcException inherits from IOException, any gRPC exception caught by the handler is automatically reported as a warning. This is confusing and hides unexpected errors; these changes ensure that gRPC exceptions are reported as errors, while ensuring that any details of the underlying exception are not leaked outside of gRPC call chains.