### PR TITLE
Add getset support to misk-redis

### DIFF
--- a/misk-redis-testing/api/misk-redis-testing.api
+++ b/misk-redis-testing/api/misk-redis-testing.api
@@ -23,6 +23,10 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;

--- a/misk-redis-testing/src/main/kotlin/misk/redis/testing/DockerRedis.kt
+++ b/misk-redis-testing/src/main/kotlin/misk/redis/testing/DockerRedis.kt
@@ -31,7 +31,7 @@ object DockerRedis : ExternalDependency {
   private const val port = 6379
   private val hostname = if (isRunningInDocker) "host.docker.internal" else "localhost"
   private val logger = getLogger<DockerRedis>()
-  private const val redisVersion = "6.2"
+  private const val redisVersion = "7.0"
 
   private val client by lazy { JedisPool(hostname, port) }
 

--- a/misk-redis-testing/src/main/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis-testing/src/main/kotlin/misk/redis/testing/FakeRedis.kt
@@ -81,6 +81,30 @@ class FakeRedis @Inject constructor(
     return value.data
   }
 
+  override fun getset(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, value)
+    return existingValue
+  }
+
+  override fun getset(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, expiryDuration, value)
+    return existingValue
+  }
+
+  override fun getsetnx(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, value)
+    return existingValue
+  }
+
+  override fun getsetnx(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, expiryDuration, value)
+    return existingValue
+  }
+
   @Synchronized
   override fun hdel(key: String, vararg fields: String): Long {
     val value = hKeyValueStore[key] ?: return 0L

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -12,6 +12,10 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
 	public final fun getClock ()Ljava/time/Clock;
 	public final fun getRandom ()Lkotlin/random/Random;
+	public fun getset (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
@@ -66,6 +70,10 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
@@ -116,6 +124,10 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun expire (Ljava/lang/String;J)Z
 	public abstract fun expireAt (Ljava/lang/String;J)Z
 	public abstract fun get (Ljava/lang/String;)Lokio/ByteString;
+	public abstract fun getset (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public abstract fun getset (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
+	public abstract fun getsetnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public abstract fun getsetnx (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public abstract fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public abstract fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
@@ -271,6 +283,10 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getset (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Lokio/ByteString;
+	public fun getsetnx (Ljava/lang/String;Lokio/ByteString;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -73,6 +73,34 @@ class FakeRedis : Redis {
   }
 
   @Synchronized
+  override fun getset(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, value)
+    return existingValue
+  }
+
+  @Synchronized
+  override fun getset(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, expiryDuration, value)
+    return existingValue
+  }
+
+  @Synchronized
+  override fun getsetnx(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, value)
+    return existingValue
+  }
+
+  @Synchronized
+  override fun getsetnx(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, expiryDuration, value)
+    return existingValue
+  }
+
+  @Synchronized
   override fun hdel(key: String, vararg fields: String): Long {
     val value = hKeyValueStore[key] ?: return 0L
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -1,6 +1,7 @@
 package misk.redis
 
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPubSub
@@ -48,6 +49,34 @@ class RealRedis(
   override fun get(key: String): ByteString? {
     val keyBytes = key.toByteArray(charset)
     return jedis { get(keyBytes) }?.toByteString()
+  }
+
+  override fun getset(key: String, value: ByteString): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().get()
+    return jedis { set(keyBytes, valueBytes, params) }?.encodeUtf8()
+  }
+
+  override fun getset(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().get().px(expiryDuration.toMillis())
+    return jedis { set(keyBytes, valueBytes, params) }?.encodeUtf8()
+  }
+
+  override fun getsetnx(key: String, value: ByteString): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().get().nx()
+    return jedis { set(keyBytes, valueBytes, params) }?.encodeUtf8()
+  }
+
+  override fun getsetnx(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().get().nx().px(expiryDuration.toMillis())
+    return jedis { set(keyBytes, valueBytes, params) }?.encodeUtf8()
   }
 
   override fun hdel(key: String, vararg fields: String): Long {

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -52,6 +52,50 @@ interface Redis {
   operator fun get(key: String): ByteString?
 
   /**
+   * Sets the [ByteString] value for the given key, and retrieves
+   * the existing value, if it was already set.
+   *
+   * @param key the key to retrieve and set
+   * @param value the new value to set
+   */
+  fun getset(key: String, value: ByteString): ByteString?
+
+  /**
+   * Sets the [ByteString] value for a key with an expiration date,
+   * and retrieves the existing value, if it was already set.
+   *
+   * @param key the key to retrieve and set
+   * @param expiryDuration the new amount of time before the key expires
+   * @param value the new value to set
+   */
+  fun getset(key: String, expiryDuration: Duration, value: ByteString): ByteString?
+
+  /**
+   * Sets the [ByteString] value for the given key, if it does not already exist,
+   * and retrieves the existing value, if it was already set.
+   *
+   * @param key the key to retrieve and set
+   * @param value the new value to set
+   *
+   * Only available on Redis 7.0.0 and higher.
+   */
+  fun getsetnx(key: String, value: ByteString): ByteString?
+
+  /**
+   * Sets the [ByteString] value for a key with an expiration date,
+   * if it does not already exist, and retrieves the existing value,
+   * if it was already set.
+   *
+   * @param key the key to retrieve and set
+   * @param expiryDuration the new amount of time before the key expires
+   * @param value the new value to set
+   *
+   * Only available on Redis 7.0.0 and higher.
+   */
+  fun getsetnx(key: String, expiryDuration: Duration, value: ByteString): ByteString?
+
+
+  /**
    * Delete one or more hash [fields] stored at [key].
    * Specified fields that do not exist are ignored.
    *

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import redis.clients.jedis.args.ListDirection
+import java.time.Duration
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -235,6 +236,52 @@ abstract class AbstractRedisTest {
 
     // Keys should be deleted
     listOf(*keysToInsert, key3).forEach { assertNull(redis[it], "Key should have been deleted") }
+  }
+
+  @Test fun getset() {
+    val key = "getset-key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+
+    assertNull(redis.getset(key, value1), "Key should be empty")
+    assertEquals(value1, redis.getset(key, value2))
+    assertEquals(value2, redis.getset(key, value3))
+  }
+
+  @Test fun getsetWithExpiryDummy() {
+    val key = "getset-key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+    val expiryDuration = Duration.ofSeconds(5L)
+
+    assertNull(redis.getset(key, expiryDuration, value1), "Key should be empty")
+    assertEquals(value1, redis.getset(key, expiryDuration, value2))
+    assertEquals(value2, redis.getset(key, expiryDuration, value3))
+  }
+
+  @Test fun getsetnx() {
+    val key = "getsetnx-key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+
+    assertNull(redis.getsetnx(key, value1), "Key should be empty")
+    assertEquals(value1, redis.getsetnx(key, value2))
+    assertEquals(value1, redis.getsetnx(key, value3))
+  }
+
+  @Test fun getsetnxWithExpiryDummy() {
+    val key = "getsetnx-key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+    val expiryDuration = Duration.ofSeconds(5L)
+
+    assertNull(redis.getsetnx(key, expiryDuration, value1), "Key should be empty")
+    assertEquals(value1, redis.getsetnx(key, expiryDuration, value2))
+    assertEquals(value1, redis.getsetnx(key, expiryDuration, value3))
   }
 
   @Test fun incrOnKeyThatDoesNotExist() {

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -159,4 +159,42 @@ class FakeRedisTest: AbstractRedisTest() {
     assertNull(redis[key], "Key did not expire")
   }
 
+  @Test fun getsetWithExpiry() {
+    val key = "key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+    val value4 = "value4".encodeUtf8()
+    val expiryDuration = Duration.ofSeconds(5L)
+
+    assertNull(redis.getset(key, expiryDuration, value1), "Key should be empty")
+
+    clock.add(Duration.ofSeconds(3))
+    assertEquals(value1, redis.getset(key, expiryDuration, value2))
+
+    clock.add(Duration.ofSeconds(4))
+    assertEquals(value2, redis.getset(key, expiryDuration, value3))
+
+    clock.add(Duration.ofSeconds(5))
+    assertNull(redis.getset(key, expiryDuration, value4), "Key should be empty after expiry")
+  }
+
+  @Test fun getsetnxWithExpiry() {
+    val key = "key"
+    val value1 = "value1".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val value3 = "value3".encodeUtf8()
+    val expiryDuration = Duration.ofSeconds(5L)
+
+    assertNull(redis.getsetnx(key, expiryDuration, value1), "Key should be empty")
+
+    clock.add(Duration.ofSeconds(3))
+    assertEquals(value1, redis.getsetnx(key, expiryDuration, value2))
+
+    clock.add(Duration.ofSeconds(4))
+    assertNull(redis.getsetnx(key, expiryDuration, value3), "Key should have expired")
+
+    clock.add(Duration.ofSeconds(2))
+    assertEquals(value3, redis.getsetnx(key, expiryDuration, value2))
+  }
 }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/DockerRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/DockerRedis.kt
@@ -30,7 +30,7 @@ object DockerRedis : ExternalDependency {
   private const val port = 6379
   private val hostname = if (isRunningInDocker) "host.docker.internal" else "localhost"
   private val logger = getLogger<DockerRedis>()
-  private const val redisVersion = "6.2"
+  private const val redisVersion = "7.0"
 
   private val client by lazy { JedisPool(hostname, port) }
 

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -80,6 +80,30 @@ class FakeRedis @Inject constructor(
     return value.data
   }
 
+  override fun getset(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, value)
+    return existingValue
+  }
+
+  override fun getset(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    set(key, expiryDuration, value)
+    return existingValue
+  }
+
+  override fun getsetnx(key: String, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, value)
+    return existingValue
+  }
+
+  override fun getsetnx(key: String, expiryDuration: Duration, value: ByteString): ByteString? {
+    val existingValue = get(key)
+    setnx(key, expiryDuration, value)
+    return existingValue
+  }
+
   @Synchronized
   override fun hdel(key: String, vararg fields: String): Long {
     val value = hKeyValueStore[key] ?: return 0L


### PR DESCRIPTION
Adds support for getting the current value and setting a new value on a single key in an atomic command. Introduces the `getset` and `getsetnx` commands, which can both be used with or without an `expiryDuration`, with the latter only setting the new value if there is a current, non-expired value at the specified key. Behind the scenes, this uses the Redis `SET` command with the `GET` option. `getsetnx` (ie. the use of `SET` with both `GET` and `NX` options) is only supported with Redis version 7.0 and later.

This change also bumps the Docker Redis `alpine` image version used for testing from `6.2` to `7.0`, the current stable version. 