### PR TITLE
chore: update dependencies, resolve dependency issues.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,43 +50,45 @@ dependencyAnalysis {
   issues {
     all {
       ignoreSourceSet("testFixtures")
+      ignoreSourceSet("test")
       onAny {
         severity("fail")
-        // Due to kotlin 1.8.20 see https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/884
-        exclude("() -> java.io.File?")
         exclude("org.jetbrains.kotlin:kotlin-test:1.8.21")
         exclude(":misk-testing")
       }
     }
     all {
       onUnusedDependencies {
-        exclude("com.github.docker-java:docker-java-api:3.3.0")
-        exclude("com.github.docker-java:docker-java-api:3.3.1")
+        exclude("com.github.docker-java:docker-java-api")
+        exclude("org.jetbrains.kotlin:kotlin-stdlib")
+      }
+      onIncorrectConfiguration {
+        exclude("org.jetbrains.kotlin:kotlin-stdlib")
       }
     }
     // False positives.
     project(":misk-gcp") {
       onUsedTransitiveDependencies {
         // Can be removed once dd-trace-ot uses 0.33.0 of open tracing.
-        exclude("io.opentracing:opentracing-util:0.32.0")
-        exclude("io.opentracing:opentracing-noop:0.33.0")
+        exclude("io.opentracing:opentracing-util")
+        exclude("io.opentracing:opentracing-noop")
       }
       onRuntimeOnly {
-        exclude("com.datadoghq:dd-trace-ot:1.23.0")
+        exclude("com.datadoghq:dd-trace-ot")
       }
     }
     project(":misk-grpc-tests") {
       onUnusedDependencies {
-        exclude("javax.annotation:javax.annotation-api:1.3.2")
+        exclude("javax.annotation:javax.annotation-api")
       }
     }
     project(":misk-jooq") {
       onIncorrectConfiguration {
-        exclude("org.jooq:jooq:3.18.2")
+        exclude("org.jooq:jooq")
       }
     }
     project(":detektive") {
-      onUnusedDependencies() {
+      onUnusedDependencies {
         exclude("com.google.inject:guice")
       }
     }
@@ -97,7 +99,7 @@ dependencyAnalysis {
       }
     }
     project(":wisp:wisp-rate-limiting:bucket4j") {
-      onUnusedDependencies() {
+      onUnusedDependencies {
         // Plugin does not recognize use of tests artifact from bucket4j's maven manifest
         exclude("com.bucket4j:bucket4j-core")
       }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
-dependencyAnalysisPlugin = "1.20.0"
+dependencyAnalysisPlugin = "1.29.0"
 kotlinBinaryCompatibilityPlugin = "0.13.1"
+kotlin = "1.9.21"
 
 [libraries]
 apacheCommonsLang3 = { module = "org.apache.commons:commons-lang3", version = "3.11" }
@@ -38,7 +39,7 @@ dockerApi = { module = "com.github.docker-java:docker-java-api", version = "3.3.
 dockerCore = { module = "com.github.docker-java:docker-java-core", version = "3.3.1" }
 dockerTransport = { module = "com.github.docker-java:docker-java-transport", version = "3.3.1" }
 dockerTransportHttpClient = { module = "com.github.docker-java:docker-java-transport-httpclient5", version = "3.3.1" }
-dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.6.10" }
+dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.10" }
 errorproneAnnotations = { module = "com.google.errorprone:error_prone_annotations", version = "2.20.0" }
 findBugs = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
 gax = { module = "com.google.api:gax", version = "2.5.0" }
@@ -117,24 +118,24 @@ kotestAssertionsShared = { module = "io.kotest:kotest-assertions-shared", versio
 kotestCommon = { module = "io.kotest:kotest-common", version = "5.6.2" }
 kotestFrameworkApi = { module = "io.kotest:kotest-framework-api", version = "5.6.2" }
 kotestJunitRunnerJvm = { module = "io.kotest:kotest-runner-junit5-jvm", version = "5.6.2" }
-kotlinAllOpenPlugin = { module = "org.jetbrains.kotlin:kotlin-allopen", version = "1.8.21" }
-kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version = "1.8.21" }
-kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version = "1.8.21" }
-kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.8.21" }
+kotlinAllOpenPlugin = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
+kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
+kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinLogging = { module = "io.github.microutils:kotlin-logging", version = "3.0.5" }
-kotlinNoArgPlugin = { module = "org.jetbrains.kotlin:kotlin-noarg", version = "1.8.21" }
+kotlinNoArgPlugin = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "kotlin" }
 kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version = "1.8.21" }
 kotlinRetry = { module = "com.michael-bull.kotlin-retry:kotlin-retry", version = "1.0.9" }
-kotlinStdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.8.21" }
-kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version = "1.8.21" }
-kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.2" }
+kotlinStdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
 kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.8.1" }
 kubernetesClient = { module = "io.kubernetes:client-java", version = "18.0.1" }
 kubernetesClientApi = { module = "io.kubernetes:client-java-api", version = "18.0.1" }
 launchDarkly = { module = "com.launchdarkly:launchdarkly-java-server-sdk", version = "6.3.0" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version = "1.4.8" }
 logbackCore = { module = "ch.qos.logback:logback-core", version = "1.4.8" }
-mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }
+mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.27.0" }
 micrometerCore = { module = "io.micrometer:micrometer-core", version = "1.11.1" }
 micrometerPrometheus = { module = "io.micrometer:micrometer-registry-prometheus", version = "1.11.1" }
 mockitoCore = { module = "org.mockito:mockito-core", version = "5.4.0" }

