### PR TITLE
Add wrappers for zadd, zscore methods for redis sorted set

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -365,3 +365,16 @@ acceptedBreaks:
       new: "method wisp.launchdarkly.LaunchDarklyFeatureFlags misk.feature.launchdarkly.LaunchDarklyModule::wispLaunchDarkly$misk_launchdarkly(jakarta.inject.Provider<com.launchdarkly.sdk.server.interfaces.LDClientInterface>,\
         \ com.squareup.moshi.Moshi, io.micrometer.core.instrument.MeterRegistry)"
       justification: "This is a provider that's not called manually"
+  "2023.12.14.222754-29dc0a1":
+    com.squareup.misk:misk-redis:
+    - code: "java.method.addedToInterface"
+      new: "method java.lang.Double misk.redis.Redis::zscore(java.lang.String, java.lang.String)"
+      justification: "adding wrappers to support zadd, zscore"
+    - code: "java.method.addedToInterface"
+      new: "method long misk.redis.Redis::zadd(java.lang.String, double, java.lang.String,\
+        \ misk.redis.Redis.ZAddOptions[])"
+      justification: "adding wrappers to support zadd, zscore"
+    - code: "java.method.addedToInterface"
+      new: "method long misk.redis.Redis::zadd(java.lang.String, java.util.Map<java.lang.String,\
+        \ java.lang.Double>, misk.redis.Redis.ZAddOptions[])"
+      justification: "adding wrappers to support zadd, zscore"

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -51,6 +51,9 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
 public abstract interface annotation class misk/redis/ForFakeRedis : java/lang/annotation/Annotation {
@@ -117,6 +120,9 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
 public final class misk/redis/RealRedis$Companion {
@@ -168,6 +174,19 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public abstract fun unwatch ([Ljava/lang/String;)V
 	public abstract fun watch ([Ljava/lang/String;)V
+	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
+	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
+}
+
+public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
+	public static final field CH Lmisk/redis/Redis$ZAddOptions;
+	public static final field GT Lmisk/redis/Redis$ZAddOptions;
+	public static final field LT Lmisk/redis/Redis$ZAddOptions;
+	public static final field NX Lmisk/redis/Redis$ZAddOptions;
+	public static final field XX Lmisk/redis/Redis$ZAddOptions;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZAddOptions;
+	public static fun values ()[Lmisk/redis/Redis$ZAddOptions;
 }
 
 public final class misk/redis/RedisClientMetrics {
@@ -398,6 +417,9 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
+	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -404,4 +404,25 @@ class FakeRedis : Redis {
     hKeyValueStore.clear()
     lKeyValueStore.clear()
   }
+
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions,
+  ): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions,
+  ): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zscore(key: String, member: String): Double? {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -469,6 +469,86 @@ interface Redis {
    * Flushes all keys from all databases.
    */
   fun flushAll()
+
+  /**
+   * Adds the specified [member] with the specified [score] to the sorted set at the [key].
+   * If a specified [member] is already a member of the sorted set, the [score] is updated and the
+   * element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. The complete list of options can be found in [ZAddOptions]
+   */
+  fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: ZAddOptions
+  ): Long
+
+  /**
+   * Adds all the specified members with the specified scores in [scoreMembers] to the sorted set
+   * at the [key]. If a specified [member] is already a member of the sorted set, the [score] is
+   * updated and the element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. The complete list of options can be found in [ZAddOptions]
+   */
+  fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: ZAddOptions
+  ): Long
+
+  /**
+   * Returns the score of [member] in the sorted set at [key].
+   *
+   * If [member] does not exist in the sorted set, or [key] does not exist, nil is returned.
+   */
+  fun zscore(
+    key: String,
+    member: String
+  ) : Double?
+
+  enum class ZAddOptions {
+    /**
+     * Only update elements that already exist. Don't add new elements.
+     */
+    XX,
+
+    /**
+     * Only add new elements. Don't update already existing elements.
+     */
+    NX,
+
+    /**
+     * Only update existing elements if the new score is less than the current score.
+     * This flag doesn't prevent adding new elements.
+     */
+    LT,
+
+    /**
+     * Only update existing elements if the new score is greater than the current score.
+     * This flag doesn't prevent adding new elements.
+     */
+    GT,
+
+    /**
+     * Modify the return value from the number of new elements added, to the total number of
+     * elements changed (CH is an abbreviation of changed). Changed elements are new elements
+     * added and elements already existing for which the score was updated. So elements specified
+     * in the command line having the same score as they had in the past are not counted.
+     * Note: normally the return value of ZADD only counts the number of new elements added.
+     */
+    CH
+  }
 }
 
 /**


### PR DESCRIPTION
Some basic commands for [Redis SortedSet ](https://redis.io/docs/data-types/sorted-sets/). [ZADD](https://redis.io/commands/zadd/) - basic command to add members to SortedSet [ZSCORE](https://redis.io/commands/zscore/) - get the score of the member in the SortedSet