### PR TITLE
Revert removed datasource binding in JdbcModule.kt to fix guice error

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
@@ -143,6 +143,9 @@ class JdbcModule @JvmOverloads constructor(
 
     // Bind DataSourceService.
     val dataSourceDecoratorsProvider = getProvider(dataSourceDecoratorsKey)
+    bind(keyOf<DataSource>(qualifier))
+      .toProvider(keyOf<DataSourceService>(qualifier))
+      .asSingleton()
     bind(keyOf<DataSourceService>(qualifier)).toProvider(object : Provider<DataSourceService> {
       @com.google.inject.Inject(optional = true) var registry: CollectorRegistry? = null
       override fun get(): DataSourceService {


### PR DESCRIPTION
Previous [PR](https://github.com/cashapp/misk/pull/2987) fixed `DataSourceService` to lazily provide a DataSource but consumers need to be updated to fix guice error on missing implementation for DataSource. This PR adds back binding of `DataSource` in `JdbcModule` to fix failing tests.

`1) [Guice/MissingImplementation]: No implementation for DataSource annotated with @MiskExemplarDb() was bound.`