### PR TITLE
Batched job handling

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -597,3 +597,188 @@ acceptedBreaks:
       new: "method misk.redis.Redis misk.redis.RedisModule::provideRedisClient$misk_redis(misk.redis.RedisClientMetrics,\
         \ redis.clients.jedis.UnifiedJedis)"
       justification: "Only breaks one client, which is owned by the author"
+  "2024.01.25.022820-30be5eb":
+    com.squareup.misk:misk-aws:
+    - code: "java.annotation.attributeValueChanged"
+      old: "class misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>"
+      new: "class misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "class misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>"
+      new: "class misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.generics.formalTypeParameterChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.jobqueue.sqs.SqsJobConsumer.QueueReceiver::<init>(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.JobHandler===)"
+      new: "parameter void misk.jobqueue.sqs.SqsJobConsumer.QueueReceiver::<init>(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.AbstractJobHandler===)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.jobqueue.sqs.SqsJobConsumer::subscribe(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.JobHandler===)"
+      new: "parameter void misk.jobqueue.sqs.SqsJobConsumer::subscribe(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.AbstractJobHandler===)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule.Companion::create(misk.jobqueue.QueueName,\
+        \ kotlin.reflect.KClass<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean)"
+      justification: "Adding batched job handler interface"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method <T extends misk.jobqueue.JobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.JobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      new: "method <T extends misk.jobqueue.AbstractJobHandler> misk.jobqueue.sqs.AwsSqsJobHandlerModule<T>\
+        \ misk.jobqueue.sqs.AwsSqsJobHandlerModule<T extends misk.jobqueue.AbstractJobHandler>::create(misk.jobqueue.QueueName,\
+        \ java.lang.Class<T>, boolean, java.util.List<? extends com.google.inject.Key<?\
+        \ extends com.google.common.util.concurrent.Service>>)"
+      justification: "Adding batched job handler interface"
+    com.squareup.misk:misk-jobqueue:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void misk.jobqueue.JobConsumer::subscribe(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.JobHandler===)"
+      new: "parameter void misk.jobqueue.JobConsumer::subscribe(misk.jobqueue.QueueName,\
+        \ ===misk.jobqueue.AbstractJobHandler===)"
+      justification: "Adding batched job handler interface"

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -3,31 +3,31 @@ package misk.jobqueue.sqs
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.toKey
-import misk.jobqueue.JobHandler
+import misk.jobqueue.AbstractJobHandler
 import misk.jobqueue.QueueName
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 import kotlin.reflect.KClass
 
 /**
  * Install this module to register a handler for an SQS queue,
  * and if specified, registers its corresponding retry queue.
  */
