### PR TITLE
Services can stop gracefully even when a dependency has failed

### DIFF
--- a/misk-service/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk-service/src/main/kotlin/misk/CoordinatedService.kt
@@ -64,8 +64,8 @@ internal class CoordinatedService(
     }
   }
 
-  private fun isTerminated(): Boolean {
-    return state() == State.TERMINATED
+  private fun isTerminatedOrFailed(): Boolean {
+    return state() == State.TERMINATED || state() == State.FAILED
   }
 
   override fun doStart() {
@@ -90,7 +90,7 @@ internal class CoordinatedService(
 
   private fun stopIfReady() {
     val canStopInner =
-      state() == State.STOPPING && dependencies.all { it.isTerminated() }
+      state() == State.STOPPING && dependencies.all { it.isTerminatedOrFailed() }
 
     // stopAsync can be called multiple times, with subsequent calls being ignored
     if (canStopInner) {


### PR DESCRIPTION
When a service fails to start, misk starts orderly shutdown by calling `serviceManager.stopAsync()` in a jvm shutdown hook. However, all services that the failed service depend on cannot have a graceful shutdown because they are waiting eternally for it to have the state `State.TERMINATED`. This PR will fix the issue.