### PR TITLE
Add wrappers for zadd and zscore methods for redis sorted set

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -87,3 +87,15 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "class misk.metrics.MetricsModule"
       justification: "These classes are not referenced anywhere in cash"
+    com.squareup.misk:misk-redis:
+    - code: "java.method.addedToInterface"
+      new: "method java.lang.Double misk.redis.Redis::zscore(java.lang.String, java.lang.String)"
+      justification: "adding wrappers to support zadd, zscore"
+    - code: "java.method.addedToInterface"
+      new: "method long misk.redis.Redis::zadd(java.lang.String, double, okio.ByteString,\
+        \ java.util.Set<java.lang.String>)"
+      justification: "adding wrappers to support zadd, zscore"
+    - code: "java.method.addedToInterface"
+      new: "method long misk.redis.Redis::zadd(java.lang.String, java.util.Map<okio.ByteString,\
+        \ java.lang.Double>, java.util.Set<java.lang.String>)"
+      justification: "adding wrappers to support zadd, zscore"

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -50,6 +50,9 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLokio/ByteString;Ljava/util/Set;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
 public abstract interface annotation class misk/redis/ForFakeRedis : java/lang/annotation/Annotation {
@@ -102,9 +105,22 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLokio/ByteString;Ljava/util/Set;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
 public final class misk/redis/RealRedis$Companion {
+}
+
+public final class misk/redis/RealRedis$ZAddOptions : java/lang/Enum {
+	public static final field CH Lmisk/redis/RealRedis$ZAddOptions;
+	public static final field GT Lmisk/redis/RealRedis$ZAddOptions;
+	public static final field LT Lmisk/redis/RealRedis$ZAddOptions;
+	public static final field NX Lmisk/redis/RealRedis$ZAddOptions;
+	public static final field XX Lmisk/redis/RealRedis$ZAddOptions;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/RealRedis$ZAddOptions;
+	public static fun values ()[Lmisk/redis/RealRedis$ZAddOptions;
 }
 
 public abstract interface class misk/redis/Redis {
@@ -152,6 +168,14 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public abstract fun unwatch ([Ljava/lang/String;)V
 	public abstract fun watch ([Ljava/lang/String;)V
+	public abstract fun zadd (Ljava/lang/String;DLokio/ByteString;Ljava/util/Set;)J
+	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;)J
+	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
+}
+
+public final class misk/redis/Redis$DefaultImpls {
+	public static synthetic fun zadd$default (Lmisk/redis/Redis;Ljava/lang/String;DLokio/ByteString;Ljava/util/Set;ILjava/lang/Object;)J
+	public static synthetic fun zadd$default (Lmisk/redis/Redis;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;ILjava/lang/Object;)J
 }
 
 public final class misk/redis/RedisClientMetrics {
@@ -307,6 +331,14 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLokio/ByteString;Ljava/util/Set;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
+}
+
+public final class misk/redis/testing/FakeRedisKt {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
 }
 
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -336,11 +336,6 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
-public final class misk/redis/testing/FakeRedisKt {
-	public static final fun main ()V
-	public static synthetic fun main ([Ljava/lang/String;)V
-}
-
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {
 }
 

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -11,6 +11,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import jakarta.inject.Inject
+import java.util.SortedMap
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
@@ -33,6 +34,9 @@ class FakeRedis : Redis {
   /** A nested hash map for hash operations. */
   private val hKeyValueStore =
     ConcurrentHashMap<String, Value<ConcurrentHashMap<String, ByteString>>>()
+
+  private val sortedSetKeyValueStore =
+    ConcurrentHashMap<String, Value<SortedMap<ByteString, Double>>>()
 
   /** A hash map for list operations. */
   private val lKeyValueStore = ConcurrentHashMap<String, Value<List<ByteString>>>()
@@ -396,6 +400,27 @@ class FakeRedis : Redis {
   }
 
   override fun publish(channel: String, message: String) {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: ByteString,
+    options: Set<String>
+  ): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<ByteString, Double>,
+    options: Set<String>,
+  ): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zscore(key: String, member: String): Double? {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -450,7 +450,88 @@ interface Redis {
    * Publish a message to a channel.
    */
   fun publish(channel: String, message: String)
+
+  /**
+   * Adds the specified [member] with the specified [score] to the sorted set at the [key].
+   * If a specified [member] is already a member of the sorted set, the [score] is updated and the
+   * element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. Options are:
+   *
+   * XX: Only update elements that already exist. Don't add new elements.
+   *
+   * NX: Only add new elements. Don't update already existing elements.
+   *
+   * LT: Only update existing elements if the new score is less than the current score.
+   *     This flag doesn't prevent adding new elements.
+   *
+   * GT: Only update existing elements if the new score is greater than the current score.
+   *     This flag doesn't prevent adding new elements.
+   *
+   * CH: Modify the return value from the number of new elements added, to the total number of
+   *     elements changed (CH is an abbreviation of changed). Changed elements are new elements
+   *     added and elements already existing for which the score was updated. So elements specified
+   *     in the command line having the same score as they had in the past are not counted.
+   *     Note: normally the return value of ZADD only counts the number of new elements added.
+   */
+  fun zadd(
+    key: String,
+    score: Double,
+    member: ByteString,
+    options: Set<String> = setOf(),
+  ): Long
+
+  /**
+   * Adds all the specified members with the specified scores in [scoreMembers] to the sorted set
+   * at the [key]. If a specified [member] is already a member of the sorted set, the [score] is
+   * updated and the element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. Options are:
+   *
+   * XX: Only update elements that already exist. Don't add new elements.
+   *
+   * NX: Only add new elements. Don't update already existing elements.
+   *
+   * LT: Only update existing elements if the new score is less than the current score.
+   *     This flag doesn't prevent adding new elements.
+   *
+   * GT: Only update existing elements if the new score is greater than the current score.
+   *     This flag doesn't prevent adding new elements.
+   *
+   * CH: Modify the return value from the number of new elements added, to the total number of
+   *     elements changed (CH is an abbreviation of changed). Changed elements are new elements
+   *     added and elements already existing for which the score was updated. So elements specified
+   *     in the command line having the same score as they had in the past are not counted.
+   *     Note: normally the return value of ZADD only counts the number of new elements added.
+   */
+  fun zadd(
+    key: String,
+    scoreMembers: Map<ByteString, Double>,
+    options: Set<String> = setOf(),
+  ): Long
+
+  /**
+   * Returns the score of [member] in the sorted set at [key].
+   *
+   * If [member] does not exist in the sorted set, or [key] does not exist, nil is returned.
+   */
+  fun zscore(
+    key: String,
+    member: String
+  ) : Double?
 }
+
+
 
 /**
  * Validates [count] is positive and non-zero.


### PR DESCRIPTION
Some basic commands for [Redis SortedSet ](https://redis.io/docs/data-types/sorted-sets/).
[ZADD](https://redis.io/commands/zadd/) - basic command to add members to SortedSet 
[ZSCORE](https://redis.io/commands/zscore/) - get the score of the member in the SortedSet
