### PR TITLE
Fix dashboard sidebar background on Hotwire tab scroll

### DIFF
--- a/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
+++ b/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
@@ -114,7 +114,7 @@ fun TagConsumer<*>.Navbar(
       }
     }
     // +"""<!-- Static sidebar for desktop -->"""
-    div("hidden xl:fixed xl:inset-y-0 xl:z-50 xl:flex xl:w-72 xl:flex-col") {
+    div("bg-gray-900 hidden xl:fixed xl:inset-y-0 xl:z-50 xl:flex xl:w-72 xl:flex-col") {
       // +"""<!-- Sidebar component, swap this element with another sidebar if you like -->"""
       div("flex grow flex-col gap-y-5 overflow-y-auto bg-black/10 px-6 ring-1 ring-white/5") {
         div("flex h-16 shrink-0 items-center") {

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/frontend/IndexPage.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/frontend/IndexPage.kt
@@ -1,5 +1,6 @@
 package com.squareup.exemplar.dashboard.frontend
 
+import com.squareup.exemplar.dashboard.admin.AlphaIndexAction
 import kotlinx.html.a
 import kotlinx.html.div
 import kotlinx.html.h1
@@ -19,6 +20,7 @@ import misk.web.mediatype.MediaTypes
 import wisp.deployment.Deployment
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.web.v2.DashboardPageLayout.Companion.BETA_PREFIX
 
 /**
  * Example page from Tailwind UI
@@ -53,6 +55,18 @@ class IndexPage @Inject constructor(
                   a(classes = "text-gray-700 hover:text-indigo-600 hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 pl-3 text-sm leading-6 font-semibold") {
                     href = EcommerceLandingPage.PATH
                     +"""Ecommerce Landing Page"""
+                  }
+                }
+                li {
+                  a(classes = "text-gray-700 hover:text-indigo-600 hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 pl-3 text-sm leading-6 font-semibold") {
+                    href = "/support/"
+                    +"""Support Custom Dashboard"""
+                  }
+                }
+                li {
+                  a(classes = "text-gray-700 hover:text-indigo-600 hover:bg-gray-50 group flex gap-x-3 rounded-md p-2 pl-3 text-sm leading-6 font-semibold") {
+                    href = "$BETA_PREFIX${AlphaIndexAction.PATH}"
+                    +"""Custom Admin Dashboard Tab"""
                   }
                 }
               }


### PR DESCRIPTION
On scroll for non-IFrame dashboard tabs, the background of the sidebar would go white on scroll. This sets a consistent background color regardless of scroll or page length.

# Before
![Screenshot 2023-08-11 at 10 29 38](https://github.com/cashapp/misk/assets/8827217/89893a06-e114-4d54-b813-13a9308a8164)

# After
![Screenshot 2023-08-11 at 10 30 07](https://github.com/cashapp/misk/assets/8827217/2c9c4f9a-25bc-4bbb-849a-b7542760e034)