### PR TITLE
Remove @JvmOverloads from Injectable constructors

### DIFF
--- a/detektive/README.md
+++ b/detektive/README.md
@@ -4,3 +4,5 @@ Custom detekt (static analysis) rules used i n Misk and in future other cashapp 
 
 Currently only contains the following rule:
 - `AnnotatePublicApisWithJvmOverloads` - Enforces the presence of `@JvmOverloads` annotation on public constructors and functions with default arguments. This is to prevent binary incompatible changes through transitive dependencies when a new argument with default value is added to public APIs.
+
+To suppress a rule violation on a specific class or function, annotate the element with `@Suppress("<RuleName>")` (see existing cases of `@Suppress("AnnotatePublicApisWithJvmOverloads")` as an example).

--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -229,8 +229,6 @@ public final class misk/sampling/Sampler$DefaultImpls {
 }
 
 public final class misk/security/ssl/CertStoreConfig {
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -296,8 +294,6 @@ public final class misk/security/ssl/SslLoader$Companion {
 }
 
 public final class misk/security/ssl/TrustStoreConfig {
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/misk-core/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
+++ b/misk-core/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
@@ -4,7 +4,8 @@ import misk.config.Redact
 import wisp.security.ssl.CertStoreConfig as WispCertStoreConfig
 import javax.inject.Inject
 
-data class CertStoreConfig @Inject @JvmOverloads constructor(
+@Suppress("AnnotatePublicApisWithJvmOverloads")
+data class CertStoreConfig @Inject constructor(
   val resource: String,
   @Redact
   val passphrase: String? = null,

--- a/misk-core/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
+++ b/misk-core/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
@@ -5,7 +5,8 @@ import misk.security.ssl.SslLoader.Companion.FORMAT_JCEKS
 import javax.inject.Inject
 import wisp.security.ssl.TrustStoreConfig as WispTrustStoreConfig
 
-data class TrustStoreConfig @Inject @JvmOverloads constructor(
+@Suppress("AnnotatePublicApisWithJvmOverloads")
+data class TrustStoreConfig @Inject constructor(
   val resource: String,
   @Redact
   val passphrase: String? = null,

--- a/misk-crypto/api/misk-crypto.api
+++ b/misk-crypto/api/misk-crypto.api
@@ -233,7 +233,6 @@ public final class misk/crypto/PgpEncrypterManager : misk/crypto/MappedKeyManage
 
 public final class misk/crypto/S3KeySource : misk/crypto/ExternalKeySource {
 	public static final field Companion Lmisk/crypto/S3KeySource$Companion;
-	public fun <init> (Lwisp/deployment/Deployment;Lcom/amazonaws/services/s3/AmazonS3;Ljava/util/Map;Lcom/amazonaws/auth/AWSCredentialsProvider;)V
 	public fun <init> (Lwisp/deployment/Deployment;Lcom/amazonaws/services/s3/AmazonS3;Ljava/util/Map;Lmisk/crypto/BucketNameSource;Lcom/amazonaws/auth/AWSCredentialsProvider;)V
 	public synthetic fun <init> (Lwisp/deployment/Deployment;Lcom/amazonaws/services/s3/AmazonS3;Ljava/util/Map;Lmisk/crypto/BucketNameSource;Lcom/amazonaws/auth/AWSCredentialsProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllKeyAliases ()Ljava/util/Map;

--- a/misk-crypto/src/main/kotlin/misk/crypto/S3KeySource.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/S3KeySource.kt
@@ -31,7 +31,8 @@ import wisp.logging.getLogger
  *
  *  If a requested key alias does not exist, this will raise a [ExternalKeyManagerException]
  */
-class S3KeySource @Inject @JvmOverloads constructor(
+@Suppress("AnnotatePublicApisWithJvmOverloads")
+class S3KeySource @Inject constructor(
   private val deployment: Deployment,
   defaultS3: AmazonS3,
   @ExternalDataKeys val allKeyAliases: Map<KeyAlias, KeyType>,


### PR DESCRIPTION
Otherwise multiple constructors annotated with `@Inject` are generated which leads to this error

> Injectable classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.

Also added instructions for suppressing violations of `AnnotatePublicApisWithJvmOverloads`.

Will look into not reporting this violation when a javax or guice Inject annotation is present later today.