### PR TITLE
Add customizable retry settings for Spanner client.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,3 +1,5 @@
+versionOverrides:
+  com.squareup.misk:misk-gcp:misk-0.18.0: "2024.01.25.022820-30be5eb"
 acceptedBreaks:
   "2023.10.17.232338-9c1976d":
     com.squareup.misk:misk-admin:
@@ -597,3 +599,14 @@ acceptedBreaks:
       new: "method misk.redis.Redis misk.redis.RedisModule::provideRedisClient$misk_redis(misk.redis.RedisClientMetrics,\
         \ redis.clients.jedis.UnifiedJedis)"
       justification: "Only breaks one client, which is owned by the author"
+  misk-0.18.0:
+    com.squareup.misk:misk-gcp:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method misk.cloud.gcp.spanner.SpannerConfig misk.cloud.gcp.spanner.SpannerConfig::copy(com.google.auth.Credentials,\
+        \ java.lang.String, misk.cloud.gcp.spanner.SpannerEmulatorConfig, java.lang.String,\
+        \ java.lang.String)"
+      new: "method misk.cloud.gcp.spanner.SpannerConfig misk.cloud.gcp.spanner.SpannerConfig::copy(com.google.auth.Credentials,\
+        \ java.lang.String, misk.cloud.gcp.spanner.SpannerEmulatorConfig, java.lang.String,\
+        \ java.lang.String, java.lang.Long, java.lang.Long, java.lang.Double, java.lang.Long,\
+        \ java.lang.Long, java.lang.Double, java.lang.Long, java.lang.Integer)"
+      justification: "Extending configuration class."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -183,6 +183,7 @@ tempestTesting = { module = "app.cash.tempest:tempest-testing" }
 tempestTestingDocker = { module = "app.cash.tempest:tempest-testing-docker" }
 tempestTestingInternal = { module = "app.cash.tempest:tempest-testing-internal" }
 tempestTestingJvm = { module = "app.cash.tempest:tempest-testing-jvm" }
+threeTenBp = { module = "org.threeten:threetenbp", version = "1.6.8" }
 sqldelightGradlePlugin = { module = "app.cash.sqldelight:gradle-plugin", version = "2.0.0" }
 sqldelightJdbcDriver = { module = "app.cash.sqldelight:jdbc-driver", version = "2.0.0" }
 sqldelightMysqlDialect = { module = "app.cash.sqldelight:mysql-dialect", version = "2.0.0" }

--- a/misk-gcp/api/misk-gcp.api
+++ b/misk-gcp/api/misk-gcp.api
@@ -161,21 +161,45 @@ public final class misk/cloud/gcp/spanner/GoogleSpannerService$Companion {
 public final class misk/cloud/gcp/spanner/SpannerConfig : wisp/config/Config {
 	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;)V
+	public fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Lcom/google/auth/Credentials;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Ljava/lang/Double;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;)Lmisk/cloud/gcp/spanner/SpannerConfig;
-	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerConfig;Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerConfig;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/Double;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Integer;)Lmisk/cloud/gcp/spanner/SpannerConfig;
+	public static synthetic fun copy$default (Lmisk/cloud/gcp/spanner/SpannerConfig;Lcom/google/auth/Credentials;Ljava/lang/String;Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Integer;ILjava/lang/Object;)Lmisk/cloud/gcp/spanner/SpannerConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCredentials ()Lcom/google/auth/Credentials;
 	public final fun getDatabase ()Ljava/lang/String;
 	public final fun getEmulator ()Lmisk/cloud/gcp/spanner/SpannerEmulatorConfig;
+	public final fun getInitial_retry_delay_ms ()Ljava/lang/Long;
+	public final fun getInitial_rpc_timeout_s ()Ljava/lang/Long;
 	public final fun getInstance_id ()Ljava/lang/String;
+	public final fun getMax_attempts ()Ljava/lang/Integer;
+	public final fun getMax_retry_delay_s ()Ljava/lang/Long;
+	public final fun getMax_rpc_timeout_s ()Ljava/lang/Long;
 	public final fun getProject_id ()Ljava/lang/String;
+	public final fun getRetry_delay_multiplier ()Ljava/lang/Double;
+	public final fun getRpc_timeout_multipler ()Ljava/lang/Double;
+	public final fun getTotal_timeout_s ()Ljava/lang/Long;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk-gcp/build.gradle.kts
+++ b/misk-gcp/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   implementation(libs.logbackCore)
   implementation(libs.openTracingDatadog)
   implementation(libs.slf4jApi)
+  implementation(libs.threeTenBp)
   implementation(libs.wireRuntime)
   implementation(project(":wisp:wisp-logging"))
   implementation(project(":wisp:wisp-moshi"))

--- a/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
+++ b/misk-gcp/src/main/kotlin/misk/cloud/gcp/spanner/SpannerConfig.kt
@@ -46,6 +46,50 @@ data class SpannerConfig @JvmOverloads constructor(
    * > GCP project - any string will do.
    */
   val project_id: String,
+
+  /**
+   * The initial amount of time to wait before retrying the request.
+   */
+  val initial_retry_delay_ms: Long? = null,
+
+  /**
+   * The maximum amount of time to wait before retrying. I.e. after this value is
+   * reached, the wait time will not increase further by the multiplier.
+   */
+  val max_retry_delay_s: Long? = null,
+
+  /**
+   * The previous wait time is multiplied by this multiplier to come up with the next
+   * wait time, until the max is reached.
+   */
+  val retry_delay_multiplier: Double? = null,
+
+  /**
+   * Configure RPC and total timeout settings.
+   * Timeout for the first RPC call. Subsequent retries will be based off this value.
+   */
+  val initial_rpc_timeout_s: Long? = null,
+
+  /**
+   * The max for the per RPC timeout.
+   */
+  val max_rpc_timeout_s: Long? = null,
+
+  /**
+   * Controls the change of timeout for each retry.
+   */
+  val rpc_timeout_multipler: Double? = null,
+
+  /**
+   * The timeout for all calls (first call + all retries).
+   */
+  val total_timeout_s: Long? = null,
+
+  /**
+   * Total number of attempts for an RPC.
+   * Setting to 1 means no retries will be attempted.
+   */
+  val max_attempts: Int? = null,
 ) : Config
 
 /**


### PR DESCRIPTION
This allows Misk services relying on Spanner to customize their RPC retry settings. Fixes #2455.