### PR TITLE
Add appName, deployment lambda for menu links

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -194,3 +194,153 @@ acceptedBreaks:
       new: "field wisp.ratelimiting.RateLimiterMetrics.LIMIT_RESET_DURATION"
       justification: "Metric label was incorrect, changing is not breaking because\
         \ there are no users of it currently"
+  "2023.11.29.153332-390d04e":
+    com.squareup.misk:misk-admin:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, java.lang.String,\
+        \ java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>,\
+        \ java.lang.String, java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, java.lang.String,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>,\
+        \ java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===java.lang.String===, java.lang.String, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, ===kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>===, java.lang.String,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, ===java.lang.String===, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>, ===kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>===,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, ===java.lang.String===, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>, ===kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>===,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, java.util.Set<java.lang.String>,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, ===java.lang.String===, java.lang.String,\
+        \ java.lang.String, java.util.Set<java.lang.String>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>, ===kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>===,\
+        \ java.lang.String, java.lang.String, java.util.Set<java.lang.String>, kotlin.reflect.KClass<?\
+        \ extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, ===java.lang.String===, java.lang.String,\
+        \ java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>, ===kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>===,\
+        \ java.lang.String, java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, java.lang.String, ===java.lang.String===, java.lang.String,\
+        \ kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      new: "parameter void misk.web.dashboard.DashboardTabProvider::<init>(java.lang.String,\
+        \ java.lang.String, kotlin.jvm.functions.Function2<? super java.lang.String,\
+        \ ? super wisp.deployment.Deployment, java.lang.String>, ===kotlin.jvm.functions.Function2<?\
+        \ super java.lang.String, ? super wisp.deployment.Deployment, java.lang.String>===,\
+        \ java.lang.String, kotlin.reflect.KClass<? extends java.lang.annotation.Annotation>)"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.returnTypeChanged"
+      old: "method java.lang.String misk.web.dashboard.DashboardTabProvider::getMenuLabel()"
+      new: "method kotlin.jvm.functions.Function2<java.lang.String, wisp.deployment.Deployment,\
+        \ java.lang.String> misk.web.dashboard.DashboardTabProvider::getMenuLabel()"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."
+    - code: "java.method.returnTypeChanged"
+      old: "method java.lang.String misk.web.dashboard.DashboardTabProvider::getMenuUrl()"
+      new: "method kotlin.jvm.functions.Function2<java.lang.String, wisp.deployment.Deployment,\
+        \ java.lang.String> misk.web.dashboard.DashboardTabProvider::getMenuUrl()"
+      justification: "No external usage of the DashboardTabProvider so this change\
+        \ is backwards compatible."

