### PR TITLE
Bugfix: Correctly setup RateLimitingSampler by passing through rate

### DIFF
--- a/misk-core/src/main/kotlin/misk/sampling/Sampler.kt
+++ b/misk-core/src/main/kotlin/misk/sampling/Sampler.kt
@@ -37,7 +37,7 @@ class RateLimitingSampler(
     RateLimiter.Factory(
       Ticker.systemTicker(),
       Sleeper.DEFAULT
-    ).create(1)
+    ).create(ratePerSecond)
   )
 
   override fun sample(): Boolean {

--- a/misk-core/src/test/kotlin/misk/sampling/SamplerTest.kt
+++ b/misk-core/src/test/kotlin/misk/sampling/SamplerTest.kt
@@ -1,0 +1,14 @@
+package misk.sampling
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SamplerTest {
+  @Test
+  fun `rate limiter sampler constructor sets rate`() {
+    val sampler = RateLimitingSampler(2L)
+    assertThat(sampler.sample()).isTrue()
+    assertThat(sampler.sample()).isTrue()
+    assertThat(sampler.sample()).isFalse()
+  }
+}


### PR DESCRIPTION
This constructor was previously hardcoding to 1 QPS
