### PR TITLE
WIP - Allow KInstallOnceModule to be installed multiple times

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
@@ -8,7 +8,7 @@ import misk.ReadyService
 import misk.ServiceModule
 import misk.database.StartDatabaseService
 import misk.healthchecks.HealthCheck
-import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 import misk.inject.asSingleton
 import misk.inject.keyOf
 import misk.inject.setOfType
@@ -36,7 +36,7 @@ class JdbcModule @JvmOverloads constructor(
   readerConfig: DataSourceConfig?,
   val databasePool: DatabasePool = RealDatabasePool,
   private val installHealthCheck: Boolean = true,
-) : KAbstractModule() {
+) : KInstallOnceModule() {
   val config = config.withDefaults()
   val readerConfig = readerConfig?.withDefaults()
 


### PR DESCRIPTION
This allows both Hibernate and Jooq to be used side-side-side in projects where one is incrementally migrating from Hibernate to Jooq.