### PR TITLE
WebServerTestingModule always set the override_shutdown_idle_timeout

### DIFF
--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -352,7 +352,8 @@ public final class misk/web/WebServerTestingModule : misk/inject/KAbstractModule
 	public static final field Companion Lmisk/web/WebServerTestingModule$Companion;
 	public fun <init> ()V
 	public fun <init> (Lmisk/web/WebConfig;)V
-	public synthetic fun <init> (Lmisk/web/WebConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/web/WebConfig;Z)V
+	public synthetic fun <init> (Lmisk/web/WebConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/web/WebServerTestingModule$Companion {

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -35,11 +35,11 @@ class WebTestingModule @JvmOverloads constructor(
  */
 class WebServerTestingModule @JvmOverloads constructor(
   private val webConfig: WebConfig = TESTING_WEB_CONFIG,
-  private val overrideShutdown: Boolean = true
+  private val overrideShutdownTimeout: Boolean = true
 ) : KAbstractModule() {
   override fun configure() {
     install(DeploymentModule(TESTING))
-    if (overrideShutdown) {
+    if (overrideShutdownTimeout) {
       install(MiskWebModule(webConfig.copy(override_shutdown_idle_timeout = 10)))
     } else {
       install(MiskWebModule(webConfig))

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -38,7 +38,7 @@ class WebServerTestingModule @JvmOverloads constructor(
 ) : KAbstractModule() {
   override fun configure() {
     install(DeploymentModule(TESTING))
-    install(MiskWebModule(webConfig))
+    install(MiskWebModule(webConfig.copy(override_shutdown_idle_timeout = 1)))
   }
 
   companion object {

--- a/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
+++ b/misk-testing/src/main/kotlin/misk/web/WebTestingModule.kt
@@ -34,11 +34,16 @@ class WebTestingModule @JvmOverloads constructor(
  * both plaintext and TLS.
  */
 class WebServerTestingModule @JvmOverloads constructor(
-  private val webConfig: WebConfig = TESTING_WEB_CONFIG
+  private val webConfig: WebConfig = TESTING_WEB_CONFIG,
+  private val overrideShutdown: Boolean = true
 ) : KAbstractModule() {
   override fun configure() {
     install(DeploymentModule(TESTING))
-    install(MiskWebModule(webConfig.copy(override_shutdown_idle_timeout = 1)))
+    if (overrideShutdown) {
+      install(MiskWebModule(webConfig.copy(override_shutdown_idle_timeout = 10)))
+    } else {
+      install(MiskWebModule(webConfig))
+    }
   }
 
   companion object {

--- a/misk/src/test/kotlin/misk/web/JettyShutdownTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyShutdownTest.kt
@@ -109,7 +109,7 @@ internal abstract class AbstractJettyShutdownTest {
             idle_timeout = idleTimeout,
             override_shutdown_idle_timeout = shutdownIdleTimeout,
           ),
-          overrideShutdown = false
+          overrideShutdownTimeout = false
         )
       )
       install(MiskTestingServiceModule())

--- a/misk/src/test/kotlin/misk/web/JettyShutdownTest.kt
+++ b/misk/src/test/kotlin/misk/web/JettyShutdownTest.kt
@@ -108,7 +108,8 @@ internal abstract class AbstractJettyShutdownTest {
           webConfig = WebServerTestingModule.TESTING_WEB_CONFIG.copy(
             idle_timeout = idleTimeout,
             override_shutdown_idle_timeout = shutdownIdleTimeout,
-          )
+          ),
+          overrideShutdown = false
         )
       )
       install(MiskTestingServiceModule())


### PR DESCRIPTION
This reduce the time jetty takes to shutdown in tests. Fast tests happy devs.