--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -346,27 +346,33 @@ public final class misk/web/dashboard/DashboardTabLoaderEntry {
 
 public final class misk/web/dashboard/DashboardTabProvider : misk/web/dashboard/ValidWebEntry, com/google/inject/Provider {
 	public field accessAnnotationEntries Ljava/util/List;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lkotlin/reflect/KClass;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public field appName Ljava/lang/String;
+	public field deployment Lwisp/deployment/Deployment;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lkotlin/reflect/KClass;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Lkotlin/reflect/KClass;)V
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Lmisk/web/dashboard/DashboardTab;
 	public final fun getAccessAnnotationEntries ()Ljava/util/List;
 	public final fun getAccessAnnotationKClass ()Lkotlin/reflect/KClass;
+	public final fun getAppName ()Ljava/lang/String;
 	public final fun getCapabilities ()Ljava/util/Set;
 	public final fun getDashboardAnnotationKClass ()Lkotlin/reflect/KClass;
 	public final fun getDashboard_slug ()Ljava/lang/String;
+	public final fun getDeployment ()Lwisp/deployment/Deployment;
 	public final fun getMenuCategory ()Ljava/lang/String;
-	public final fun getMenuLabel ()Ljava/lang/String;
-	public final fun getMenuUrl ()Ljava/lang/String;
+	public final fun getMenuLabel ()Lkotlin/jvm/functions/Function2;
+	public final fun getMenuUrl ()Lkotlin/jvm/functions/Function2;
 	public final fun getServices ()Ljava/util/Set;
 	public final fun getSlug ()Ljava/lang/String;
 	public final fun getUrl_path_prefix ()Ljava/lang/String;
 	public final fun setAccessAnnotationEntries (Ljava/util/List;)V
+	public final fun setAppName (Ljava/lang/String;)V
+	public final fun setDeployment (Lwisp/deployment/Deployment;)V
 }
 
 public final class misk/web/dashboard/DashboardTheme {

--- a/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/DashboardModule.kt
@@ -8,6 +8,8 @@ import misk.web.v2.DashboardIFrameTabAction
 import misk.web.v2.DashboardIndexAccessBlock
 import misk.web.v2.DashboardIndexBlock
 import okio.ByteString.Companion.encodeUtf8
+import wisp.deployment.Deployment
+import wisp.deployment.PRODUCTION
 
 /** Handles installation of Misk Dashboard components (admin dashboard or custom...). */
 class DashboardModule @JvmOverloads constructor(
@@ -63,6 +65,34 @@ class DashboardModule @JvmOverloads constructor(
       val dashboardTabProvider = DashboardTabProvider(
         slug = "menu-link-$hash",
         url_path_prefix = url,
+        menuLabel = { _, _ -> label },
+        menuUrl = { _, _ -> url },
+        menuCategory = category,
+        dashboard_slug = slugify<DA>(),
+        accessAnnotationKClass = AA::class,
+        dashboardAnnotationKClass = DA::class,
+      )
+      return DashboardModule(
+        dashboardTabProvider = dashboardTabProvider,
+      )
+    }
+
+    /**
+     * Create menu link with [label] for [url] under menu [category]
+     * for a dashboard [DA] with access [AA].
+     *
+     * If [category] is empty, it will appear at the top of the menu list.
+     */
+    inline fun <reified DA : Annotation, reified AA : Annotation> createMenuLink(
+      noinline label: (appName: String, deployment: Deployment) -> String,
+      noinline url: (appName: String, deployment: Deployment) -> String,
+      category: String = "",
+    ): DashboardModule {
+      // Create a unique hash for the link that will not conflict with any other link
+      val hash = (label.toString() + url.toString() + category).encodeUtf8().sha256().hex().take(24)
+      val dashboardTabProvider = DashboardTabProvider(
+        slug = "menu-link-$hash",
+        url_path_prefix = url("app", PRODUCTION),
         menuLabel = label,
         menuUrl = url,
         menuCategory = category,
@@ -95,8 +125,8 @@ class DashboardModule @JvmOverloads constructor(
       val dashboardTabProvider = DashboardTabProvider(
         slug = slug,
         url_path_prefix = urlPathPrefix,
-        menuLabel = menuLabel,
-        menuUrl = menuUrl,
+        menuLabel = { _, _ -> menuLabel },
+        menuUrl = { _, _ -> menuUrl },
         menuCategory = menuCategory,
         dashboard_slug = slugify<DA>(),
         accessAnnotationKClass = AA::class,
@@ -135,8 +165,8 @@ class DashboardModule @JvmOverloads constructor(
       val dashboardTabProvider = DashboardTabProvider(
         slug = slug,
         url_path_prefix = urlPathPrefix,
-        menuLabel = menuLabel,
-        menuUrl = menuUrl,
+        menuLabel = { _, _ -> menuLabel },
+        menuUrl = { _, _ -> menuUrl },
         menuCategory = menuCategory,
         dashboard_slug = slugify<DA>(),
         accessAnnotationKClass = AA::class,
@@ -180,8 +210,8 @@ class DashboardModule @JvmOverloads constructor(
       val dashboardTabProvider = DashboardTabProvider(
         slug = slug,
         url_path_prefix = urlPathPrefix,
-        menuLabel = menuLabel,
-        menuUrl = menuUrl,
+        menuLabel = { _, _ -> menuLabel },
+        menuUrl = { _, _ -> menuUrl },
         menuCategory = menuCategory,
         dashboard_slug = slugify<DA>(),
         accessAnnotationKClass = AA::class,
@@ -223,8 +253,8 @@ class DashboardModule @JvmOverloads constructor(
       val dashboardTabProvider = DashboardTabProvider(
         slug = slug,
         url_path_prefix = urlPathPrefix,
-        menuLabel = menuLabel,
-        menuUrl = menuUrl,
+        menuLabel = { _, _ -> menuLabel },
+        menuUrl = { _, _ -> menuUrl },
         menuCategory = menuCategory,
         dashboard_slug = slugify<DA>(),
         accessAnnotationKClass = AA::class,

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/ExemplarDashboardModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/ExemplarDashboardModule.kt
@@ -88,6 +88,13 @@ class ExemplarDashboardModule : KAbstractModule() {
         menuCategory = "Admin Tools"
       )
     )
+
+    // Custom links
+    install(DashboardModule.createMenuLink<AdminDashboard, AdminDashboardAccess>(
+      label = { appName, deployment -> "Internal Tool" },
+      url = { appName, deployment -> "https://internal-tool.cash.app/?app=$appName&deployment=$deployment" },
+      category = "Internal"
+    ))
   }
 }
 


### PR DESCRIPTION
Internal tools often have permalinks per service and deployment
environment. This change make it possible to pass in a lambda instead of
a static string for an admin dashboard menu link's label and url.

This makes it possible to link to an example internal tool with a URL like below.

```kotlin
https://internal-tool.${deployment.name}.company.tld/service/$appName
```
