### PR TITLE
Actions: Enable basic coroutine `WebAction`

### DIFF
--- a/misk/src/test/kotlin/misk/web/actions/CoroutineActionTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/CoroutineActionTest.kt
@@ -1,0 +1,78 @@
+package misk.web.actions
+
+import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
+import com.squareup.protos.test.grpc.HelloReply
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.currentCoroutineContext
+import misk.MiskTestingServiceModule
+import misk.moshi.adapter
+import misk.security.authz.Unauthenticated
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+@MiskTest(startService = true)
+class CoroutineActionTest {
+  @MiskTestModule
+  val module = Modules.combine(
+    WebServerTestingModule(),
+    MiskTestingServiceModule(),
+    WebActionModule.create<SuspendGreetWebAction>(),
+  )
+
+  @Inject private lateinit var jetty: JettyService
+
+  @Inject private lateinit var moshi: Moshi
+
+  private val httpClient = OkHttpClient()
+
+  @Test
+  fun `verify calling suspend function in web action can access current context`() {
+    val request = get("/suspend_greet")
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.code).isEqualTo(200)
+    val body = moshi.adapter<HelloReply>().fromJson(response.body!!.string())!!
+    assertThat(body.message).isEqualTo(
+      buildString {
+        append("Hola: ")
+        append("CoroutineName(WebAction: ")
+          .append(SuspendGreetWebAction::class.simpleName)
+          .append(".")
+          .append(SuspendGreetWebAction::hello.name)
+          .append(")")
+      }
+    )
+  }
+
+  @Singleton
+  internal class SuspendGreetWebAction @Inject constructor() : WebAction {
+    @Unauthenticated
+    @Get("/suspend_greet")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    suspend fun hello(): HelloReply {
+      // Without properly wrapping a call to this function in a coroutine scope,
+      // [currentCoroutineContext] will throw an exception.
+      val currentContext = currentCoroutineContext()
+      return HelloReply("Hola: ${currentContext[CoroutineName]}")
+    }
+  }
+
+  private fun get(path: String): Request {
+    return Request.Builder()
+      .get()
+      .url(jetty.httpServerUrl.newBuilder().encodedPath(path).build())
+      .build()
+  }
+}


### PR DESCRIPTION
The intention of this change is to make it viable to write [kotlinx.coroutines](https://kotlinlang.org/docs/coroutines-guide.html#0)-based actions. This change causes `WebAction` implementations written with `suspend` ingress points to properly execute. Without this change, accessing the current context will throw a confusing and misleading `NullPointerException`.

This change does not imply that there's no other issues with using `suspend` functions as ingress points, but it does allow experimentation.

### Reviewer questions

1. Should this be blocked behind a feature flag?
   * It is entirely opt-in by writing `suspend` actions, but also implies there is more support than exists.