### PR TITLE
Add a way to disable non error request logging

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -711,6 +711,13 @@ acceptedBreaks:
       justification: "{Adding a new backwards compatible option to the request logging\
         \ interceptor}"
     - code: "java.method.numberOfParametersChanged"
+      old: "method misk.web.interceptors.ActionLoggingConfig misk.web.interceptors.ActionLoggingConfig::copy(long,\
+        \ long, double, double, java.util.List<java.lang.String>)"
+      new: "method misk.web.interceptors.ActionLoggingConfig misk.web.interceptors.ActionLoggingConfig::copy(long,\
+        \ long, double, double, java.util.List<java.lang.String>, misk.web.interceptors.RequestLoggingMode)"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    - code: "java.method.numberOfParametersChanged"
       old: "method void misk.web.interceptors.RequestLoggingInterceptor::<init>(misk.Action,\
         \ misk.scope.ActionScoped<misk.MiskCaller>, com.google.common.base.Ticker,\
         \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
@@ -721,6 +728,19 @@ acceptedBreaks:
         \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
         \ long, double, double, misk.web.interceptors.RequestResponseCapture, java.util.List<?\
         \ extends misk.web.interceptors.RequestLoggingTransformer>, misk.web.interceptors.RequestLoggingConstraints)"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.web.interceptors.RequestLoggingInterceptor::<init>(misk.Action,\
+        \ misk.scope.ActionScoped<misk.MiskCaller>, com.google.common.base.Ticker,\
+        \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
+        \ long, double, double, misk.web.interceptors.RequestResponseCapture, java.util.List<?\
+        \ extends misk.web.interceptors.RequestLoggingTransformer>)"
+      new: "method void misk.web.interceptors.RequestLoggingInterceptor::<init>(misk.Action,\
+        \ misk.scope.ActionScoped<misk.MiskCaller>, com.google.common.base.Ticker,\
+        \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
+        \ long, double, double, misk.web.interceptors.RequestResponseCapture, java.util.List<?\
+        \ extends misk.web.interceptors.RequestLoggingTransformer>, misk.web.interceptors.RequestLoggingMode)"
       justification: "{Adding a new backwards compatible option to the request logging\
         \ interceptor}"
     - code: "{revapi check code}"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -703,6 +703,26 @@ acceptedBreaks:
       justification: "{Adding a new backwards compatible option to the request logging\
         \ interceptor}"
     com.squareup.misk:misk:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method misk.web.interceptors.ActionLoggingConfig misk.web.interceptors.ActionLoggingConfig::copy(long,\
+        \ long, double, double, java.util.List<java.lang.String>)"
+      new: "method misk.web.interceptors.ActionLoggingConfig misk.web.interceptors.ActionLoggingConfig::copy(long,\
+        \ long, double, double, java.util.List<java.lang.String>, misk.web.interceptors.RequestLoggingConstraints)"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.web.interceptors.RequestLoggingInterceptor::<init>(misk.Action,\
+        \ misk.scope.ActionScoped<misk.MiskCaller>, com.google.common.base.Ticker,\
+        \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
+        \ long, double, double, misk.web.interceptors.RequestResponseCapture, java.util.List<?\
+        \ extends misk.web.interceptors.RequestLoggingTransformer>)"
+      new: "method void misk.web.interceptors.RequestLoggingInterceptor::<init>(misk.Action,\
+        \ misk.scope.ActionScoped<misk.MiskCaller>, com.google.common.base.Ticker,\
+        \ misk.random.ThreadLocalRandom, misk.web.interceptors.LogRateLimiter, long,\
+        \ long, double, double, misk.web.interceptors.RequestResponseCapture, java.util.List<?\
+        \ extends misk.web.interceptors.RequestLoggingTransformer>, misk.web.interceptors.RequestLoggingConstraints)"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
     - code: "{revapi check code}"
       justification: "{Adding a new backwards compatible option to the request logging\
         \ interceptor}"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -597,3 +597,320 @@ acceptedBreaks:
       new: "method misk.redis.Redis misk.redis.RedisModule::provideRedisClient$misk_redis(misk.redis.RedisClientMetrics,\
         \ redis.clients.jedis.UnifiedJedis)"
       justification: "Only breaks one client, which is owned by the author"
