### PR TITLE
fix: guard against bad service init with provider of health checks

### DIFF
--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckService.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckService.kt
@@ -23,7 +23,7 @@ internal class ReadinessCheckService @Inject constructor(
   private val config: WebConfig,
   private val clock: Clock,
   private val serviceManagerProvider: Provider<ServiceManager>,
-  @JvmSuppressWildcards private val healthChecks: List<Provider<HealthCheck>>,
+  @JvmSuppressWildcards private val healthCheckProvider: Provider<List<HealthCheck>>,
   @ReadinessRefreshQueue private val taskQueue: RepeatedTaskQueue,
 ): AbstractIdleService() {
   @Volatile
@@ -65,14 +65,12 @@ internal class ReadinessCheckService @Inject constructor(
     // logs with.
     if (!servicesNotRunning.isEmpty()) return
 
-    val statuses = getHealthChecks().map { it.status() }
+    val statuses = healthCheckProvider.get().map { it.status() }
 
     // Get time AFTER health checks have completed
     val lastUpdate = clock.instant()
     status = CachedStatus(lastUpdate, statuses)
   }
-
-  fun getHealthChecks(): List<HealthCheck> = healthChecks.map{ it.get() }
 
   data class CachedStatus(
     val lastUpdate: Instant,


### PR DESCRIPTION
There appears to be an issue with the DynamoDB service bindings, which produces this error:

```
IllegalArgumentException: `dynamoDb` is only usable while the service is running
```

This change attempts to defend against it by lazily requesting the health checks, which will occur after all services are ready.