### PR TITLE
Tries to fix flaky cronTest

### DIFF
--- a/misk-cron/src/test/kotlin/misk/cron/CronTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronTest.kt
@@ -75,12 +75,14 @@ class CronTest {
     // Cluster weight is 100 by default, so the cron will run.
     clock.add(Duration.ofMinutes(1))
     waitForNextPendingTask().task()
+    cronManager.waitForCronsComplete()
     assertThat(minuteCron.counter).isEqualTo(1)
 
     // Cluster weight is set to 0, so now the cron will not run.
     fakeClusterWeight.setClusterWeight(0)
     clock.add(Duration.ofMinutes(1))
     waitForNextPendingTask().task()
+    cronManager.waitForCronsComplete()
     assertThat(minuteCron.counter).isEqualTo(1)
   }
 


### PR DESCRIPTION
* The tests is running a lambda that is enqueuing some job to run async, and it's asserting the side effect of the job. It's possible the job still is not done running by the time the side effects are asserted. This change adds a line to ensure all the queued threads are completed before asserting the side effect.