### PR TITLE
Replace version.ref instances with explicit versions in the TOML file

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 dependencyAnalysisPlugin = "1.29.0"
 kotlinBinaryCompatibilityPlugin = "0.13.1"
-kotlin = "1.9.21"
 
 [libraries]
 apacheCommonsLang3 = { module = "org.apache.commons:commons-lang3", version = "3.11" }
@@ -118,16 +117,16 @@ kotestAssertionsShared = { module = "io.kotest:kotest-assertions-shared", versio
 kotestCommon = { module = "io.kotest:kotest-common", version = "5.6.2" }
 kotestFrameworkApi = { module = "io.kotest:kotest-framework-api", version = "5.6.2" }
 kotestJunitRunnerJvm = { module = "io.kotest:kotest-runner-junit5-jvm", version = "5.6.2" }
-kotlinAllOpenPlugin = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
-kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
-kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlinAllOpenPlugin = { module = "org.jetbrains.kotlin:kotlin-allopen", version = "1.9.21" }
+kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version = "1.9.21" }
+kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version = "1.9.21" }
+kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.9.21" }
 kotlinLogging = { module = "io.github.microutils:kotlin-logging", version = "3.0.5" }
-kotlinNoArgPlugin = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "kotlin" }
+kotlinNoArgPlugin = { module = "org.jetbrains.kotlin:kotlin-noarg", version = "1.9.21" }
 kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version = "1.8.21" }
 kotlinRetry = { module = "com.michael-bull.kotlin-retry:kotlin-retry", version = "1.0.9" }
-kotlinStdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinStdLibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version = "1.9.21" }
+kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version = "1.9.21" }
 kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
 kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.8.1" }
 kubernetesClient = { module = "io.kubernetes:client-java", version = "18.0.1" }


### PR DESCRIPTION
Our internal tooling is not currenlty capable of validating version refs.