### PR TITLE
Allow disabling NotFoundAction via WebConfig

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -445,3 +445,20 @@ acceptedBreaks:
         \ misk.redis.Redis.ZRangeType, misk.redis.Redis.ZRangeMarker, misk.redis.Redis.ZRangeMarker,\
         \ boolean, misk.redis.Redis.ZRangeLimit)"
       justification: "adding wrappers to support zrange"
+  "2024.01.11.170843-d27a872":
+    com.squareup.misk:misk:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method misk.web.WebConfig misk.web.WebConfig::copy(int, long, int, java.lang.String,\
+        \ misk.web.WebSslConfig, misk.web.WebUnixDomainSocketConfig, boolean, java.lang.Integer,\
+        \ java.lang.Integer, java.lang.Integer, int, int, int, boolean, misk.web.exceptions.ActionExceptionLogLevelConfig,\
+        \ java.lang.Integer, double, boolean, int, java.util.Map<java.lang.String,\
+        \ misk.web.CorsConfig>, boolean, org.slf4j.event.Level, misk.web.ConcurrencyLimiterConfig,\
+        \ int, java.lang.Integer, java.lang.Integer, java.lang.Long, int, int, boolean)"
+      new: "method misk.web.WebConfig misk.web.WebConfig::copy(int, long, int, java.lang.String,\
+        \ misk.web.WebSslConfig, misk.web.WebUnixDomainSocketConfig, boolean, java.lang.Integer,\
+        \ java.lang.Integer, java.lang.Integer, int, int, int, boolean, misk.web.exceptions.ActionExceptionLogLevelConfig,\
+        \ java.lang.Integer, double, boolean, int, java.util.Map<java.lang.String,\
+        \ misk.web.CorsConfig>, boolean, org.slf4j.event.Level, misk.web.ConcurrencyLimiterConfig,\
+        \ int, java.lang.Integer, java.lang.Integer, java.lang.Long, int, int, boolean,\
+        \ boolean)"
+      justification: "New parameter has a default value"

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1482,7 +1482,8 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;I)V
 	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;II)V
 	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZ)V
-	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZ)V
+	public synthetic fun <init> (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()I
@@ -1507,14 +1508,15 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun component29 ()I
 	public final fun component3 ()I
 	public final fun component30 ()Z
+	public final fun component31 ()Z
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lmisk/web/WebSslConfig;
 	public final fun component6 ()Lmisk/web/WebUnixDomainSocketConfig;
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/lang/Integer;
-	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZ)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZ)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJILjava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
@@ -1531,6 +1533,7 @@ public final class misk/web/WebConfig : wisp/config/Config {
 	public final fun getHttp_header_cache_size ()Ljava/lang/Integer;
 	public final fun getHttp_request_header_size ()Ljava/lang/Integer;
 	public final fun getIdle_timeout ()J
+	public final fun getInstall_default_not_found_action ()Z
 	public final fun getJetty_max_concurrent_streams ()Ljava/lang/Integer;
 	public final fun getJetty_max_thread_pool_queue_size ()I
 	public final fun getJetty_max_thread_pool_size ()I

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -261,7 +261,9 @@ class MiskWebModule @JvmOverloads constructor(
     install(WebActionModule.create<ReadinessCheckAction>())
 
     install(WebActionModule.create<LivenessCheckAction>())
-    install(WebActionModule.create<NotFoundAction>())
+    if (config.install_default_not_found_action) {
+      install(WebActionModule.create<NotFoundAction>())
+    }
 
     val maxThreads = config.jetty_max_thread_pool_size
     val minThreads = min(config.jetty_min_thread_pool_size, maxThreads)

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -134,7 +134,10 @@ data class WebConfig @JvmOverloads constructor(
   val readiness_max_age_ms: Int = 10000,
 
   /** If possible (e.g. running on JDK 21) misk will attempt to use a virtual thread executor for jetty. */
-  val use_virtual_threads: Boolean = false
+  val use_virtual_threads: Boolean = false,
+
+  /** If true install NotFoundAction, the default action when a path is not found. */
+  val install_default_not_found_action: Boolean = true,
 ) : Config
 
 data class WebSslConfig @JvmOverloads constructor(

--- a/misk/src/test/kotlin/misk/web/actions/DisabledNotFoundActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/DisabledNotFoundActionTest.kt
@@ -1,0 +1,60 @@
+package misk.web.actions
+
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.WebServerTestingModule
+import misk.web.WebTestingModule.Companion.TESTING_WEB_CONFIG
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import misk.web.mediatype.asMediaType
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+// This is a separate test from NotFoundActionTest because changing the WebConfig within a class
+// is not worth the hassle.
+@MiskTest(startService = true)
+internal class DisabledNotFoundActionTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  val httpClient = OkHttpClient()
+
+  @Inject private lateinit var jettyService: JettyService
+
+  @Test
+  fun defaultNotFoundActionCanBeDisabled() {
+    val request = get("/unknown", MediaTypes.APPLICATION_JSON.asMediaType())
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code).isEqualTo(404)
+    // This message is created by WebActionsServlet.sendNotFound, and not the NotFoundAction
+    assertThat(response.body!!.string())
+      .matches("Nothing found at GET http://127.0.0.1:[0-9]*/unknown")
+  }
+
+  private fun get(path: String, acceptedMediaType: MediaType? = null): Request {
+    return Request.Builder()
+      .get()
+      .url(jettyService.httpServerUrl.newBuilder().encodedPath(path).build())
+      .header("Accept", acceptedMediaType.toString())
+      .build()
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(
+        WebServerTestingModule(
+          TESTING_WEB_CONFIG.copy(
+            install_default_not_found_action = false,
+          )
+        )
+      )
+      install(MiskTestingServiceModule())
+    }
+  }
+}


### PR DESCRIPTION
At Faire we want to be able to bind our own 404 action, and forward requests to another service. As discussed on Slack, neither the existing `NotFoundAction` or the `WebProxyAction` works for this case. Adding an option to not install the default action allows us to bind our own without having to worry about overlapping paths.