### PR TITLE
Fallback to action scope key subtypes, if a requested key is missing

### DIFF
--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -19,7 +19,6 @@ import okhttp3.MediaType
 import org.slf4j.MDC
 import java.util.regex.Matcher
 import com.google.inject.Provider
-import misk.api.HttpRequest
 import javax.servlet.http.HttpServletRequest
 import kotlin.reflect.KType
 
@@ -111,7 +110,6 @@ internal class BoundAction<A : WebAction>(
     val initialSeedData = mapOf<Key<*>, Any?>(
       keyOf<HttpServletRequest>() to request,
       keyOf<HttpCall>() to httpCall,
-      keyOf<HttpRequest>() to httpCall,
       keyOf<Action>() to action,
     )
     val seedData =


### PR DESCRIPTION
For example, given `HttpCall` extends `HttpRequest`, the value for `HttpCall` key will be returned when the `HttpRequest` key is requested (only if a `HttpRequest` key is not set).

See this PR for related prior work:
https://github.com/cashapp/misk/pull/3104