### PR TITLE
Disable jedis call to redis Client SetInfo

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
@@ -2,6 +2,7 @@ package misk.redis
 
 import org.apache.commons.pool2.PooledObject
 import org.apache.commons.pool2.PooledObjectFactory
+import redis.clients.jedis.ClientSetInfoConfig
 import redis.clients.jedis.Connection
 import redis.clients.jedis.ConnectionFactory
 import redis.clients.jedis.ConnectionPoolConfig
@@ -18,7 +19,7 @@ internal class JedisPooledWithMetrics(
   replicationGroupConfig: RedisReplicationGroupConfig,
   ssl: Boolean = true,
   requiresPassword: Boolean = true,
-) : JedisPooled (
+) : JedisPooled(
   PooledConnectionProviderWithMetrics(
     metrics,
     poolConfig,
@@ -63,6 +64,8 @@ private fun createJedisClientConfig(
       })
     .database(Protocol.DEFAULT_DATABASE)
     .ssl(ssl)
+    //CLIENT SETINFO is only supported in Redis v7.2+
+    .clientSetInfoConfig(ClientSetInfoConfig.DISABLED)
     .build()
 }
 


### PR DESCRIPTION
[Client SetInfo](https://redis.io/commands/client-setinfo/) is only supported for redis 7.2+, we currently use <7.0. Even though the errors could be ignored, we are disabling this for now to prevent spike in `errorstat`. 

More Context: https://github.com/redis/jedis/issues/3648 

Tested against an exemplar service and verified there is no increase in `errorstat` anymore shown in redis metrics when invoking a command after startup.