### PR TITLE
Add deployment to DashboardIndexAccessBlock

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,52 @@
+acceptedBreaks:
+  "2023.10.17.232338-9c1976d":
+    com.squareup.misk:misk-admin:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.web.v2.DashboardIndexAction::<init>(misk.scope.ActionScoped<misk.MiskCaller>,\
+        \ misk.web.v2.DashboardPageLayout, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ java.util.List<misk.web.v2.DashboardIndexAccessBlock>, java.util.List<misk.web.v2.DashboardIndexBlock>)"
+      new: "method void misk.web.v2.DashboardIndexAction::<init>(misk.scope.ActionScoped<misk.MiskCaller>,\
+        \ misk.web.v2.DashboardPageLayout, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ java.util.List<misk.web.v2.DashboardIndexAccessBlock>, java.util.List<misk.web.v2.DashboardIndexBlock>,\
+        \ wisp.deployment.Deployment)"
+      justification: "Only one downstream usage, can break it without many problems."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter misk.web.v2.DashboardIndexAccessBlock misk.web.v2.DashboardIndexAccessBlock::copy(kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>, ===kotlin.jvm.functions.Function5<?\
+        \ super kotlinx.html.TagConsumer<?>, ? super java.lang.String, ? super misk.MiskCaller,\
+        \ ? super java.util.List<misk.web.dashboard.DashboardTab>, ? super java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ kotlin.Unit>===)"
+      new: "parameter misk.web.v2.DashboardIndexAccessBlock misk.web.v2.DashboardIndexAccessBlock::copy(kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>, ===kotlin.jvm.functions.Function6<?\
+        \ super kotlinx.html.TagConsumer<?>, ? super java.lang.String, ? super wisp.deployment.Deployment,\
+        \ ? super misk.MiskCaller, ? super java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ ? super java.util.List<misk.web.dashboard.DashboardTab>, kotlin.Unit>===)"
+      justification: "Only one downstream usage, can break it without many problems."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.v2.DashboardIndexAccessBlock::<init>(kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>, ===kotlin.jvm.functions.Function5<?\
+        \ super kotlinx.html.TagConsumer<?>, ? super java.lang.String, ? super misk.MiskCaller,\
+        \ ? super java.util.List<misk.web.dashboard.DashboardTab>, ? super java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ kotlin.Unit>===)"
+      new: "parameter void misk.web.v2.DashboardIndexAccessBlock::<init>(kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>, ===kotlin.jvm.functions.Function6<?\
+        \ super kotlinx.html.TagConsumer<?>, ? super java.lang.String, ? super wisp.deployment.Deployment,\
+        \ ? super misk.MiskCaller, ? super java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ ? super java.util.List<misk.web.dashboard.DashboardTab>, kotlin.Unit>===)"
+      justification: "Only one downstream usage, can break it without many problems."
+    - code: "java.method.returnTypeChanged"
+      old: "method kotlin.jvm.functions.Function5<kotlinx.html.TagConsumer<?>, java.lang.String,\
+        \ misk.MiskCaller, java.util.List<misk.web.dashboard.DashboardTab>, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ kotlin.Unit> misk.web.v2.DashboardIndexAccessBlock::component2()"
+      new: "method kotlin.jvm.functions.Function6<kotlinx.html.TagConsumer<?>, java.lang.String,\
+        \ wisp.deployment.Deployment, misk.MiskCaller, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ java.util.List<misk.web.dashboard.DashboardTab>, kotlin.Unit> misk.web.v2.DashboardIndexAccessBlock::component2()"
+      justification: "Only one downstream usage, can break it without many problems."
+    - code: "java.method.returnTypeChanged"
+      old: "method kotlin.jvm.functions.Function5<kotlinx.html.TagConsumer<?>, java.lang.String,\
+        \ misk.MiskCaller, java.util.List<misk.web.dashboard.DashboardTab>, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ kotlin.Unit> misk.web.v2.DashboardIndexAccessBlock::getBlock()"
+      new: "method kotlin.jvm.functions.Function6<kotlinx.html.TagConsumer<?>, java.lang.String,\
+        \ wisp.deployment.Deployment, misk.MiskCaller, java.util.List<misk.web.dashboard.DashboardTab>,\
+        \ java.util.List<misk.web.dashboard.DashboardTab>, kotlin.Unit> misk.web.v2.DashboardIndexAccessBlock::getBlock()"
+      justification: "Only one downstream usage, can break it without many problems."

--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -849,21 +849,21 @@ public final class misk/web/v2/DashboardIFrameTabAction : misk/web/actions/WebAc
 }
 
 public final class misk/web/v2/DashboardIndexAccessBlock {
-	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function5;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function6;)V
 	public final fun component1 ()Lkotlin/reflect/KClass;
-	public final fun component2 ()Lkotlin/jvm/functions/Function5;
-	public final fun copy (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function5;)Lmisk/web/v2/DashboardIndexAccessBlock;
-	public static synthetic fun copy$default (Lmisk/web/v2/DashboardIndexAccessBlock;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function5;ILjava/lang/Object;)Lmisk/web/v2/DashboardIndexAccessBlock;
+	public final fun component2 ()Lkotlin/jvm/functions/Function6;
+	public final fun copy (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function6;)Lmisk/web/v2/DashboardIndexAccessBlock;
+	public static synthetic fun copy$default (Lmisk/web/v2/DashboardIndexAccessBlock;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function6;ILjava/lang/Object;)Lmisk/web/v2/DashboardIndexAccessBlock;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnnotation ()Lkotlin/reflect/KClass;
-	public final fun getBlock ()Lkotlin/jvm/functions/Function5;
+	public final fun getBlock ()Lkotlin/jvm/functions/Function6;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class misk/web/v2/DashboardIndexAction : misk/web/actions/WebAction {
 	public static final field Companion Lmisk/web/v2/DashboardIndexAction$Companion;
-	public fun <init> (Lmisk/scope/ActionScoped;Lmisk/web/v2/DashboardPageLayout;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public fun <init> (Lmisk/scope/ActionScoped;Lmisk/web/v2/DashboardPageLayout;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lwisp/deployment/Deployment;)V
 	public final fun get ()Ljava/lang/String;
 }
 

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/ExemplarDashboardModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/ExemplarDashboardModule.kt
@@ -35,6 +35,7 @@ import misk.web.resources.StaticResourceAction
 import misk.web.resources.StaticResourceEntry
 import misk.web.v2.DashboardIndexAccessBlock
 import misk.web.v2.DashboardIndexBlock
+import wisp.deployment.Deployment
 
 class ExemplarDashboardModule : KAbstractModule() {
   override fun configure() {
@@ -111,7 +112,7 @@ class ExemplarDashboardModule : KAbstractModule() {
       )
     )
 
-    val dashboardIndexAccessBlock = DashboardIndexAccessBlock<AdminDashboard> { appName: String, caller: MiskCaller?, authenticatedTabs: List<DashboardTab>, dashboardTabs: List<DashboardTab> ->
+    val dashboardIndexAccessBlock = DashboardIndexAccessBlock<AdminDashboard> { appName: String, deployment: Deployment, caller: MiskCaller?, authenticatedTabs: List<DashboardTab>, dashboardTabs: List<DashboardTab> ->
       val dashboardTabCapabilities = dashboardTabs.flatMap { it.capabilities }.toSet()
 
       val h3TextColor = when {


### PR DESCRIPTION
Providing deployment within the access block allows for more context rich access notices which take into account the `DevelopmentOnly` semantics for locally running development service.