### PR TITLE
Small cleanups to AccessInterceptor.Factory

### DIFF
--- a/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
@@ -85,9 +85,9 @@ class AccessInterceptor private constructor(
       if (actionEntries.size > 1) {
         val (openAuthEntries, closedAuthEntries) = actionEntries.partition { it.services.isEmpty() && it.capabilities.isEmpty() }
         if (openAuthEntries.isNotEmpty() && closedAuthEntries.isNotEmpty()) {
-          val openAuthString = openAuthEntries.joinToString(separator = ",") { it.annotation.simpleName.toString() }
-          val closedAuthString = closedAuthEntries.joinToString(separator = ",") { it.annotation.simpleName.toString() }
-          logger.warn("Conflicting auth annotations on ${action.name}::${action.function.name}(), @$openAuthString no longer have any effect due to @$closedAuthString")
+          val openAuthString = openAuthEntries.joinToString(separator = ",") { "@${it.annotation.simpleName.toString()}" }
+          val closedAuthString = closedAuthEntries.joinToString(separator = ",") { "@${it.annotation.simpleName.toString()}" }
+          logger.warn("Conflicting auth annotations on ${action.name}::${action.function.name}(), $openAuthString won't have any effect due to $closedAuthString")
         }
       }
 

--- a/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
@@ -36,10 +36,23 @@ class AccessInterceptor private constructor(
       val actionEntries = mutableListOf<AccessAnnotationEntry>()
       for (annotation in action.function.annotations) when {
         annotation is Authenticated -> actionEntries += annotation.toAccessAnnotationEntry()
-        annotation is Unauthenticated -> actionEntries += annotation.toAccessAnnotationEntry()
         registeredEntries.find { it.annotation == annotation.annotationClass } != null -> {
           actionEntries += registeredEntries.find { it.annotation == annotation.annotationClass }!!
         }
+      }
+
+      // Do not intercept if this action is explicitly marked as unauthenticated.
+      if (action.hasAnnotation<Unauthenticated>()) {
+        check(actionEntries.isEmpty()) {
+          val otherAnnotations = actionEntries
+            .filterNot { it.annotation == Unauthenticated::class }
+            .map { "@${it.annotation.qualifiedName!!}" }
+            .sorted()
+            .joinToString()
+          """${action.name}::${action.function.name}() is annotated with @${Unauthenticated::class.qualifiedName}, but also annotated with the following access annotations: $otherAnnotations. This is a contradiction.
+          """.trimIndent()
+        }
+        return null
       }
 
       // No access annotations. Fail with a useful message.
@@ -69,18 +82,13 @@ class AccessInterceptor private constructor(
           """.trimMargin()
       }
 
-      // This action is explicitly marked as unauthenticated.
-      if (action.hasAnnotation<Unauthenticated>()) {
-        check(actionEntries.size == 1) {
-          val otherAnnotations = actionEntries
-            .filterNot { it.annotation == Unauthenticated::class }
-            .map { "@${it.annotation.qualifiedName!!}" }
-            .sorted()
-            .joinToString()
-          """${action.name}::${action.function.name}() is annotated with @${Unauthenticated::class.qualifiedName}, but also annotated with the following access annotations: $otherAnnotations. This is a contradiction.
-          """.trimIndent()
+      if (actionEntries.size > 1) {
+        val (openAuthEntries, closedAuthEntries) = actionEntries.partition { it.services.isEmpty() && it.capabilities.isEmpty() }
+        if (openAuthEntries.isNotEmpty() && closedAuthEntries.isNotEmpty()) {
+          val openAuthString = openAuthEntries.joinToString(separator = ",") { it.annotation.simpleName.toString() }
+          val closedAuthString = closedAuthEntries.joinToString(separator = ",") { it.annotation.simpleName.toString() }
+          logger.warn("Conflicting auth annotations on ${action.name}::${action.function.name}(), @$openAuthString no longer have any effect due to @$closedAuthString")
         }
-        return null
       }
 
       // Return an interceptor representing the union of the capabilities/services of all
@@ -94,10 +102,6 @@ class AccessInterceptor private constructor(
 
     private fun Authenticated.toAccessAnnotationEntry() = AccessAnnotationEntry(
       Authenticated::class, services.toList(), capabilities.toList()
-    )
-
-    private fun Unauthenticated.toAccessAnnotationEntry() = AccessAnnotationEntry(
-      Unauthenticated::class, listOf(), listOf()
     )
 
     private inline fun <reified T : Annotation> Action.hasAnnotation() =

--- a/misk/src/test/kotlin/misk/web/actions/AuthenticationTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/AuthenticationTest.kt
@@ -151,7 +151,7 @@ class AuthenticationTest {
     // the interceptor on the endpoint.
 
     assertThat(logCollector.takeEvents(AccessInterceptor::class).map { it.message }).contains(
-      "Conflicting auth annotations on EmptyAuthenticatedWithCustomAnnototationAccessAction::get(), @Authenticated no longer have any effect due to @CustomCapabilityAccess"
+      "Conflicting auth annotations on EmptyAuthenticatedWithCustomAnnototationAccessAction::get(), @Authenticated won't have any effect due to @CustomCapabilityAccess"
     )
   }
 

--- a/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
+++ b/misk/src/test/kotlin/misk/web/actions/TestWebActionModule.kt
@@ -26,6 +26,7 @@ import misk.web.interceptors.LogRequestResponse
 import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
 import jakarta.inject.Inject
+import misk.logging.LogCollectorModule
 import misk.security.authz.Authenticated
 
 // Common module for web action-related tests to use that bind up some sample web actions
@@ -34,6 +35,7 @@ class TestWebActionModule : KAbstractModule() {
     install(WebServerTestingModule())
     install(MiskTestingServiceModule())
     install(AccessControlModule())
+    install(LogCollectorModule())
 
     install(WebActionModule.create<CustomServiceAccessAction>())
     install(WebActionModule.create<CustomCapabilityAccessAction>())


### PR DESCRIPTION
- Rearrange the `@Unauthenticated` logic, without changing any API or behaviour
- Log a warning if both open access annotations and closed access annotations are on the same action

Open Access annotations are annotations with no services or capabilities, for example `@Authenticated` with no arguments.