### PR TITLE
Add additional datadog trace headers to track

### DIFF
--- a/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestBodyLoggingInterceptor.kt
@@ -109,7 +109,8 @@ internal data class HeadersCapture(
           "x-ddtrace-parent_span_id",
           "x-datadog-parent-id",
           "x-datadog-trace-id",
-          "x-datadog-span-id",
+          "x-datadog-sampling-priority",
+          "x-request-id",
         )
       }
   )


### PR DESCRIPTION
For distributed tracing with datadog there are 2 more headers we'd like to see sent by services: reference: https://istio.io/latest/docs/tasks/observability/distributed-tracing/overview/


original PR that added the earlier headers: https://github.com/cashapp/misk/pull/2834/files