+  "2024.01.29.234331-880e488":
+    app.cash.wisp:bucket4j:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-aws-environment:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-client:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-config:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-containers-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-deployment:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-deployment-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-feature:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-feature-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-launchdarkly:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-lease:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-lease-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-logging:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-logging-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-moshi:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-rate-limiting:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-resource-loader:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-resource-loader-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-sampling:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-ssl:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-task:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-time-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-token:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-token-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    app.cash.wisp:wisp-tracing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-action-scopes:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-actions:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-admin:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-api:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-aws:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-aws-dynamodb:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-aws2-dynamodb:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-clustering:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-clustering-dynamodb:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-config:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-core:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-cron:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-crypto:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-datadog:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-events:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-events-core:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-events-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-exceptions-dynamodb:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-feature:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-feature-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-gcp:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-grpc-reflect:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-grpc-tests:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-hibernate:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-hibernate-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-hotwire:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-inject:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-inject-guice7-test:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-jdbc:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-jobqueue:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-jooq:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-launchdarkly:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-launchdarkly-core:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-lease:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-metrics:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-metrics-digester:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-policy:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-prometheus:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-proto:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-rate-limiting-bucket4j-dynamodb-v1:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-rate-limiting-bucket4j-mysql:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-rate-limiting-bucket4j-redis:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-redis:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-service:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-slack:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-sqldelight:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-sqldelight-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-tailwind:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-testing:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-transactional-jobqueue:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:misk-warmup:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"
+    com.squareup.misk:samples:
+    - code: "{revapi check code}"
+      justification: "{Adding a new backwards compatible option to the request logging\
+        \ interceptor}"

