### PR TITLE
chore: make bom project refer to relative parent instead of root project

### DIFF
--- a/misk-bom/build.gradle.kts
+++ b/misk-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   constraints {
-    project.rootProject.subprojects.forEach { subproject ->
+    project.parent?.subprojects?.forEach { subproject ->
       if (subproject.name != "misk-bom") {
         api(subproject)
       }


### PR DESCRIPTION
This makes it possible to sync misk to a monorepo if we decide to do so in the future