--- a/misk-action-scopes/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -24,7 +24,7 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
   }
 
   override fun submit(runnable: Runnable): ListenableFuture<*> {
-    val wrapped = wrap<Unit>(Callable { runnable.run() })
+    val wrapped = wrap<Unit> { runnable.run() }
     return delegate().submit(wrapped)
   }
 
@@ -43,8 +43,8 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
   }
 
   @Throws(InterruptedException::class, ExecutionException::class)
-  override fun <T> invokeAny(callables: Collection<Callable<T>>): T {
-    return delegate().invokeAny(callables.map { wrap(it) })
+  override fun <T> invokeAny(callables: Collection<Callable<T>>): T & Any {
+    return delegate().invokeAny(callables.map { wrap(it) })!!
   }
 
   @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
@@ -52,11 +52,11 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
     callables: Collection<Callable<T>>,
     timeout: Long,
     timeUnit: TimeUnit
-  ): T {
-    return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
+  ): T & Any {
+    return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)!!
   }
 
   override fun execute(runnable: Runnable) {
-    delegate().submit(wrap<Unit>(Callable { runnable.run() }))
+    delegate().submit(wrap<Unit> { runnable.run() })
   }
 }

--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -436,6 +436,7 @@ public final class misk/web/dashboard/MiskWebColor : java/lang/Enum {
 	public static final field TEXT Lmisk/web/dashboard/MiskWebColor;
 	public static final field WHITE Lmisk/web/dashboard/MiskWebColor;
 	public static final field YELLOW Lmisk/web/dashboard/MiskWebColor;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getHexColor ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/dashboard/MiskWebColor;
 	public static fun values ()[Lmisk/web/dashboard/MiskWebColor;
@@ -634,6 +635,7 @@ public final class misk/web/metadata/config/ConfigMetadataAction$ConfigTabMode :
 	public static final field SAFE Lmisk/web/metadata/config/ConfigMetadataAction$ConfigTabMode;
 	public static final field SHOW_REDACTED_EFFECTIVE_CONFIG Lmisk/web/metadata/config/ConfigMetadataAction$ConfigTabMode;
 	public static final field UNSAFE_LEAK_MISK_SECRETS Lmisk/web/metadata/config/ConfigMetadataAction$ConfigTabMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/metadata/config/ConfigMetadataAction$ConfigTabMode;
 	public static fun values ()[Lmisk/web/metadata/config/ConfigMetadataAction$ConfigTabMode;
 }

--- a/misk-aws/api/misk-aws.api
+++ b/misk-aws/api/misk-aws.api
@@ -99,6 +99,7 @@ public final class misk/jobqueue/sqs/AwsSqsJobQueueModuleKt {
 public final class misk/jobqueue/sqs/AwsSqsJobReceiverPolicy : java/lang/Enum {
 	public static final field BALANCED_MAX Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
 	public static final field ONE_FLAG_ONLY Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
 	public static fun values ()[Lmisk/jobqueue/sqs/AwsSqsJobReceiverPolicy;
 }

--- a/misk-crypto/api/misk-crypto.api
+++ b/misk-crypto/api/misk-crypto.api
@@ -199,6 +199,7 @@ public final class misk/crypto/KeyType : java/lang/Enum {
 	public static final field PGP_ENCRYPT Lmisk/crypto/KeyType;
 	public static final field SIGNATURE Lmisk/crypto/KeyType;
 	public static final field STREAMING_AEAD Lmisk/crypto/KeyType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/crypto/KeyType;
 	public static fun values ()[Lmisk/crypto/KeyType;
 }

--- a/misk-grpc-reflect/build.gradle.kts
+++ b/misk-grpc-reflect/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
   implementation(libs.kotlinLogging)
   implementation(libs.kotlinReflect)
   implementation(libs.okio)
-  implementation(libs.wireGrpcClient)
   implementation(libs.wireRuntime)
   implementation(libs.wireSchema)
   implementation(project(":wisp:wisp-logging"))

--- a/misk-grpc-tests/build.gradle.kts
+++ b/misk-grpc-tests/build.gradle.kts
@@ -78,7 +78,6 @@ dependencies {
   implementation(libs.grpcNetty)
   implementation(libs.grpcProtobuf)
   implementation(libs.javaxAnnotation)
-  implementation(libs.kotlinxCoroutines)
   implementation(libs.nettyHandler)
   implementation(libs.wireGrpcClient)
   implementation(libs.wireRuntime)

--- a/misk-hibernate/api/misk-hibernate.api
+++ b/misk-hibernate/api/misk-hibernate.api
@@ -2,6 +2,7 @@ public final class misk/hibernate/BindPolicy : java/lang/Enum {
 	public static final field APPEND Lmisk/hibernate/BindPolicy;
 	public static final field PREPEND Lmisk/hibernate/BindPolicy;
 	public static final field REPLACE Lmisk/hibernate/BindPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/hibernate/BindPolicy;
 	public static fun values ()[Lmisk/hibernate/BindPolicy;
 }
@@ -146,6 +147,7 @@ public final class misk/hibernate/Operator : java/lang/Enum {
 	public static final field LT Lmisk/hibernate/Operator;
 	public static final field NE Lmisk/hibernate/Operator;
 	public static final field NOT_IN Lmisk/hibernate/Operator;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/hibernate/Operator;
 	public static fun values ()[Lmisk/hibernate/Operator;
 }

--- a/misk-hotwire/api/misk-hotwire.api
+++ b/misk-hotwire/api/misk-hotwire.api
@@ -28,6 +28,7 @@ public final class misk/turbo/TurboStreamAction : java/lang/Enum {
 	public static final field REMOVE Lmisk/turbo/TurboStreamAction;
 	public static final field REPLACE Lmisk/turbo/TurboStreamAction;
 	public static final field UPDATE Lmisk/turbo/TurboStreamAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/turbo/TurboStreamAction;
 	public static fun values ()[Lmisk/turbo/TurboStreamAction;
 }

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -209,6 +209,7 @@ public final class misk/jdbc/Check : java/lang/Enum {
 	public static final field COWRITE Lmisk/jdbc/Check;
 	public static final field FULL_SCATTER Lmisk/jdbc/Check;
 	public static final field TABLE_SCAN Lmisk/jdbc/Check;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/Check;
 	public static fun values ()[Lmisk/jdbc/Check;
 }
@@ -422,6 +423,7 @@ public final class misk/jdbc/DataSourceType : java/lang/Enum {
 	public static final field TIDB Lmisk/jdbc/DataSourceType;
 	public static final field VITESS_MYSQL Lmisk/jdbc/DataSourceType;
 	public final fun getDriverClassName ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getHibernateDialect ()Ljava/lang/String;
 	public final fun isVitess ()Z
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/DataSourceType;
@@ -476,6 +478,7 @@ public final class misk/jdbc/JDBCSession$HookType : java/lang/Enum {
 	public static final field POST Lmisk/jdbc/JDBCSession$HookType;
 	public static final field PRE Lmisk/jdbc/JDBCSession$HookType;
 	public static final field SESSION_CLOSE Lmisk/jdbc/JDBCSession$HookType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/JDBCSession$HookType;
 	public static fun values ()[Lmisk/jdbc/JDBCSession$HookType;
 }
@@ -773,6 +776,7 @@ public final class misk/vitess/ShardsKt {
 public final class misk/vitess/TabletType : java/lang/Enum {
 	public static final field MASTER Lmisk/vitess/TabletType;
 	public static final field REPLICA Lmisk/vitess/TabletType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getValue ()I
 	public static fun valueOf (Ljava/lang/String;)Lmisk/vitess/TabletType;
 	public static fun values ()[Lmisk/vitess/TabletType;

--- a/misk-jooq/api/misk-jooq.api
+++ b/misk-jooq/api/misk-jooq.api
@@ -46,6 +46,7 @@ public final class misk/jooq/JooqSession$HookType : java/lang/Enum {
 	public static final field POST Lmisk/jooq/JooqSession$HookType;
 	public static final field PRE Lmisk/jooq/JooqSession$HookType;
 	public static final field SESSION_CLOSE Lmisk/jooq/JooqSession$HookType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jooq/JooqSession$HookType;
 	public static fun values ()[Lmisk/jooq/JooqSession$HookType;
 }

--- a/misk-policy/api/misk-policy.api
+++ b/misk-policy/api/misk-policy.api
@@ -99,6 +99,7 @@ public final class misk/policy/opa/OpaMetrics$Names : java/lang/Enum {
 	public static final field opa_rego_query_eval Lmisk/policy/opa/OpaMetrics$Names;
 	public static final field opa_server_handler Lmisk/policy/opa/OpaMetrics$Names;
 	public static final field opa_server_query_cache_hit Lmisk/policy/opa/OpaMetrics$Names;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/policy/opa/OpaMetrics$Names;
 	public static fun values ()[Lmisk/policy/opa/OpaMetrics$Names;
 }

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -202,6 +202,7 @@ public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
 	public static final field LT Lmisk/redis/Redis$ZAddOptions;
 	public static final field NX Lmisk/redis/Redis$ZAddOptions;
 	public static final field XX Lmisk/redis/Redis$ZAddOptions;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZAddOptions;
 	public static fun values ()[Lmisk/redis/Redis$ZAddOptions;
 }
@@ -264,6 +265,7 @@ public final class misk/redis/Redis$ZRangeScoreMarker : misk/redis/Redis$ZRangeM
 public final class misk/redis/Redis$ZRangeType : java/lang/Enum {
 	public static final field INDEX Lmisk/redis/Redis$ZRangeType;
 	public static final field SCORE Lmisk/redis/Redis$ZRangeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZRangeType;
 	public static fun values ()[Lmisk/redis/Redis$ZRangeType;
 }

--- a/misk-slack/api/misk-slack.api
+++ b/misk-slack/api/misk-slack.api
@@ -67,6 +67,7 @@ public final class misk/slack/SlackWebhookResponse : java/lang/Enum {
 	public static final field missing_text_or_fallback_or_attachments Lmisk/slack/SlackWebhookResponse;
 	public static final field ok Lmisk/slack/SlackWebhookResponse;
 	public static final field user_not_found Lmisk/slack/SlackWebhookResponse;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/slack/SlackWebhookResponse;
 	public static fun values ()[Lmisk/slack/SlackWebhookResponse;
 }

--- a/misk-slack/build.gradle.kts
+++ b/misk-slack/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   implementation(libs.retrofitMoshi)
   implementation(project(":wisp:wisp-logging"))
   implementation(project(":wisp:wisp-moshi"))
+  implementation(libs.okio)
 
   testImplementation(libs.assertj)
   testImplementation(libs.guava)

--- a/misk-tailwind/api/misk-tailwind.api
+++ b/misk-tailwind/api/misk-tailwind.api
@@ -76,6 +76,7 @@ public final class misk/tailwind/icons/Heroicons : java/lang/Enum {
 	public static final field OUTLINE_XMARK Lmisk/tailwind/icons/Heroicons;
 	public static final field QUEUE_LIST Lmisk/tailwind/icons/Heroicons;
 	public final fun getDefaultModifierClass ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getRawHtml ()Lkotlin/jvm/functions/Function1;
 	public final fun getSvgClass ()Ljava/lang/String;

--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -192,6 +192,7 @@ public final class misk/testing/LogLevel$Level : java/lang/Enum {
 	public static final field ERROR Lmisk/testing/LogLevel$Level;
 	public static final field INFO Lmisk/testing/LogLevel$Level;
 	public static final field WARN Lmisk/testing/LogLevel$Level;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/testing/LogLevel$Level;
 	public static fun values ()[Lmisk/testing/LogLevel$Level;
 }

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1172,6 +1172,7 @@ public final class misk/tasks/Status : java/lang/Enum {
 	public static final field NO_RESCHEDULE Lmisk/tasks/Status;
 	public static final field NO_WORK Lmisk/tasks/Status;
 	public static final field OK Lmisk/tasks/Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun metricLabel ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/tasks/Status;
 	public static fun values ()[Lmisk/tasks/Status;
@@ -1262,6 +1263,7 @@ public final class misk/web/DispatchMechanism : java/lang/Enum {
 	public static final field POST Lmisk/web/DispatchMechanism;
 	public static final field PUT Lmisk/web/DispatchMechanism;
 	public static final field WEBSOCKET Lmisk/web/DispatchMechanism;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getMethod ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/DispatchMechanism;
 	public static fun values ()[Lmisk/web/DispatchMechanism;
@@ -1583,6 +1585,7 @@ public final class misk/web/WebSslConfig$CipherCompatibility : java/lang/Enum {
 	public static final field COMPATIBLE Lmisk/web/WebSslConfig$CipherCompatibility;
 	public static final field MODERN Lmisk/web/WebSslConfig$CipherCompatibility;
 	public static final field RESTRICTED Lmisk/web/WebSslConfig$CipherCompatibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/WebSslConfig$CipherCompatibility;
 	public static fun values ()[Lmisk/web/WebSslConfig$CipherCompatibility;
 }
@@ -1591,6 +1594,7 @@ public final class misk/web/WebSslConfig$MutualAuth : java/lang/Enum {
 	public static final field DESIRED Lmisk/web/WebSslConfig$MutualAuth;
 	public static final field NONE Lmisk/web/WebSslConfig$MutualAuth;
 	public static final field REQUIRED Lmisk/web/WebSslConfig$MutualAuth;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/WebSslConfig$MutualAuth;
 	public static fun values ()[Lmisk/web/WebSslConfig$MutualAuth;
 }
@@ -1676,6 +1680,7 @@ public final class misk/web/concurrencylimits/ConcurrencyLimiterStrategy : java/
 	public static final field GRADIENT2 Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public static final field SETTABLE Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public static final field VEGAS Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 	public static fun values ()[Lmisk/web/concurrencylimits/ConcurrencyLimiterStrategy;
 }

--- a/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
+++ b/misk/src/main/kotlin/misk/concurrent/WrappingListeningExecutorService.kt
@@ -24,7 +24,7 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
   }
 
   override fun submit(runnable: Runnable): ListenableFuture<*> {
-    val wrapped = wrap<Unit>(Callable { runnable.run() })
+    val wrapped = wrap<Unit> { runnable.run() }
     return delegate().submit(wrapped)
   }
 
@@ -43,8 +43,8 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
   }
 
   @Throws(InterruptedException::class, ExecutionException::class)
-  override fun <T> invokeAny(callables: Collection<Callable<T>>): T {
-    return delegate().invokeAny(callables.map { wrap(it) })
+  override fun <T> invokeAny(callables: Collection<Callable<T>>): T & Any {
+    return delegate().invokeAny(callables.map { wrap(it) })!!
   }
 
   @Throws(InterruptedException::class, ExecutionException::class, TimeoutException::class)
@@ -52,11 +52,11 @@ abstract class WrappingListeningExecutorService : ForwardingListeningExecutorSer
     callables: Collection<Callable<T>>,
     timeout: Long,
     timeUnit: TimeUnit
-  ): T {
-    return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)
+  ): T & Any {
+    return delegate().invokeAny(callables.map { wrap(it) }, timeout, timeUnit)!!
   }
 
   override fun execute(runnable: Runnable) {
-    delegate().submit(wrap<Unit>(Callable { runnable.run() }))
+    delegate().submit(wrap<Unit> { runnable.run() })
   }
 }

--- a/wisp/wisp-logging-testing/build.gradle.kts
+++ b/wisp/wisp-logging-testing/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     api(libs.logbackClassic)
-    api(libs.kotlinLogging)
     api(libs.assertj)
     implementation(libs.logbackCore)
     implementation(libs.slf4jApi)

--- a/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
+++ b/wisp/wisp-rate-limiting/api/wisp-rate-limiting.api
@@ -108,6 +108,7 @@ public final class wisp/ratelimiting/RateLimiterMetrics$ConsumptionResult : java
 	public static final field EXCEPTION Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;
 	public static final field REJECTED Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;
 	public static final field SUCCESS Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;
 	public static fun values ()[Lwisp/ratelimiting/RateLimiterMetrics$ConsumptionResult;
 }

--- a/wisp/wisp-task/api/wisp-task.api
+++ b/wisp/wisp-task/api/wisp-task.api
@@ -74,6 +74,7 @@ public final class wisp/task/Status : java/lang/Enum {
 	public static final field NO_RESCHEDULE Lwisp/task/Status;
 	public static final field NO_WORK Lwisp/task/Status;
 	public static final field OK Lwisp/task/Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun metricLabel ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lwisp/task/Status;
 	public static fun values ()[Lwisp/task/Status;


### PR DESCRIPTION
* Updated several plugins:
    * Dependency Analysis Gradle Plugin, which required...
    * Kotlin to 1.9.x, which required...
    * Dokka to 1.9.10, and
    * Vanniktech Maven Publish plugin 0.27.0.
* The Kotlin update also necessitated some code changes. I'm not sure I resolved those in the best manner.

I then ran `buildhealth` (which didn't work before the above changes) and resolved the issues it reported. I punted on the `test` advice to keep the PR small. (Out of curiosity, why do you run `projectHealth` instead?)

There are some ABI changes. From a quick glance, it looks like they're a new method added to enum classes by newer Kotlin.