### PR TITLE
Add external icon for external links in dashboard menu

### DIFF
--- a/misk-tailwind/api/misk-tailwind.api
+++ b/misk-tailwind/api/misk-tailwind.api
@@ -63,6 +63,7 @@ public final class misk/tailwind/icons/Heroicons : java/lang/Enum {
 	public static final field MAGNIFYING_GLASS Lmisk/tailwind/icons/Heroicons;
 	public static final field MINI_ARROW_LONG_LEFT Lmisk/tailwind/icons/Heroicons;
 	public static final field MINI_ARROW_LONG_RIGHT Lmisk/tailwind/icons/Heroicons;
+	public static final field MINI_ARROW_TOP_RIGHT_ON_SQUARE Lmisk/tailwind/icons/Heroicons;
 	public static final field MINI_CHEVRON_DOWN Lmisk/tailwind/icons/Heroicons;
 	public static final field MINI_CHEVRON_UP Lmisk/tailwind/icons/Heroicons;
 	public static final field MINI_CHEVRON_UP_DOWN Lmisk/tailwind/icons/Heroicons;

--- a/misk-tailwind/src/main/kotlin/misk/tailwind/icons/Heroicons.kt
+++ b/misk-tailwind/src/main/kotlin/misk/tailwind/icons/Heroicons.kt
@@ -250,4 +250,18 @@ enum class Heroicons(
     """.trimIndent()
     },
   ),
+  MINI_ARROW_TOP_RIGHT_ON_SQUARE(
+    id = "mini/arrow-top-right-on-square",
+    svgClass = "ml-3 h-5 w-5",
+    defaultModifierClass = "text-gray-400",
+    rawHtml = {
+      """
+      <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+        <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+      </svg>
+
+    """.trimIndent()
+    },
+  ),
 }

--- a/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
+++ b/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
@@ -15,6 +15,8 @@ import kotlinx.html.span
 import kotlinx.html.ul
 import kotlinx.html.unsafe
 import misk.tailwind.Link
+import misk.tailwind.icons.Heroicons
+import misk.tailwind.icons.heroicon
 import wisp.deployment.Deployment
 
 data class MenuSection(
@@ -210,7 +212,7 @@ private fun TagConsumer<*>.NavMenu(menuSections: List<MenuSection>) {
                         unsafe { +it }
                       }
                     } ?: let {
-                      a(classes = "$isSelectedStyles group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold") {
+                      a(classes = "$isSelectedStyles group flex justify-between gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold") {
                         href = link.href
 
                         if (link.dataTurbo == true) {
@@ -226,6 +228,10 @@ private fun TagConsumer<*>.NavMenu(menuSections: List<MenuSection>) {
                         }
 
                         +link.label
+
+                        if (link.openInNewTab) {
+                          heroicon(Heroicons.MINI_ARROW_TOP_RIGHT_ON_SQUARE)
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
<img width="429" alt="Screenshot 2023-12-06 at 10 16 51" src="https://github.com/cashapp/misk/assets/8827217/ae557c82-e607-4919-9825-816d1ccd370c">

Adds icon to right side of menu link to indicate it will be an external link, not an inline dashboard tab.