### PR TITLE
This server variable is called tx_read_only in MySQL < 5.7.20

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/WritableConnectionValidator.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/WritableConnectionValidator.kt
@@ -37,7 +37,6 @@ internal class WritableConnectionValidator(
       "@@global.innodb_read_only",
       "@@global.read_only",
       "@@global.super_read_only",
-      "@@global.transaction_read_only",
     )
   }
 }


### PR DESCRIPTION
See https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_tx_read_only. Dropping it for now as it's not expected to be useful during Aurora MySQL upgrades. If we want to add support for this we will need to do explicit version checks as they're done in `com.mysql.cj.jdbc.ConnectionImpl#isReadOnly(boolean useSessionStatus)`:

```java
 String s = this.session.queryServerVariable(
                    versionMeetsMinimum(8, 0, 3) || (versionMeetsMinimum(5, 7, 20) && !versionMeetsMinimum(8, 0, 0)) ? "@@session.transaction_read_only"
                            : "@@session.tx_read_only");
```