### PR TITLE
Add wrapper for redis' zrange command

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -434,3 +434,14 @@ acceptedBreaks:
       old: "method long misk.clustering.dynamo.DynamoClusterConfig::component2()"
       new: "method java.lang.String misk.clustering.dynamo.DynamoClusterConfig::component2()"
       justification: "No external usage, code is still in development"
+    com.squareup.misk:misk-redis:
+    - code: "java.method.addedToInterface"
+      new: "method java.util.List<kotlin.Pair<okio.ByteString, java.lang.Double>>\
+        \ misk.redis.Redis::zrangeWithScores(java.lang.String, misk.redis.Redis.ZRangeType,\
+        \ misk.redis.Redis.ZRangeMarker, misk.redis.Redis.ZRangeMarker, boolean, misk.redis.Redis.ZRangeLimit)"
+      justification: "adding wrappers to support zrange"
+    - code: "java.method.addedToInterface"
+      new: "method java.util.List<okio.ByteString> misk.redis.Redis::zrange(java.lang.String,\
+        \ misk.redis.Redis.ZRangeType, misk.redis.Redis.ZRangeMarker, misk.redis.Redis.ZRangeMarker,\
+        \ boolean, misk.redis.Redis.ZRangeLimit)"
+      justification: "adding wrappers to support zrange"

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -53,6 +53,8 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
 	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -122,6 +124,8 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
 	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -176,7 +180,14 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun watch ([Ljava/lang/String;)V
 	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
 	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public abstract fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
+}
+
+public final class misk/redis/Redis$DefaultImpls {
+	public static synthetic fun zrange$default (Lmisk/redis/Redis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun zrangeWithScores$default (Lmisk/redis/Redis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
@@ -187,6 +198,74 @@ public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
 	public static final field XX Lmisk/redis/Redis$ZAddOptions;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZAddOptions;
 	public static fun values ()[Lmisk/redis/Redis$ZAddOptions;
+}
+
+public final class misk/redis/Redis$ZRangeIndexMarker : misk/redis/Redis$ZRangeMarker {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lmisk/redis/Redis$ZRangeIndexMarker;
+	public static synthetic fun copy$default (Lmisk/redis/Redis$ZRangeIndexMarker;IILjava/lang/Object;)Lmisk/redis/Redis$ZRangeIndexMarker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIntValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/redis/Redis$ZRangeLexMarker : misk/redis/Redis$ZRangeMarker {
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lmisk/redis/Redis$ZRangeLexMarker;
+	public static synthetic fun copy$default (Lmisk/redis/Redis$ZRangeLexMarker;Ljava/lang/String;ZZILjava/lang/Object;)Lmisk/redis/Redis$ZRangeLexMarker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStringValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isIncluded ()Z
+	public final fun isInfinite ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/redis/Redis$ZRangeLimit {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lmisk/redis/Redis$ZRangeLimit;
+	public static synthetic fun copy$default (Lmisk/redis/Redis$ZRangeLimit;IIILjava/lang/Object;)Lmisk/redis/Redis$ZRangeLimit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getOffset ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class misk/redis/Redis$ZRangeMarker {
+	public fun <init> (Ljava/lang/Object;Z)V
+	public final fun getIncluded ()Z
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class misk/redis/Redis$ZRangeScoreMarker : misk/redis/Redis$ZRangeMarker {
+	public fun <init> (DZ)V
+	public synthetic fun <init> (DZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()Z
+	public final fun copy (DZ)Lmisk/redis/Redis$ZRangeScoreMarker;
+	public static synthetic fun copy$default (Lmisk/redis/Redis$ZRangeScoreMarker;DZILjava/lang/Object;)Lmisk/redis/Redis$ZRangeScoreMarker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDoubleValue ()D
+	public fun hashCode ()I
+	public final fun isIncluded ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/redis/Redis$ZRangeType : java/lang/Enum {
+	public static final field INDEX Lmisk/redis/Redis$ZRangeType;
+	public static final field LEX Lmisk/redis/Redis$ZRangeType;
+	public static final field SCORE Lmisk/redis/Redis$ZRangeType;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZRangeType;
+	public static fun values ()[Lmisk/redis/Redis$ZRangeType;
 }
 
 public final class misk/redis/RedisClientMetrics {
@@ -419,6 +498,8 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
 	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)J
+	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -211,22 +211,6 @@ public final class misk/redis/Redis$ZRangeIndexMarker : misk/redis/Redis$ZRangeM
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class misk/redis/Redis$ZRangeLexMarker : misk/redis/Redis$ZRangeMarker {
-	public fun <init> (Ljava/lang/String;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun copy (Ljava/lang/String;ZZ)Lmisk/redis/Redis$ZRangeLexMarker;
-	public static synthetic fun copy$default (Lmisk/redis/Redis$ZRangeLexMarker;Ljava/lang/String;ZZILjava/lang/Object;)Lmisk/redis/Redis$ZRangeLexMarker;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getStringValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isIncluded ()Z
-	public final fun isInfinite ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class misk/redis/Redis$ZRangeLimit {
 	public fun <init> (II)V
 	public final fun component1 ()I
@@ -262,7 +246,6 @@ public final class misk/redis/Redis$ZRangeScoreMarker : misk/redis/Redis$ZRangeM
 
 public final class misk/redis/Redis$ZRangeType : java/lang/Enum {
 	public static final field INDEX Lmisk/redis/Redis$ZRangeType;
-	public static final field LEX Lmisk/redis/Redis$ZRangeType;
 	public static final field SCORE Lmisk/redis/Redis$ZRangeType;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZRangeType;
 	public static fun values ()[Lmisk/redis/Redis$ZRangeType;

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -11,6 +11,9 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import jakarta.inject.Inject
+import misk.redis.Redis.ZRangeLimit
+import misk.redis.Redis.ZRangeMarker
+import misk.redis.Redis.ZRangeType
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
@@ -423,6 +426,28 @@ class FakeRedis : Redis {
   }
 
   override fun zscore(key: String, member: String): Double? {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zrange(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<ByteString?> {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<Pair<ByteString?, Double>> {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -471,10 +471,6 @@ class RealRedis(
       ZRangeType.SCORE ->
         zrangeByScore(key, start as ZRangeScoreMarker, stop as ZRangeScoreMarker, reverse,
                       withScore, limit)
-
-      ZRangeType.LEX ->
-        throw RuntimeException("Unsupported UnifiedJedis implementation of BYLEX option for " +
-                                 "zrange command")
     }
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -494,31 +494,31 @@ class RealRedis(
       Either.Left(unifiedJedis.zrangeByScore(key.toByteArray(charset),
                                      minString.toByteArray(charset),
                                      maxString.toByteArray(charset)))
-    } else if (limit == null && !reverse && withScore) {
+    } else if (limit == null && !reverse) {
       Either.Right(unifiedJedis.zrangeByScoreWithScores(key.toByteArray(charset),
                                                         minString.toByteArray(charset),
                                                         maxString.toByteArray(charset)))
-    } else if (limit == null && reverse && !withScore) {
+    } else if (limit == null && !withScore) {
       Either.Left(unifiedJedis.zrevrangeByScore(key.toByteArray(charset),
                                              maxString.toByteArray(charset),
                                              minString.toByteArray(charset)))
-    } else if (limit == null && reverse && withScore){
+    } else if (limit == null){
       Either.Right(unifiedJedis.zrevrangeByScoreWithScores(key.toByteArray(charset),
                                                         maxString.toByteArray(charset),
                                                         minString.toByteArray(charset)))
-    } else if (limit != null && !reverse && !withScore) {
+    } else if (!reverse && !withScore) {
       Either.Left(unifiedJedis.zrangeByScore(key.toByteArray(charset),
                                              minString.toByteArray(charset),
                                              maxString.toByteArray(charset),
                                              limit.offset,
                                              limit.count))
-    } else if (limit != null && !reverse && withScore) {
+    } else if (!reverse) {
       Either.Right(unifiedJedis.zrangeByScoreWithScores(key.toByteArray(charset),
                                                         minString.toByteArray(charset),
                                                         maxString.toByteArray(charset),
                                                         limit.offset,
                                                         limit.count))
-    } else if (limit != null && reverse && !withScore) {
+    } else if (!withScore) {
       Either.Left(unifiedJedis.zrevrangeByScore(key.toByteArray(charset),
                                              maxString.toByteArray(charset),
                                              minString.toByteArray(charset),
@@ -528,7 +528,7 @@ class RealRedis(
       Either.Right(unifiedJedis.zrevrangeByScoreWithScores(key.toByteArray(charset),
                                                         maxString.toByteArray(charset),
                                                         minString.toByteArray(charset),
-                                                        limit!!.offset,
+                                                        limit.offset,
                                                         limit.count))
     }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -5,6 +5,11 @@ import misk.redis.Redis.ZAddOptions.GT
 import misk.redis.Redis.ZAddOptions.LT
 import misk.redis.Redis.ZAddOptions.NX
 import misk.redis.Redis.ZAddOptions.XX
+import misk.redis.Redis.ZRangeIndexMarker
+import misk.redis.Redis.ZRangeLimit
+import misk.redis.Redis.ZRangeMarker
+import misk.redis.Redis.ZRangeScoreMarker
+import misk.redis.Redis.ZRangeType
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import redis.clients.jedis.JedisCluster
@@ -421,6 +426,28 @@ class RealRedis(
       key.toByteArray(charset),
       member.toByteArray(charset)
     )
+  }
+
+  override fun zrange(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<ByteString?> {
+    throw NotImplementedError("Client not implemented for this operation")
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<Pair<ByteString?, Double>> {
+    throw NotImplementedError("Client not implemented for this operation")
   }
 
   // Gets a Jedis instance from the pool, and times the requested method invocations.

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -521,7 +521,8 @@ interface Redis {
    * Returns the specified range of elements in the sorted set stored at [key].
    *
    * ZRANGE can perform different [type]s of range queries: by index (rank), by the score, or by
-   * lexicographical order. See [ZRangeType] for different types of range queries.
+   * lexicographical order. Currently only index and score type range queries are supported.
+   * See [ZRangeType] for different types of range queries.
    *
    * You can specify the [start] and [stop] of the range you want to filter by.
    * Depending on the [type] you will have to use the appropriate type of [ZRangeMarker].
@@ -590,12 +591,7 @@ interface Redis {
      *
      * Use [ZRangeScoreMarker] to specify the start and stop for this type.
      */
-    SCORE,
-
-    /**
-     * This is currently not supported.
-     */
-    LEX
+    SCORE
   }
 
   abstract class ZRangeMarker(
@@ -632,15 +628,6 @@ interface Redis {
       return ans
     }
   }
-
-  /**
-   * This is currently not supported.
-   */
-  data class ZRangeLexMarker(
-    val stringValue: String,
-    val isIncluded: Boolean,
-    val isInfinite: Boolean = false
-  ): ZRangeMarker(stringValue, isIncluded)
 
   /**
    * The limit argument in [zrange] and [zrangeWithScores] can be used to obtain a sub-range from

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -517,6 +517,24 @@ interface Redis {
     member: String
   ) : Double?
 
+  /**
+   * Returns the specified range of elements in the sorted set stored at [key].
+   *
+   * ZRANGE can perform different [type]s of range queries: by index (rank), by the score, or by
+   * lexicographical order. See [ZRangeType] for different types of range queries.
+   *
+   * You can specify the [start] and [stop] of the range you want to filter by.
+   * Depending on the [type] you will have to use the appropriate type of [ZRangeMarker].
+   *
+   * The order of elements is from the lowest to the highest score.
+   * Elements with the same score are ordered lexicographically.
+   *
+   * Setting [reverse] reverses the ordering, so elements are ordered from highest to lowest score,
+   * and score ties are resolved by reverse lexicographical ordering.
+   *
+   * The [limit] argument can be used to obtain a sub-range from the matching elements.
+   * See [ZRangeLimit] for more info.
+   */
   fun zrange(
     key: String,
     type: ZRangeType = ZRangeType.INDEX,
@@ -526,6 +544,9 @@ interface Redis {
     limit: ZRangeLimit? = null,
   ): List<ByteString?>
 
+  /**
+   * This is similar to [zrange] but returns the scores along with the members.
+   */
   fun zrangeWithScores(
     key: String,
     type: ZRangeType = ZRangeType.INDEX,
@@ -535,14 +556,45 @@ interface Redis {
     limit: ZRangeLimit? = null,
   ): List<Pair<ByteString?, Double>>
 
+  /**
+   * Different types of range queries.
+   */
   enum class ZRangeType {
-    // value will be type int
+    /**
+     * The <start> and <stop> arguments represent zero-based indexes.
+     * These arguments specify an inclusive range.
+     *
+     * The indexes can also be negative numbers indicating offsets from the end of the sorted set,
+     * with -1 being the last element of the sorted set and so on.
+     *
+     * Out of range indexes do not produce an error.
+     * If <start> is greater than either the end index of the sorted set or <stop>,
+     * an empty list is returned.
+     * If <stop> is greater than the end index of the sorted set, Redis will use the last element
+     * of the sorted set.
+     *
+     * Use [ZRangeIndexMarker] to specify the start and stop for this type.
+     */
     INDEX,
 
-    // value will be type double
+    /**
+     * returns the range of elements from the sorted set having scores equal or between <start>
+     * and <stop>
+     *
+     * <start> and <stop> can be -inf and +inf, denoting the negative and positive infinities,
+     * respectively. This means that you are not required to know the highest or lowest score in the
+     * sorted set to get all elements from or up to a certain score.
+     *
+     * By default, the score intervals specified by <start> and <stop> are closed (inclusive).
+     * It is possible to specify an open interval.
+     *
+     * Use [ZRangeScoreMarker] to specify the start and stop for this type.
+     */
     SCORE,
 
-    // value will be type String
+    /**
+     * This is currently not supported.
+     */
     LEX
   }
 
@@ -551,10 +603,20 @@ interface Redis {
     val included: Boolean
   )
 
+  /**
+   * To be used when [ZRangeType] is [ZRangeType.INDEX].
+   * The [intValue] should be an integer specifying the index (start or stop)
+   */
   data class ZRangeIndexMarker(
     val intValue: Int
   ): ZRangeMarker(intValue, true)
 
+  /**
+   * To be used when [ZRangeType] is [ZRangeType.SCORE].
+   * The [doubleValue] should be a double specifying the score (start or stop)
+   * By default the range is included. Set [isIncluded] to false in order to exclude the start or
+   * stop.
+   */
   data class ZRangeScoreMarker(
     val doubleValue: Double,
     val isIncluded: Boolean = true,
@@ -571,12 +633,23 @@ interface Redis {
     }
   }
 
+  /**
+   * This is currently not supported.
+   */
   data class ZRangeLexMarker(
     val stringValue: String,
     val isIncluded: Boolean,
     val isInfinite: Boolean = false
   ): ZRangeMarker(stringValue, isIncluded)
 
+  /**
+   * The limit argument in [zrange] and [zrangeWithScores] can be used to obtain a sub-range from
+   * the matching elements similar to SELECT LIMIT offset, count in SQL.
+   * A negative [count] returns all elements from the [offset].
+   * Keep in mind that if <offset> is large, the sorted set needs to be traversed for
+   * <offset> elements before getting to the elements to return, which can add up to O(N) time
+   * complexity.
+   */
   data class ZRangeLimit(
     val offset: Int,
     val count: Int

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -517,6 +517,71 @@ interface Redis {
     member: String
   ) : Double?
 
+  fun zrange(
+    key: String,
+    type: ZRangeType = ZRangeType.INDEX,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean = false,
+    limit: ZRangeLimit? = null,
+  ): List<ByteString?>
+
+  fun zrangeWithScores(
+    key: String,
+    type: ZRangeType = ZRangeType.INDEX,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean = false,
+    limit: ZRangeLimit? = null,
+  ): List<Pair<ByteString?, Double>>
+
+  enum class ZRangeType {
+    // value will be type int
+    INDEX,
+
+    // value will be type double
+    SCORE,
+
+    // value will be type String
+    LEX
+  }
+
+  abstract class ZRangeMarker(
+    val value: Any,
+    val included: Boolean
+  )
+
+  data class ZRangeIndexMarker(
+    val intValue: Int
+  ): ZRangeMarker(intValue, true)
+
+  data class ZRangeScoreMarker(
+    val doubleValue: Double,
+    val isIncluded: Boolean = true,
+  ): ZRangeMarker(doubleValue, isIncluded) {
+    override fun toString(): String {
+      var ans = when (this.doubleValue) {
+        Double.MAX_VALUE -> "+inf"
+        Double.MIN_VALUE -> "-inf"
+        else -> this.doubleValue.toString()
+      }
+
+      if (!this.isIncluded) ans = "($ans"
+      return ans
+    }
+  }
+
+  data class ZRangeLexMarker(
+    val stringValue: String,
+    val isIncluded: Boolean,
+    val isInfinite: Boolean = false
+  ): ZRangeMarker(stringValue, isIncluded)
+
+  data class ZRangeLimit(
+    val offset: Int,
+    val count: Int
+  )
+
   enum class ZAddOptions {
     /**
      * Only update elements that already exist. Don't add new elements.

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -2431,4 +2431,121 @@ abstract class AbstractRedisTest {
     )
   }
 
+  @Test fun `zrange by score test - limit cases negative count`() {
+    val key = "bar1"
+
+    // The members with same score are lex arranged.
+    redis.zadd(
+      key,
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
+    )
+
+    assertEquals(
+      listOf(
+        "b".encodeUtf8(),
+        "c".encodeUtf8(),
+        "yy".encodeUtf8(),
+        "ad".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        limit = ZRangeLimit(
+          3,
+          -1
+        )
+      )
+    )
+
+    assertEquals(
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          9.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        limit = ZRangeLimit(
+          3,
+          -2
+        )
+      )
+    )
+    assertEquals(
+      listOf(
+        "b".encodeUtf8(),
+        "bb".encodeUtf8(),
+        "bz".encodeUtf8(),
+        "ba".encodeUtf8(),
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true,
+        limit = ZRangeLimit(
+          3,
+          -3
+        )
+      )
+    )
+    assertEquals(
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true,
+        limit = ZRangeLimit(
+          3,
+          -4
+        )
+      )
+    )
+  }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -966,7 +966,13 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
     // standard happy case. get first four lowest score members.
     assertEquals(
@@ -976,17 +982,38 @@ abstract class AbstractRedisTest {
         "b".encodeUtf8(),
         "yy".encodeUtf8()
       ),
-      redis.zrange(key, INDEX,
-                   ZRangeIndexMarker(0), ZRangeIndexMarker(3))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(3)
+      )
     )
     assertEquals(
       listOf(
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7)
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(3))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(3)
+      )
     )
     assertEquals(
       listOf(
@@ -995,16 +1022,40 @@ abstract class AbstractRedisTest {
         "b".encodeUtf8(),
         "bb".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(3), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(3),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 10.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5)
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(3), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(3),
+        true
+      )
     )
   }
 
@@ -1013,7 +1064,13 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
     // stop index exceeds the size. So stop index is the last one.
     assertEquals(
@@ -1024,17 +1081,42 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(100))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(100)
+      )
     )
     assertEquals(
       listOf(
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 10.0)
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(100))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(100)
+      )
     )
     assertEquals(
       listOf(
@@ -1044,17 +1126,44 @@ abstract class AbstractRedisTest {
         "bb".encodeUtf8(),
         "bz".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(100), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(100),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 10.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3)
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(100), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(100),
+        true
+      )
     )
   }
 
@@ -1063,24 +1172,52 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
     // when start is greater than stop, empty set is returned.
     assertEquals(
       listOf(),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(3), ZRangeIndexMarker(1))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(3),
+        ZRangeIndexMarker(1)
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(3), ZRangeIndexMarker(1))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(3),
+        ZRangeIndexMarker(1)
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(3), ZRangeIndexMarker(1), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(3),
+        ZRangeIndexMarker(1),
+        true
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(3), ZRangeIndexMarker(1), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(3),
+        ZRangeIndexMarker(1),
+        true
+      )
     )
   }
 
@@ -1089,7 +1226,13 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
 
     // negative indices. get second last to last
@@ -1098,28 +1241,62 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(-1))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 10.0)
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(-1))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
         "bb".encodeUtf8(),
         "bz".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(-1), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3)
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(-1), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
   }
 
@@ -1128,7 +1305,13 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
 
     // negative indices. get last 100 or as much there is.
@@ -1140,17 +1323,42 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-100), ZRangeIndexMarker(-1))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-100),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 10.0)
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-100), ZRangeIndexMarker(-1))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-100),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
@@ -1160,19 +1368,45 @@ abstract class AbstractRedisTest {
         "bb".encodeUtf8(),
         "bz".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-100), ZRangeIndexMarker(-1), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-100),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 10.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3)
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-100), ZRangeIndexMarker(-1), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-100),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
-
   }
 
   @Test fun `zrange by index test - mixed indices - get from second last to second`() {
@@ -1180,25 +1414,53 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
 
     // mixed indices. empty set --> going from second last to second.
     assertEquals(
       listOf(),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(1))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(1)
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(1))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(1)
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(1), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(1),
+        true
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(-2), ZRangeIndexMarker(1), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(-2),
+        ZRangeIndexMarker(1),
+        true
+      )
     )
   }
 
@@ -1207,7 +1469,13 @@ abstract class AbstractRedisTest {
 
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0
+      )
     )
 
     // mixed indices. get from second to second last
@@ -1217,15 +1485,34 @@ abstract class AbstractRedisTest {
         "b".encodeUtf8(),
         "yy".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(1), ZRangeIndexMarker(-2))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(1),
+        ZRangeIndexMarker(-2)
+      )
     )
     assertEquals(
       listOf(
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7)
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(1), ZRangeIndexMarker(-2))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(1),
+        ZRangeIndexMarker(-2)
+      )
     )
     assertEquals(
       listOf(
@@ -1233,15 +1520,36 @@ abstract class AbstractRedisTest {
         "b".encodeUtf8(),
         "bb".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(1), ZRangeIndexMarker(-2), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(1),
+        ZRangeIndexMarker(-2),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(1), ZRangeIndexMarker(-2), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(1),
+        ZRangeIndexMarker(-2),
+        true
+      )
     )
   }
 
@@ -1251,7 +1559,15 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 10.0, "c" to 5.0, "ba" to 2.3)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 10.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
     )
 
     assertEquals(
@@ -1264,19 +1580,50 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1))
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
-        Pair("ba".encodeUtf8(), 2.3),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 10.0)
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1))
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(-1)
+      )
     )
     assertEquals(
       listOf(
@@ -1288,19 +1635,52 @@ abstract class AbstractRedisTest {
         "bz".encodeUtf8(),
         "ba".encodeUtf8(),
       ),
-      redis.zrange(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1), true)
+      redis.zrange(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 10.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("ba".encodeUtf8(), 2.3)
+        Pair(
+          "ad".encodeUtf8(),
+          10.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1), true)
+      redis.zrangeWithScores(
+        key,
+        INDEX,
+        ZRangeIndexMarker(0),
+        ZRangeIndexMarker(-1),
+        true
+      )
     )
   }
 
@@ -1310,7 +1690,15 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 9.0, "c" to 5.0, "ba" to 2.3)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
     )
 
     assertEquals(
@@ -1323,22 +1711,50 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, SCORE,
-                   ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0))
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0)
+      )
     )
 
     assertEquals(
       listOf(
-        Pair("ba".encodeUtf8(), 2.3),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 9.0)
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          9.0
+        )
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(-10.0),
-                             ZRangeScoreMarker(10.0)
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0)
       )
     )
     assertEquals(
@@ -1351,19 +1767,52 @@ abstract class AbstractRedisTest {
         "bz".encodeUtf8(),
         "ba".encodeUtf8(),
       ),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0), true)
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 9.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("ba".encodeUtf8(), 2.3)
+        Pair(
+          "ad".encodeUtf8(),
+          9.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0), true)
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true
+      )
     )
   }
 
@@ -1373,7 +1822,15 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 9.0, "c" to 5.0, "ba" to 2.3)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
     )
 
     assertEquals(
@@ -1386,20 +1843,51 @@ abstract class AbstractRedisTest {
         "yy".encodeUtf8(),
         "ad".encodeUtf8()
       ),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE))
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(Double.MIN_VALUE),
+        ZRangeScoreMarker(Double.MAX_VALUE)
+      )
     )
 
     assertEquals(
       listOf(
-        Pair("ba".encodeUtf8(), 2.3),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("ad".encodeUtf8(), 9.0)
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "ad".encodeUtf8(),
+          9.0
+        )
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE))
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(Double.MIN_VALUE),
+        ZRangeScoreMarker(Double.MAX_VALUE)
+      )
     )
     assertEquals(
       listOf(
@@ -1411,19 +1899,52 @@ abstract class AbstractRedisTest {
         "bz".encodeUtf8(),
         "ba".encodeUtf8(),
       ),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE), true)
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(Double.MIN_VALUE),
+        ZRangeScoreMarker(Double.MAX_VALUE),
+        true
+      )
     )
     assertEquals(
       listOf(
-        Pair("ad".encodeUtf8(), 9.0),
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("b".encodeUtf8(), 5.0),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("ba".encodeUtf8(), 2.3)
+        Pair(
+          "ad".encodeUtf8(),
+          9.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "ba".encodeUtf8(),
+          2.3
+        )
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE), true)
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(Double.MIN_VALUE),
+        ZRangeScoreMarker(Double.MAX_VALUE),
+        true
+      )
     )
   }
 
@@ -1433,25 +1954,55 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 9.0, "c" to 5.0, "ba" to 2.3)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
     )
 
     assertEquals(
       listOf(),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(10.0), ZRangeScoreMarker(-10.0))
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(10.0),
+        ZRangeScoreMarker(-10.0)
+      )
     )
 
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(10.0), ZRangeScoreMarker(-10.0))
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(10.0),
+        ZRangeScoreMarker(-10.0)
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(10.0), ZRangeScoreMarker(-10.0), true)
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(10.0),
+        ZRangeScoreMarker(-10.0),
+        true
+      )
     )
     assertEquals(
       listOf(),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(10.0), ZRangeScoreMarker(-10.0), true)
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(10.0),
+        ZRangeScoreMarker(-10.0),
+        true
+      )
     )
   }
 
@@ -1461,84 +2012,315 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 9.0, "ba" to 2.3)
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "ba" to 2.3
+      )
     )
 
     // start included, stop included.
     assertEquals(
-      listOf("bb".encodeUtf8(), "b".encodeUtf8(), "yy".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7))
+      listOf(
+        "bb".encodeUtf8(),
+        "b".encodeUtf8(),
+        "yy".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(6.7)
+      )
     )
     assertEquals(
-      listOf(Pair("bb".encodeUtf8(), 4.5), Pair("b".encodeUtf8(), 5.0),
-             Pair("yy".encodeUtf8(), 6.7)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7))
+      listOf(
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(6.7)
+      )
     )
     assertEquals(
-      listOf("yy".encodeUtf8(), "b".encodeUtf8(), "bb".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7), true)
+      listOf(
+        "yy".encodeUtf8(),
+        "b".encodeUtf8(),
+        "bb".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(6.7),
+        true
+      )
     )
     assertEquals(
-      listOf(Pair("yy".encodeUtf8(), 6.7), Pair("b".encodeUtf8(), 5.0),
-             Pair("bb".encodeUtf8(), 4.5)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7), true)
+      listOf(
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(6.7),
+        true
+      )
     )
 
     // start not included, stop included.
     assertEquals(
-      listOf("b".encodeUtf8(), "yy".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7))
+      listOf(
+        "b".encodeUtf8(),
+        "yy".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(6.7)
+      )
     )
     assertEquals(
-      listOf(Pair("b".encodeUtf8(), 5.0), Pair("yy".encodeUtf8(), 6.7)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7))
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(6.7)
+      )
     )
     assertEquals(
-      listOf("yy".encodeUtf8(), "b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7), true)
+      listOf(
+        "yy".encodeUtf8(),
+        "b".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(6.7),
+        true
+      )
     )
     assertEquals(
-      listOf(Pair("yy".encodeUtf8(), 6.7), Pair("b".encodeUtf8(), 5.0)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7), true)
+      listOf(
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(6.7),
+        true
+      )
     )
 
     // start not included, stop not included.
     assertEquals(
       listOf("b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7, false))
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        )
+      )
     )
     assertEquals(
-      listOf(Pair("b".encodeUtf8(), 5.0)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7, false))
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        )
+      )
     )
     assertEquals(
       listOf("b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7, false), true)
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        ),
+        true
+      )
     )
     assertEquals(
-      listOf(Pair("b".encodeUtf8(), 5.0)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(6.7, false), true)
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(
+          4.5,
+          false
+        ),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        ),
+        true
+      )
     )
-
 
     // start included, stop not included.
     assertEquals(
-      listOf("bb".encodeUtf8(), "b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7, false))
+      listOf(
+        "bb".encodeUtf8(),
+        "b".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        )
+      )
     )
     assertEquals(
-      listOf(Pair("bb".encodeUtf8(), 4.5), Pair("b".encodeUtf8(), 5.0)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7, false))
+      listOf(
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        )
+      )
     )
     assertEquals(
-      listOf("b".encodeUtf8(), "bb".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7, false), true)
+      listOf(
+        "b".encodeUtf8(),
+        "bb".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        ),
+        true
+      )
     )
     assertEquals(
-      listOf(Pair("b".encodeUtf8(), 5.0), Pair("bb".encodeUtf8(), 4.5)),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(4.5), ZRangeScoreMarker(6.7, false), true)
+      listOf(
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(4.5),
+        ZRangeScoreMarker(
+          6.7,
+          false
+        ),
+        true
+      )
     )
-
   }
 
   @Test fun `zrange by score test - limit cases`() {
@@ -1547,38 +2329,105 @@ abstract class AbstractRedisTest {
     // The members with same score are lex arranged.
     redis.zadd(
       key,
-      mapOf("b" to 5.0, "bz" to 2.3, "bb" to 4.5, "yy" to 6.7, "ad" to 9.0, "c" to 5.0, "ba" to 2.3)
-    )
-
-    assertEquals(
-      listOf("bz".encodeUtf8(), "bb".encodeUtf8(), "b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0),
-                   limit = ZRangeLimit(1, 3))
+      mapOf(
+        "b" to 5.0,
+        "bz" to 2.3,
+        "bb" to 4.5,
+        "yy" to 6.7,
+        "ad" to 9.0,
+        "c" to 5.0,
+        "ba" to 2.3
+      )
     )
 
     assertEquals(
       listOf(
-        Pair("bz".encodeUtf8(), 2.3),
-        Pair("bb".encodeUtf8(), 4.5),
-        Pair("b".encodeUtf8(), 5.0)
+        "bz".encodeUtf8(),
+        "bb".encodeUtf8(),
+        "b".encodeUtf8()
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0),
-                             limit = ZRangeLimit(1, 3)
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        limit = ZRangeLimit(
+          1,
+          3
+        )
+      )
+    )
+
+    assertEquals(
+      listOf(
+        Pair(
+          "bz".encodeUtf8(),
+          2.3
+        ),
+        Pair(
+          "bb".encodeUtf8(),
+          4.5
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        )
+      ),
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        limit = ZRangeLimit(
+          1,
+          3
+        )
       )
     )
     assertEquals(
-      listOf("yy".encodeUtf8(), "c".encodeUtf8(), "b".encodeUtf8()),
-      redis.zrange(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0), true,
-                   limit = ZRangeLimit(1, 3))
+      listOf(
+        "yy".encodeUtf8(),
+        "c".encodeUtf8(),
+        "b".encodeUtf8()
+      ),
+      redis.zrange(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true,
+        limit = ZRangeLimit(
+          1,
+          3
+        )
+      )
     )
     assertEquals(
       listOf(
-        Pair("yy".encodeUtf8(), 6.7),
-        Pair("c".encodeUtf8(), 5.0),
-        Pair("b".encodeUtf8(), 5.0),
+        Pair(
+          "yy".encodeUtf8(),
+          6.7
+        ),
+        Pair(
+          "c".encodeUtf8(),
+          5.0
+        ),
+        Pair(
+          "b".encodeUtf8(),
+          5.0
+        ),
       ),
-      redis.zrangeWithScores(key, SCORE, ZRangeScoreMarker(-10.0), ZRangeScoreMarker(10.0), true,
-                             limit = ZRangeLimit(1, 3))
+      redis.zrangeWithScores(
+        key,
+        SCORE,
+        ZRangeScoreMarker(-10.0),
+        ZRangeScoreMarker(10.0),
+        true,
+        limit = ZRangeLimit(
+          1,
+          3
+        )
+      )
     )
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -10,6 +10,7 @@ import misk.redis.Redis.ZRangeLimit
 import misk.redis.Redis.ZRangeScoreMarker
 import misk.redis.Redis.ZRangeType.INDEX
 import misk.redis.Redis.ZRangeType.SCORE
+import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -962,1590 +963,385 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - happy case`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair)
+    val expectedMapForReverse =
+      mapOf(ad_9Pair, yy_6_7Pair, c_5Pair, b_5Pair)
+    val start = 0
+    val stop = 3
+
     // standard happy case. get first four lowest score members.
-    assertEquals(
-      listOf(
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "yy".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(3)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(3)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(3),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(3),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - stop index exceeds the size`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
-    // stop index exceeds the size. So stop index is the last one.
-    assertEquals(
-      listOf(
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(100)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(100)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(100),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(100),
-        true
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
+    val expectedMapForReverse =
+      mapOf(ad_9Pair, yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
+    val start = 0
+    val stop = 100
+
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - start is greater than stop`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse = mapOf<String, Double>()
+    val expectedMapForReverse = mapOf<String, Double>()
+    val start = 3
+    val stop = 1
+
     // when start is greater than stop, empty set is returned.
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(3),
-        ZRangeIndexMarker(1)
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(3),
-        ZRangeIndexMarker(1)
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(3),
-        ZRangeIndexMarker(1),
-        true
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(3),
-        ZRangeIndexMarker(1),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - negative indices - get second last to last`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse = mapOf(yy_6_7Pair, ad_9Pair)
+    val expectedMapForReverse = mapOf(bz_2_3Pair, ba_2_3Pair)
+    val start = -2
+    val stop = -1
 
     // negative indices. get second last to last
-    assertEquals(
-      listOf(
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - negative indices - get last 100 or as many as there are`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
+    val expectedMapForReverse =
+      mapOf(ad_9Pair, yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
+    val start = -100
+    val stop = -1
 
     // negative indices. get last 100 or as much there is.
-    assertEquals(
-      listOf(
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-100),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-100),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-100),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-100),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - mixed indices - get from second last to second`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse = mapOf<String, Double>()
+    val expectedMapForReverse = mapOf<String, Double>()
+    val start = -2
+    val stop = 1
 
     // mixed indices. empty set --> going from second last to second.
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(1)
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(1)
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(1),
-        true
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(-2),
-        ZRangeIndexMarker(1),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by index test - mixed indices - get from second to second last`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair)
+    val expectedMapForReverse =
+      mapOf(yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair, bz_2_3Pair)
+    val start = 1
+    val stop = -2
 
     // mixed indices. get from second to second last
-    assertEquals(
-      listOf(
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "yy".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(1),
-        ZRangeIndexMarker(-2)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(1),
-        ZRangeIndexMarker(-2)
-      )
-    )
-    assertEquals(
-      listOf(
-        "yy".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(1),
-        ZRangeIndexMarker(-2),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(1),
-        ZRangeIndexMarker(-2),
-        true
-      )
-    )
-  }
-
-  @Test fun `zrange by index test - same score lex sorted`() {
-    val key = "bar1"
-
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 10.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
-
-    assertEquals(
-      listOf(
-        "ba".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "c".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(-1)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "c".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "ba".encodeUtf8(),
-      ),
-      redis.zrange(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          10.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        INDEX,
-        ZRangeIndexMarker(0),
-        ZRangeIndexMarker(-1),
-        true
-      )
-    )
+    checkZRangeIndexResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by score test - happy case`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
+    val expectedMapForReverse =
+      mapOf(ad_9Pair, yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
+    val start = -10.0
+    val stop = 10.0
 
-    assertEquals(
-      listOf(
-        "ba".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "c".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0)
-      )
-    )
-
-    assertEquals(
-      listOf(
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          9.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "c".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "ba".encodeUtf8(),
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          9.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true
-      )
-    )
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by score test - infinity cases`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
+    val expectedMapForNonReverse =
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
+    val expectedMapForReverse =
+      mapOf(ad_9Pair, yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
+    val start = Double.MIN_VALUE
+    val stop = Double.MAX_VALUE
 
-    assertEquals(
-      listOf(
-        "ba".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "c".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(Double.MIN_VALUE),
-        ZRangeScoreMarker(Double.MAX_VALUE)
-      )
-    )
-
-    assertEquals(
-      listOf(
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          9.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(Double.MIN_VALUE),
-        ZRangeScoreMarker(Double.MAX_VALUE)
-      )
-    )
-    assertEquals(
-      listOf(
-        "ad".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "c".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "ba".encodeUtf8(),
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(Double.MIN_VALUE),
-        ZRangeScoreMarker(Double.MAX_VALUE),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "ad".encodeUtf8(),
-          9.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(Double.MIN_VALUE),
-        ZRangeScoreMarker(Double.MAX_VALUE),
-        true
-      )
-    )
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by score test - start score exceeds stop`() {
-    val key = "bar1"
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
+    val expectedMapForNonReverse = mapOf<String, Double>()
+    val expectedMapForReverse = mapOf<String, Double>()
+    val start = 10.0
+    val stop = -10.0
 
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(10.0),
-        ZRangeScoreMarker(-10.0)
-      )
-    )
-
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(10.0),
-        ZRangeScoreMarker(-10.0)
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(10.0),
-        ZRangeScoreMarker(-10.0),
-        true
-      )
-    )
-    assertEquals(
-      listOf(),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(10.0),
-        ZRangeScoreMarker(-10.0),
-        true
-      )
-    )
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
-  @Test fun `zrange by score test - star and stop inclusion cases`() {
-    val key = "bar1"
+  @Test fun `zrange by score test - start included, stop included`() {
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "ba" to 2.3
-      )
-    )
+    val expectedMapForNonReverse = mapOf(bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair)
+    val expectedMapForReverse = mapOf(yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair)
+    val start = 4.5
+    val stop = 6.7
 
-    // start included, stop included.
-    assertEquals(
-      listOf(
-        "bb".encodeUtf8(),
-        "b".encodeUtf8(),
-        "yy".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(6.7)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(6.7)
-      )
-    )
-    assertEquals(
-      listOf(
-        "yy".encodeUtf8(),
-        "b".encodeUtf8(),
-        "bb".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(6.7),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(6.7),
-        true
-      )
-    )
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
+  }
 
-    // start not included, stop included.
-    assertEquals(
-      listOf(
-        "b".encodeUtf8(),
-        "yy".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(6.7)
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(6.7)
-      )
-    )
-    assertEquals(
-      listOf(
-        "yy".encodeUtf8(),
-        "b".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(6.7),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(6.7),
-        true
-      )
-    )
+  @Test fun `zrange by score test - start not included, stop included`() {
+    redis.zadd(key,
+          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // start not included, stop not included.
-    assertEquals(
-      listOf("b".encodeUtf8()),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        )
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        )
-      )
-    )
-    assertEquals(
-      listOf("b".encodeUtf8()),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        ),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(
-          4.5,
-          false
-        ),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        ),
-        true
-      )
-    )
+    val expectedMapForNonReverse = mapOf(b_5Pair, c_5Pair, yy_6_7Pair)
+    val expectedMapForReverse = mapOf(yy_6_7Pair, c_5Pair, b_5Pair)
+    val start = ZRangeScoreMarker(4.5, false)
+    val stop = ZRangeScoreMarker(6.7)
 
-    // start included, stop not included.
-    assertEquals(
-      listOf(
-        "bb".encodeUtf8(),
-        "b".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        )
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        )
-      )
-    )
-    assertEquals(
-      listOf(
-        "b".encodeUtf8(),
-        "bb".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        ),
-        true
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(4.5),
-        ZRangeScoreMarker(
-          6.7,
-          false
-        ),
-        true
-      )
-    )
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
+  }
+
+  @Test fun `zrange by score test - start not included, stop not included`() {
+    redis.zadd(key,
+          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    val expectedMapForNonReverse = mapOf(b_5Pair, c_5Pair)
+    val expectedMapForReverse = mapOf(c_5Pair, b_5Pair)
+    val start = ZRangeScoreMarker(4.5, false)
+    val stop = ZRangeScoreMarker(6.7, false)
+
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
+  }
+
+  @Test fun `zrange by score test - start included, stop not included`() {
+    redis.zadd(key,
+          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    val expectedMapForNonReverse = mapOf(bb_4_5Pair, b_5Pair, c_5Pair)
+    val expectedMapForReverse = mapOf(c_5Pair, b_5Pair, bb_4_5Pair)
+    val start = ZRangeScoreMarker(4.5)
+    val stop = ZRangeScoreMarker(6.7, false)
+
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse, start, stop)
   }
 
   @Test fun `zrange by score test - limit cases`() {
-    val key = "bar1"
+    redis.zadd(key,
+        mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
-    // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
+    val m2 = mapOf(bz_2_3Pair, bb_4_5Pair, b_5Pair)
+    val m3 = mapOf(yy_6_7Pair, c_5Pair, b_5Pair)
+    val limit = ZRangeLimit(1, 3)
 
-    assertEquals(
-      listOf(
-        "bz".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "b".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        limit = ZRangeLimit(
-          1,
-          3
-        )
-      )
-    )
-
-    assertEquals(
-      listOf(
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        )
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        limit = ZRangeLimit(
-          1,
-          3
-        )
-      )
-    )
-    assertEquals(
-      listOf(
-        "yy".encodeUtf8(),
-        "c".encodeUtf8(),
-        "b".encodeUtf8()
-      ),
-      redis.zrange(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true,
-        limit = ZRangeLimit(
-          1,
-          3
-        )
-      )
-    )
-    assertEquals(
-      listOf(
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-      ),
-      redis.zrangeWithScores(
-        key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true,
-        limit = ZRangeLimit(
-          1,
-          3
-        )
-      )
-    )
+    checkZRangeScoreResponse(m2, m3, -10.0, 10.0, limit)
   }
 
   @Test fun `zrange by score test - limit cases negative count`() {
-    val key = "bar1"
 
     // The members with same score are lex arranged.
-    redis.zadd(
-      key,
-      mapOf(
-        "b" to 5.0,
-        "bz" to 2.3,
-        "bb" to 4.5,
-        "yy" to 6.7,
-        "ad" to 9.0,
-        "c" to 5.0,
-        "ba" to 2.3
-      )
-    )
+    redis.zadd(key,
+               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
 
+    val m2 = mapOf(b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
+    val m3 = mapOf(b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
+    val limit = ZRangeLimit(3, -2)
+    val start = -10.0
+    val stop = 10.0
+
+    checkZRangeScoreResponse(m2, m3, start, stop, limit)
+  }
+
+  private fun checkZRangeIndexResponse(
+    expectedMapForNonReverse: Map<String, Double>,
+    expectedMapForReverse: Map<String, Double>,
+    start: Int,
+    stop: Int
+  ) {
     assertEquals(
-      listOf(
-        "b".encodeUtf8(),
-        "c".encodeUtf8(),
-        "yy".encodeUtf8(),
-        "ad".encodeUtf8()
-      ),
+      expectedMapForNonReverse.encodedKeys(),
       redis.zrange(
         key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        limit = ZRangeLimit(
-          3,
-          -1
-        )
+        INDEX,
+        ZRangeIndexMarker(start),
+        ZRangeIndexMarker(stop),
       )
     )
-
     assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "c".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "yy".encodeUtf8(),
-          6.7
-        ),
-        Pair(
-          "ad".encodeUtf8(),
-          9.0
-        )
-      ),
+      expectedMapForNonReverse.toEncodedListOfPairs(),
       redis.zrangeWithScores(
         key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        limit = ZRangeLimit(
-          3,
-          -2
-        )
+        INDEX,
+        ZRangeIndexMarker(start),
+        ZRangeIndexMarker(stop)
       )
     )
     assertEquals(
-      listOf(
-        "b".encodeUtf8(),
-        "bb".encodeUtf8(),
-        "bz".encodeUtf8(),
-        "ba".encodeUtf8(),
-      ),
+      expectedMapForReverse.encodedKeys(),
       redis.zrange(
         key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true,
-        limit = ZRangeLimit(
-          3,
-          -3
-        )
+        INDEX,
+        ZRangeIndexMarker(start),
+        ZRangeIndexMarker(stop),
+        true
       )
     )
     assertEquals(
-      listOf(
-        Pair(
-          "b".encodeUtf8(),
-          5.0
-        ),
-        Pair(
-          "bb".encodeUtf8(),
-          4.5
-        ),
-        Pair(
-          "bz".encodeUtf8(),
-          2.3
-        ),
-        Pair(
-          "ba".encodeUtf8(),
-          2.3
-        )
-      ),
+      expectedMapForReverse.toEncodedListOfPairs(),
       redis.zrangeWithScores(
         key,
-        SCORE,
-        ZRangeScoreMarker(-10.0),
-        ZRangeScoreMarker(10.0),
-        true,
-        limit = ZRangeLimit(
-          3,
-          -4
-        )
+        INDEX,
+        ZRangeIndexMarker(start),
+        ZRangeIndexMarker(stop),
+        true
       )
     )
   }
+
+  private fun checkZRangeScoreResponse(
+    expectedMapForNonReverse: Map<String, Double>,
+    expectedMapForReverse: Map<String, Double>,
+    start: Double,
+    stop: Double,
+    limit: ZRangeLimit? = null
+  ) {
+    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse,
+                             ZRangeScoreMarker(start), ZRangeScoreMarker(stop), limit)
+  }
+
+
+  private fun checkZRangeScoreResponse(
+    expectedMapForNonReverse: Map<String, Double>,
+    expectedMapForReverse: Map<String, Double>,
+    start: ZRangeScoreMarker,
+    stop: ZRangeScoreMarker,
+    limit: ZRangeLimit? = null
+  ) {
+    if (limit == null) {
+      assertEquals(
+        expectedMapForNonReverse.encodedKeys(),
+        redis.zrange(
+          key,
+          SCORE,
+          start,
+          stop
+        )
+      )
+      assertEquals(
+        expectedMapForNonReverse.toEncodedListOfPairs(),
+        redis.zrangeWithScores(
+          key,
+          SCORE,
+          start,
+          stop
+        )
+      )
+      assertEquals(
+        expectedMapForReverse.encodedKeys(),
+        redis.zrange(
+          key,
+          SCORE,
+          start,
+          stop,
+          true
+        )
+      )
+      assertEquals(
+        expectedMapForReverse.toEncodedListOfPairs(),
+        redis.zrangeWithScores(
+          key,
+          SCORE,
+          start,
+          stop,
+          true
+        )
+      )
+    } else {
+      assertEquals(
+        expectedMapForNonReverse.encodedKeys(),
+        redis.zrange(
+          key,
+          SCORE,
+          start,
+          stop,
+          limit = limit
+        )
+      )
+      assertEquals(
+        expectedMapForNonReverse.toEncodedListOfPairs(),
+        redis.zrangeWithScores(
+          key,
+          SCORE,
+          start,
+          stop,
+          limit = limit
+        )
+      )
+      assertEquals(
+        expectedMapForReverse.encodedKeys(),
+        redis.zrange(
+          key,
+          SCORE,
+          start,
+          stop,
+          true,
+          limit = limit
+        )
+      )
+      assertEquals(
+        expectedMapForReverse.toEncodedListOfPairs(),
+        redis.zrangeWithScores(
+          key,
+          SCORE,
+          start,
+          stop,
+          true,
+          limit = limit
+        )
+      )
+    }
+  }
+
+  companion object {
+    // common vars used in tests for sorted set commands
+    val b_5Pair = "b" to 5.0
+    val bz_2_3Pair = "bz" to 2.3
+    val bb_4_5Pair = "bb" to 4.5
+    val yy_6_7Pair = "yy" to 6.7
+    val ad_9Pair = "ad" to 9.0
+    val c_5Pair = "c" to 5.0
+    val ba_2_3Pair = "ba" to 2.3
+    val key = "foo"
+  }
+
+  private fun Map<String, Double>.toEncodedListOfPairs() : List<Pair<ByteString, Double>> =
+    this.entries.map { Pair(it.key.encodeUtf8(), it.value) }.toList()
+
+  private fun List<String>.encoded(): List<ByteString> = this.map { it.encodeUtf8() }.toList()
+
+  private fun Map<String, Double>.encodedKeys() : List<ByteString> =
+    this.entries.map { it.key.encodeUtf8() }.toList()
+
 }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -18,6 +18,11 @@ import misk.redis.Redis.ZAddOptions.NX
 import misk.redis.Redis.ZAddOptions.LT
 import misk.redis.Redis.ZAddOptions.GT
 import misk.redis.Redis.ZAddOptions.CH
+import misk.redis.Redis.ZRangeIndexMarker
+import misk.redis.Redis.ZRangeLimit
+import misk.redis.Redis.ZRangeMarker
+import misk.redis.Redis.ZRangeScoreMarker
+import misk.redis.Redis.ZRangeType
 import redis.clients.jedis.exceptions.JedisDataException
 import kotlin.math.max
 import kotlin.math.min
@@ -571,6 +576,28 @@ class FakeRedis @Inject constructor(
     }
 
     return currentScore
+  }
+
+  override fun zrange(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<ByteString?> {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<Pair<ByteString?, Double>> {
+    throw NotImplementedError("Fake client not implemented for this operation")
   }
   }
 }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -630,9 +630,10 @@ class FakeRedis @Inject constructor(
     reverse: Boolean
   ): List<Pair<ByteString?, Double>> {
     val scores = if (!reverse) sortedSet.keys.toList() else sortedSet.keys.toList().reversed()
-    val length = scores.size
     var minInt = start.intValue
     var maxInt = stop.intValue
+    var length = 0
+    sortedSet.values.forEach { length += it.size }
 
     if (minInt < -length) minInt = -length
     if (minInt < 0) minInt += length
@@ -644,16 +645,18 @@ class FakeRedis @Inject constructor(
 
     if (minInt > maxInt) return listOf()
 
-    fun Int.cmp() = this in minInt..maxInt
-
     val ans = mutableListOf<Pair<ByteString?, Double>>()
+    var ctr = 0
 
-    for (idx in scores.indices.filter { it.cmp() }) {
+    for (idx in scores.indices) {
       val score = scores[idx]
       var members = sortedSet[score]!!.sorted()
       if (reverse) members = members.reversed()
       for (member in members) {
-        ans.add(Pair(member.encodeUtf8(), score))
+        if (ctr in minInt..maxInt) {
+          ans.add(Pair(member.encodeUtf8(), score))
+        }
+        ctr++
       }
     }
 

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -618,9 +618,6 @@ class FakeRedis @Inject constructor(
           reverse = reverse,
           limit = limit
         )
-      ZRangeType.LEX ->
-        throw RuntimeException("Unsupported UnifiedJedis implementation of BYLEX option for " +
-                                 "zrange command")
     }
 
     return ansWithScore

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -695,6 +695,8 @@ class FakeRedis @Inject constructor(
       count = limit.count
     }
 
+    if  (count < 0) count = Int.MAX_VALUE
+
     val filteredScores = scores.filter { it.cmp() }
 
     for (score in filteredScores) {


### PR DESCRIPTION
It will be easier to review this by the commits..
The first three commits are the important ones.
- 1st commit : Change sortedSet data structure in fake redis. Representing it as `HashMap<Double, HashSet<String>>>` which more closely represents how sorted set actually works in redis.
- 2nd commit: Add Interface of wrappers for zrange command.
- 3rd commit: The actual implementation of default (by index) and by score options of zrange.
- Rest of commits: Fixed linting, added documentation, added more tests.