### PR TITLE
Read gRPC status from response trailers to fix client metrics

### DIFF
--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -81,10 +81,8 @@ class ClientMetricsInterceptor private constructor(
     response: Response
   ) {
     val grpcStatusHeader = if (readTrailers) {
-      /**
-       * If the response has trailers, we should use them to get the grpc-status.
-       * trailers() is only available after HTTP response body has been consumed.
-       */
+      // If the response has trailers, we should use them to get the grpc-status.
+      // trailers() is only available after HTTP response body has been consumed.
       response.trailers()[GRPC_STATUS_HEADER] ?: response.headers[GRPC_STATUS_HEADER]
     } else {
       response.headers[GRPC_STATUS_HEADER]

--- a/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientMetricsInterceptor.kt
@@ -148,14 +148,14 @@ class ClientMetricsInterceptor private constructor(
   }
 
   private class TrailerAwareResponseBody(
-    private val responseBody: ResponseBody,
+    private val delegate: ResponseBody,
     private val func: () -> Unit
   ) : ResponseBody() {
-    override fun contentLength() = responseBody.contentLength()
-    override fun contentType() = responseBody.contentType()
-    override fun source() = responseBody.source()
+    override fun contentLength() = delegate.contentLength()
+    override fun contentType() = delegate.contentType()
+    override fun source() = delegate.source()
     override fun close() {
-      responseBody.close()
+      delegate.close()
       func.invoke()
     }
   }


### PR DESCRIPTION
Currently, our client metrics interceptor is not capturing the correct status codes for gRPC errors. It reads the `grpc-status` from the headers but Misk is sending it in the trailers from [ExceptionHandlingInterceptor](https://github.com/cashapp/misk/blob/1f9aab29f5a601e256dd1b21b0ec9b2c233fecae/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt#L90). If it doesn't exist, it uses the response status code which defaults to 200. This could lead to missed alerts on critical issues.

We could also change `ExceptionHandlingInterceptor` to pass it in the header. But it is more common and standard to have the `grcp-status` information in the trailers. [wire](https://github.com/square/wire/blob/8ae99171c2e5262b1892acede3724fec53c50209/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt#L192) also reads the `grpc-status` from the response trailers first then the header. 

Tested against exemplar services: s2s between misk -> misk and misk->armeria