### PR TITLE
Enhance bucket4j functionality

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -155,3 +155,21 @@ acceptedBreaks:
         \ ===redis.clients.jedis.JedisPoolConfig===)"
       justification: "New constructor was added to use the new pool config class in\
         \ latest version but kept the old constructor and marked it as deprecated"
+  "2023.11.07.125331-45dfef7":
+    app.cash.wisp:wisp-rate-limiting:
+    - code: "java.method.addedToInterface"
+      new: "method long wisp.ratelimiting.RateLimiter::availableTokens(java.lang.String,\
+        \ wisp.ratelimiting.RateLimitConfiguration)"
+      justification: "No other implementations"
+    - code: "java.method.addedToInterface"
+      new: "method void wisp.ratelimiting.RateLimiter::resetBucket(java.lang.String,\
+        \ wisp.ratelimiting.RateLimitConfiguration)"
+      justification: "No other implementations"
+    - code: "java.method.addedToInterface"
+      new: "method wisp.ratelimiting.RateLimiter.ConsumptionData wisp.ratelimiting.RateLimiter::consumeTokenIdempotently(java.lang.String,\
+        \ wisp.ratelimiting.RateLimitConfiguration, long, java.lang.String)"
+      justification: "No other implementations"
+    - code: "java.method.addedToInterface"
+      new: "method wisp.ratelimiting.RateLimiter.TestConsumptionResult wisp.ratelimiting.RateLimiter::testConsumptionAttempt(java.lang.String,\
+        \ wisp.ratelimiting.RateLimitConfiguration, long)"
+      justification: "No other implementations"

--- a/misk-rate-limiting-bucket4j-dynamodb-v1/src/test/kotlin/misk/ratelimiting/bucket4j/dynamodb/v1/DynamoDBV1RateLimiterTest.kt
+++ b/misk-rate-limiting-bucket4j-dynamodb-v1/src/test/kotlin/misk/ratelimiting/bucket4j/dynamodb/v1/DynamoDBV1RateLimiterTest.kt
@@ -46,13 +46,17 @@ class DynamoDBV1RateLimiterTest {
       val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
       with(result) {
         assertThat(didConsume).isTrue()
-        assertThat(remaining).isEqualTo(4L - it)
+        assertThat(remaining)
+          .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+          .isEqualTo(4L - it)
       }
     }
     val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
     with(result) {
       assertThat(didConsume).isFalse()
-      assertThat(remaining).isZero()
+      assertThat(remaining)
+        .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+        .isZero()
     }
   }
 
@@ -82,7 +86,9 @@ class DynamoDBV1RateLimiterTest {
     }
     assertThat(result.consumptionData.didConsume).isFalse()
     assertThat(result.result).isNull()
-    assertThat(result.consumptionData.remaining).isZero()
+    assertThat(result.consumptionData.remaining)
+      .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+      .isZero()
     assertThat(counter).isEqualTo(TestRateLimitConfig.capacity)
 
     // Elapse enough time that the next request refills the bucket

--- a/misk-rate-limiting-bucket4j-mysql/src/test/kotlin/misk/ratelimiting/bucket4j/mysql/MySQLBucket4jRateLimiterTests.kt
+++ b/misk-rate-limiting-bucket4j-mysql/src/test/kotlin/misk/ratelimiting/bucket4j/mysql/MySQLBucket4jRateLimiterTests.kt
@@ -46,13 +46,17 @@ class MySQLBucket4jRateLimiterTests {
       val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
       with(result) {
         assertThat(didConsume).isTrue()
-        assertThat(remaining).isEqualTo(4L - it)
+        assertThat(remaining)
+          .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+          .isEqualTo(4L - it)
       }
     }
     val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
     with(result) {
       assertThat(didConsume).isFalse()
-      assertThat(remaining).isZero()
+      assertThat(remaining)
+        .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+        .isZero()
     }
   }
 

--- a/misk-rate-limiting-bucket4j-redis/src/test/kotlin/misk/ratelimiting/bucket4j/redis/RedisRateLimiterTest.kt
+++ b/misk-rate-limiting-bucket4j-redis/src/test/kotlin/misk/ratelimiting/bucket4j/redis/RedisRateLimiterTest.kt
@@ -46,13 +46,17 @@ class RedisRateLimiterTest {
       val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
       with(result) {
         assertThat(didConsume).isTrue()
-        assertThat(remaining).isEqualTo(4L - it)
+        assertThat(remaining)
+          .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+          .isEqualTo(4L - it)
       }
     }
     val result = rateLimiter.consumeToken(KEY, TestRateLimitConfig)
     with(result) {
       assertThat(didConsume).isFalse()
-      assertThat(remaining).isZero()
+      assertThat(remaining)
+        .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+        .isZero()
     }
   }
 
@@ -82,7 +86,9 @@ class RedisRateLimiterTest {
     }
     assertThat(result.consumptionData.didConsume).isFalse()
     assertThat(result.result).isNull()
