### PR TITLE
Allow the MYSQL_HOST env var to override the hard-coded default

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -128,7 +128,7 @@ data class DataSourceConfig @JvmOverloads constructor(
       DataSourceType.MYSQL -> {
         copy(
           port = port ?: 3306,
-          host = host ?: "127.0.0.1",
+          host = host ?: System.getenv("MYSQL_HOST") ?: "127.0.0.1",
           database = database ?: ""
         )
       }


### PR DESCRIPTION
All the other database types auto-detect if they are inside a docker container and use host.docker.internal. However, the MySQL codepath does not. Doing the same thing here would be ideal, but is tricky for reasons discussed at https://cash.slack.com/archives/C01M5M297T7/p1699385740943289. Instead, allow setting a MYSQL_HOST envvar to override the hard-coded default.