### PR TITLE
[DONT MERGE] Trying revapi on the recent breaking misk-metrics change

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,2 @@
+versionOverrides:
+  com.squareup.misk:misk-metrics:misk-0.18.0: "2023.10.10.000002-b1ed23e"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ buildscript {
     classpath(Dependencies.protobufGradlePlugin)
     classpath(Dependencies.jgit)
     classpath(Dependencies.wireGradlePlugin)
+    classpath("com.palantir.gradle.revapi:gradle-revapi:1.7.0")
   }
 }
 

--- a/misk-metrics/api/misk-metrics.api
+++ b/misk-metrics/api/misk-metrics.api
@@ -1,19 +1,14 @@
 public final class misk/metrics/FakeMetrics : misk/metrics/Metrics {
-	public fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
-	public fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
 	public final fun get (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun getAllSamples ()Lkotlin/sequences/Sequence;
-	public fun getMetrics ()Lmisk/metrics/v2/Metrics;
 	public final fun getSample (Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
 	public static synthetic fun getSample$default (Lmisk/metrics/FakeMetrics;Ljava/lang/String;[Lkotlin/Pair;Ljava/lang/String;ILjava/lang/Object;)Lio/prometheus/client/Collector$MetricFamilySamples$Sample;
-	public fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
 	public final fun histogramCount (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramMean (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramP50 (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramP99 (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramQuantile (Ljava/lang/String;Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
 	public final fun histogramSum (Ljava/lang/String;[Lkotlin/Pair;)Ljava/lang/Double;
-	public fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
 }
 
 public final class misk/metrics/FakeMetricsKt {
@@ -65,28 +60,33 @@ public final class misk/metrics/HistogramRegistry$DefaultImpls {
 	public static fun newHistogram (Lmisk/metrics/HistogramRegistry;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lmisk/metrics/Histogram;
 }
 
-public abstract interface class misk/metrics/Metrics {
+public class misk/metrics/Metrics {
 	public static final field Companion Lmisk/metrics/Metrics$Companion;
-	public abstract fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
-	public abstract fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
-	public abstract fun getMetrics ()Lmisk/metrics/v2/Metrics;
-	public abstract fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
-	public abstract fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
+	public fun <init> (Lmisk/metrics/v2/Metrics;)V
+	public final fun counter (Ljava/lang/String;Ljava/lang/String;)Lio/prometheus/client/Counter;
+	public final fun counter (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
+	public static synthetic fun counter$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Counter;
+	public final fun gauge (Ljava/lang/String;)Lio/prometheus/client/Gauge;
+	public final fun gauge (Ljava/lang/String;Ljava/lang/String;)Lio/prometheus/client/Gauge;
+	public final fun gauge (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
+	public static synthetic fun gauge$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Gauge;
+	public final fun getMetrics ()Lmisk/metrics/v2/Metrics;
+	public final fun histogram (Ljava/lang/String;)Lmisk/metrics/Histogram;
+	public final fun histogram (Ljava/lang/String;Ljava/lang/String;)Lmisk/metrics/Histogram;
+	public final fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lmisk/metrics/Histogram;
+	public final fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lmisk/metrics/Histogram;
+	public final fun histogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
+	public static synthetic fun histogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/Histogram;
+	public final fun legacyHistogram (Ljava/lang/String;)Lmisk/metrics/Histogram;
+	public final fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;)Lmisk/metrics/Histogram;
+	public final fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lmisk/metrics/Histogram;
+	public final fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lmisk/metrics/Histogram;
+	public final fun legacyHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
+	public static synthetic fun legacyHistogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/Histogram;
 }
 
 public final class misk/metrics/Metrics$Companion {
 	public final fun factory (Lmisk/metrics/v2/Metrics;)Lmisk/metrics/Metrics;
-}
-
-public final class misk/metrics/Metrics$DefaultImpls {
-	public static fun counter (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Counter;
-	public static synthetic fun counter$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Counter;
-	public static fun gauge (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/prometheus/client/Gauge;
-	public static synthetic fun gauge$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/prometheus/client/Gauge;
-	public static fun histogram (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
-	public static synthetic fun histogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/Histogram;
-	public static fun legacyHistogram (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;)Lmisk/metrics/Histogram;
-	public static synthetic fun legacyHistogram$default (Lmisk/metrics/Metrics;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/metrics/Histogram;
 }
 
 public final class misk/metrics/MetricsKt {

--- a/misk-metrics/build.gradle.kts
+++ b/misk-metrics/build.gradle.kts
@@ -7,12 +7,13 @@ plugins {
   `java-library`
   id("com.vanniktech.maven.publish.base")
   `java-test-fixtures`
+  id("com.palantir.revapi")
 }
 
 dependencies {
   api(project(":misk-inject"))
   api(Dependencies.prometheusClient)
-  implementation(Dependencies.jakartaInject)
+  api(Dependencies.jakartaInject)
   implementation(Dependencies.findBugs)
   implementation(Dependencies.guava)
   implementation(Dependencies.guice)

--- a/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt
@@ -1,6 +1,8 @@
 package misk.metrics
 
 import misk.metrics.v2.Metrics
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 
 /**
  * Interface for application code to emit metrics to a metrics backend like Prometheus.
@@ -13,8 +15,11 @@ import misk.metrics.v2.Metrics
   replaceWith = ReplaceWith("misk.metrics.v2.Metrics"),
   level = DeprecationLevel.WARNING
 )
-interface Metrics {
-  fun getMetrics(): Metrics
+@Singleton
+open class Metrics @Inject constructor(
+  private val metricsV2: Metrics
+) {
+  fun getMetrics(): Metrics = metricsV2
 
   /**
    * counter creates and registers a new `Counter` prometheus type.
@@ -30,6 +35,7 @@ interface Metrics {
     message = "Misk Metrics V1 is Deprecated, please use V2",
     level = DeprecationLevel.WARNING
   )
+  @JvmOverloads
   fun counter(
     name: String,
     help: String,
@@ -50,6 +56,7 @@ interface Metrics {
     message = "Misk Metrics V1 is Deprecated, please use V2",
     level = DeprecationLevel.WARNING
   )
+  @JvmOverloads
   fun gauge(
     name: String,
     help: String = "",
@@ -83,6 +90,7 @@ interface Metrics {
     level = DeprecationLevel.WARNING,
     replaceWith = ReplaceWith("legacyHistogram(name,help,labelNames,quantiles,maxAgeSeconds)")
   )
+  @JvmOverloads
   fun histogram(
     name: String,
     help: String = "",
@@ -117,6 +125,7 @@ interface Metrics {
     message = "Recommend migrating to misk.metrics.v2.Metrics.histogram. See kdoc for detail",
     level = DeprecationLevel.WARNING
   )
+  @JvmOverloads
   fun legacyHistogram(
     name: String,
     help: String = "",
@@ -126,10 +135,7 @@ interface Metrics {
   ) = getMetrics().legacyHistogram(name, help, labelNames, quantiles, maxAgeSeconds)
 
   companion object {
-    fun factory(metrics: Metrics) = object : misk.metrics.Metrics {
-      override fun getMetrics() = metrics
-
-    }
+    fun factory(metrics: Metrics) = Metrics(metrics)
   }
 }
 

--- a/misk-metrics/src/testFixtures/kotlin/misk/metrics/FakeMetrics.kt
+++ b/misk-metrics/src/testFixtures/kotlin/misk/metrics/FakeMetrics.kt
@@ -16,56 +16,9 @@ import jakarta.inject.Singleton
   level = DeprecationLevel.WARNING
 )
 @Singleton
-class FakeMetrics @Inject internal constructor(private val registry: CollectorRegistry) : Metrics {
-
-  private val v2Metrics = misk.metrics.v2.Metrics.factory(registry)
-
-  override fun getMetrics() = v2Metrics
-
-  @Deprecated(
-    message = "Misk Metrics V1 is Deprecated, please use V2",
-    level = DeprecationLevel.WARNING
-  )
-  override fun counter(name: String, help: String, labelNames: List<String>) = super.counter(
-    name,
-    help,
-    labelNames
-  )
-
-  @Deprecated(
-    message = "Misk Metrics V1 is Deprecated, please use V2",
-    level = DeprecationLevel.WARNING
-  )
-  override fun gauge(name: String, help: String, labelNames: List<String>) = super.gauge(
-    name,
-    help,
-    labelNames
-  )
-
-  @Deprecated(
-    message = "Recommend migrating to misk.metrics.v2.Metrics.histogram. See kdoc for detail",
-    level = DeprecationLevel.WARNING
-  )
-  override fun legacyHistogram(
-    name: String,
-    help: String,
-    labelNames: List<String>,
-    quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
-  ) = super.legacyHistogram(name, help, labelNames, quantiles, maxAgeSeconds)
-
-  @Deprecated(
-    message = "Recommend migrating to misk.metrics.v2.Metrics.histogram. See kdoc for detail",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith("legacyHistogram(name,help,labelNames,quantiles,maxAgeSeconds)")
-  )
-  override fun histogram(
-    name: String,
-    help: String,
-    labelNames: List<String>,
-    quantiles: Map<Double, Double>,
-    maxAgeSeconds: Long?
-  ) = super.histogram(name, help, labelNames, quantiles, maxAgeSeconds)
+class FakeMetrics @Inject internal constructor(private val registry: CollectorRegistry) : Metrics(
+  misk.metrics.v2.Metrics.factory(registry)
+) {
 
   /** Returns a measurement for a [counter] or [gauge]. */
   @Deprecated("Use same extention method on CollectorRegistry instead")

--- a/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
+++ b/misk-prometheus/src/main/kotlin/misk/metrics/backends/prometheus/PrometheusMetrics.kt
@@ -17,7 +17,7 @@ import jakarta.inject.Singleton
 @Singleton
 internal class PrometheusMetrics @Inject internal constructor(
   private val metricsV2: MetricsV2
-) : Metrics {
+) : Metrics(metricsV2) {
   companion object {
     /**
      * @return a version of the name, sanitized to remove elements that are incompatible
@@ -25,6 +25,4 @@ internal class PrometheusMetrics @Inject internal constructor(
      */
     fun sanitize(name: String) = name.replace("[\\-\\.\t]", "_")
   }
-
-  override fun getMetrics() = metricsV2
 }


### PR DESCRIPTION
```
$ gradle revapi

> Task :misk-metrics:revapi FAILED

...
> There were Java public API/ABI breaks reported by revapi:

  java.class.kindChanged: Class kind changed from 'interface' to 'class'.

  old: interface misk.metrics.Metrics
  new: class misk.metrics.Metrics

  SOURCE: BREAKING, BINARY: BREAKING
```