### PR TITLE
Upgrade wire to latest and update api dumps for proto classes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -191,10 +191,10 @@ tink = { module = "com.google.crypto.tink:tink", version = "1.6.1" }
 tinkAwskms = { module = "com.google.crypto.tink:tink-awskms", version = "1.6.1" }
 tinkGcpkms = { module = "com.google.crypto.tink:tink-gcpkms", version = "1.6.1" }
 tracingDatadog = { module = "com.datadoghq:dd-trace-api", version = "1.23.0" }
-wireBom = { module = "com.squareup.wire:wire-bom", version = "4.8.1" }
-wireGradlePlugin = { module = "com.squareup.wire:wire-gradle-plugin", version = "4.8.1" }
-wireGrpcClient = { module = "com.squareup.wire:wire-grpc-client", version = "4.8.1" }
-wireMoshiAdapter = { module = "com.squareup.wire:wire-moshi-adapter", version = "4.8.1" }
-wireReflector = { module = "com.squareup.wire:wire-reflector", version = "4.8.1" }
-wireRuntime = { module = "com.squareup.wire:wire-runtime", version = "4.8.1" }
-wireSchema = { module = "com.squareup.wire:wire-schema", version = "4.8.1" }
+wireBom = { module = "com.squareup.wire:wire-bom", version = "4.9.3" }
+wireGradlePlugin = { module = "com.squareup.wire:wire-gradle-plugin", version = "4.9.3" }
+wireGrpcClient = { module = "com.squareup.wire:wire-grpc-client", version = "4.9.3" }
+wireMoshiAdapter = { module = "com.squareup.wire:wire-moshi-adapter", version = "4.9.3" }
+wireReflector = { module = "com.squareup.wire:wire-reflector", version = "4.9.3" }
+wireRuntime = { module = "com.squareup.wire:wire-runtime", version = "4.9.3" }
+wireSchema = { module = "com.squareup.wire:wire-schema", version = "4.9.3" }

--- a/misk-grpc-tests/api/misk-grpc-tests.api
+++ b/misk-grpc-tests/api/misk-grpc-tests.api
@@ -82,6 +82,7 @@ public final class routeguide/Feature$Builder : com/squareup/wire/Message$Builde
 }
 
 public final class routeguide/Feature$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/Feature;
 }
 
 public final class routeguide/FeatureDatabase : com/squareup/wire/Message {
@@ -109,6 +110,7 @@ public final class routeguide/FeatureDatabase$Builder : com/squareup/wire/Messag
 }
 
 public final class routeguide/FeatureDatabase$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/FeatureDatabase;
 }
 
 public final class routeguide/GrpcRouteGuideClient : routeguide/RouteGuideClient {
@@ -147,6 +149,7 @@ public final class routeguide/Point$Builder : com/squareup/wire/Message$Builder 
 }
 
 public final class routeguide/Point$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/Point;
 }
 
 public final class routeguide/Rectangle : com/squareup/wire/Message {
@@ -177,6 +180,7 @@ public final class routeguide/Rectangle$Builder : com/squareup/wire/Message$Buil
 }
 
 public final class routeguide/Rectangle$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/Rectangle;
 }
 
 public abstract interface class routeguide/RouteGuideClient : com/squareup/wire/Service {
@@ -1040,6 +1044,7 @@ public final class routeguide/RouteNote$Builder : com/squareup/wire/Message$Buil
 }
 
 public final class routeguide/RouteNote$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/RouteNote;
 }
 
 public final class routeguide/RouteSummary : com/squareup/wire/Message {
@@ -1076,5 +1081,6 @@ public final class routeguide/RouteSummary$Builder : com/squareup/wire/Message$B
 }
 
 public final class routeguide/RouteSummary$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lrouteguide/RouteSummary;
 }
 

--- a/misk-proto/api/misk-proto.api
+++ b/misk-proto/api/misk-proto.api
@@ -29,5 +29,6 @@ public final class misk/proto/Status$Builder : com/squareup/wire/Message$Builder
 }
 
 public final class misk/proto/Status$Companion {
+	public final synthetic fun build (Lkotlin/jvm/functions/Function1;)Lmisk/proto/Status;
 }
 


### PR DESCRIPTION
Looks like a `build` method has been added to wire Kotlin companion objects in a recent wire version, which leads to changes in api dumps.