### PR TITLE
Add runBlocking method to actionScope

### DIFF
--- a/misk-action-scopes/api/misk-action-scopes.api
+++ b/misk-action-scopes/api/misk-action-scopes.api
@@ -24,6 +24,8 @@ public final class misk/scope/ActionScope : java/lang/AutoCloseable {
 	public final fun propagate (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Callable;
 	public final fun propagate (Lkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
 	public final fun propagate (Lkotlin/reflect/KFunction;)Lkotlin/reflect/KFunction;
+	public final fun runBlocking (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public final fun runBlocking (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public final fun snapshotActionScope ()Ljava/util/Map;
 }
 

--- a/misk-action-scopes/src/test/kotlin/misk/scope/coroutine/ActionScopedCoroutineTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/coroutine/ActionScopedCoroutineTest.kt
@@ -1,0 +1,98 @@
+package misk.scope.coroutine;
+
+import com.google.inject.Guice
+import com.google.inject.Key
+import com.google.inject.name.Named
+import com.google.inject.name.Names
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import misk.inject.getInstance
+import misk.inject.keyOf
+import misk.scope.ActionScope
+import misk.scope.ActionScoped
+import misk.scope.TestActionScopedProviderModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ActionScopedCoroutineTest {
+  class Tester {
+    @Inject
+    @Named("foo") lateinit var foo: ActionScoped<String>
+
+    fun fooValue() = foo.get()
+  }
+
+  @Test
+  fun propagatesIfInScope() {
+    val injector = Guice.createInjector(
+      TestActionScopedProviderModule(),
+    )
+
+    val tester = injector.getInstance<Tester>()
+    val scope = injector.getInstance(ActionScope::class.java)
+
+    val seedData: Map<Key<*>, Any> = mapOf(
+      keyOf<String>(Names.named("from-seed")) to "my seed data"
+    )
+
+    val value = scope.enter(seedData).use {
+      scope.runBlocking {
+        tester.fooValue()
+      }
+    }
+
+    assertThat(value).isEqualTo("my seed data and bar and foo!")
+  }
+
+  @Test
+  fun propagatesOnOtherDispatcher() {
+    val injector = Guice.createInjector(
+      TestActionScopedProviderModule(),
+    )
+
+    val tester = injector.getInstance<Tester>()
+    val scope = injector.getInstance(ActionScope::class.java)
+
+    val seedData: Map<Key<*>, Any> = mapOf(
+      keyOf<String>(Names.named("from-seed")) to "my seed data"
+    )
+
+    val value = scope.enter(seedData).use {
+      scope.runBlocking(Dispatchers.IO) {
+        tester.fooValue()
+      }
+    }
+
+    assertThat(value).isEqualTo("my seed data and bar and foo!")
+  }
+
+  @Test
+  fun doesNotPropagateOutsideOfScope() {
+    val injector = Guice.createInjector(
+      TestActionScopedProviderModule(),
+    )
+
+    val scope = injector.getInstance(ActionScope::class.java)
+
+    val inScope = scope.runBlocking {
+      scope.inScope()
+    }
+
+    assertThat(inScope).isFalse()
+  }
+
+  @Test
+  fun doesNotPropagateOutsideOfScopeOnOtherDispatcher() {
+    val injector = Guice.createInjector(
+      TestActionScopedProviderModule(),
+    )
+
+    val scope = injector.getInstance(ActionScope::class.java)
+
+    val inScope = scope.runBlocking(Dispatchers.IO) {
+      scope.inScope()
+    }
+
+    assertThat(inScope).isFalse()
+  }
+}


### PR DESCRIPTION
In misk people frequently invoke `runBlocking` without passing the approriate
actionScope context to propagate the scope. This results in difficult to diagnose
bugs.

Adding this small utility that should just do the right thing, inside or outside
of a current scope.
