### PR TITLE
Fix publish version to use UTC

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -87,8 +87,10 @@ jobs:
       - name: Assign a version
         id: assign_version
         run: |
-          # set a version name like "2023.05.26.091805-c1fcb3a"
-          VERSION="$(git log -n1 --pretty='format:%cd' --date=format:'%Y.%m.%d.%H%M%S')-$(git rev-parse --short=7 HEAD)"
+          # Set a version name like "2023.05.26.091805-c1fcb3a".
+          # Note the use of %ct which gets the timestamp in UTC, in seconds since UNIX epoch to 
+          # avoid time zone differences leading to non-linear versioning.
+          VERSION="$(TZ=UTC0 git show --quiet --date='format-local:%Y.%m.%d.%H%M%S' --format='%cd')-$(git rev-parse --short=7 HEAD)"
           echo "VERSION_NAME=$VERSION" >> gradle.properties
           cat gradle.properties
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Previous logic returned the timezone relevant timestamp leading to non-linear published versions if contributors in subsequent PRs merged on the same day were in different timezones.

For example, the following note the following 4 commits in pasted in order and their computed versions.

```
d0fdd7ad4f (HEAD -> master, tag: v2023.11.30.170920-d0fdd7a, origin/master, origin/HEAD) Integrate JedisCluster for Redis Cluster support and implement DockerRedisCluster for testing (#3023)
67922ca6d0 (tag: v2023.11.30.153418-67922ca) Add appName, deployment lambda for menu links (#3034)
f81483b3a7 (tag: v2023.11.30.184104-f81483b) Fix non-admin Misk-Web dashboards (#3033)
390d04effe (tag: v2023.11.29.153332-390d04e) Add a MySQL bucket4j pruner (#3024)
```

Highlighting just the versions

```
2023.11.30.170920-d0fdd7a
2023.11.30.153418-67922ca
2023.11.30.184104-f81483b
2023.11.29.153332-390d04e
```

Notably, this issue results in resolution failure since Gradle and other dependency selection will choose the latest as alpha sorted since Maven coordinates do not use the git commit history to determine what is latest.

This fix should resolve this problem going forward since the computed versions will always use UTC timestamps instead of time zone adjusted.