### PR TITLE
Adding optional callback parameter to misk retry function

### DIFF
--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -28,6 +28,8 @@ public final class misk/backoff/FlatBackoff : misk/backoff/Backoff {
 
 public final class misk/backoff/RetriesKt {
 	public static final fun retry (ILmisk/backoff/Backoff;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun retry (ILmisk/backoff/Backoff;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun retry$default (ILmisk/backoff/Backoff;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class misk/concurrent/ExecutorServiceFactory {

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -2,8 +2,9 @@ package misk.backoff
 
 /**
  * Retries the provided function up to a certain number of times, applying the given backoff
- * between each retry. The retry function is provided with current retry count, in case this is
- * relevant
+ * between each retry. If provided, the onRetry callback is called when a retry happens, allowing
+ * clients to perform a task (log, emit metrics) every time a retry occurs.
+ * The retry function is provided with current retry count, in case this is relevant.
  */
 @JvmOverloads
 fun <A> retry(

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -5,7 +5,13 @@ package misk.backoff
  * between each retry. The retry function is provided with current retry count, in case this is
  * relevant
  */
-fun <A> retry(upTo: Int, withBackoff: Backoff, f: (retryCount: Int) -> A): A {
+@JvmOverloads
+fun <A> retry(
+  upTo: Int,
+  withBackoff: Backoff,
+  onRetry: ((retryCount: Int, exception: Exception) -> Unit)? = null,
+  f: (retryCount: Int) -> A,
+  ): A {
   require(upTo > 0) { "must support at least one call" }
 
   withBackoff.reset()
@@ -20,6 +26,7 @@ fun <A> retry(upTo: Int, withBackoff: Backoff, f: (retryCount: Int) -> A): A {
     } catch (e: DontRetryException) {
       throw e
     } catch (e: Exception) {
+      onRetry?.invoke(i + 1, e)
       lastException = e
 
       if (i + 1 < upTo) {

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -11,7 +11,7 @@ fun <A> retry(
   upTo: Int,
   withBackoff: Backoff,
   onRetry: ((retryCount: Int, exception: Exception) -> Unit)? = null,
-  f: (retryCount: Int) -> A,
+  block: (retryCount: Int) -> A,
   ): A {
   require(upTo > 0) { "must support at least one call" }
 
@@ -21,7 +21,7 @@ fun <A> retry(
 
   for (i in 0 until upTo) {
     try {
-      val result = f(i)
+      val result = block(i)
       withBackoff.reset()
       return result
     } catch (e: DontRetryException) {

--- a/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
+++ b/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
@@ -64,4 +64,21 @@ internal class RetryTest {
     // Backoff should be reset to base delay after success
     assertThat(backoff.nextRetry()).isEqualTo(Duration.ofMillis(10))
   }
+
+  @Test fun callsOnRetryCallbackIfProvided() {
+    var retryCount = 0
+    var retried = 0
+    // simply counts the number of times it was called
+    val onRetryFunction: (retries: Int, exception: Exception) -> Unit = { _, _ ->
+      retried = retried.inc()
+    }
+
+    // f is a function that throws an exception twice in a row
+    retry(3, FlatBackoff(), onRetryFunction) {
+      retryCount = retryCount.inc()
+      if(retryCount < 3) throw Exception("a failure that triggers a retry")
+    }
+
+    assertThat(retried).isEqualTo(2)
+  }
 }


### PR DESCRIPTION
### Context
Misk's `retry` wrapper is used by [tens of services](https://github.com/search?q=org%3Asquareup+import+misk.backoff.retry&type=code) at Cash. This helper is mostly used to wrap RPC/HTTP calls as follows:

```
val response = retry(upTo = 3, withBackoff = FlatBackoff()) {
          myDependencyClient.aRPCCall(params)
    }
```
If the code wrapped by `retry` throws any exception that isn't of type `DontRetryException`, the `retry` block will swallow the exception, apply the backoff policy, and retry the same block up to the maximum defined number of retries.

### Problem
This exception swallowing makes it harder for clients to log or emit metrics of retries, which decreases overall service observability across cash. One possible solution to this problem is to wrap your own call in a `try / catch`, log / emit metrics, and rethrow the exception so that the `retry` wrapper can catch it again, swallow it, and reapply the backoff policy.

```
val response = retry(upTo = 3, withBackoff = FlatBackoff()) {
          try {
          myDependencyClient.aRPCCall(params)
         } catch (e: Exception) {
            logger.log("something went wrong: ${e.message}")
            metrics.emit("a metric")
            
            throw exception
         }
    }
```

Despite being a feasible solution, I couldn't find evidence that any service is doing this currently.

### Solution
This PR introduces an optional parameter of type `(retryCount: Int, exception: Exception) -> Unit)` (meaning a function that returns no value, and receives two parameters: retryCount and exception). This callback function is called (if supplied) when a retry happens within the `retry` wrapper.

The block above would be written like this:
```
val observabilityCallback: (retries: Int, e: Exception) -> Unit = { retries, e ->
        logger.log("something went wrong: ${e.message}")
       metrics.emit("a metric")
    }
val response = retry(upTo = 3, withBackoff = FlatBackoff(), onRetry = observabilityCallback) {
          myDependencyClient.aRPCCall(params)
    }
```

This should hopefully nudge other engineers to add better observability into their services when using this wrapper, while keeping the library backwards compatible and flexible.