--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -301,5 +301,14 @@ public abstract interface annotation class misk/web/interceptors/LogRequestRespo
 	public abstract fun errorRatePerSecond ()J
 	public abstract fun excludedEnvironments ()[Ljava/lang/String;
 	public abstract fun ratePerSecond ()J
+	public abstract fun requestLoggingConstraints ()Lmisk/web/interceptors/RequestLoggingConstraints;
+}
+
+public final class misk/web/interceptors/RequestLoggingConstraints : java/lang/Enum {
+	public static final field ALL Lmisk/web/interceptors/RequestLoggingConstraints;
+	public static final field ERROR_ONLY Lmisk/web/interceptors/RequestLoggingConstraints;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/web/interceptors/RequestLoggingConstraints;
+	public static fun values ()[Lmisk/web/interceptors/RequestLoggingConstraints;
 }
 

--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -301,14 +301,14 @@ public abstract interface annotation class misk/web/interceptors/LogRequestRespo
 	public abstract fun errorRatePerSecond ()J
 	public abstract fun excludedEnvironments ()[Ljava/lang/String;
 	public abstract fun ratePerSecond ()J
-	public abstract fun requestLoggingConstraints ()Lmisk/web/interceptors/RequestLoggingConstraints;
+	public abstract fun requestLoggingMode ()Lmisk/web/interceptors/RequestLoggingMode;
 }
 
-public final class misk/web/interceptors/RequestLoggingConstraints : java/lang/Enum {
-	public static final field ALL Lmisk/web/interceptors/RequestLoggingConstraints;
-	public static final field ERROR_ONLY Lmisk/web/interceptors/RequestLoggingConstraints;
+public final class misk/web/interceptors/RequestLoggingMode : java/lang/Enum {
+	public static final field ALL Lmisk/web/interceptors/RequestLoggingMode;
+	public static final field ERROR_ONLY Lmisk/web/interceptors/RequestLoggingMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lmisk/web/interceptors/RequestLoggingConstraints;
-	public static fun values ()[Lmisk/web/interceptors/RequestLoggingConstraints;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/web/interceptors/RequestLoggingMode;
+	public static fun values ()[Lmisk/web/interceptors/RequestLoggingMode;
 }
 

--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
@@ -14,6 +14,8 @@ package misk.web.interceptors
  * If you would like to turn off rate limiting and emit all logs, set ratePerSecond and/or
  * errorRatePerSecond to 0.
  *
+ * If you would like to turn off logging for all non-error requests, set enableNonErrorLogging to false.
+ *
  * Percentage sampling is used to sample request and response bodies, with 0.0 for none and 1.0 for all.
  * Valid values are in the range [0.0, 1.0].
  *
@@ -34,4 +36,6 @@ annotation class LogRequestResponse(
   val errorBodySampling: Double = 0.0,
   /** which deploy environments will not have request/response logging enabled **/
   val excludedEnvironments: Array<String> = [],
+  /** By default log non-error responses **/
+  val enableNonErrorLogging: Boolean = true,
 )

--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
@@ -14,7 +14,8 @@ package misk.web.interceptors
  * If you would like to turn off rate limiting and emit all logs, set ratePerSecond and/or
  * errorRatePerSecond to 0.
  *
- * If you would like to turn off logging for all non-error requests, set enableNonErrorLogging to false.
+ * If you would like to turn off logging for all non-error requests, set requestLoggingConstraints to ERROR_ONLY.
+ * otherwise, all requests will be logged (excluding those otherwise rate limited, etc).
  *
  * Percentage sampling is used to sample request and response bodies, with 0.0 for none and 1.0 for all.
  * Valid values are in the range [0.0, 1.0].
@@ -37,5 +38,16 @@ annotation class LogRequestResponse(
   /** which deploy environments will not have request/response logging enabled **/
   val excludedEnvironments: Array<String> = [],
   /** By default log non-error responses **/
-  val enableNonErrorLogging: Boolean = true,
+  val requestLoggingConstraints: RequestLoggingConstraints = RequestLoggingConstraints.ALL,
 )
+
+enum class RequestLoggingConstraints {
+  /**
+   * Log all requests and responses, rate limiting, etc still apply.
+   **/
+  ALL,
+  /**
+   * Log only error requests and responses, rate limiting, etc still apply.
+   **/
+  ERROR_ONLY,
+}

--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogRequestResponse.kt
@@ -14,7 +14,7 @@ package misk.web.interceptors
  * If you would like to turn off rate limiting and emit all logs, set ratePerSecond and/or
  * errorRatePerSecond to 0.
  *
- * If you would like to turn off logging for all non-error requests, set requestLoggingConstraints to ERROR_ONLY.
+ * If you would like to turn off logging for all non-error requests, set requestLoggingMode to ERROR_ONLY.
  * otherwise, all requests will be logged (excluding those otherwise rate limited, etc).
  *
  * Percentage sampling is used to sample request and response bodies, with 0.0 for none and 1.0 for all.
@@ -38,10 +38,10 @@ annotation class LogRequestResponse(
   /** which deploy environments will not have request/response logging enabled **/
   val excludedEnvironments: Array<String> = [],
   /** By default log non-error responses **/
-  val requestLoggingConstraints: RequestLoggingConstraints = RequestLoggingConstraints.ALL,
+  val requestLoggingMode: RequestLoggingMode = RequestLoggingMode.ALL,
 )
 
-enum class RequestLoggingConstraints {
+enum class RequestLoggingMode {
   /**
    * Log all requests and responses, rate limiting, etc still apply.
    **/

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1790,20 +1790,23 @@ public final class misk/web/interceptors/ActionLoggingConfig {
 	public fun <init> (JJD)V
 	public fun <init> (JJDD)V
 	public fun <init> (JJDDLjava/util/List;)V
-	public synthetic fun <init> (JJDDLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;)V
+	public synthetic fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()J
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (JJDDLjava/util/List;)Lmisk/web/interceptors/ActionLoggingConfig;
-	public static synthetic fun copy$default (Lmisk/web/interceptors/ActionLoggingConfig;JJDDLjava/util/List;ILjava/lang/Object;)Lmisk/web/interceptors/ActionLoggingConfig;
+	public final fun component6 ()Lmisk/web/interceptors/RequestLoggingConstraints;
+	public final fun copy (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;)Lmisk/web/interceptors/ActionLoggingConfig;
+	public static synthetic fun copy$default (Lmisk/web/interceptors/ActionLoggingConfig;JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;ILjava/lang/Object;)Lmisk/web/interceptors/ActionLoggingConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBodySampling ()D
 	public final fun getErrorBodySampling ()D
 	public final fun getErrorRatePerSecond ()J
 	public final fun getExcludedEnvironments ()Ljava/util/List;
 	public final fun getRatePerSecond ()J
+	public final fun getRequestLoggingConstraints ()Lmisk/web/interceptors/RequestLoggingConstraints;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1790,23 +1790,23 @@ public final class misk/web/interceptors/ActionLoggingConfig {
 	public fun <init> (JJD)V
 	public fun <init> (JJDD)V
 	public fun <init> (JJDDLjava/util/List;)V
-	public fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;)V
-	public synthetic fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingMode;)V
+	public synthetic fun <init> (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()J
 	public final fun component3 ()D
 	public final fun component4 ()D
 	public final fun component5 ()Ljava/util/List;
-	public final fun component6 ()Lmisk/web/interceptors/RequestLoggingConstraints;
-	public final fun copy (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;)Lmisk/web/interceptors/ActionLoggingConfig;
-	public static synthetic fun copy$default (Lmisk/web/interceptors/ActionLoggingConfig;JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingConstraints;ILjava/lang/Object;)Lmisk/web/interceptors/ActionLoggingConfig;
+	public final fun component6 ()Lmisk/web/interceptors/RequestLoggingMode;
+	public final fun copy (JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingMode;)Lmisk/web/interceptors/ActionLoggingConfig;
+	public static synthetic fun copy$default (Lmisk/web/interceptors/ActionLoggingConfig;JJDDLjava/util/List;Lmisk/web/interceptors/RequestLoggingMode;ILjava/lang/Object;)Lmisk/web/interceptors/ActionLoggingConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBodySampling ()D
 	public final fun getErrorBodySampling ()D
 	public final fun getErrorRatePerSecond ()J
 	public final fun getExcludedEnvironments ()Ljava/util/List;
 	public final fun getRatePerSecond ()J
-	public final fun getRequestLoggingConstraints ()Lmisk/web/interceptors/RequestLoggingConstraints;
+	public final fun getRequestLoggingMode ()Lmisk/web/interceptors/RequestLoggingMode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -36,7 +36,7 @@ class RequestLoggingInterceptor internal constructor(
   private val errorBodySampling: Double,
   private val bodyCapture: RequestResponseCapture,
   private val requestLoggingTransformers: List<RequestLoggingTransformer>,
-  private val requestLoggingConstraints: RequestLoggingConstraints,
+  private val requestLoggingMode: RequestLoggingMode,
 ) : NetworkInterceptor {
   @Singleton
   class Factory @Inject internal constructor(
@@ -82,7 +82,7 @@ class RequestLoggingInterceptor internal constructor(
         config.errorBodySampling,
         bodyCapture,
         requestLoggingTransformers,
-        config.requestLoggingConstraints,
+        config.requestLoggingMode,
       )
     }
   }
@@ -127,7 +127,7 @@ class RequestLoggingInterceptor internal constructor(
 
     val isError = statusCode > 299 || error != null
 
-    if (!isError && requestLoggingConstraints == RequestLoggingConstraints.ERROR_ONLY) {
+    if (!isError && requestLoggingMode == RequestLoggingMode.ERROR_ONLY) {
       return
     }
 
@@ -186,7 +186,7 @@ data class ActionLoggingConfig @JvmOverloads constructor(
   val bodySampling: Double = 0.0,
   val errorBodySampling: Double = 0.0,
   val excludedEnvironments: List<String> = listOf(),
-  val requestLoggingConstraints: RequestLoggingConstraints = RequestLoggingConstraints.ALL,
+  val requestLoggingMode: RequestLoggingMode = RequestLoggingMode.ALL,
 ) {
   companion object {
     fun fromAnnotation(logRequestResponse: LogRequestResponse): ActionLoggingConfig = ActionLoggingConfig(
@@ -195,7 +195,7 @@ data class ActionLoggingConfig @JvmOverloads constructor(
       bodySampling = logRequestResponse.bodySampling,
       errorBodySampling = logRequestResponse.errorBodySampling,
       excludedEnvironments = logRequestResponse.excludedEnvironments.toList(),
-      requestLoggingConstraints = logRequestResponse.requestLoggingConstraints,
+      requestLoggingMode = logRequestResponse.requestLoggingMode,
     )
 
     fun fromConfigMapOrAnnotation(

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLoggingInterceptor.kt
@@ -36,7 +36,7 @@ class RequestLoggingInterceptor internal constructor(
   private val errorBodySampling: Double,
   private val bodyCapture: RequestResponseCapture,
   private val requestLoggingTransformers: List<RequestLoggingTransformer>,
-  private val enableNonErrorLogging: Boolean,
+  private val requestLoggingConstraints: RequestLoggingConstraints,
 ) : NetworkInterceptor {
   @Singleton
   class Factory @Inject internal constructor(
@@ -82,7 +82,7 @@ class RequestLoggingInterceptor internal constructor(
         config.errorBodySampling,
         bodyCapture,
         requestLoggingTransformers,
-        config.enableNonErrorLogging,
+        config.requestLoggingConstraints,
       )
     }
   }
@@ -127,7 +127,7 @@ class RequestLoggingInterceptor internal constructor(
 
     val isError = statusCode > 299 || error != null
 
-    if (!isError && !enableNonErrorLogging) {
+    if (!isError && requestLoggingConstraints == RequestLoggingConstraints.ERROR_ONLY) {
       return
     }
 
@@ -186,7 +186,7 @@ data class ActionLoggingConfig @JvmOverloads constructor(
   val bodySampling: Double = 0.0,
   val errorBodySampling: Double = 0.0,
   val excludedEnvironments: List<String> = listOf(),
-  val enableNonErrorLogging: Boolean = true,
+  val requestLoggingConstraints: RequestLoggingConstraints = RequestLoggingConstraints.ALL,
 ) {
   companion object {
     fun fromAnnotation(logRequestResponse: LogRequestResponse): ActionLoggingConfig = ActionLoggingConfig(
@@ -195,7 +195,7 @@ data class ActionLoggingConfig @JvmOverloads constructor(
       bodySampling = logRequestResponse.bodySampling,
       errorBodySampling = logRequestResponse.errorBodySampling,
       excludedEnvironments = logRequestResponse.excludedEnvironments.toList(),
-      enableNonErrorLogging = logRequestResponse.enableNonErrorLogging,
+      requestLoggingConstraints = logRequestResponse.requestLoggingConstraints,
     )
 
     fun fromConfigMapOrAnnotation(

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -181,14 +181,14 @@ internal class RequestLoggingInterceptorTest {
 
   @Test
   fun noNonErrorRequestLogging() {
-    assertThat(invoke("/call/noNonErrorRequestLoggingAction/fail", "caller").code)
+    assertThat(invoke("/call/errorOnlyRequestLoggingAction/fail", "caller").code)
       .isEqualTo(500)
-    assertThat(invoke("/call/noNonErrorRequestLoggingAction/hello", "caller")
+    assertThat(invoke("/call/errorOnlyRequestLoggingAction/hello", "caller")
       .isSuccessful
     ).isTrue()
     val messages = logCollector.takeMessages(RequestLoggingInterceptor::class)
     assertThat(messages).containsExactly(
-      "NoNonErrorRequestLoggingAction principal=caller time=100.0 ms failed"
+      "errorOnlyRequestLoggingAction principal=caller time=100.0 ms failed"
     )
   }
 
@@ -327,7 +327,7 @@ internal class RequestLoggingInterceptorTest {
       install(WebActionModule.create<RateLimitingRequestLoggingAction>())
       install(WebActionModule.create<RateLimitingIncludesBodyRequestLoggingAction>())
       install(WebActionModule.create<NoRateLimitingRequestLoggingAction>())
-      install(WebActionModule.create<NoNonErrorRequestLoggingAction>())
+      install(WebActionModule.create<errorOnlyRequestLoggingAction>())
       install(WebActionModule.create<ExceptionThrowingRequestLoggingAction>())
       install(WebActionModule.create<NoRequestLoggingAction>())
       install(WebActionModule.create<RequestLoggingActionWithHeaders>())
@@ -383,11 +383,11 @@ internal class NoRateLimitingRequestLoggingAction @Inject constructor() : WebAct
   fun call(@PathParam message: String) = "echo: $message"
 }
 
-internal class NoNonErrorRequestLoggingAction @Inject constructor() : WebAction {
-  @Get("/call/noNonErrorRequestLoggingAction/{message}")
+internal class errorOnlyRequestLoggingAction @Inject constructor() : WebAction {
+  @Get("/call/errorOnlyRequestLoggingAction/{message}")
   @Unauthenticated
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
-  @LogRequestResponse(enableNonErrorLogging = false)
+  @LogRequestResponse(requestLoggingConstraints = RequestLoggingConstraints.ERROR_ONLY)
   fun call(@PathParam message: String) : String {
     if (message == "fail") {
       throw IllegalStateException(message)

--- a/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/RequestLoggingInterceptorTest.kt
@@ -387,7 +387,7 @@ internal class errorOnlyRequestLoggingAction @Inject constructor() : WebAction {
   @Get("/call/errorOnlyRequestLoggingAction/{message}")
   @Unauthenticated
   @ResponseContentType(MediaTypes.APPLICATION_JSON)
-  @LogRequestResponse(requestLoggingConstraints = RequestLoggingConstraints.ERROR_ONLY)
+  @LogRequestResponse(requestLoggingMode = RequestLoggingMode.ERROR_ONLY)
   fun call(@PathParam message: String) : String {
     if (message == "fail") {
       throw IllegalStateException(message)


### PR DESCRIPTION
This makes changes to the request logging interceptor in order to allow disabling logging of non-error requests completely.

Currently, the logging interceptor does not allow you to set the rate limit to 0 as 0 is used to specify no limit. I didn't want to break backwards compatility to change it from 0 to -1 for no limit and 0 for no logging. Instead I've added a new config boolean that can be used to set it to not log for non-error responses.

The reason that I've added this is that a rate limit of 1 is too high for high volume APIs when there are a large number of pods handling requests. The rate limiting is done on a per pod basis, so a rate limit of 1/second with 100 pods will result in about 8.5million logs per day. I'd like a way to just turn these off!