### PR TITLE
use KInstallOnceModule so we don't have issues of double installing modules

### DIFF
--- a/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature-testing/src/main/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -8,12 +8,12 @@ import misk.feature.DynamicConfig
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
 import misk.feature.testing.FakeFeatureFlagsOverrideModule.FakeFeatureFlagsOverride
-import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import misk.inject.parameterizedType
 import misk.inject.toKey
 import misk.inject.typeLiteral
 import jakarta.inject.Inject
+import misk.inject.KInstallOnceModule
 import kotlin.reflect.KClass
 
 /**
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
 @Deprecated("Replace the dependency on misk-feature-testing with testFixtures(misk-feature)")
 class FakeFeatureFlagsModule @JvmOverloads constructor(
   private val qualifier: KClass<out Annotation>? = null
-) : KAbstractModule() {
+) : KInstallOnceModule() {
   private val overrides = mutableListOf<FakeFeatureFlagsOverrideModule>()
 
   override fun configure() {

--- a/misk-feature/src/testFixtures/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
+++ b/misk-feature/src/testFixtures/kotlin/misk/feature/testing/FakeFeatureFlagsModule.kt
@@ -8,12 +8,12 @@ import misk.feature.DynamicConfig
 import misk.feature.FeatureFlags
 import misk.feature.FeatureService
 import misk.feature.testing.FakeFeatureFlagsOverrideModule.FakeFeatureFlagsOverride
-import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import misk.inject.parameterizedType
 import misk.inject.toKey
 import misk.inject.typeLiteral
 import jakarta.inject.Inject
+import misk.inject.KInstallOnceModule
 import kotlin.reflect.KClass
 
 /**
@@ -25,7 +25,7 @@ import kotlin.reflect.KClass
  */
 class FakeFeatureFlagsModule(
   private val qualifier: KClass<out Annotation>? = null
-) : KAbstractModule() {
+) : KInstallOnceModule() {
   private val overrides = mutableListOf<FakeFeatureFlagsOverrideModule>()
 
   override fun configure() {

--- a/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetricsModule.kt
+++ b/misk-metrics-testing/src/main/kotlin/misk/metrics/v2/FakeMetricsModule.kt
@@ -1,10 +1,10 @@
 package misk.metrics.v2
 
 import io.prometheus.client.CollectorRegistry
-import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 
 @Deprecated("Replace the dependency on misk-metrics-testing with testFixtures(misk-metrics)")
-class FakeMetricsModule : KAbstractModule() {
+class FakeMetricsModule : KInstallOnceModule() {
   override fun configure() {
     bind<CollectorRegistry>().toInstance(CollectorRegistry(true))
     bind<Metrics>().to<FakeMetrics>()

--- a/misk-metrics/src/testFixtures/kotlin/misk/metrics/v2/FakeMetricsModule.kt
+++ b/misk-metrics/src/testFixtures/kotlin/misk/metrics/v2/FakeMetricsModule.kt
@@ -1,9 +1,9 @@
 package misk.metrics.v2
 
 import io.prometheus.client.CollectorRegistry
-import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 
-class FakeMetricsModule : KAbstractModule() {
+class FakeMetricsModule : KInstallOnceModule() {
   override fun configure() {
     bind<CollectorRegistry>().toInstance(CollectorRegistry(true))
     bind<Metrics>().to<FakeMetrics>()


### PR DESCRIPTION
This is using KInstallOnceModule that was introduced in https://github.com/cashapp/misk/pull/2538.

