### PR TITLE
Prefer Histogram over Summaries

### DIFF
--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -45,8 +45,6 @@ interface Metrics {
   /**
    * histogram creates and registers a new `Summary` prometheus type.
    *
-   * Deprecated: if you really need a summary metric, use [misk.metrics.v2.Metrics.summary] instead.
-   *
    * For legacy reasons this function is called histogram(...) but it's not backed by a histogram
    * because of issues with the previous time series backend.
    *
@@ -66,7 +64,7 @@ interface Metrics {
    *  for the metric. The key of the map is the quantile as a ratio (e.g. 0.99 represents p99) and
    *  the value is the "tolerable error" of the computed quantile.
    */
-  @Deprecated("Use misk.metrics.v2.Metrics.summary instead")
+  @Deprecated("Recommend migrating to misk.metrics.v2.Metrics.histogram. See kdoc for detail")
   fun histogram(
     name: String,
     help: String = "",

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -94,6 +94,9 @@ interface Metrics {
    *
    * See https://prometheus.github.io/client_java/io/prometheus/client/Summary.html for more info.
    *
+   * NB: Summaries can be an order of magnitude more expensive than histograms in terms of CPU.
+   * Unless you require the specific properties of a summary, consider using [histogram] instead.
+   *
    * @param name the name of the metric which will be supplied to prometheus.
    *  Must be unique across all metric types.
    * @param help human-readable help text that will be supplied to prometheus.


### PR DESCRIPTION
Summaries can be an order of magnitude more expensive in terms of CPU than Histograms. We should not be encouraging migration to Summaries for v1 histogram usage.