-class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
+class AwsSqsJobHandlerModule<T : AbstractJobHandler> private constructor(
   private val queueName: QueueName,
   private val handler: KClass<T>,
   private val installRetryQueue: Boolean,
   private val dependsOn: List<Key<out Service>>,
 ) : KAbstractModule() {
   override fun configure() {
-    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
+    newMapBinder<QueueName, AbstractJobHandler>().addBinding(queueName).to(handler.java)
 
     if (installRetryQueue) {
-      newMapBinder<QueueName, JobHandler>().addBinding(queueName.retryQueue).to(handler.java)
+      newMapBinder<QueueName, AbstractJobHandler>().addBinding(queueName.retryQueue).to(handler.java)
     }
 
     install(
@@ -40,14 +40,14 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 
   companion object {
     @JvmOverloads
-    inline fun <reified T : JobHandler> create(
+    inline fun <reified T : AbstractJobHandler> create(
       queueName: QueueName,
       installRetryQueue: Boolean = true,
       dependsOn: List<Key<out Service>> = emptyList(),
     ): AwsSqsJobHandlerModule<T> = create(queueName, T::class, installRetryQueue, dependsOn)
 
     @JvmStatic @JvmOverloads
-    fun <T : JobHandler> create(
+    fun <T : AbstractJobHandler> create(
       queueName: QueueName,
       handlerClass: Class<T>,
       installRetryQueue: Boolean = true,
@@ -60,7 +60,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
      * Returns a module that registers a handler for an SQS queue.
      */
     @JvmOverloads
-    fun <T : JobHandler> create(
+    fun <T : AbstractJobHandler> create(
       queueName: QueueName,
       handlerClass: KClass<T>,
       installRetryQueue: Boolean = true,
@@ -75,7 +75,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 internal class AwsSqsJobHandlerSubscriptionService @Inject constructor(
   private val attributeImporter: AwsSqsQueueAttributeImporter,
   private val consumer: SqsJobConsumer,
-  private val consumerMapping: Map<QueueName, JobHandler>,
+  private val consumerMapping: Map<QueueName, AbstractJobHandler>,
   private val externalQueues: Map<QueueName, AwsSqsQueueConfig>,
   private val config: AwsSqsJobQueueConfig
 ) : AbstractIdleService() {

--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -1,3 +1,10 @@
+public abstract interface class misk/jobqueue/AbstractJobHandler {
+}
+
+public abstract interface class misk/jobqueue/BatchedJobHandler : misk/jobqueue/AbstractJobHandler {
+	public abstract fun handleJobs (Ljava/util/Collection;)V
+}
+
 public final class misk/jobqueue/DevelopmentJobProcessorModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;)Lmisk/tasks/RepeatedTaskQueue;
@@ -83,7 +90,7 @@ public abstract interface class misk/jobqueue/Job {
 }
 
 public abstract interface class misk/jobqueue/JobConsumer {
-	public abstract fun subscribe (Lmisk/jobqueue/QueueName;Lmisk/jobqueue/JobHandler;)V
+	public abstract fun subscribe (Lmisk/jobqueue/QueueName;Lmisk/jobqueue/AbstractJobHandler;)V
 	public abstract fun unsubscribe (Lmisk/jobqueue/QueueName;)V
 }
 
@@ -91,7 +98,7 @@ public final class misk/jobqueue/JobConsumerKt {
 	public static final fun subscribe (Lmisk/jobqueue/JobConsumer;Lmisk/jobqueue/QueueName;Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract interface class misk/jobqueue/JobHandler {
+public abstract interface class misk/jobqueue/JobHandler : misk/jobqueue/AbstractJobHandler {
 	public abstract fun handleJob (Lmisk/jobqueue/Job;)V
 }
 

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/AbstractJobHandler.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/AbstractJobHandler.kt
@@ -1,0 +1,6 @@
+package misk.jobqueue
+
+/**
+ * A sealed interface for implementing job handlers with differing behaviours.
+ */
+sealed interface AbstractJobHandler

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/BatchedJobHandler.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/BatchedJobHandler.kt
@@ -1,0 +1,12 @@
+package misk.jobqueue
+
+/**
+ * A [BatchedJobHandler] is an application implemented interface that handles jobs received by this
+ * service. The difference between this and [JobHandler] is that this interface allows for jobs to
+ * be handled in a batch. Caveats in [JobHandler] regarding idempotence, repeated delivery, and
+ * the need for explicit acknowledgement or deadlettering for each job still apply.
+ *
+ */
+interface BatchedJobHandler : AbstractJobHandler {
+  fun handleJobs(jobs: Collection<Job>)
+}

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobConsumer.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobConsumer.kt
@@ -7,7 +7,7 @@ interface JobConsumer {
    * begin receiving messages from the underlying job queue and dispatch them to the provided
    * handler. A service may only have one subscription outstanding per queue
    */
-  fun subscribe(queueName: QueueName, handler: JobHandler)
+  fun subscribe(queueName: QueueName, handler: AbstractJobHandler)
   fun unsubscribe(queueName: QueueName)
 }
 

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobHandler.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobHandler.kt
@@ -7,13 +7,13 @@ package misk.jobqueue
  * [Job.deadLetter] to put the job onto the associated dead letter queue. The jobqueue framework
  * assumes that the underlying queueing system is at-least-once, so handlers must be prepared
  * for the possibility that a job will be delivered more than once (for example if the process
- * fails or the visibility timeout expires after processing but before acknowledgement). Typically
+ * fails or the visibility timeout expires after processing but before acknowledgement). Typically,
  * this is handled by either storing some sort of ticket in the local database when the job is
  * enqueued and deleting it as part of the application transaction when the job is processed
  * but prior to acknowledgement, or by storing some sort of "processed marker" in the local
  * database during job processing and ignoring jobs whose marker is already recorded.
  *
  */
-interface JobHandler {
+interface JobHandler : AbstractJobHandler {
   fun handleJob(job: Job)
 }

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/DevelopmentJobQueueTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/DevelopmentJobQueueTest.kt
@@ -9,6 +9,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
 import jakarta.inject.Inject
+import misk.jobqueue.testutilities.ExampleJobEnqueuer
+import misk.jobqueue.testutilities.GREEN_QUEUE
+import misk.jobqueue.testutilities.RED_QUEUE
 
 @MiskTest(startService = true)
 internal class DevelopmentJobQueueTest {

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueBatchedTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueBatchedTest.kt
@@ -1,0 +1,82 @@
+package misk.jobqueue
+
+import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.jobqueue.testutilities.ColorException
+import misk.jobqueue.testutilities.ENQUEUER_QUEUE
+import misk.jobqueue.testutilities.EnqueuerJobHandler
+import misk.jobqueue.testutilities.ExampleJob
+import misk.jobqueue.testutilities.ExampleJobHint
+import misk.jobqueue.testutilities.GREEN_QUEUE
+import misk.jobqueue.testutilities.RED_QUEUE
+import misk.logging.LogCollectorModule
+import misk.moshi.adapter
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import wisp.logging.getLogger
+import java.util.concurrent.ConcurrentHashMap
+
+@MiskTest(startService = true)
+internal class FakeJobQueueBatchedTest : FakeJobQueueTest() {
+  @Suppress("unused")
+  @MiskTestModule
+  val module = BatchedTestModule()
+
+  override val loggerClass = ExampleBatchedJobHandler::class
+}
+
+class BatchedTestModule : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(LogCollectorModule())
+    install(FakeJobHandlerModule.create<ExampleBatchedJobHandler>(RED_QUEUE))
+    install(FakeJobHandlerModule.create<ExampleBatchedJobHandler>(GREEN_QUEUE))
+    install(FakeJobHandlerModule.create<EnqueuerJobHandler>(ENQUEUER_QUEUE))
+    install(FakeJobQueueModule())
+  }
+}
+
+@Singleton
+class ExampleBatchedJobHandler @Inject private constructor(moshi: Moshi) :
+  BatchedJobHandler {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+  private val jobsExecutedOnce = ConcurrentHashMap<String, Boolean>()
+
+  override fun handleJobs(jobs: Collection<Job>) {
+    jobs.forEach { job ->
+      val deserializedJob = jobAdapter.fromJson(job.body)!!
+      log.info { "received ${deserializedJob.color} job with message: ${deserializedJob.message}" }
+
+      assertThat(job.attributes).containsEntry("key", "value")
+
+      val key = "${deserializedJob.color}:${deserializedJob.hint}:${deserializedJob.message}"
+      val jobExecutedBefore = jobsExecutedOnce.putIfAbsent(key, true) == true
+      when (deserializedJob.hint) {
+        ExampleJobHint.DONT_ACK -> return@forEach
+        ExampleJobHint.DEAD_LETTER -> {
+          job.deadLetter()
+          return@forEach
+        }
+        ExampleJobHint.DEAD_LETTER_ONCE -> if (!jobExecutedBefore) {
+          job.deadLetter()
+          return@forEach
+        }
+        ExampleJobHint.THROW -> throw ColorException()
+        ExampleJobHint.THROW_ONCE -> if (!jobExecutedBefore) {
+          throw ColorException()
+        }
+        else -> Unit
+      }
+
+      job.acknowledge()
+    }
+  }
+
+  companion object {
+    private val log = getLogger<ExampleBatchedJobHandler>()
+  }
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueUnbatchedTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueUnbatchedTest.kt
@@ -1,0 +1,79 @@
+package misk.jobqueue
+
+import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.jobqueue.testutilities.ColorException
+import misk.jobqueue.testutilities.ENQUEUER_QUEUE
+import misk.jobqueue.testutilities.EnqueuerJobHandler
+import misk.jobqueue.testutilities.ExampleJob
+import misk.jobqueue.testutilities.ExampleJobHint
+import misk.jobqueue.testutilities.GREEN_QUEUE
+import misk.jobqueue.testutilities.RED_QUEUE
+import misk.logging.LogCollectorModule
+import misk.moshi.adapter
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions
+import wisp.logging.getLogger
+import java.util.concurrent.ConcurrentHashMap
+
+@MiskTest(startService = true)
+class FakeJobQueueUnbatchedTest : FakeJobQueueTest() {
+  @Suppress("unused")
+  @MiskTestModule
+  val module = TestModule()
+
+  override val loggerClass = ExampleJobHandler::class
+}
+
+class TestModule : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(LogCollectorModule())
+    install(FakeJobHandlerModule.create<ExampleJobHandler>(RED_QUEUE))
+    install(FakeJobHandlerModule.create<ExampleJobHandler>(GREEN_QUEUE))
+    install(FakeJobHandlerModule.create<EnqueuerJobHandler>(ENQUEUER_QUEUE))
+    install(FakeJobQueueModule())
+  }
+}
+
+@Singleton
+class ExampleJobHandler @Inject private constructor(moshi: Moshi) : JobHandler {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+  private val jobsExecutedOnce = ConcurrentHashMap<String, Boolean>()
+
+  override fun handleJob(job: Job) {
+    val deserializedJob = jobAdapter.fromJson(job.body)!!
+    log.info { "received ${deserializedJob.color} job with message: ${deserializedJob.message}" }
+
+    Assertions.assertThat(job.attributes).containsEntry("key", "value")
+
+    val key = "${deserializedJob.color}:${deserializedJob.hint}:${deserializedJob.message}"
+    val jobExecutedBefore = jobsExecutedOnce.putIfAbsent(key, true) == true
+    when (deserializedJob.hint) {
+      ExampleJobHint.DONT_ACK -> return
+      ExampleJobHint.DEAD_LETTER -> {
+        job.deadLetter()
+        return
+      }
+      ExampleJobHint.DEAD_LETTER_ONCE -> if (!jobExecutedBefore) {
+        job.deadLetter()
+        return
+      }
+      ExampleJobHint.THROW -> throw ColorException()
+      ExampleJobHint.THROW_ONCE -> if (!jobExecutedBefore) {
+        throw ColorException()
+      }
+      else -> Unit
+    }
+
+    job.acknowledge()
+  }
+
+  companion object {
+    private val log = getLogger<ExampleJobHandler>()
+  }
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/Color.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/Color.kt
@@ -1,0 +1,8 @@
+package misk.jobqueue.testutilities
+
+internal enum class Color {
+  RED,
+  GREEN
+}
+
+internal class ColorException : Throwable()

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/EnqueuerJobHandler.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/EnqueuerJobHandler.kt
@@ -1,0 +1,23 @@
+package misk.jobqueue.testutilities
+
+import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
+import misk.jobqueue.Job
+import misk.jobqueue.JobHandler
+import misk.jobqueue.JobQueue
+import misk.moshi.adapter
+
+internal class EnqueuerJobHandler @Inject private constructor(
+  private val jobQueue: JobQueue,
+  moshi: Moshi
+) : JobHandler {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+
+  override fun handleJob(job: Job) {
+    jobQueue.enqueue(
+      queueName = GREEN_QUEUE,
+      body = jobAdapter.toJson(ExampleJob(color = Color.GREEN, message = "We made it!"))
+    )
+    job.acknowledge()
+  }
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJob.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJob.kt
@@ -1,0 +1,7 @@
+package misk.jobqueue.testutilities
+
+internal data class ExampleJob(
+  val color: Color,
+  val message: String,
+  val hint: ExampleJobHint? = null
+)

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJobEnqueuer.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJobEnqueuer.kt
@@ -1,0 +1,44 @@
+package misk.jobqueue.testutilities
+
+import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
+import misk.jobqueue.JobQueue
+import misk.moshi.adapter
+import java.time.Duration
+
+internal class ExampleJobEnqueuer @Inject private constructor(
+  private val jobQueue: JobQueue,
+  moshi: Moshi
+) {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+
+  fun enqueueRed(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    val job = ExampleJob(Color.RED, message, hint)
+    jobQueue.enqueue(
+      RED_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
+      attributes = mapOf("key" to "value")
+    )
+  }
+
+  fun enqueueGreen(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    val job = ExampleJob(Color.GREEN, message, hint)
+    jobQueue.enqueue(
+      GREEN_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
+      attributes = mapOf("key" to "value")
+    )
+  }
+
+  fun batchEnqueueRed(messages: List<String>, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    jobQueue.batchEnqueue(RED_QUEUE, messages.map {
+      JobQueue.JobRequest(
+        body = jobAdapter.toJson(ExampleJob(Color.RED, it, hint)),
+        deliveryDelay = deliveryDelay,
+        attributes = mapOf("key" to "value")
+      )
+    })
+  }
+
+  fun enqueueEnqueuer() {
+    jobQueue.enqueue(ENQUEUER_QUEUE, body = "")
+  }
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJobHint.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/ExampleJobHint.kt
@@ -1,0 +1,9 @@
+package misk.jobqueue.testutilities
+
+internal enum class ExampleJobHint {
+  DONT_ACK,
+  THROW,
+  THROW_ONCE,
+  DEAD_LETTER,
+  DEAD_LETTER_ONCE
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/Queues.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/testutilities/Queues.kt
@@ -1,0 +1,7 @@
+package misk.jobqueue.testutilities
+
+import misk.jobqueue.QueueName
+
+internal val RED_QUEUE = QueueName("red_queue")
+internal val GREEN_QUEUE = QueueName("green_queue")
+internal val ENQUEUER_QUEUE = QueueName("first_step_queue")

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobHandlerModule.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobHandlerModule.kt
@@ -3,21 +3,21 @@ package misk.jobqueue
 import misk.inject.KAbstractModule
 import kotlin.reflect.KClass
 
-class FakeJobHandlerModule<T : JobHandler> private constructor(
+class FakeJobHandlerModule<T : AbstractJobHandler> private constructor(
   private val queueName: QueueName,
   private val handler: KClass<T>
 ) : KAbstractModule() {
 
   override fun configure() {
-    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
+    newMapBinder<QueueName, AbstractJobHandler>().addBinding(queueName).to(handler.java)
   }
 
   companion object {
-    inline fun <reified T : JobHandler> create(queueName: QueueName):
+    inline fun <reified T : AbstractJobHandler> create(queueName: QueueName):
       FakeJobHandlerModule<T> = create(queueName, T::class)
 
     @JvmStatic
-    fun <T : JobHandler> create(
+    fun <T : AbstractJobHandler> create(
       queueName: QueueName,
       handlerClass: Class<T>
     ): FakeJobHandlerModule<T> {
@@ -27,7 +27,7 @@ class FakeJobHandlerModule<T : JobHandler> private constructor(
     /**
      * Returns a module that registers a handler for a fake job queue.
      */
-    fun <T : JobHandler> create(
+    fun <T : AbstractJobHandler> create(
       queueName: QueueName,
       handlerClass: KClass<T>
     ): FakeJobHandlerModule<T> {


### PR DESCRIPTION
## Description
The goal of this PR is to enable "batched" job handling, i.e. for a job handler to be given all its messages at once rather than have them processed in their own threads. 


To enable this without changing how regular `JobHandler` processing is handled, we create a hierarchy for job handlers:

```mermaid
stateDiagram-v2
    AbstractJobHander --> JobHandler
    AbstractJobHander --> BatchedJobHandler
```

and switch the implementation based on which class has been bound. 

Review note: most of the new files in the `test` bundle have just been extracted from `FakeJobQueueTest.kt`, and are otherwise the same as before