### PR TITLE
Stop jetty last when shutdown_sleep_ms is set to greater than 0

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1604,7 +1604,11 @@ public final class misk/web/actions/InternalErrorAction : misk/web/actions/WebAc
 }
 
 public final class misk/web/actions/LivenessCheckAction : misk/web/actions/WebAction {
+	public static final field Companion Lmisk/web/actions/LivenessCheckAction$Companion;
 	public final fun livenessCheck ()Lmisk/web/Response;
+}
+
+public final class misk/web/actions/LivenessCheckAction$Companion {
 }
 
 public final class misk/web/actions/NotFoundAction : misk/web/actions/WebAction {
@@ -1617,7 +1621,11 @@ public final class misk/web/actions/NotFoundAction$Companion {
 }
 
 public final class misk/web/actions/ReadinessCheckAction : misk/web/actions/WebAction {
+	public static final field Companion Lmisk/web/actions/ReadinessCheckAction$Companion;
 	public final fun readinessCheck ()Lmisk/web/Response;
+}
+
+public final class misk/web/actions/ReadinessCheckAction$Companion {
 }
 
 public final class misk/web/actions/StatusAction : misk/web/actions/WebAction {
@@ -1914,9 +1922,13 @@ public final class misk/web/interceptors/WideOpenDevelopmentInterceptorFactory :
 }
 
 public final class misk/web/jetty/JettyService : com/google/common/util/concurrent/AbstractIdleService {
+	public static final field Companion Lmisk/web/jetty/JettyService$Companion;
 	public final fun getHealthServerUrl ()Lokhttp3/HttpUrl;
 	public final fun getHttpServerUrl ()Lokhttp3/HttpUrl;
 	public final fun getHttpsServerUrl ()Lokhttp3/HttpUrl;
+}
+
+public final class misk/web/jetty/JettyService$Companion {
 }
 
 public final class misk/web/jetty/MeasuredQueuedThreadPool : misk/web/jetty/MeasuredThreadPool {

--- a/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/LivenessCheckAction.kt
@@ -2,6 +2,9 @@ package misk.web.actions
 
 import com.google.common.util.concurrent.Service.State
 import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Provider
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.security.authz.Unauthenticated
 import misk.web.AvailableWhenDegraded
 import misk.web.Get
@@ -9,15 +12,10 @@ import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 import wisp.logging.getLogger
-import jakarta.inject.Inject
-import com.google.inject.Provider
-import jakarta.inject.Singleton
-
-private val logger = getLogger<LivenessCheckAction>()
 
 @Singleton
 class LivenessCheckAction @Inject internal constructor(
-  private val serviceManagerProvider: Provider<ServiceManager>
+  private val serviceManagerProvider: Provider<ServiceManager>,
 ) : WebAction {
 
   @Get("/_liveness")
@@ -34,8 +32,15 @@ class LivenessCheckAction @Inject internal constructor(
     }
 
     for (service in failedServices) {
-      logger.info("Service failed: $service")
+      // Only log failed services.
+      if (service.state() == State.FAILED) {
+        logger.info("Service failed: $service")
+      }
     }
     return Response("", statusCode = 503)
+  }
+
+  companion object {
+    private val logger = getLogger<LivenessCheckAction>()
   }
 }

--- a/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
+++ b/misk/src/main/kotlin/misk/web/actions/ReadinessCheckAction.kt
@@ -1,6 +1,10 @@
 package misk.web.actions
 
+import com.google.common.util.concurrent.Service.State
 import com.google.common.util.concurrent.ServiceManager
+import com.google.inject.Provider
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.healthchecks.HealthCheck
 import misk.security.authz.Unauthenticated
 import misk.web.AvailableWhenDegraded
@@ -9,32 +13,30 @@ import misk.web.Response
 import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 import wisp.logging.getLogger
-import jakarta.inject.Inject
-import com.google.inject.Provider
-import jakarta.inject.Singleton
-
-private val logger = getLogger<ReadinessCheckAction>()
 
 @Singleton
 class ReadinessCheckAction @Inject internal constructor(
   private val serviceManagerProvider: Provider<ServiceManager>,
-  @JvmSuppressWildcards private val healthChecks: List<HealthCheck>
+  private val healthChecks: List<HealthCheck>,
 ) : WebAction {
-
   @Get("/_readiness")
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
   @Unauthenticated
   @AvailableWhenDegraded
   fun readinessCheck(): Response<String> {
-    val servicesNotRunning = serviceManagerProvider.get().servicesByState().values().asList()
-      .filterNot { it.isRunning }
-
-    for (service in servicesNotRunning) {
-      logger.info("Service not running: $service")
+    val servicesNotRunning = serviceManagerProvider.get().servicesByState().values().filterNot {
+      it.isRunning
     }
 
-    if (!servicesNotRunning.isEmpty()) {
-      // Don't do healthchecks if services haven't all started. The app isn't in a good state yet,
+    for (service in servicesNotRunning) {
+      // Only log failed services.
+      if (service.state() == State.TERMINATED) {
+        logger.info("Service not running: $service")
+      }
+    }
+
+    if (servicesNotRunning.isNotEmpty()) {
+      // Don't do health checks if services haven't all started. The app isn't in a good state yet,
       // and a health check could end up triggering random errors that we don't want to flood the
       // logs with.
       return Response("", statusCode = 503)
@@ -52,5 +54,9 @@ class ReadinessCheckAction @Inject internal constructor(
       logger.info("Failed health check: ${healthCheck.messages}")
     }
     return Response("", statusCode = 503)
+  }
+
+  companion object {
+    private val logger = getLogger<ReadinessCheckAction>()
   }
 }


### PR DESCRIPTION
This commit, combined with a previous removal of a jetty shutdown hook, means that shutdown_sleep_ms will sleep for N ms to allow requests to drain.

The shutdown process with shutdown_sleep_ms=30000 will be:
1. Services that are upstream of jetty shutdown
2. Jetty is told to shutdown -- We sleep for 30 seconds
3. Jetty dependencies shutdown
4. Jetty itself shutsdown (for real this time)

The 30 second sleep gives us time to drain the requests that are inflight, and keeping jetty alive means that our istio sidecar remains open allowing outbound requests to suceed until the end.