-    assertThat(result.consumptionData.remaining).isZero()
+    assertThat(result.consumptionData.remaining)
+      .isEqualTo(rateLimiter.availableTokens(KEY, TestRateLimitConfig))
+      .isZero()
     assertThat(counter).isEqualTo(TestRateLimitConfig.capacity)
 
     // Elapse enough time that the next request refills the bucket

--- a/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
+++ b/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
@@ -6,8 +6,11 @@ public abstract interface class wisp/ratelimiting/RateLimitConfiguration {
 }
 
 public abstract interface class wisp/ratelimiting/RateLimiter {
+	public abstract fun availableTokens (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;)J
 	public abstract fun consumeToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)Lwisp/ratelimiting/RateLimiter$ConsumptionData;
 	public abstract fun releaseToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)V
+	public abstract fun resetBucket (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;)V
+	public abstract fun testConsumptionAttempt (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;
 	public abstract fun withToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;Lkotlin/jvm/functions/Function0;)Lwisp/ratelimiting/RateLimiter$ExecutionResult;
 }
 
@@ -29,6 +32,7 @@ public final class wisp/ratelimiting/RateLimiter$ConsumptionData {
 public final class wisp/ratelimiting/RateLimiter$DefaultImpls {
 	public static synthetic fun consumeToken$default (Lwisp/ratelimiting/RateLimiter;Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;JILjava/lang/Object;)Lwisp/ratelimiting/RateLimiter$ConsumptionData;
 	public static synthetic fun releaseToken$default (Lwisp/ratelimiting/RateLimiter;Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;JILjava/lang/Object;)V
+	public static synthetic fun testConsumptionAttempt$default (Lwisp/ratelimiting/RateLimiter;Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;JILjava/lang/Object;)Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;
 	public static fun withToken (Lwisp/ratelimiting/RateLimiter;Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;Lkotlin/jvm/functions/Function0;)Lwisp/ratelimiting/RateLimiter$ExecutionResult;
 }
 
@@ -41,6 +45,21 @@ public final class wisp/ratelimiting/RateLimiter$ExecutionResult {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConsumptionData ()Lwisp/ratelimiting/RateLimiter$ConsumptionData;
 	public final fun getResult ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class wisp/ratelimiting/RateLimiter$TestConsumptionResult {
+	public fun <init> (ZJLjava/time/Instant;)V
+	public final fun component1 ()Z
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/time/Instant;
+	public final fun copy (ZJLjava/time/Instant;)Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;
+	public static synthetic fun copy$default (Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;ZJLjava/time/Instant;ILjava/lang/Object;)Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCouldHaveConsumed ()Z
+	public final fun getRemaining ()J
+	public final fun getResetTime ()Ljava/time/Instant;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
+++ b/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
@@ -67,11 +67,21 @@ public final class wisp/ratelimiting/RateLimiter$TestConsumptionResult {
 public final class wisp/ratelimiting/RateLimiterMetrics {
 	public static final field ATTEMPT_COUNTER_NAME Ljava/lang/String;
 	public static final field Companion Lwisp/ratelimiting/RateLimiterMetrics$Companion;
+	public static final field LIMIT_AVAILABILITY_DURATION Ljava/lang/String;
+	public static final field LIMIT_CONSUMPTION_DURATION Ljava/lang/String;
+	public static final field LIMIT_RELEASE_DURATION Ljava/lang/String;
+	public static final field LIMIT_RESET_DURATION Ljava/lang/String;
+	public static final field LIMIT_TEST_DURATION Ljava/lang/String;
 	public static final field RATE_LIMIT_TAG Ljava/lang/String;
 	public static final field RESULT_TAG Ljava/lang/String;
 	public static final field TOTAL_CONSUMED_COUNTER_NAME Ljava/lang/String;
 	public fun <init> (Lio/micrometer/core/instrument/MeterRegistry;)V
 	public final fun consumptionAttempts (Lwisp/ratelimiting/RateLimitConfiguration;Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;)Lio/micrometer/core/instrument/Counter;
+	public final fun limitAvailabilityDuration (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/DistributionSummary;
+	public final fun limitConsumptionDuration (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/DistributionSummary;
+	public final fun limitReleaseDuration (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/DistributionSummary;
+	public final fun limitResetDuration (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/DistributionSummary;
+	public final fun limitTestDuration (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/DistributionSummary;
 	public final fun tokensConsumed (Lwisp/ratelimiting/RateLimitConfiguration;)Lio/micrometer/core/instrument/Counter;
 }
 

--- a/wisp/wisp-rate-limiting/bucket4j/api/bucket4j.api
+++ b/wisp/wisp-rate-limiting/bucket4j/api/bucket4j.api
@@ -2,8 +2,11 @@ public final class wisp/ratelimiting/bucket4j/Bucket4jRateLimiter : wisp/ratelim
 	public fun <init> (Lio/github/bucket4j/distributed/proxy/ProxyManager;Ljava/time/Clock;)V
 	public fun <init> (Lio/github/bucket4j/distributed/proxy/ProxyManager;Ljava/time/Clock;Lio/micrometer/core/instrument/MeterRegistry;)V
 	public synthetic fun <init> (Lio/github/bucket4j/distributed/proxy/ProxyManager;Ljava/time/Clock;Lio/micrometer/core/instrument/MeterRegistry;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun availableTokens (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;)J
 	public fun consumeToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)Lwisp/ratelimiting/RateLimiter$ConsumptionData;
 	public fun releaseToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)V
+	public fun resetBucket (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;)V
+	public fun testConsumptionAttempt (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;J)Lwisp/ratelimiting/RateLimiter$TestConsumptionResult;
 	public fun withToken (Ljava/lang/String;Lwisp/ratelimiting/RateLimitConfiguration;Lkotlin/jvm/functions/Function0;)Lwisp/ratelimiting/RateLimiter$ExecutionResult;
 }
 

--- a/wisp/wisp-rate-limiting/src/main/kotlin/wisp/ratelimiting/RateLimiterMetrics.kt
+++ b/wisp/wisp-rate-limiting/src/main/kotlin/wisp/ratelimiting/RateLimiterMetrics.kt
@@ -1,6 +1,7 @@
 package wisp.ratelimiting
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 
 class RateLimiterMetrics(private val meterRegistry: MeterRegistry) {
@@ -17,6 +18,56 @@ class RateLimiterMetrics(private val meterRegistry: MeterRegistry) {
     Counter.builder(TOTAL_CONSUMED_COUNTER_NAME)
       .description("count of total tokens consumed by config")
       .tag(RATE_LIMIT_TAG, configuration.name)
+      .register(meterRegistry)
+
+  fun limitConsumptionDuration(
+    configuration: RateLimitConfiguration,
+  ): DistributionSummary =
+    DistributionSummary.builder(LIMIT_CONSUMPTION_DURATION)
+      .description("duration in ms of rate limit consumption")
+      .tag(RATE_LIMIT_TAG, configuration.name)
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
+      .register(meterRegistry)
+
+  fun limitTestDuration(
+    configuration: RateLimitConfiguration,
+  ): DistributionSummary =
+    DistributionSummary.builder(LIMIT_TEST_DURATION)
+      .description("duration in ms of rate limit consumption testing")
+      .tag(RATE_LIMIT_TAG, configuration.name)
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
+      .register(meterRegistry)
+
+  fun limitAvailabilityDuration(
+    configuration: RateLimitConfiguration,
+  ): DistributionSummary =
+    DistributionSummary.builder(LIMIT_AVAILABILITY_DURATION)
+      .description("duration in ms of rate limit token availability checking")
+      .tag(RATE_LIMIT_TAG, configuration.name)
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
+      .register(meterRegistry)
+
+  fun limitReleaseDuration(
+    configuration: RateLimitConfiguration,
+  ): DistributionSummary =
+    DistributionSummary.builder(LIMIT_RELEASE_DURATION)
+      .description("duration in ms of rate limit release")
+      .tag(RATE_LIMIT_TAG, configuration.name)
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
+      .register(meterRegistry)
+
+  fun limitResetDuration(
+    configuration: RateLimitConfiguration,
+  ): DistributionSummary =
+    DistributionSummary.builder(LIMIT_RESET_DURATION)
+      .description("duration in ms of rate limit bucket reset")
+      .tag(RATE_LIMIT_TAG, configuration.name)
+      .percentilePrecision(4)
+      .publishPercentiles(0.5, 0.75, 0.95, 0.99, 0.999)
       .register(meterRegistry)
 
   enum class ConsumptionResult {
@@ -37,6 +88,11 @@ class RateLimiterMetrics(private val meterRegistry: MeterRegistry) {
   }
 
   companion object {
+    const val LIMIT_CONSUMPTION_DURATION = "rate_limiter.limit_consumption_duration"
+    const val LIMIT_TEST_DURATION = "rate_limiter.limit_test_duration"
+    const val LIMIT_AVAILABILITY_DURATION = "rate_limiter.limit_availability_duration"
+    const val LIMIT_RELEASE_DURATION = "rate_limiter.limit_release_duration"
+    const val LIMIT_RESET_DURATION = "rate_limiter.limit_release_duration"
     const val ATTEMPT_COUNTER_NAME = "rate_limiter.consumption_attempts"
     const val TOTAL_CONSUMED_COUNTER_NAME = "rate_limiter.tokens_consumed"
     const val RATE_LIMIT_TAG = "rate_limit_config"


### PR DESCRIPTION
This PR has two commits:
* First, it adds functionality to the `RateLimiter` interface that allows services to check the number of available tokens in a bucket, reset buckets to their max capacity, and test consumption from a bucket.
* Second, it adds performance metrics to these and the already existing operations, so services can monitor how long it takes to consume/release/etc a rate limit token