### PR TITLE
Better error messages for MiskConfig lists

### DIFF
--- a/misk-config/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk-config/src/main/kotlin/misk/config/MiskConfig.kt
@@ -124,7 +124,7 @@ object MiskConfig {
       @Suppress("UNCHECKED_CAST")
       return mapper.readValue(jsonNode.toString(), configClass) as T
     } catch (e: UnrecognizedPropertyException) {
-      val path = Joiner.on('.').join(e.path.map { it.fieldName })
+      val path = Joiner.on('.').join(e.path.map { it.fieldName ?: it.index })
       logger.warn(e) {
         "$configFile: '$path' not found in '${configClass.simpleName}', ignoring " +
           suggestSpelling(e)
@@ -157,7 +157,7 @@ object MiskConfig {
     configFile: String,
     jsonNode: JsonNode
   ): Nothing {
-    val path = Joiner.on('.').join(e.path.map { it.fieldName })
+    val path = Joiner.on('.').join(e.path.map { it.fieldName ?: it.index })
     throw IllegalStateException(
       "could not find '${path}' of '${configClass.simpleName}'" +
         " in $configFile or in any of the combined logical config " +

--- a/misk-config/src/test/kotlin/misk/config/MiskConfigTest.kt
+++ b/misk-config/src/test/kotlin/misk/config/MiskConfigTest.kt
@@ -97,6 +97,17 @@ class MiskConfigTest {
   }
 
   @Test
+  fun friendErrorMessageWhenConfigPropertyMissingInList() {
+    val exception = assertFailsWith<IllegalStateException> {
+      MiskConfig.load<TestConfig>("missing_property_in_list", TESTING)
+    }
+
+    assertThat(exception).hasMessageContaining(
+      "could not find 'collection.0.name' of 'TestConfig' in missing_property_in_list-testing.yaml"
+    )
+  }
+
+  @Test
   fun friendlyErrorMessagesWhenFileUnparseable() {
     val exception = assertFailsWith<IllegalStateException> {
       MiskConfig.load<TestConfig>("unparsable", TESTING)
@@ -115,6 +126,15 @@ class MiskConfigTest {
     assertThat(logCollector.takeMessages(MiskConfig::class))
       .hasSize(1)
       .allMatch { it.contains("'consumer_b.blue_items' not found") }
+  }
+
+  @Test
+  fun friendLogsWhenConfigPropertyNotFoundInList() {
+    MiskConfig.load<TestConfig>("unknownproperty_in_list", TESTING)
+
+    assertThat(logCollector.takeMessages(MiskConfig::class))
+      .hasSize(1)
+      .allMatch { it.contains("'collection.0.power_level' not found") }
   }
 
   @Test

--- a/misk-config/src/test/kotlin/misk/config/TestConfig.kt
+++ b/misk-config/src/test/kotlin/misk/config/TestConfig.kt
@@ -11,11 +11,14 @@ data class TestConfig(
   val consumer_b: ConsumerConfig,
   val duration: DurationConfig,
   val nested: NestedConfig,
+  val collection: List<CollectionItem>,
   val action_exception_log_level: ActionExceptionLogLevelConfig
 ) : Config
 
 data class ConsumerConfig(val min_items: Int = 0, val max_items: Int) : Config
 data class DurationConfig(val interval: Duration) : Config
+
+data class CollectionItem(val name: String, val optional: Int?) : Config
 
 data class NestedConfig(val child_nested: ChildNestedConfig) : Config
 data class ChildNestedConfig(val nested_value: String) : Config

--- a/misk-config/src/test/resources/missing_property_in_list-common.yaml
+++ b/misk-config/src/test/resources/missing_property_in_list-common.yaml
@@ -8,8 +8,6 @@ consumer_a:
 consumer_b:
   min_items: 1
   max_items: 2
-  # min_and_max exist, but blue_items is deliberately unknown!
-  blue_items: 3
 
 duration:
   interval: "PT1S"
@@ -21,5 +19,6 @@ nested:
   child_nested:
     nested_value: nested value
 
+# a collection that is intentionally missing the required `name` element for one of its items
 collection:
-  - name: "Hello"
+  - optional: 100

--- a/misk-config/src/test/resources/test_app-common.yaml
+++ b/misk-config/src/test/resources/test_app-common.yaml
@@ -18,3 +18,8 @@ action_exception_log_level:
 nested:
   child_nested:
     nested_value: nested value
+
+collection:
+  - name: "First Item"
+  - name: "Second Item"
+    optional: 100

--- a/misk-config/src/test/resources/unknownproperty_in_list-common.yaml
+++ b/misk-config/src/test/resources/unknownproperty_in_list-common.yaml
@@ -8,8 +8,6 @@ consumer_a:
 consumer_b:
   min_items: 1
   max_items: 2
-  # min_and_max exist, but blue_items is deliberately unknown!
-  blue_items: 3
 
 duration:
   interval: "PT1S"
@@ -23,3 +21,5 @@ nested:
 
 collection:
   - name: "Hello"
+    # name exists, but power_level is deliberately unknown!
+    power_level: "Yep"


### PR DESCRIPTION
Currently if a field is missing/unrecognised within a misk config list Misk will fail with a `NullPointerException`.

This happens because we are using the JSON `fieldName` to construct the path to the offending node, but list items do not have a `fieldName` (instead they have an `index`).

This PR fixes this issue such, list entries are now identified with index and will have errors like:

- "'collection.0.power_level' not found"
- "could not find 'collection.0.name' of 'TestConfig' in missing_property_in_list-testing.yaml"