### PR TITLE
More corner cases for graceful shutdown on service failure

### DIFF
--- a/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -10,20 +10,18 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.test.assertFailsWith
 
 class CoordinatedServiceTest {
 
   @RepeatedTest(100) fun fuzzCoordinatedServiceGraphStartAndStop() {
-    fun service(id: String): Pair<Key<*>, Service> = key(id) to FakeService(id).toCoordinated()
-
     val services = List(10) { service("$it") }.shuffled()
 
     // Build randomized service graph and dependency chain
     val manager = ServiceGraphBuilder().also { builder ->
-      services.forEach { (key, service) ->
-        builder.addService(key, service)
-      }
+      services.forEach { builder.addService(it) }
       val randomKeys = services.shuffled().map { it.first }.toMutableList()
       val dependencies = mutableListOf<Key<*>>()
       while(randomKeys.isNotEmpty()) {
@@ -46,14 +44,23 @@ class CoordinatedServiceTest {
     assertThat(services).allMatch { (_, service) -> service.state() == Service.State.TERMINATED }
   }
 
-  @Test fun canStopWhenADependencyHasFailed() {
-    val service = FakeService("service").toCoordinated()
-    val failOnStartService = FailOnStartService().toCoordinated()
+  @Test fun canShutDownGracefullyOnStartFailure() {
+    class FailOnStartService : AbstractIdleService() {
+      override fun startUp() = error("failed to start")
+      override fun shutDown() {}
+    }
+
+    val canStartService = service("canStartService")
+    val neverStartedService = service("neverStartedService")
+    val failOnStartService =
+      key("failOnStartService") to FailOnStartService().toCoordinated()
 
     val manager = ServiceGraphBuilder().also { builder ->
-      builder.addService(key("service"), service)
-      builder.addService(key("failOnStartService"), failOnStartService)
-      builder.addDependency(key("failOnStartService"), key("service"))
+      builder.addService(canStartService)
+      builder.addService(failOnStartService)
+      builder.addService(neverStartedService)
+      builder.addDependency(failOnStartService.first, canStartService.first)
+      builder.addDependency(neverStartedService.first, failOnStartService.first)
     }.build()
 
     manager.startAsync()
@@ -62,10 +69,37 @@ class CoordinatedServiceTest {
     }.isInstanceOf(IllegalStateException::class.java)
 
     manager.stopAsync()
+    manager.awaitStopped(5, TimeUnit.SECONDS)
+
+    assertThat(canStartService.second.state()).isEqualTo(Service.State.TERMINATED)
+    assertThat(failOnStartService.second.state()).isEqualTo(Service.State.FAILED)
+    assertThat(neverStartedService.second.state()).isEqualTo(Service.State.TERMINATED)
+  }
+
+  @Test fun canShutDownGracefullyOnStopFailure() {
+    class FailOnStopService : AbstractIdleService() {
+      override fun startUp() {}
+      override fun shutDown() = error("failed to stop")
+    }
+
+    val service = service("service")
+    val failOnStopService =
+      key("failOnStopService") to FailOnStopService().toCoordinated()
+
+    val manager = ServiceGraphBuilder().also { builder ->
+      builder.addService(failOnStopService)
+      builder.addService(service)
+      builder.addDependency(failOnStopService.first, service.first)
+    }.build()
+
+    manager.startAsync()
+    manager.awaitHealthy()
+
+    manager.stopAsync()
     manager.awaitStopped()
 
-    assertThat(service.state()).isEqualTo(Service.State.TERMINATED)
-    assertThat(failOnStartService.state()).isEqualTo(Service.State.FAILED)
+    assertThat(service.second.state()).isEqualTo(Service.State.TERMINATED)
+    assertThat(failOnStopService.second.state()).isEqualTo(Service.State.FAILED)
   }
 
   @Test fun cannotAddRunningServiceAsDependency() {
@@ -106,20 +140,19 @@ class CoordinatedServiceTest {
     service.stopAsync()
   }
 
-  private class FailOnStartService : AbstractIdleService() {
-    override fun startUp() {
-      throw RuntimeException("Failed to start")
-    }
-
-    override fun shutDown() {}
-  }
-
   private class FakeService(
     val name: String
   ) : AbstractIdleService() {
     override fun startUp() {}
     override fun shutDown() {}
     override fun toString() = "FakeService-$name"
+  }
+
+  private fun service(id: String): Pair<Key<*>, CoordinatedService> =
+    key(id) to FakeService(id).toCoordinated()
+
+  private fun ServiceGraphBuilder.addService(pair: Pair<Key<*>, Service>) {
+    addService(pair.first, pair.second)
   }
 
   private fun Service.toCoordinated() = CoordinatedService(Provider { this })


### PR DESCRIPTION
I noticed this PR https://github.com/cashapp/misk/pull/2961 missed a few corner cases:

1. All services depending on the fail-to-start service are stuck on shutdown. This is because the outer services (i.e., `CoordinatedService`) are in `STARTING` state, so Guava will call `doCancelStart()` instead of `doStop()` ([proof](https://github.com/google/guava/blob/5a0af313bb89e72419aec20aa232e73d95356cb3/guava/src/com/google/common/util/concurrent/AbstractService.java#L280C19-L280C19)). 
2. If a service fails to stop, all services it depends on may stuck on shutdown. This is because the service doesn't call `directDependsOn.forEach { it.stopIfReady() }` when it fails.