### PR TITLE
Add revapi for binary compatibility checks on CI

### DIFF
--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -30,6 +30,22 @@ jobs:
       - name: API Check
         run: gradle apiCheck
 
+  breakingChangeDetection:
+    name: ABI Breaking Change Detection
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Hermit
+        run: ./bin/hermit env -r >> $GITHUB_ENV
+
+      - name: ABI Check
+        run: gradle revapi
+
   dependencyAnalysis:
     name: Dependency Analysis
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ buildscript {
     classpath(Dependencies.protobufGradlePlugin)
     classpath(Dependencies.jgit)
     classpath(Dependencies.wireGradlePlugin)
+    classpath(Dependencies.revapiGradlePlugin)
   }
 }
 
@@ -122,6 +123,8 @@ subprojects {
           "exemplarchat",
           "misk-bom"
       ).contains(name)) {
+    apply(plugin = "com.palantir.revapi")
+
     extensions.configure(DetektExtension::class) {
       parallel = true
       buildUponDefaultConfig = false
@@ -232,12 +235,7 @@ subprojects {
 
       // Disable the default `detekt` task and enable `detektMain` which has type resolution enabled
       dependsOn(dependsOn.filterNot { name != "detekt" })
-      if (!listOf(
-              "detektive",
-              "exemplar",
-              "exemplarchat",
-              "misk-bom"
-          ).contains(project.name)) {
+      if (tasks.findByName("detektMain") != null) {
         dependsOn("detektMain")
       }
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -165,6 +165,7 @@ object Dependencies {
   val retrofitProtobuf = "com.squareup.retrofit2:converter-protobuf:2.9.0"
   val retrofitScalars = "com.squareup.retrofit2:converter-scalars:2.9.0"
   val retrofitWire = "com.squareup.retrofit2:converter-wire:2.9.0"
+  val revapiGradlePlugin = "com.palantir.gradle.revapi:gradle-revapi:1.7.0"
   val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
   val slf4jApi = "org.slf4j:slf4j-api:2.0.7"
   val tempest2Testing = "app.cash.tempest:tempest2-testing"


### PR DESCRIPTION
Refer to this PR for the errors revapi fails with for breaking changes:
https://github.com/cashapp/misk/pull/2967

**Out of Scope: Running this task locally**
 
This won't run on local builds at the moment. I'm not quiet sure what gradle task folks run locally, I usually run `check`. The build is currently set up in a way which [makes](https://github.com/cashapp/misk/blob/a64f303d375336e23cf0de40d9759c0300f26618/build.gradle.kts#L217-L231) the CI test tasks depend on `check`, so making `check` depend on `revapi` means revapi would also run as part of each test step on CI, which is not idea.

I'll start some follow up conversation on this topic on slack.