### PR TITLE
fix: make MiskOpaMetrics a singleton. This was causing issues like

### DIFF
--- a/misk-policy/src/main/kotlin/misk/policy/opa/MiskOpaMetrics.kt
+++ b/misk-policy/src/main/kotlin/misk/policy/opa/MiskOpaMetrics.kt
@@ -3,12 +3,14 @@ package misk.policy.opa
 import io.prometheus.client.Counter
 import io.prometheus.client.Histogram
 import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.metrics.v2.Metrics
 import java.lang.IllegalArgumentException
 
 /**
  * Maps [OpaResponse.metrics] into prometheus counters and histograms.
  */
+@Singleton
 class MiskOpaMetrics @Inject constructor(metrics: Metrics) : OpaMetrics {
 
   @Suppress("ktlint:enum-entry-name-case")


### PR DESCRIPTION
```
com.google.inject.ProvisionException: Unable to provision, see the following errors:
1) [Guice/ErrorInjectingConstructor]: IllegalArgumentException: Failed to register Collector of type Counter: opa_server_query_cache_hit_total is already in use by another Collector of type Counter

at MiskOpaMetrics.<init>(MiskOpaMetrics.kt:12)
```

when binding for multiple times