### PR TITLE
Bind FakeRedis as a Singleton

### DIFF
--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RedisTestModule.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RedisTestModule.kt
@@ -4,14 +4,18 @@ import misk.inject.KAbstractModule
 import misk.inject.keyOf
 import misk.redis.Redis
 import misk.time.FakeClock
+
 import jakarta.inject.Qualifier
 import kotlin.random.Random
 
+/**
+ * Installs a singleton [FakeRedis] for testing.
+ */
 class RedisTestModule(private val random: Random = Random.Default) : KAbstractModule() {
   override fun configure() {
     requireBinding<FakeClock>()
     bind(keyOf<Random>(ForFakeRedis::class)).toInstance(random)
-    bind<Redis>().to(keyOf<FakeRedis>())
+    bind<Redis>().to(keyOf<FakeRedis>()).asEagerSingleton()
   }
 }
 


### PR DESCRIPTION
FakeRedis was originally bound as a singleton instance, but was mistakenly changed in https://github.com/cashapp/misk/pull/2731/files#diff-f726c371558ec7d903ff3c3977496c0b0966f14699f22e060c61f4ad9e921095R11.

While this likely wasn't noticed by many consumers, we're flipping it back because it has caused a problem with an internal test where we expect the singleton scope for the unit.

**This is potentially a behavior change for tests.**