### PR TITLE
moves misk-rate-limiting-bucket4j-redis to `testShardHibernate`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,7 +232,8 @@ subprojects {
               "misk-jdbc",
               "misk-jdbc-testing",
               "misk-hibernate",
-              "misk-hibernate-testing"
+              "misk-hibernate-testing",
+              "misk-rate-limiting-bucket4j-redis"
           ).contains(project.name)) {
         testShardHibernate.dependsOn(this)
       } else {


### PR DESCRIPTION
* this is a quick proof of concept to see if this makes the race conditions in ci to go away. Probably we want a better strategy to handle these
