### PR TITLE
Remove required parameter playCdn from HtmlLayout

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/dashboard/HtmlLayout.kt
+++ b/misk-admin/src/main/kotlin/misk/web/dashboard/HtmlLayout.kt
@@ -4,6 +4,6 @@ import kotlinx.html.TagConsumer
 import misk.tailwind.TailwindHtmlLayout
 
 /** Default setup of HTML for a page including head and install of CSS/JS dependencies. */
-fun TagConsumer<*>.HtmlLayout(appRoot: String, title: String, playCdn: Boolean, appCssPath: String? = null, headBlock: TagConsumer<*>.() -> Unit = {}, bodyBlock: TagConsumer<*>.() -> Unit) {
+fun TagConsumer<*>.HtmlLayout(appRoot: String, title: String, playCdn: Boolean = false, appCssPath: String? = null, headBlock: TagConsumer<*>.() -> Unit = {}, bodyBlock: TagConsumer<*>.() -> Unit) {
   TailwindHtmlLayout(appRoot = appRoot, title = title, playCdn = playCdn, appCssPath = appCssPath, headBlock = headBlock, bodyBlock = bodyBlock)
 }

--- a/misk-tailwind/src/main/kotlin/misk/tailwind/TailwindHtmlLayout.kt
+++ b/misk-tailwind/src/main/kotlin/misk/tailwind/TailwindHtmlLayout.kt
@@ -10,7 +10,7 @@ import kotlinx.html.script
 import kotlinx.html.title
 import misk.turbo.addHotwireHeadImports
 
-fun TagConsumer<*>.TailwindHtmlLayout(appRoot: String, title: String, playCdn: Boolean, appCssPath: String? = null, headBlock: TagConsumer<*>.() -> Unit = {}, bodyBlock: TagConsumer<*>.() -> Unit) {
+fun TagConsumer<*>.TailwindHtmlLayout(appRoot: String, title: String, playCdn: Boolean = false, appCssPath: String? = null, headBlock: TagConsumer<*>.() -> Unit = {}, bodyBlock: TagConsumer<*>.() -> Unit) {
   html {
     attributes["class"] = "h-full bg-white"
     head {


### PR DESCRIPTION
Misk now serves a cached version of the Tailwind Play CDN. In the future
it will build a minified, tree-shaken per-service CSS. For now this
parameter doesn't need to be filled and isn't used, but may be in the
future.
