### PR TITLE
Integrate JedisCluster for Redis Cluster support and implement DockerRedisCluster for testing

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -176,6 +176,63 @@ public final class misk/redis/RedisClientMetrics {
 public final class misk/redis/RedisClientMetrics$Companion {
 }
 
+public final class misk/redis/RedisClusterConfig : java/util/LinkedHashMap, wisp/config/Config {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public fun containsValue (Lmisk/redis/RedisClusterReplicationGroupConfig;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/Object;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun get (Ljava/lang/String;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public final synthetic fun getOrDefault (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getOrDefault (Ljava/lang/Object;Lmisk/redis/RedisClusterReplicationGroupConfig;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun getOrDefault (Ljava/lang/String;Lmisk/redis/RedisClusterReplicationGroupConfig;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public final fun keySet ()Ljava/util/Set;
+	public final synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun remove (Ljava/lang/Object;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public final fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun remove (Ljava/lang/String;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun remove (Ljava/lang/String;Lmisk/redis/RedisClusterReplicationGroupConfig;)Z
+	public final fun size ()I
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class misk/redis/RedisClusterModule : misk/inject/KAbstractModule {
+	public fun <init> (Lmisk/redis/RedisClusterConfig;Lredis/clients/jedis/ConnectionPoolConfig;)V
+	public fun <init> (Lmisk/redis/RedisClusterConfig;Lredis/clients/jedis/ConnectionPoolConfig;Z)V
+	public synthetic fun <init> (Lmisk/redis/RedisClusterConfig;Lredis/clients/jedis/ConnectionPoolConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class misk/redis/RedisClusterReplicationGroupConfig {
+	public fun <init> (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;)V
+	public fun <init> (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/String;)V
+	public fun <init> (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/String;I)V
+	public synthetic fun <init> (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lmisk/redis/RedisNodeConfig;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun copy (Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/String;I)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public static synthetic fun copy$default (Lmisk/redis/RedisClusterReplicationGroupConfig;Lmisk/redis/RedisNodeConfig;Ljava/lang/String;ILjava/lang/String;IILjava/lang/Object;)Lmisk/redis/RedisClusterReplicationGroupConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClient_name ()Ljava/lang/String;
+	public final fun getConfiguration_endpoint ()Lmisk/redis/RedisNodeConfig;
+	public final fun getMax_attempts ()I
+	public final fun getRedis_auth_password ()Ljava/lang/String;
+	public final fun getTimeout_ms ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class misk/redis/RedisConfig : java/util/LinkedHashMap, wisp/config/Config {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V
@@ -269,6 +326,21 @@ public final class misk/redis/testing/DockerRedis : misk/testing/ExternalDepende
 	public fun getId ()Ljava/lang/String;
 	public fun shutdown ()V
 	public fun startup ()V
+}
+
+public final class misk/redis/testing/DockerRedisCluster : misk/testing/ExternalDependency {
+	public static final field INSTANCE Lmisk/redis/testing/DockerRedisCluster;
+	public fun afterEach ()V
+	public fun beforeEach ()V
+	public final fun getConfig ()Lmisk/redis/RedisClusterConfig;
+	public fun getId ()Ljava/lang/String;
+	public fun shutdown ()V
+	public fun startup ()V
+}
+
+public final class misk/redis/testing/DockerRedisClusterKt {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
 }
 
 public final class misk/redis/testing/DockerRedisKt {

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -20,6 +20,8 @@ interface Redis {
   /**
    * Deletes multiple keys.
    *
+   * On cluster mode, this might trigger multiple calls to Redis
+   *
    * @param keys the keys to delete
    * @return 0 if none of the keys were deleted, otherwise a positive integer
    *         representing the number of keys that were deleted
@@ -29,6 +31,8 @@ interface Redis {
   /**
    * Retrieves the values for the given list of keys.
    *
+   * On cluster mode, this might trigger multiple calls to Redis
+   *
    * @param keys the keys to retrieve
    * @return a list of String in the same order as the specified list of keys.
    * For each key, a value will be returned if a key was found, otherwise null is returned.
@@ -37,6 +41,8 @@ interface Redis {
 
   /**
    * Sets the key value pairs.
+   *
+   * On cluster mode, this might trigger multiple calls to Redis
    *
    * @param keyValues the list of keys and values in alternating order.
    */
@@ -209,7 +215,7 @@ interface Redis {
    * This command comes in place of the now deprecated [brpoplpush]. Doing BLMOVE RIGHT LEFT is
    * equivalent.
    *
-   * For Redis Cluster, source and destination must be in the same hash slot.
+   * Throws an error if using Redis Cluster and source and destination are not in the same hash slot
    *
    * See [lmove] for more information.
    */
@@ -228,7 +234,7 @@ interface Redis {
    * another client pushes to it or until timeout is reached. A timeout of zero can be used to block
    * indefinitely.
    *
-   * For Redis Cluster, source and destination must be in the same hash slot.
+   * Throws an error if using Redis Cluster and source and destination are not in the same hash slot
    *
    * See [rpoplpush] for more information.
    *
@@ -253,7 +259,7 @@ interface Redis {
    * from the list and pushing it as first/last element of the list, so it can be considered as a
    * list rotation command (or a no-op if wherefrom is the same as whereto).
    *
-   * For Redis Cluster, source and destination must be in the same hash slot.
+   * Throws an error if using Redis Cluster and source and destination are not in the same hash slot
    *
    * This command comes in place of the now deprecated RPOPLPUSH. Doing LMOVE RIGHT LEFT is
    * equivalent.
@@ -353,7 +359,7 @@ interface Redis {
    * list and pushing it as first element of the list, so it can be considered as a list rotation
    * command.
    *
-   * For Redis Cluster, source and destination must be in the same hash slot.
+   * Throws an error if using Redis Cluster and source and destination are not in the same hash slot
    *
    * As of Redis version 6.2.0, this command is regarded as deprecated.
    *

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -209,6 +209,8 @@ interface Redis {
    * This command comes in place of the now deprecated [brpoplpush]. Doing BLMOVE RIGHT LEFT is
    * equivalent.
    *
+   * For Redis Cluster, source and destination must be in the same hash slot.
+   *
    * See [lmove] for more information.
    */
   fun blmove(
@@ -225,6 +227,8 @@ interface Redis {
    * behaves exactly like [rpoplpush]. When source is empty, Redis will block the connection until
    * another client pushes to it or until timeout is reached. A timeout of zero can be used to block
    * indefinitely.
+   *
+   * For Redis Cluster, source and destination must be in the same hash slot.
    *
    * See [rpoplpush] for more information.
    *
@@ -248,6 +252,8 @@ interface Redis {
    * and destination are the same, the operation is equivalent to removing the first/last element
    * from the list and pushing it as first/last element of the list, so it can be considered as a
    * list rotation command (or a no-op if wherefrom is the same as whereto).
+   *
+   * For Redis Cluster, source and destination must be in the same hash slot.
    *
    * This command comes in place of the now deprecated RPOPLPUSH. Doing LMOVE RIGHT LEFT is
    * equivalent.
@@ -346,6 +352,8 @@ interface Redis {
    * and destination are the same, the operation is equivalent to removing the last element from the
    * list and pushing it as first element of the list, so it can be considered as a list rotation
    * command.
+   *
+   * For Redis Cluster, source and destination must be in the same hash slot.
    *
    * As of Redis version 6.2.0, this command is regarded as deprecated.
    *

--- a/misk-redis/src/main/kotlin/misk/redis/RedisClusterConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisClusterConfig.kt
@@ -1,0 +1,33 @@
+package misk.redis
+
+import misk.config.Redact
+import redis.clients.jedis.JedisCluster.DEFAULT_MAX_ATTEMPTS
+import redis.clients.jedis.Protocol
+import wisp.config.Config
+
+/**
+ * Top-level configuration element for all redis clusters
+ */
+class RedisClusterConfig : LinkedHashMap<String, RedisClusterReplicationGroupConfig>, Config {
+  constructor() : super()
+  constructor(m: Map<String, RedisClusterReplicationGroupConfig>) : super(m)
+}
+
+/**
+ * Configuration element for a Redis Cluster
+ * @property configuration_endpoint The endpoint of a node in the cluster that can be used to
+ * discover the rest of the cluster.
+ * @property client_name An optional parameter to identify the client application.
+ * @property max_attempts The maximum number of attempts in case of failure.
+ * @property redis_auth_password The password to use for the connection to the cluster.
+ * @property timeout_ms The connection and socket timeout in milliseconds.
+ */
+data class RedisClusterReplicationGroupConfig @JvmOverloads constructor(
+  val configuration_endpoint: RedisNodeConfig,
+  val client_name: String? = null,
+  val max_attempts: Int = DEFAULT_MAX_ATTEMPTS,
+  @Redact
+  val redis_auth_password: String,
+  val timeout_ms: Int = Protocol.DEFAULT_TIMEOUT
+)
+

--- a/misk-redis/src/main/kotlin/misk/redis/RedisClusterModule.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisClusterModule.kt
@@ -1,0 +1,92 @@
+package misk.redis
+
+import com.google.common.base.Ticker
+import com.google.inject.Provides
+import jakarta.inject.Singleton
+import misk.ReadyService
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+import misk.metrics.v2.Metrics
+import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.HostAndPort
+import redis.clients.jedis.JedisCluster
+import wisp.deployment.Deployment
+
+/**
+ * Configures a [Redis] client that interacts with a Redis cluster. This also installs a
+ * [ServiceModule] for [RedisService].
+ *
+ * To use this, install a [RedisClusterModule] and add a corresponding [RedisClusterConfig] to your
+ * application’s config YAML.
+ *
+ * If other services require a working client connection to Redis before they can be used, specify a
+ * dependency like:
+ *
+ * ```
+ * install(ServiceModule<MyService>()
+ *     .dependsOn(keyOf<RedisService>())
+ * )
+ * ```
+ *
+ *
+ * [redisClusterConfig]: Only one replication group config is supported; this module will use the first
+ * configuration it finds. An empty [RedisReplicationGroupConfig.redis_auth_password] is only
+ * permitted in fake environments. See [Deployment].
+ *
+ * This initiates a [JedisCluster] which automatically discovers the topology of the Redis cluster,
+ * and routes commands to the appropriate node based on the hash slot of the key.
+ *
+ * Note: This has some limitations regarding multi-key operations that involve keys belonging to
+ * different slots. Some unsupported functions in [JedisCluster] were addressed in this custom
+ * wrapper (e.g. `mset`, `mget` and `del`) but not the atomic operations such as `rpoplpush`, `lmove`,
+ * `brpoplpush` etc. as it is not recommended. For more information, refer to the following links:
+ *
+ * https://redis.io/docs/reference/cluster-spec/
+ * https://redis.com/blog/redis-clustering-best-practices-with-keys/
+ */
+class RedisClusterModule @JvmOverloads constructor(
+  private val redisClusterConfig: RedisClusterConfig,
+  private val connectionPoolConfig: ConnectionPoolConfig,
+  private val useSsl: Boolean = true
+) : KAbstractModule() {
+
+  override fun configure() {
+    bind<RedisClusterConfig>().toInstance(redisClusterConfig)
+    install(ServiceModule<RedisService>().enhancedBy<ReadyService>())
+    requireBinding<Metrics>()
+  }
+
+  @Provides @Singleton
+  internal fun provideRedisClusterClient(
+    config: RedisClusterConfig,
+    deployment: Deployment,
+    metrics: Metrics,
+    ticker: Ticker,
+  ): Redis {
+    // Get the first replication group, we only support 1 replication group per service.
+    val replicationGroup = config[config.keys.first()]
+      ?: throw RuntimeException("At least 1 replication group must be specified")
+
+    // Create our jedis pool with client-side metrics.
+    val clientMetrics = RedisClientMetrics(ticker, metrics)
+
+    val jedisCluster = JedisCluster(
+      HostAndPort(
+        replicationGroup.configuration_endpoint.hostname,
+        replicationGroup.configuration_endpoint.port
+      ),
+      replicationGroup.timeout_ms,
+      replicationGroup.timeout_ms,
+      replicationGroup.max_attempts,
+      replicationGroup.redis_auth_password.ifEmpty {
+        check(!deployment.isReal) { "Redis auth password cannot be empty in a real environment!" }
+        null
+      },
+      replicationGroup.client_name,
+      connectionPoolConfig,
+      useSsl
+    )
+
+    return RealRedis(jedisCluster, clientMetrics)
+  }
+}

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -402,9 +402,9 @@ abstract class AbstractRedisTest {
 
   @Test fun lmoveOnSeparateKeys() {
     // Setup
-    val sourceKey = "foo"
+    val sourceKey = "{same-slot-key}1"
     val sourceElements = listOf("bar", "bat").map { it.encodeUtf8() }
-    val destinationKey = "oof"
+    val destinationKey = "{same-slot-key}2"
     val destinationElements = listOf("baz".encodeUtf8())
 
     redis.rpush(sourceKey, *sourceElements.toTypedArray())
@@ -586,9 +586,9 @@ abstract class AbstractRedisTest {
 
   @Test fun rpoplpushOnSeparateKeys() {
     // Setup
-    val sourceKey = "foo"
+    val sourceKey = "{same-slot-key}3"
     val sourceElements = listOf("bar", "bat").map { it.encodeUtf8() }
-    val destinationKey = "oof"
+    val destinationKey = "{same-slot-key}4"
     val destinationElements = listOf("baz".encodeUtf8())
 
     redis.rpush(sourceKey, *sourceElements.toTypedArray())

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
@@ -1,0 +1,132 @@
+package misk.redis
+
+import com.google.inject.Module
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.redis.testing.DockerRedisCluster
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.exceptions.JedisClusterOperationException
+import wisp.deployment.TESTING
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@MiskTest
+class RealRedisClusterTest : AbstractRedisTest() {
+
+  @Suppress("unused")
+  @MiskTestModule
+  private val module: Module = object : KAbstractModule() {
+    override fun configure() {
+      install(RedisClusterModule(DockerRedisCluster.config, ConnectionPoolConfig(), useSsl = false))
+      install(MiskTestingServiceModule())
+      install(DeploymentModule(TESTING))
+    }
+  }
+
+  @Suppress("unused")
+  @MiskExternalDependency
+  private val dockerRedisCluster = DockerRedisCluster
+
+  /**
+   * Using keys that belong to different slots https://redis.io/docs/reference/cluster-spec/
+   * If the key contains a "{...}" pattern, only the substring between { and } is hashed
+   * therefore {k}1 and {k}2 are in the same slot
+   */
+  private val keys =
+    listOf("{k}1", "{t}1", "{k}2", "{m}1", "{m}2", "{k}3", "{t}2")
+
+  @Inject override lateinit var redis: Redis
+
+  @Test
+  fun `batch get and set for keys not in the same slot`() {
+
+    // mget returns null for all keys
+    assertThat(redis.mget(*keys.toTypedArray())).isEqualTo(
+      listOf(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      )
+    )
+
+    // Set values as the key using mset
+    val keyValues = keys.flatMap { listOf(it.encodeUtf8(), it.encodeUtf8()) }.toTypedArray()
+    redis.mset(*keyValues)
+
+    // mget should return the correct values in the right order
+    val values = redis.mget(*keys.toTypedArray())
+    assertThat(values).isEqualTo(keys.map { it.encodeUtf8() })
+
+  }
+
+  @Test
+  fun `batch delete for keys not in the same slot`() {
+    val keysToInsert = keys.toTypedArray()
+    val nonExistentKey = "nonExistentKey"
+    val value = "value".encodeUtf8()
+
+    // Set all keys except nonExistentKey
+    keysToInsert.forEach { redis[it] = value }
+    keysToInsert.forEach { assertEquals(value, redis[it], "Key should have been set") }
+    assertNull(redis[nonExistentKey], "Key should not have been set")
+
+    // Try deleting all three keys, only 2 should actually get deleted
+    assertEquals(
+      keys.size,
+      redis.del(*keysToInsert, nonExistentKey),
+      "${keys.size} keys should have been deleted"
+    )
+
+    // Keys should be deleted
+    listOf(*keysToInsert, nonExistentKey).forEach {
+      assertNull(
+        redis[it],
+        "Key should have been deleted"
+      )
+    }
+  }
+
+  @Test
+  fun `atomic rpoplpush throws cross-cluster error for keys not in the same slot`() {
+
+    assertFailsOnKeysInNotSameSlot {
+      redis.rpoplpush(
+        sourceKey = "{pop}1",
+        destinationKey = "{push}1",
+      )
+    }
+  }
+
+  @Test
+  fun `atomic lmove throws cross-cluster error for keys not in the same slot`() {
+    assertFailsOnKeysInNotSameSlot {
+      redis.lmove(
+        sourceKey = "{k}1",
+        destinationKey = "{t}1",
+        from = ListDirection.RIGHT,
+        to = ListDirection.LEFT,
+      )
+    }
+  }
+
+  private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
+    assertThatThrownBy { block() }
+      .isInstanceOf(JedisClusterOperationException::class.java)
+      .hasMessage("Keys must belong to same hashslot.")
+  }
+
+}

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/DockerRedisCluster.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/DockerRedisCluster.kt
@@ -1,0 +1,117 @@
+package misk.redis.testing
+
+import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.HostConfig
+import com.github.dockerjava.api.model.Ports
+import com.google.common.base.Stopwatch
+import misk.redis.RedisClusterConfig
+import misk.redis.RedisClusterReplicationGroupConfig
+import misk.redis.RedisNodeConfig
+import misk.testing.ExternalDependency
+import redis.clients.jedis.HostAndPort
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisCluster
+import wisp.containers.Composer
+import wisp.containers.Container
+import wisp.containers.ContainerUtil
+import wisp.logging.getLogger
+import java.lang.Thread.sleep
+import java.time.Duration
+
+/**
+ * To use this in tests:
+ *
+ * 1. Install a `RedisClusterModule` instead of a `FakeRedisModule`.
+ *    Make sure to supply the [DockerRedisCluster.config] as the [RedisClusterConfig].
+ * 2. Add `@MiskExternalDependency private val dockerRedis: DockerRedisCluster` to your test class.
+ */
+object DockerRedisCluster : ExternalDependency {
+  private val REDIS_CLUSTER_PORTS = listOf(7000, 7001, 7002, 7003, 7004, 7005)
+  private const val initialPort = 7000
+  private val hostname = if (ContainerUtil.isRunningInDocker) "host.docker.internal" else "localhost"
+  private val logger = getLogger<DockerRedisCluster>()
+  private const val redisVersion = "7.0.10"
+
+  private val jedis by lazy { JedisCluster(HostAndPort(hostname, initialPort)) }
+
+  private val redisNodeConfig = RedisNodeConfig(hostname, initialPort)
+  private val groupConfig = RedisClusterReplicationGroupConfig(
+    configuration_endpoint = redisNodeConfig,
+    redis_auth_password = "",
+    timeout_ms = 1_000,
+  )
+  val config = RedisClusterConfig(mapOf("test-group" to groupConfig))
+
+  private const val containerName = "misk-redis-cluster-testing"
+  private val composer = Composer(
+    containerName,
+    Container {
+      val envVars = listOf("IP=0.0.0.0", "INITIAL_PORT=$initialPort", "MASTERS=3", "SLAVES_PER_MASTER=1")
+      withImage("grokzen/redis-cluster:$redisVersion")
+      withName(containerName)
+      withExposedPorts(*REDIS_CLUSTER_PORTS.map { ExposedPort.tcp(it) }.toTypedArray())
+      withHostConfig(
+        HostConfig().withPortBindings(Ports().apply {
+          REDIS_CLUSTER_PORTS.forEach { port ->
+            bind(ExposedPort.tcp(port), Ports.Binding.bindPort(port))
+          }
+        })
+      )
+      withEnv(envVars)
+    }
+  )
+
+  override fun startup() {
+    try {
+      composer.start()
+    } catch (tr: Throwable) {
+      throw IllegalStateException("Could not start Docker client. Is Docker running?", tr)
+    }
+    val stopwatch = Stopwatch.createStarted()
+
+    while (true) {
+      try {
+        //We invoke redis commands to verify connection
+        //even if jedis.ping returns a response, it's possible cluster is not assembled yet
+        val clusterInfo = jedis.clusterNodes.values.first().resource.use {connection ->
+          Jedis(connection).use {
+            it.clusterInfo()
+          }
+        }
+        check(clusterInfo.contains("cluster_state:ok"))
+        jedis.mget("{key}1", "{key}2")
+        logger.info { "Sent GET command, got a reply" }
+        break
+      } catch (e: Exception) {
+        sleep(200)
+      }
+      if (stopwatch.elapsed() > Duration.ofSeconds(60)) {
+        error("Could not get a reply from Redis within 30 seconds. Is the Redis Cluster container running?")
+      }
+    }
+    logger.info { "Redis v$redisVersion is ready!" }
+  }
+
+  override fun shutdown() {
+    with(jedis) {
+      close()
+    }
+    composer.stop()
+  }
+
+  override fun beforeEach() {
+    jedis.flushAll()
+  }
+
+  override fun afterEach() {
+    // No op.
+  }
+}
+
+fun main() {
+  DockerRedisCluster.startup()
+  // Debug commands here.
+  sleep(Duration.ofSeconds(60).toMillis())
+  DockerRedisCluster.shutdown()
+}
+


### PR DESCRIPTION
**Why?**

Redis Cluster enables horizontal scaling by distributing data and workload across multiple Redis nodes. If a master node fails, one of the slave nodes is promoted, ensuring uninterrupted service. With automatic cluster topology discovery and routing, it provides a more resilient architecture.

**What?**

This adds new classes to support cluster mode:

- `RedisClusterConfig` to configure the cluster endpoint
- `RedisClusterModule` to configure and instantiate JedisCluster
- `DockerRedisCluster` which creates a docker container with Redis Cluster for testing
- `RealRedisClusterTest` includes all existing unit tests for supported commands and new ones for distributed keys

`RealRedis` was also modified to support multi-key batch operations `mget`, `mset` and `del` by grouping keys by slot first before calling the appropriate `JedisCluster` command.

**Testing**

Added new test class for cluster mode that encapsulates existing tests for all supported redis commands. Also tested manually by publishing to maven local then using this version on another service that uses Redis. Verified `DockerRedisCluster` for existing tests and connection to a local Redis cluster.