### PR TITLE
Duplicate MiskMetricsModules should be identical

### DIFF
--- a/misk-metrics/src/main/kotlin/misk/metrics/MetricsModule.kt
+++ b/misk-metrics/src/main/kotlin/misk/metrics/MetricsModule.kt
@@ -9,7 +9,9 @@ import misk.inject.asSingleton
 class MetricsModule : KAbstractModule() {
   override fun configure() {
     bind<CollectorRegistry>().toProvider(CollectorRegistryProvider::class.java).asSingleton()
-
+    bind<HistogramRegistry>().toProvider(HistogramRegistryProvider::class.java).asSingleton()
+    bind<Metrics>().toProvider(MetricsProvider::class.java).asSingleton()
+    bind<misk.metrics.v2.Metrics>().toProvider(V2MetricsProvider::class.java).asSingleton()
   }
 
   /**
@@ -19,6 +21,22 @@ class MetricsModule : KAbstractModule() {
   internal class CollectorRegistryProvider @Inject constructor() : Provider<CollectorRegistry> {
     override fun get(): CollectorRegistry {
       return CollectorRegistry()
+    }
+  }
+
+  internal class HistogramRegistryProvider @Inject constructor(private val metrics: Metrics) : Provider<HistogramRegistry> {
+    override fun get(): HistogramRegistry {
+      return HistogramRegistry.factory(metrics)
+    }
+  }
+  internal class MetricsProvider @Inject constructor(private val v2Metrics: misk.metrics.v2.Metrics) : Provider<Metrics> {
+    override fun get(): Metrics {
+      return Metrics.factory(v2Metrics)
+    }
+  }
+  internal class V2MetricsProvider @Inject constructor(private val registry: CollectorRegistry) : Provider<misk.metrics.v2.Metrics> {
+    override fun get(): misk.metrics.v2.Metrics {
+      return misk.metrics.v2.Metrics.factory(registry)
     }
   }
 }


### PR DESCRIPTION
This was supposed to be the same as the prometheus one, such that I could safely delete the prometheus project at a later date.