### PR TITLE
Set Support endpoints to use SupportDashboardAccess annotation

### DIFF
--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarAccessModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarAccessModule.kt
@@ -1,5 +1,6 @@
 package com.squareup.exemplar
 
+import com.squareup.exemplar.dashboard.SupportDashboardAccess
 import misk.MiskCaller
 import misk.inject.KAbstractModule
 import misk.security.authz.*
@@ -16,8 +17,14 @@ class ExemplarAccessModule : KAbstractModule() {
       capabilities = listOf("admin_console"))
     )
 
+    // Give engineers access to the admin dashboard for Exemplar service
+    multibind<AccessAnnotationEntry>().toInstance(
+      AccessAnnotationEntry<SupportDashboardAccess>(
+        capabilities = listOf("customer_support"))
+    )
+
     // Setup authentication in the development environment
     bind<MiskCaller>().annotatedWith<DevelopmentOnly>()
-      .toInstance(MiskCaller(user = "triceratops", capabilities = setOf("admin_console", "users")))
+      .toInstance(MiskCaller(user = "triceratops", capabilities = setOf("admin_console", "customer_support", "users")))
   }
 }

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/support/SupportBravoIndexAction.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/support/SupportBravoIndexAction.kt
@@ -1,14 +1,14 @@
 package com.squareup.exemplar.dashboard.support
 
+import com.squareup.exemplar.dashboard.SupportDashboardAccess
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import kotlinx.html.h1
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
-import misk.web.dashboard.AdminDashboardAccess
 import misk.web.mediatype.MediaTypes
 import misk.web.v2.DashboardPageLayout
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 
 @Singleton
 class SupportBravoIndexAction @Inject constructor(
@@ -16,7 +16,7 @@ class SupportBravoIndexAction @Inject constructor(
 ) : WebAction {
   @Get("/support/bravo/")
   @ResponseContentType(MediaTypes.TEXT_HTML)
-  @AdminDashboardAccess
+  @SupportDashboardAccess
   fun get(): String = dashboardPageLayout
     .newBuilder()
     .build { appName, _, _ ->

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/support/SupportDashboardIndexAction.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/dashboard/support/SupportDashboardIndexAction.kt
@@ -1,14 +1,14 @@
 package com.squareup.exemplar.dashboard.support
 
+import com.squareup.exemplar.dashboard.SupportDashboardAccess
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import kotlinx.html.h1
 import misk.web.Get
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
-import misk.web.dashboard.AdminDashboardAccess
 import misk.web.mediatype.MediaTypes
 import misk.web.v2.DashboardPageLayout
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 
 @Singleton
 class SupportDashboardIndexAction @Inject constructor(
@@ -16,7 +16,7 @@ class SupportDashboardIndexAction @Inject constructor(
 ) : WebAction {
   @Get("/support/")
   @ResponseContentType(MediaTypes.TEXT_HTML)
-  @AdminDashboardAccess
+  @SupportDashboardAccess
   fun get(): String = dashboardPageLayout
     .newBuilder()
     .build { appName, _, _ ->


### PR DESCRIPTION
This closes the loop in exemplar code for a custom dashboard using a custom access annotation and custom access capabilities.