### PR TITLE
Rework testFixtures FakeMetrics to use extention methods

### DIFF
--- a/misk-metrics/api/misk-metrics.api
+++ b/misk-metrics/api/misk-metrics.api
@@ -15,6 +15,19 @@ public final class misk/metrics/FakeMetrics : misk/metrics/Metrics {
 	public fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
 }
 
+public final class misk/metrics/FakeMetricsKt {
+	public static final fun get (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun getAllSamples (Lio/prometheus/client/CollectorRegistry;)Lkotlin/sequences/Sequence;
+	public static final fun getSample (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
+	public static synthetic fun getSample$default (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;ILjava/lang/Object;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
+	public static final fun summaryCount (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun summaryMean (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun summaryP50 (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun summaryP99 (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun summaryQuantile (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+	public static final fun summarySum (Lio/prometheus/client/CollectorRegistry;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
+}
+
 public final class misk/metrics/FakeMetricsModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 }

--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -85,7 +85,7 @@ interface Metrics {
   fun histogram(
     name: String,
     help: String = "",
-    labelNames: List<String>,
+    labelNames: List<String> = listOf(),
     quantiles: Map<Double, Double> = defaultQuantiles,
     maxAgeSeconds: Long? = null
   ): Histogram
@@ -119,7 +119,7 @@ interface Metrics {
   fun legacyHistogram(
     name: String,
     help: String = "",
-    labelNames: List<String>,
+    labelNames: List<String> = listOf(),
     quantiles: Map<Double, Double> = defaultQuantiles,
     maxAgeSeconds: Long? = null
   ): Histogram

--- a/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
@@ -85,7 +85,7 @@ interface Metrics {
   fun histogram(
     name: String,
     help: String = "",
-    labelNames: List<String>,
+    labelNames: List<String> = listOf(),
     buckets: List<Double> = defaultBuckets
   ): Histogram
 
@@ -108,7 +108,7 @@ interface Metrics {
   fun summary(
     name: String,
     help: String = "",
-    labelNames: List<String>,
+    labelNames: List<String> = listOf(),
     quantiles: Map<Double, Double> = defaultQuantiles,
     maxAgeSeconds: Long? = null
   ): Summary
@@ -142,7 +142,7 @@ interface Metrics {
   fun legacyHistogram(
     name: String,
     help: String = "",
-    labelNames: List<String>,
+    labelNames: List<String> = listOf(),
     quantiles: Map<Double, Double> = misk.metrics.defaultQuantiles,
     maxAgeSeconds: Long? = null
   ): misk.metrics.Histogram

--- a/misk-metrics/src/test/kotlin/misk/metrics/FakeMetricsTest.kt
+++ b/misk-metrics/src/test/kotlin/misk/metrics/FakeMetricsTest.kt
@@ -1,6 +1,7 @@
 package misk.metrics
 
 import io.prometheus.client.Collector.MetricFamilySamples.Sample
+import io.prometheus.client.CollectorRegistry
 import jakarta.inject.Inject
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -11,51 +12,52 @@ import org.junit.jupiter.api.Test
 class FakeMetricsTest {
   @MiskTestModule val module = FakeMetricsModule()
 
-  @Inject lateinit var metrics: FakeMetrics
+  @Inject lateinit var metrics: Metrics
+  @Inject lateinit var registry: CollectorRegistry
 
   @Test
   internal fun `count happy path`() {
-    assertThat(metrics.get("gets", "status" to "200")).isNull()
+    assertThat(registry.get("gets", "status" to "200")).isNull()
     val counter = metrics.counter("gets", "-", labelNames = listOf("status"))
       .labels("200")
     counter.inc()
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(1.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(1.0)
     counter.inc()
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(2.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(2.0)
   }
 
   @Test
   internal fun `gauge happy path`() {
-    assertThat(metrics.get("thread_count", "state" to "running")).isNull()
+    assertThat(registry.get("thread_count", "state" to "running")).isNull()
     val gauge = metrics.gauge("thread_count", "-", labelNames = listOf("state"))
       .labels("running")
     gauge.set(20.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(20.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(20.0)
     gauge.set(30.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(30.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(30.0)
   }
 
   @Test
   internal fun `histogram happy path`() {
-    assertThat(metrics.get("call_times", "status" to "200")).isNull()
+    assertThat(registry.get("call_times", "status" to "200")).isNull()
     val histogram = metrics.histogram("call_times", "-", labelNames = listOf("status"))
     histogram.record(100.0, "200")
-    assertThat(metrics.histogramMean("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.histogramSum("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.histogramCount("call_times", "status" to "200")).isEqualTo(1.0)
-    assertThat(metrics.histogramP50("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summarySum("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summaryCount("call_times", "status" to "200")).isEqualTo(1.0)
+    assertThat(registry.summaryP50("call_times", "status" to "200")).isEqualTo(100.0)
     histogram.record(99.0, "200")
     histogram.record(101.0, "200")
-    assertThat(metrics.histogramMean("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.histogramSum("call_times", "status" to "200")).isEqualTo(300.0)
-    assertThat(metrics.histogramCount("call_times", "status" to "200")).isEqualTo(3.0)
-    assertThat(metrics.histogramP50("call_times", "status" to "200")).isIn(99.0, 100.0, 101.0)
+    assertThat(registry.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summarySum("call_times", "status" to "200")).isEqualTo(300.0)
+    assertThat(registry.summaryCount("call_times", "status" to "200")).isEqualTo(3.0)
+    assertThat(registry.summaryP50("call_times", "status" to "200")).isIn(99.0, 100.0, 101.0)
   }
 
   @Test
   internal fun `different label values`() {
-    assertThat(metrics.get("gets", "status" to "200")).isNull()
-    assertThat(metrics.get("gets", "status" to "503")).isNull()
+    assertThat(registry.get("gets", "status" to "200")).isNull()
+    assertThat(registry.get("gets", "status" to "503")).isNull()
 
     val counter = metrics.counter("gets", "-", labelNames = listOf("status"))
     val counter200s = counter.labels("200")
@@ -63,61 +65,61 @@ class FakeMetricsTest {
 
     counter200s.inc(7.0)
     counter503s.inc(9.0)
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(7.0)
-    assertThat(metrics.get("gets", "status" to "503")).isEqualTo(9.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(7.0)
+    assertThat(registry.get("gets", "status" to "503")).isEqualTo(9.0)
 
     counter200s.inc(10.0)
     counter503s.inc(20.0)
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(17.0)
-    assertThat(metrics.get("gets", "status" to "503")).isEqualTo(29.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(17.0)
+    assertThat(registry.get("gets", "status" to "503")).isEqualTo(29.0)
   }
 
   @Test
   internal fun `different names`() {
-    assertThat(metrics.get("gets")).isNull()
-    assertThat(metrics.get("puts")).isNull()
-    assertThat(metrics.get("gets_total")).isNull()
-    assertThat(metrics.get("puts_total")).isNull()
+    assertThat(registry.get("gets")).isNull()
+    assertThat(registry.get("puts")).isNull()
+    assertThat(registry.get("gets_total")).isNull()
+    assertThat(registry.get("puts_total")).isNull()
 
     val getsCounter = metrics.counter("gets", "-")
     val putsCounter = metrics.counter("puts", "-")
 
     getsCounter.inc(7.0)
     putsCounter.inc(9.0)
-    assertThat(metrics.get("gets")).isEqualTo(7.0)
-    assertThat(metrics.get("puts")).isEqualTo(9.0)
+    assertThat(registry.get("gets")).isEqualTo(7.0)
+    assertThat(registry.get("puts")).isEqualTo(9.0)
 
     getsCounter.inc(10.0)
     putsCounter.inc(20.0)
-    assertThat(metrics.get("gets")).isEqualTo(17.0)
-    assertThat(metrics.get("puts")).isEqualTo(29.0)
-    assertThat(metrics.get("gets_total")).isEqualTo(17.0)
-    assertThat(metrics.get("puts_total")).isEqualTo(29.0)
+    assertThat(registry.get("gets")).isEqualTo(17.0)
+    assertThat(registry.get("puts")).isEqualTo(29.0)
+    assertThat(registry.get("gets_total")).isEqualTo(17.0)
+    assertThat(registry.get("puts_total")).isEqualTo(29.0)
   }
 
   @Test
   internal fun `histogram quantiles`() {
-    val histogram = metrics.histogram("call_times", "-", labelNames = listOf())
+    val histogram = metrics.legacyHistogram("call_times", "-")
 
     histogram.record(400.0)
-    assertThat(metrics.histogramP50("call_times")).isEqualTo(400.0)
-    assertThat(metrics.histogramP99("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(400.0)
 
     histogram.record(450.0)
-    assertThat(metrics.histogramP50("call_times")).isEqualTo(400.0)
-    assertThat(metrics.histogramP99("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(450.0)
 
     histogram.record(500.0)
-    assertThat(metrics.histogramP50("call_times")).isEqualTo(450.0)
-    assertThat(metrics.histogramP99("call_times")).isEqualTo(500.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(500.0)
 
     histogram.record(550.0)
-    assertThat(metrics.histogramP50("call_times")).isEqualTo(450.0)
-    assertThat(metrics.histogramP99("call_times")).isEqualTo(550.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(550.0)
 
     histogram.record(600.0)
-    assertThat(metrics.histogramP50("call_times")).isEqualTo(500.0)
-    assertThat(metrics.histogramP99("call_times")).isEqualTo(600.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(500.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(600.0)
   }
 
   @Test
@@ -125,9 +127,9 @@ class FakeMetricsTest {
     metrics.counter("counter_total", "-", listOf("foo")).labels("bar").inc()
     metrics.gauge("gauge", "-", listOf("foo")).labels("bar").inc()
     val quantiles = mapOf(0.5 to 0.5, 0.99 to 0.99)
-    metrics.histogram("histogram", "-", listOf("foo"), quantiles).record(1.0, "bar")
+    metrics.legacyHistogram("histogram", "-", listOf("foo"), quantiles).record(1.0, "bar")
 
-    assertThat(metrics.getAllSamples().toList()).contains(
+    assertThat(registry.getAllSamples().toList()).contains(
       Sample("counter_total", listOf("foo"), listOf("bar"), 1.0),
       Sample("gauge", listOf("foo"), listOf("bar"), 1.0),
       Sample("histogram", listOf("foo", "quantile"), listOf("bar", "0.5"), 1.0),

--- a/misk-metrics/src/test/kotlin/misk/metrics/v2/FakeMetricsTest.kt
+++ b/misk-metrics/src/test/kotlin/misk/metrics/v2/FakeMetricsTest.kt
@@ -1,78 +1,89 @@
 package misk.metrics.v2
 
 import io.prometheus.client.Collector.MetricFamilySamples.Sample
+import io.prometheus.client.CollectorRegistry
 import jakarta.inject.Inject
+import misk.metrics.FakeMetricsModule
+import misk.metrics.get
+import misk.metrics.getAllSamples
+import misk.metrics.summaryCount
+import misk.metrics.summaryMean
+import misk.metrics.summaryP50
+import misk.metrics.summaryP99
+import misk.metrics.summarySum
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 @MiskTest(startService = false)
+
 class FakeMetricsTest {
   @MiskTestModule val module = FakeMetricsModule()
 
-  @Inject lateinit var metrics: FakeMetrics
+  @Inject lateinit var metrics: Metrics
+  @Inject lateinit var registry: CollectorRegistry
 
   @Test
   internal fun `count happy path`() {
-    assertThat(metrics.get("gets", "status" to "200")).isNull()
+    assertThat(registry.get("gets", "status" to "200")).isNull()
     val counter = metrics.counter("gets", "-", labelNames = listOf("status"))
       .labels("200")
     counter.inc()
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(1.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(1.0)
     counter.inc()
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(2.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(2.0)
   }
 
   @Test
   internal fun `gauge happy path`() {
-    assertThat(metrics.get("thread_count", "state" to "running")).isNull()
+    assertThat(registry.get("thread_count", "state" to "running")).isNull()
     val gauge = metrics.gauge("thread_count", "-", labelNames = listOf("state"))
       .labels("running")
     gauge.set(20.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(20.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(20.0)
     gauge.set(30.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(30.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(30.0)
   }
 
   @Test
   internal fun `peakGauge happy path`() {
-    assertThat(metrics.get("thread_count", "state" to "running")).isNull()
+    assertThat(registry.get("thread_count", "state" to "running")).isNull()
     val peakGauge = metrics.peakGauge("thread_count", "-", labelNames = listOf("state"))
       .labels("running")
     peakGauge.record(10.0)
     peakGauge.record(20.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(20.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(20.0)
     // Another get without a set should result in seeing the initial value (0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(0.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(0.0)
     peakGauge.record(30.0)
     peakGauge.record(20.0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(30.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(30.0)
     // Another get without a set should result in seeing the initial value (0)
-    assertThat(metrics.get("thread_count", "state" to "running")).isEqualTo(0.0)
+    assertThat(registry.get("thread_count", "state" to "running")).isEqualTo(0.0)
   }
 
   @Test
   internal fun `summary happy path`() {
-    assertThat(metrics.get("call_times", "status" to "200")).isNull()
+    assertThat(registry.get("call_times", "status" to "200")).isNull()
     val summary = metrics.summary("call_times", "-", labelNames = listOf("status"))
     summary.labels("200").observe(100.0)
-    assertThat(metrics.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.summarySum("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.summaryCount("call_times", "status" to "200")).isEqualTo(1.0)
-    assertThat(metrics.summaryP50("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summarySum("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summaryCount("call_times", "status" to "200")).isEqualTo(1.0)
+    assertThat(registry.summaryP50("call_times", "status" to "200")).isEqualTo(100.0)
     summary.labels("200").observe(99.0)
     summary.labels("200").observe(101.0)
-    assertThat(metrics.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
-    assertThat(metrics.summarySum("call_times", "status" to "200")).isEqualTo(300.0)
-    assertThat(metrics.summaryCount("call_times", "status" to "200")).isEqualTo(3.0)
-    assertThat(metrics.summaryP50("call_times", "status" to "200")).isIn(99.0, 100.0, 101.0)
+    assertThat(registry.summaryMean("call_times", "status" to "200")).isEqualTo(100.0)
+    assertThat(registry.summarySum("call_times", "status" to "200")).isEqualTo(300.0)
+    assertThat(registry.summaryCount("call_times", "status" to "200")).isEqualTo(3.0)
+    assertThat(registry.summaryP50("call_times", "status" to "200")).isIn(99.0, 100.0, 101.0)
   }
 
   @Test
   internal fun `different label values`() {
-    assertThat(metrics.get("gets", "status" to "200")).isNull()
-    assertThat(metrics.get("gets", "status" to "503")).isNull()
+    assertThat(registry.get("gets", "status" to "200")).isNull()
+    assertThat(registry.get("gets", "status" to "503")).isNull()
 
     val counter = metrics.counter("gets", "-", labelNames = listOf("status"))
     val counter200s = counter.labels("200")
@@ -80,61 +91,61 @@ class FakeMetricsTest {
 
     counter200s.inc(7.0)
     counter503s.inc(9.0)
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(7.0)
-    assertThat(metrics.get("gets", "status" to "503")).isEqualTo(9.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(7.0)
+    assertThat(registry.get("gets", "status" to "503")).isEqualTo(9.0)
 
     counter200s.inc(10.0)
     counter503s.inc(20.0)
-    assertThat(metrics.get("gets", "status" to "200")).isEqualTo(17.0)
-    assertThat(metrics.get("gets", "status" to "503")).isEqualTo(29.0)
+    assertThat(registry.get("gets", "status" to "200")).isEqualTo(17.0)
+    assertThat(registry.get("gets", "status" to "503")).isEqualTo(29.0)
   }
 
   @Test
   internal fun `different names`() {
-    assertThat(metrics.get("gets")).isNull()
-    assertThat(metrics.get("puts")).isNull()
-    assertThat(metrics.get("gets_total")).isNull()
-    assertThat(metrics.get("puts_total")).isNull()
+    assertThat(registry.get("gets")).isNull()
+    assertThat(registry.get("puts")).isNull()
+    assertThat(registry.get("gets_total")).isNull()
+    assertThat(registry.get("puts_total")).isNull()
 
     val getsCounter = metrics.counter("gets", "-")
     val putsCounter = metrics.counter("puts", "-")
 
     getsCounter.inc(7.0)
     putsCounter.inc(9.0)
-    assertThat(metrics.get("gets")).isEqualTo(7.0)
-    assertThat(metrics.get("puts")).isEqualTo(9.0)
+    assertThat(registry.get("gets")).isEqualTo(7.0)
+    assertThat(registry.get("puts")).isEqualTo(9.0)
 
     getsCounter.inc(10.0)
     putsCounter.inc(20.0)
-    assertThat(metrics.get("gets")).isEqualTo(17.0)
-    assertThat(metrics.get("puts")).isEqualTo(29.0)
-    assertThat(metrics.get("gets_total")).isEqualTo(17.0)
-    assertThat(metrics.get("puts_total")).isEqualTo(29.0)
+    assertThat(registry.get("gets")).isEqualTo(17.0)
+    assertThat(registry.get("puts")).isEqualTo(29.0)
+    assertThat(registry.get("gets_total")).isEqualTo(17.0)
+    assertThat(registry.get("puts_total")).isEqualTo(29.0)
   }
 
   @Test
   internal fun `summary quantiles`() {
-    val summary = metrics.summary("call_times", "-", labelNames = listOf())
+    val summary = metrics.summary("call_times", "-")
 
     summary.observe(400.0)
-    assertThat(metrics.summaryP50("call_times")).isEqualTo(400.0)
-    assertThat(metrics.summaryP99("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(400.0)
 
     summary.observe(450.0)
-    assertThat(metrics.summaryP50("call_times")).isEqualTo(400.0)
-    assertThat(metrics.summaryP99("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(400.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(450.0)
 
     summary.observe(500.0)
-    assertThat(metrics.summaryP50("call_times")).isEqualTo(450.0)
-    assertThat(metrics.summaryP99("call_times")).isEqualTo(500.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(500.0)
 
     summary.observe(550.0)
-    assertThat(metrics.summaryP50("call_times")).isEqualTo(450.0)
-    assertThat(metrics.summaryP99("call_times")).isEqualTo(550.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(450.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(550.0)
 
     summary.observe(600.0)
-    assertThat(metrics.summaryP50("call_times")).isEqualTo(500.0)
-    assertThat(metrics.summaryP99("call_times")).isEqualTo(600.0)
+    assertThat(registry.summaryP50("call_times")).isEqualTo(500.0)
+    assertThat(registry.summaryP99("call_times")).isEqualTo(600.0)
   }
 
   @Test
@@ -143,7 +154,7 @@ class FakeMetricsTest {
     metrics.gauge("gauge", "-", listOf("foo")).labels("bar").inc()
     metrics.histogram("histogram", "-", listOf("foo"), listOf(1.0, 2.0)).labels("bar").observe(1.0)
 
-    assertThat(metrics.getAllSamples().toList()).contains(
+    assertThat(registry.getAllSamples().toList()).contains(
       Sample("counter_total", listOf("foo"), listOf("bar"), 1.0),
       Sample("gauge", listOf("foo"), listOf("bar"), 1.0),
       Sample("histogram_bucket", listOf("foo", "le"), listOf("bar", "1.0"), 1.0),

--- a/misk-metrics/src/testFixtures/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics/src/testFixtures/kotlin/misk/metrics/FakeMetrics.kt
@@ -86,75 +86,138 @@ class FakeMetrics @Inject internal constructor(
   ): Histogram = legacyHistogram(name, help, labelNames, quantiles, maxAgeSeconds)
 
   /** Returns a measurement for a [counter] or [gauge]. */
-  fun get(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels)?.value
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun get(name: String, vararg labels: Pair<String, String>): Double? = registry.get(name, *labels)
 
   /** Returns the number of histogram samples taken. */
-  fun histogramCount(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels, sampleName = name + "_count")?.value
+  @Deprecated("Use summaryCount extention method on CollectorRegistry instead")
+  fun histogramCount(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryCount(name, *labels)
 
   /** Returns the sum of all histogram samples taken. */
-  fun histogramSum(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels, sampleName = name + "_sum")?.value
+  @Deprecated("Use summarySum extention method on CollectorRegistry instead")
+  fun histogramSum(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summarySum(name, *labels)
 
   /** Returns the average of all histogram samples taken. */
-  fun histogramMean(name: String, vararg labels: Pair<String, String>): Double? {
-    val sum = histogramSum(name, *labels) ?: return null
-    val count = histogramCount(name, *labels) ?: return null
-    return sum / count
-  }
+  @Deprecated("Use summaryMean extention method on CollectorRegistry instead")
+  fun histogramMean(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryMean(name, *labels)
 
   /**
    * Returns the median for a [histogram]. In small samples this is the element preceding
    * the middle element.
    */
-  fun histogramP50(name: String, vararg labels: Pair<String, String>): Double? =
-    histogramQuantile(name, "0.5", *labels)
+  @Deprecated("Use summaryP50 extention method on CollectorRegistry instead")
+  fun histogramP50(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryP50(name, *labels)
 
   /**
    * Returns the 0.99th percentile for a [histogram]. In small samples this is the second largest
    * element.
    */
-  fun histogramP99(name: String, vararg labels: Pair<String, String>): Double? =
-    histogramQuantile(name, "0.99", *labels)
+  @Deprecated("Use summaryP99 extention method on CollectorRegistry instead")
+  fun histogramP99(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryP99(name, *labels)
 
+  @Deprecated("Use summaryQuantile extention method on CollectorRegistry instead")
   fun histogramQuantile(
     name: String,
     quantile: String,
     vararg labels: Pair<String, String>
-  ): Double? {
-    val extraLabels = labels.toList() + ("quantile" to quantile)
-    return getSample(name, extraLabels.toTypedArray())?.value
-  }
+  ) = registry.summaryQuantile(name, quantile, *labels)
 
+  @Deprecated("Use same extention method on CollectorRegistry instead")
   fun getSample(
     name: String,
     labels: Array<out Pair<String, String>>,
     sampleName: String? = null
-  ): Sample? {
-    val metricFamilySamples = registry.metricFamilySamples()
-      .asSequence()
-      .firstOrNull {
-        it.name == name || (it.type == Collector.Type.COUNTER && "${it.name}_total" == name)
-      }
-      ?: return null
+  ) = registry.getSample(name, labels, sampleName)
 
-    val familySampleName = sampleName
-      ?: if (metricFamilySamples.type == Collector.Type.COUNTER && !name.endsWith("_total")) {
-        "${name}_total"
-      } else {
-        name
-      }
-
-    val labelNames = labels.map { it.first }
-    val labelValues = labels.map { it.second }
-
-    return metricFamilySamples.samples
-      .firstOrNull {
-        it.name == familySampleName && it.labelNames == labelNames && it.labelValues == labelValues
-      }
-  }
-
-  fun getAllSamples(): Sequence<Sample> =
-    registry.metricFamilySamples().asSequence().flatMap { it.samples }
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun getAllSamples(): Sequence<Sample> = registry.getAllSamples()
 }
+
+/** Returns a measurement for a [counter] or [gauge]. */
+fun CollectorRegistry.get(name: String, vararg labels: Pair<String, String>): Double? =
+  getSample(name, labels)?.value
+
+/** Returns the number of histogram samples taken. */
+fun CollectorRegistry.summaryCount(name: String, vararg labels: Pair<String, String>): Double? =
+  getSample(name, labels, sampleName = name + "_count")?.value
+
+/** Returns the sum of all histogram samples taken. */
+fun CollectorRegistry.summarySum(name: String, vararg labels: Pair<String, String>): Double? =
+  getSample(name, labels, sampleName = name + "_sum")?.value
+
+/** Returns the average of all histogram samples taken. */
+fun CollectorRegistry.summaryMean(name: String, vararg labels: Pair<String, String>): Double? {
+  val sum = summarySum(name, *labels) ?: return null
+  val count = summaryCount(name, *labels) ?: return null
+  return sum / count
+}
+
+/**
+ * Returns the median for a [histogram]. In small samples this is the element preceding
+ * the middle element.
+ */
+fun CollectorRegistry.summaryP50(name: String, vararg labels: Pair<String, String>): Double? =
+  summaryQuantile(name, "0.5", *labels)
+
+/**
+ * Returns the 0.99th percentile for a [histogram]. In small samples this is the second largest
+ * element.
+ */
+fun CollectorRegistry.summaryP99(name: String, vararg labels: Pair<String, String>): Double? =
+  summaryQuantile(name, "0.99", *labels)
+
+fun CollectorRegistry.summaryQuantile(
+  name: String,
+  quantile: String,
+  vararg labels: Pair<String, String>
+): Double? {
+  val extraLabels = labels.toList() + ("quantile" to quantile)
+  return getSample(name, extraLabels.toTypedArray())?.value
+}
+
+fun CollectorRegistry.getSample(
+  name: String,
+  labels: Array<out Pair<String, String>>,
+  sampleName: String? = null
+): Sample? {
+
+  val metricFamilySamples = this.metricFamilySamples()
+    .asSequence()
+    .firstOrNull {
+      it.name == name || (it.type == Collector.Type.COUNTER && "${it.name}_total" == name)
+    }
+    ?: return null
+
+  val familySampleName = sampleName
+    ?: if (metricFamilySamples.type == Collector.Type.COUNTER && !name.endsWith("_total")) {
+      "${name}_total"
+    } else {
+      name
+    }
+
+  val labelNames = labels.map { it.first }
+  val labelValues = labels.map { it.second }
+
+  return metricFamilySamples.samples
+    .firstOrNull {
+      it.name == familySampleName && it.labelNames == labelNames && it.labelValues == labelValues
+    }
+}
+
+fun CollectorRegistry.getAllSamples(): Sequence<Sample> =
+  this.metricFamilySamples().asSequence().flatMap { it.samples }

--- a/misk-metrics/src/testFixtures/kotlin/misk/metrics/v2/FakeMetrics.kt
+++ b/misk-metrics/src/testFixtures/kotlin/misk/metrics/v2/FakeMetrics.kt
@@ -1,6 +1,5 @@
 package misk.metrics.v2
 
-import io.prometheus.client.Collector
 import io.prometheus.client.Collector.MetricFamilySamples.Sample
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Counter
@@ -9,6 +8,15 @@ import io.prometheus.client.Histogram
 import io.prometheus.client.Summary
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.metrics.get
+import misk.metrics.getAllSamples
+import misk.metrics.getSample
+import misk.metrics.summaryCount
+import misk.metrics.summaryMean
+import misk.metrics.summaryP50
+import misk.metrics.summaryP99
+import misk.metrics.summaryQuantile
+import misk.metrics.summarySum
 
 /**
  * An in-memory metrics store with APIs to verify which metrics were collected.
@@ -97,75 +105,64 @@ class FakeMetrics @Inject internal constructor(
   }
 
   /** Returns a measurement for a [counter] or [gauge]. */
-  fun get(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels)?.value
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun get(name: String, vararg labels: Pair<String, String>): Double? = registry.get(name, *labels)
 
   /** Returns the number of histogram samples taken. */
-  fun summaryCount(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels, sampleName = name + "_count")?.value
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun summaryCount(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryCount(name, *labels)
 
   /** Returns the sum of all histogram samples taken. */
-  fun summarySum(name: String, vararg labels: Pair<String, String>): Double? =
-    getSample(name, labels, sampleName = name + "_sum")?.value
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun summarySum(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summarySum(name, *labels)
 
   /** Returns the average of all histogram samples taken. */
-  fun summaryMean(name: String, vararg labels: Pair<String, String>): Double? {
-    val sum = summarySum(name, *labels) ?: return null
-    val count = summaryCount(name, *labels) ?: return null
-    return sum / count
-  }
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun summaryMean(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryMean(name, *labels)
 
   /**
    * Returns the median for a [histogram]. In small samples this is the element preceding
    * the middle element.
    */
-  fun summaryP50(name: String, vararg labels: Pair<String, String>): Double? =
-    summaryQuantile(name, "0.5", *labels)
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun summaryP50(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryP50(name, *labels)
 
   /**
    * Returns the 0.99th percentile for a [histogram]. In small samples this is the second largest
    * element.
    */
-  fun summaryP99(name: String, vararg labels: Pair<String, String>): Double? =
-    summaryQuantile(name, "0.99", *labels)
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun summaryP99(
+    name: String,
+    vararg labels: Pair<String, String>
+  ): Double? = registry.summaryP99(name, *labels)
 
+  @Deprecated("Use same extention method on CollectorRegistry instead")
   fun summaryQuantile(
     name: String,
     quantile: String,
     vararg labels: Pair<String, String>
-  ): Double? {
-    val extraLabels = labels.toList() + ("quantile" to quantile)
-    return getSample(name, extraLabels.toTypedArray())?.value
-  }
+  ) = registry.summaryQuantile(name, quantile, *labels)
 
+  @Deprecated("Use same extention method on CollectorRegistry instead")
   fun getSample(
     name: String,
     labels: Array<out Pair<String, String>>,
     sampleName: String? = null
-  ): Sample? {
-    val metricFamilySamples = registry.metricFamilySamples()
-      .asSequence()
-      .firstOrNull {
-        it.name == name || (it.type == Collector.Type.COUNTER && "${it.name}_total" == name)
-      }
-      ?: return null
+  ) = registry.getSample(name, labels, sampleName)
 
-    val familySampleName = sampleName
-      ?: if (metricFamilySamples.type == Collector.Type.COUNTER && !name.endsWith("_total")) {
-        "${name}_total"
-      } else {
-        name
-      }
-
-    val labelNames = labels.map { it.first }
-    val labelValues = labels.map { it.second }
-
-    return metricFamilySamples.samples
-      .firstOrNull {
-        it.name == familySampleName && it.labelNames == labelNames && it.labelValues == labelValues
-      }
-  }
-
-  fun getAllSamples(): Sequence<Sample> =
-    registry.metricFamilySamples().asSequence().flatMap { it.samples }
+  @Deprecated("Use same extention method on CollectorRegistry instead")
+  fun getAllSamples(): Sequence<Sample> = registry.getAllSamples()
 }


### PR DESCRIPTION
By doing this, we no longer actually need FakeMetrics, nor FakeMetricsModule really. Instead we can use the real Metrics type. This doesn't mean that the testFixture FakeMetrics goes away entirely, instead it will hold the extension methods that are used to make testing easier.

As these are based around the prometheus CollectorRegistry, we will need to eventually port them to a micrometer backed registry as part of the migration. This will result in either new extension methods, or rewriting the uses of these ones into micrometer equivalents, as it tends to be more robust for testing purposes.