### PR TITLE
Add support for custom healthcheck execution for misk-aws-dynamodb

### DIFF
--- a/misk-aws-dynamodb/api/misk-aws-dynamodb.api
+++ b/misk-aws-dynamodb/api/misk-aws-dynamodb.api
@@ -75,7 +75,8 @@ public abstract interface class misk/dynamodb/DynamoDbService : com/google/commo
 
 public class misk/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
 	public fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;)V
-	public synthetic fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;Ljava/util/Map;)V
+	public synthetic fun <init> (Lcom/amazonaws/ClientConfiguration;[Lkotlin/reflect/KClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> ([Lkotlin/reflect/KClass;)V
 	protected fun configure ()V
 	public fun configureClient (Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDBClientBuilder;)V
@@ -86,11 +87,14 @@ public class misk/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
 }
 
 public final class misk/dynamodb/RequiredDynamoDbTable {
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;)V
+	public synthetic fun <init> (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lmisk/dynamodb/RequiredDynamoDbTable;
-	public static synthetic fun copy$default (Lmisk/dynamodb/RequiredDynamoDbTable;Ljava/lang/String;ILjava/lang/Object;)Lmisk/dynamodb/RequiredDynamoDbTable;
+	public final fun component2 ()Lmisk/healthchecks/HealthCheck;
+	public final fun copy (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;)Lmisk/dynamodb/RequiredDynamoDbTable;
+	public static synthetic fun copy$default (Lmisk/dynamodb/RequiredDynamoDbTable;Ljava/lang/String;Lmisk/healthchecks/HealthCheck;ILjava/lang/Object;)Lmisk/dynamodb/RequiredDynamoDbTable;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomHealthCheck ()Lmisk/healthchecks/HealthCheck;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk-aws-dynamodb/api/misk-aws-dynamodb.api
+++ b/misk-aws-dynamodb/api/misk-aws-dynamodb.api
@@ -1,5 +1,6 @@
 public final class misk/aws/dynamodb/testing/DockerDynamoDbModule : misk/inject/KAbstractModule {
-	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> ([Lkotlin/reflect/KClass;)V
 	public fun <init> ([Lmisk/aws/dynamodb/testing/DynamoDbTable;)V
 	public final fun provideRequiredTables ()Ljava/util/List;
@@ -24,7 +25,8 @@ public final class misk/aws/dynamodb/testing/DynamoDbTable {
 }
 
 public final class misk/aws/dynamodb/testing/InProcessDynamoDbModule : misk/inject/KAbstractModule {
-	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> ([Lkotlin/reflect/KClass;)V
 	public fun <init> ([Lmisk/aws/dynamodb/testing/DynamoDbTable;)V
 	public final fun provideRequiredTables ()Ljava/util/List;
@@ -48,6 +50,11 @@ public final class misk/aws/dynamodb/testing/TestDynamoDb : com/google/common/ut
 	public fun stopAsync ()Lcom/google/common/util/concurrent/Service;
 }
 
+public final class misk/aws/dynamodb/testing/TestHealthChecksKt {
+	public static final fun getHealthyHealthCheck ()Lmisk/healthchecks/HealthCheck;
+	public static final fun getUnhealthyHealthCheck ()Lmisk/healthchecks/HealthCheck;
+}
+
 public abstract interface class misk/dynamodb/DyTimestampedEntity {
 	public abstract fun getCreated_at ()Ljava/util/Date;
 	public abstract fun getUpdated_at ()Ljava/util/Date;
@@ -58,6 +65,10 @@ public abstract interface class misk/dynamodb/DyTimestampedEntity {
 public abstract interface class misk/dynamodb/DyVersionedEntity {
 	public abstract fun getVersion ()J
 	public abstract fun setVersion (J)V
+}
+
+public abstract interface class misk/dynamodb/DynamoDBHealthCheckFactory {
+	public abstract fun create (Lcom/amazonaws/services/dynamodbv2/AmazonDynamoDB;)Lmisk/healthchecks/HealthCheck;
 }
 
 public final class misk/dynamodb/DynamoDbHealthCheck : misk/healthchecks/HealthCheck {
@@ -87,14 +98,14 @@ public class misk/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
 }
 
 public final class misk/dynamodb/RequiredDynamoDbTable {
-	public fun <init> (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;)V
-	public synthetic fun <init> (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lmisk/dynamodb/DynamoDBHealthCheckFactory;)V
+	public synthetic fun <init> (Ljava/lang/String;Lmisk/dynamodb/DynamoDBHealthCheckFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lmisk/healthchecks/HealthCheck;
-	public final fun copy (Ljava/lang/String;Lmisk/healthchecks/HealthCheck;)Lmisk/dynamodb/RequiredDynamoDbTable;
-	public static synthetic fun copy$default (Lmisk/dynamodb/RequiredDynamoDbTable;Ljava/lang/String;Lmisk/healthchecks/HealthCheck;ILjava/lang/Object;)Lmisk/dynamodb/RequiredDynamoDbTable;
+	public final fun component2 ()Lmisk/dynamodb/DynamoDBHealthCheckFactory;
+	public final fun copy (Ljava/lang/String;Lmisk/dynamodb/DynamoDBHealthCheckFactory;)Lmisk/dynamodb/RequiredDynamoDbTable;
+	public static synthetic fun copy$default (Lmisk/dynamodb/RequiredDynamoDbTable;Ljava/lang/String;Lmisk/dynamodb/DynamoDBHealthCheckFactory;ILjava/lang/Object;)Lmisk/dynamodb/RequiredDynamoDbTable;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCustomHealthCheck ()Lmisk/healthchecks/HealthCheck;
+	public final fun getHealthCheckFactory ()Lmisk/dynamodb/DynamoDBHealthCheckFactory;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDBHealthCheckFactory.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDBHealthCheckFactory.kt
@@ -1,0 +1,11 @@
+package misk.dynamodb
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import misk.healthchecks.HealthCheck
+
+fun interface DynamoDBHealthCheckFactory {
+  /**
+   * Creates a [HealthCheck] instance.
+   */
+  fun create(dynamoDb: AmazonDynamoDB): HealthCheck
+}

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
@@ -18,6 +18,7 @@ class DynamoDbHealthCheck @Inject constructor(
         if (table.healthCheck != null) {
           val result = table.healthCheck.status()
           if (!result.isHealthy) {
+            logger.error { "error performing DynamoDB ${table.healthCheck::class.simpleName ?: "custom"} health check for ${table.name}" }
             return result
           }
         } else {

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
@@ -15,10 +15,10 @@ class DynamoDbHealthCheck @Inject constructor(
   override fun status(): HealthStatus {
     for (table in requiredTables) {
       try {
-        if (table.healthCheck != null) {
-          val result = table.healthCheck.status()
+        if (table.healthCheckFactory != null) {
+          val result = table.healthCheckFactory.create(dynamoDb).status()
           if (!result.isHealthy) {
-            logger.error { "error performing DynamoDB ${table.healthCheck::class.simpleName ?: "custom"} health check for ${table.name}" }
+            logger.error { "error performing DynamoDB ${table.healthCheckFactory::class.simpleName ?: "custom"} health check for ${table.name}" }
             return result
           }
         } else {

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt
@@ -15,7 +15,14 @@ class DynamoDbHealthCheck @Inject constructor(
   override fun status(): HealthStatus {
     for (table in requiredTables) {
       try {
-        dynamoDb.describeTable(table.name)
+        if (table.healthCheck != null) {
+          val result = table.healthCheck.status()
+          if (!result.isHealthy) {
+            return result
+          }
+        } else {
+          dynamoDb.describeTable(table.name)
+        }
       } catch (e: Exception) {
         logger.error(e) { "error performing DynamoDB health check for ${table.name}" }
         return HealthStatus.unhealthy("DynamoDB: failed to describe ${table.name}")

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RealDynamoDbModule.kt
@@ -25,15 +25,17 @@ import kotlin.reflect.full.findAnnotation
  * used to create a DynamoDbMapper for querying of a DynamoDb table.
  *
  * @param requiredTableTypes a list of mapper classes annotated [DynamoDBTable].
+ * @param customTableHealthChecks map of mapper class to [HealthCheck] for custom Healthcheck execution.
  */
 open class RealDynamoDbModule @JvmOverloads constructor(
   private val clientConfig: ClientConfiguration = ClientConfiguration(),
   vararg requiredTableTypes: KClass<*>,
+  private val customTableHealthChecks: Map<KClass<*>, HealthCheck> = mapOf(),
 ) : KAbstractModule() {
   private val requiredTables: List<RequiredDynamoDbTable> = requiredTableTypes.map {
     val annotation = it.findAnnotation<DynamoDBTable>()
       ?: throw IllegalArgumentException("no @DynamoDBTable on $it")
-    RequiredDynamoDbTable(annotation.tableName)
+    RequiredDynamoDbTable(annotation.tableName, customTableHealthChecks[it])
   }
 
   override fun configure() {

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
@@ -1,16 +1,14 @@
 package misk.dynamodb
 
-import misk.healthchecks.HealthCheck
-
 /**
  * A table that must be available in the DynamoDB instance. If this table doesn't exist, the service
  * will not start up.
  *
- * HealthCheck can be provided for custom HealthCheck.
+ * [healthCheckFactory] can be provided for custom HealthCheck.
  *
  * The table name is sometimes prefixed with the service name, like "urlshortener.urls".
  */
 data class RequiredDynamoDbTable(
   val name: String,
-  val healthCheck: HealthCheck? = null
+  val healthCheckFactory: DynamoDBHealthCheckFactory? = null
 )

--- a/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
+++ b/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/RequiredDynamoDbTable.kt
@@ -1,11 +1,16 @@
 package misk.dynamodb
 
+import misk.healthchecks.HealthCheck
+
 /**
  * A table that must be available in the DynamoDB instance. If this table doesn't exist, the service
  * will not start up.
  *
+ * HealthCheck can be provided for custom HealthCheck.
+ *
  * The table name is sometimes prefixed with the service name, like "urlshortener.urls".
  */
 data class RequiredDynamoDbTable(
-  val name: String
+  val name: String,
+  val healthCheck: HealthCheck? = null
 )

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbTest.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DockerDynamoDbTest.kt
@@ -1,6 +1,5 @@
 package misk.aws.dynamodb.testing
 
-import com.amazonaws.services.dynamodbv2.model.BillingMode
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
@@ -8,20 +7,12 @@ import misk.testing.MiskTestModule
 
 @MiskTest(startService = true)
 class DockerDynamoDbTest : AbstractDynamoDbTest() {
-  @MiskTestModule val module = TestModule()
+  @MiskTestModule val module = TestModule(DockerDynamoDbModule(tables, tableToHealthChecks))
 
-  class TestModule : KAbstractModule() {
+  class TestModule(private val dockerModule: DockerDynamoDbModule) : KAbstractModule() {
     override fun configure() {
       install(MiskTestingServiceModule())
-
-      install(
-        DockerDynamoDbModule(
-          DynamoDbTable(DyMovie::class),
-          DynamoDbTable(DyCharacter::class) {
-            it.withBillingMode(BillingMode.PAY_PER_REQUEST)
-          }
-        )
-      )
+      install(dockerModule)
     }
   }
 }

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DyCharacter.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DyCharacter.kt
@@ -4,11 +4,15 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
 
-@DynamoDBTable(tableName = "characters")
+@DynamoDBTable(tableName = DyCharacter.tableName)
 class DyCharacter {
   @DynamoDBHashKey(attributeName = "movie_name")
   var movie_name: String = ""
 
   @DynamoDBRangeKey(attributeName = "character_name")
   var character_name: String = ""
+
+  companion object {
+    const val tableName = "characters"
+  }
 }

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DyMovie.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/DyMovie.kt
@@ -10,7 +10,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverted
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter
 import java.time.LocalDate
 
-@DynamoDBTable(tableName = "movies")
+@DynamoDBTable(tableName = DyMovie.tableName)
 class DyMovie {
   @DynamoDBHashKey(attributeName = "name")
   var name: String? = null
@@ -23,6 +23,10 @@ class DyMovie {
   @DynamoDBIndexHashKey(globalSecondaryIndexName = "movies.release_date_index")
   @DynamoDBAttribute
   var directed_by: String? = null
+
+  companion object {
+    const val tableName = "movies"
+  }
 }
 
 internal class LocalDateTypeConverter : DynamoDBTypeConverter<String, LocalDate> {

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbTest.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/InProcessDynamoDbTest.kt
@@ -1,6 +1,5 @@
 package misk.aws.dynamodb.testing
 
-import com.amazonaws.services.dynamodbv2.model.BillingMode
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
@@ -8,20 +7,12 @@ import misk.testing.MiskTestModule
 
 @MiskTest(startService = true)
 class InProcessDynamoDbTest : AbstractDynamoDbTest() {
-  @MiskTestModule val module = TestModule()
+  @MiskTestModule val module = TestModule(InProcessDynamoDbModule(tables, tableToHealthChecks))
 
-  class TestModule : KAbstractModule() {
+  class TestModule(private val inProcessModule: InProcessDynamoDbModule) : KAbstractModule() {
     override fun configure() {
       install(MiskTestingServiceModule())
-
-      install(
-        InProcessDynamoDbModule(
-          DynamoDbTable(DyMovie::class),
-          DynamoDbTable(DyCharacter::class) {
-            it.withBillingMode(BillingMode.PAY_PER_REQUEST)
-          }
-        )
-      )
+      install(inProcessModule)
     }
   }
 }

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/RealDynamoDbModuleTest.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/RealDynamoDbModuleTest.kt
@@ -1,0 +1,40 @@
+package misk.aws.dynamodb.testing
+
+import misk.dynamodb.RealDynamoDbModule
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class RealDynamoDbModuleTest {
+  @Test
+  fun `init with mapper classes`() {
+    val module =
+      RealDynamoDbModule(requiredTableTypes = arrayOf(DyMovie::class, DyCharacter::class))
+    val requiredTables = module.provideRequiredTables()
+    assertEquals(DyCharacter.tableName, requiredTables[1].name)
+    assertNull(requiredTables[1].healthCheck)
+  }
+
+  @Test
+  fun `init with mapper classes and custom healthchecks`() {
+    val healthCheck = FakeHealthyHealthCheck()
+    val module = RealDynamoDbModule(
+      requiredTableTypes = arrayOf(DyMovie::class, DyCharacter::class),
+      customTableHealthChecks = mapOf(DyMovie::class to healthCheck)
+    )
+
+    val requiredTables = module.provideRequiredTables()
+    assertEquals(2, requiredTables.size)
+    assertEquals(DyMovie.tableName, requiredTables[0].name)
+    assertEquals(healthCheck, requiredTables[0].healthCheck!!)
+
+    assertEquals(DyCharacter.tableName, requiredTables[1].name)
+    assertNull(requiredTables[1].healthCheck)
+  }
+
+  internal class FakeHealthyHealthCheck : HealthCheck {
+    override fun status(): HealthStatus = HealthStatus.healthy()
+  }
+}

--- a/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/RealDynamoDbModuleTest.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/aws/dynamodb/testing/RealDynamoDbModuleTest.kt
@@ -1,5 +1,6 @@
 package misk.aws.dynamodb.testing
 
+import misk.dynamodb.DynamoDBHealthCheckFactory
 import misk.dynamodb.RealDynamoDbModule
 import misk.healthchecks.HealthCheck
 import misk.healthchecks.HealthStatus
@@ -14,24 +15,24 @@ class RealDynamoDbModuleTest {
       RealDynamoDbModule(requiredTableTypes = arrayOf(DyMovie::class, DyCharacter::class))
     val requiredTables = module.provideRequiredTables()
     assertEquals(DyCharacter.tableName, requiredTables[1].name)
-    assertNull(requiredTables[1].healthCheck)
+    assertNull(requiredTables[1].healthCheckFactory)
   }
 
   @Test
-  fun `init with mapper classes and custom healthchecks`() {
-    val healthCheck = FakeHealthyHealthCheck()
+  fun `init with mapper classes and custom health checks`() {
+    val healthCheckFactory = DynamoDBHealthCheckFactory { _ -> FakeHealthyHealthCheck() }
     val module = RealDynamoDbModule(
       requiredTableTypes = arrayOf(DyMovie::class, DyCharacter::class),
-      customTableHealthChecks = mapOf(DyMovie::class to healthCheck)
+      customHealthCheckFactories = mapOf(DyMovie::class to healthCheckFactory)
     )
 
     val requiredTables = module.provideRequiredTables()
     assertEquals(2, requiredTables.size)
     assertEquals(DyMovie.tableName, requiredTables[0].name)
-    assertEquals(healthCheck, requiredTables[0].healthCheck!!)
+    assertEquals(healthCheckFactory, requiredTables[0].healthCheckFactory!!)
 
     assertEquals(DyCharacter.tableName, requiredTables[1].name)
-    assertNull(requiredTables[1].healthCheck)
+    assertNull(requiredTables[1].healthCheckFactory)
   }
 
   internal class FakeHealthyHealthCheck : HealthCheck {

--- a/misk-aws-dynamodb/src/test/kotlin/misk/dynamodb/DynamoDbHealthCheckTest.kt
+++ b/misk-aws-dynamodb/src/test/kotlin/misk/dynamodb/DynamoDbHealthCheckTest.kt
@@ -1,0 +1,71 @@
+package misk.dynamodb
+
+import com.amazonaws.services.dynamodbv2.AbstractAmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import com.amazonaws.services.dynamodbv2.model.DescribeTableResult
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DynamoDbHealthCheckTest {
+  private lateinit var amazonDynamoDB: AmazonDynamoDB
+  private lateinit var healthyHealthCheck: HealthCheck
+  private lateinit var unhealthyHealthCheck: HealthCheck
+
+  @BeforeEach
+  fun setup() {
+    amazonDynamoDB = FakeAmazonDb()
+    healthyHealthCheck = object : HealthCheck {
+      override fun status(): HealthStatus = HealthStatus.healthy()
+    }
+    unhealthyHealthCheck = object : HealthCheck {
+      override fun status(): HealthStatus = HealthStatus.unhealthy()
+    }
+  }
+
+  @Test
+  fun `status returns healthy when all tables are healthy`() {
+    val tables = listOf(RequiredDynamoDbTable("t1"), RequiredDynamoDbTable("t2"))
+    assertTrue(DynamoDbHealthCheck(amazonDynamoDB, tables).status().isHealthy)
+  }
+
+  @Test
+  fun `status returns healthy when describe table fails`() {
+    val tables = listOf(RequiredDynamoDbTable("t1"), RequiredDynamoDbTable(unhealthyTable))
+    assertFalse(DynamoDbHealthCheck(amazonDynamoDB, tables).status().isHealthy)
+  }
+
+  @Test
+  fun `status returns custom unhealthy status when custom health check fails`() {
+    val tables = listOf(RequiredDynamoDbTable("UnhealthyTable", unhealthyHealthCheck))
+    assertFalse(DynamoDbHealthCheck(amazonDynamoDB, tables).status().isHealthy)
+  }
+
+  @Test
+  fun `status returns healthy when custom health check is healthy`() {
+    val tables = listOf(RequiredDynamoDbTable("HealthyTable", healthyHealthCheck))
+    assertTrue(DynamoDbHealthCheck(amazonDynamoDB, tables).status().isHealthy)
+  }
+
+  @Test
+  fun `status returns healthy when default healt check table and custom health check tables are healthy`() {
+    val tables =
+      listOf(RequiredDynamoDbTable("t1"), RequiredDynamoDbTable("HealthyTable", healthyHealthCheck))
+    assertTrue(DynamoDbHealthCheck(amazonDynamoDB, tables).status().isHealthy)
+  }
+
+  companion object {
+    const val unhealthyTable = "busyTable"
+  }
+
+  internal class FakeAmazonDb : AbstractAmazonDynamoDB() {
+    override fun describeTable(tableName: String): DescribeTableResult {
+      if (tableName == unhealthyTable) throw AmazonDynamoDBException("DynamoDbHealthCheckTest: Table is in bad state.")
+      return DescribeTableResult()
+    }
+  }
+}

--- a/misk-aws-dynamodb/src/testFixtures/kotlin/misk/aws/dynamodb/testing/TestHealthChecks.kt
+++ b/misk-aws-dynamodb/src/testFixtures/kotlin/misk/aws/dynamodb/testing/TestHealthChecks.kt
@@ -1,0 +1,12 @@
+package misk.aws.dynamodb.testing
+
+import misk.healthchecks.HealthCheck
+import misk.healthchecks.HealthStatus
+
+val healthyHealthCheck = object : HealthCheck {
+  override fun status() = HealthStatus.healthy()
+}
+
+val unhealthyHealthCheck = object : HealthCheck {
+  override fun status() = HealthStatus.unhealthy()
+}


### PR DESCRIPTION
### About
Support custom health checks for each dynamodb mapper/table for `misk-aws-dynamodb` clients. 
Custom health check provides clients to use different strategy for dynamodb health check over the [default one](https://github.com/cashapp/misk/blob/074409c49ba01c19d04bddc7a0b6f396a9377e8f/misk-aws-dynamodb/src/main/kotlin/misk/dynamodb/DynamoDbHealthCheck.kt#L18), which uses `AmazonDynamoDb.describeTable` control pane API.

### Why
The default health check's use of `describeTable` can be an issue when a large fleet of Misk applications regularly run periodic health checks against DynamoDB tables, as there is an account-level TPS threshold for control pane API requests per [AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html).

> DescribeTable/ListTables
> _You can submit up to 2,500 requests per second of read-only (DescribeTable, ListTables) control plane API requests in any combination._

This can lead to applications occasionally failing health checks due to unpredictable and elevated latency and shared account level threshold for control plane API calls.

Also, concurrent control plane API requests to the same table can be throttled, which can affect if a single service has many replicas.

This change allows clients to use alternative HealthCheck mechanisms per each mapper table.
