### PR TITLE
Don't enforce the `AnnotatePublicApisWithJvmOverloads` rule on APIs annotated with `@Inject`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,11 @@ dependencyAnalysis {
         exclude("org.jooq:jooq:3.18.2")
       }
     }
+    project(":detektive") {
+      onUnusedDependencies() {
+        exclude("com.google.inject:guice")
+      }
+    }
   }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -22,6 +22,7 @@ object Dependencies {
   val dependencyAnalysisPluginVersion = "1.20.0"
   val detektApi = "io.gitlab.arturbosch.detekt:detekt-api:1.23.0"
   val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
+  val detektPsiUtils = "io.gitlab.arturbosch.detekt:detekt-psi-utils:1.23.0"
   val detektTest = "io.gitlab.arturbosch.detekt:detekt-test:1.23.0"
   val detektTestUtils = "io.gitlab.arturbosch.detekt:detekt-test-utils:1.23.0"
   val dockerApi = "com.github.docker-java:docker-java-api:3.3.0"

--- a/detektive/build.gradle.kts
+++ b/detektive/build.gradle.kts
@@ -5,11 +5,13 @@ plugins {
 
 dependencies {
   compileOnly(Dependencies.detektApi)
+  compileOnly(Dependencies.detektPsiUtils)
   compileOnly(Dependencies.kotlinCompilerEmbeddable)
 
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.detektTest)
   testImplementation(Dependencies.detektTestUtils)
+  testImplementation(Dependencies.guice)
   testImplementation(Dependencies.junitApi)
   testImplementation(Dependencies.junitParams)
   testImplementation(Dependencies.kotlinTest)

--- a/detektive/src/test/kotlin/cash/detektive/javacompat/AnnotatePublicApisWithJvmOverloadsTest.kt
+++ b/detektive/src/test/kotlin/cash/detektive/javacompat/AnnotatePublicApisWithJvmOverloadsTest.kt
@@ -127,6 +127,22 @@ internal class AnnotatePublicApisWithJvmOverloadsTest(private val env: KotlinCor
       ),
       //Constructors
       NoErrorTestCase(
+        description = "Public constructor annotated with javax Inject",
+        code = """
+        import javax.inject.Inject
+
+        class Subject @Inject constructor(x: String = "", y: Int) {}
+        """
+      ),
+      NoErrorTestCase(
+        description = "Public constructor annotated with guice Inject",
+        code = """
+        import com.google.inject.Inject
+
+        class Subject @Inject constructor(x: String = "", y: Int) {}
+        """
+      ),
+      NoErrorTestCase(
         description = "Public constructor without default arguments",
         code = """
         class Subject(x: String, y: Int) {}

--- a/misk-core/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
+++ b/misk-core/src/main/kotlin/misk/security/ssl/CertStoreConfig.kt
@@ -4,7 +4,6 @@ import misk.config.Redact
 import wisp.security.ssl.CertStoreConfig as WispCertStoreConfig
 import javax.inject.Inject
 
-@Suppress("AnnotatePublicApisWithJvmOverloads")
 data class CertStoreConfig @Inject constructor(
   val resource: String,
   @Redact

--- a/misk-core/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
+++ b/misk-core/src/main/kotlin/misk/security/ssl/TrustStoreConfig.kt
@@ -5,7 +5,6 @@ import misk.security.ssl.SslLoader.Companion.FORMAT_JCEKS
 import javax.inject.Inject
 import wisp.security.ssl.TrustStoreConfig as WispTrustStoreConfig
 
-@Suppress("AnnotatePublicApisWithJvmOverloads")
 data class TrustStoreConfig @Inject constructor(
   val resource: String,
   @Redact

--- a/misk-crypto/src/main/kotlin/misk/crypto/S3KeySource.kt
+++ b/misk-crypto/src/main/kotlin/misk/crypto/S3KeySource.kt
@@ -31,7 +31,6 @@ import wisp.logging.getLogger
  *
  *  If a requested key alias does not exist, this will raise a [ExternalKeyManagerException]
  */
-@Suppress("AnnotatePublicApisWithJvmOverloads")
 class S3KeySource @Inject constructor(
   private val deployment: Deployment,
   defaultS3: AmazonS3,


### PR DESCRIPTION
Follow-up from https://github.com/cashapp/misk/pull/2877 