### PR TITLE
Provide a `getIfInScope` on `ActionScoped` to avoid the need for injecting both ActionScope and ActionScoped

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -599,6 +599,11 @@ acceptedBreaks:
       new: "method misk.redis.Redis misk.redis.RedisModule::provideRedisClient$misk_redis(misk.redis.RedisClientMetrics,\
         \ redis.clients.jedis.UnifiedJedis)"
       justification: "Only breaks one client, which is owned by the author"
+  "2024.02.06.235139-89b7018":
+    com.squareup.misk:misk-api:
+    - code: "java.method.addedToInterface"
+      new: "method T misk.scope.ActionScoped<T>::getIfInScope()"
+      justification: "{there is a default implementation for the method}"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk-action-scopes/src/main/kotlin/misk/scope/RealActionScoped.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/RealActionScoped.kt
@@ -8,4 +8,6 @@ internal class RealActionScoped<T> @Inject internal constructor(
   val scope: ActionScope
 ) : ActionScoped<T> {
   override fun get(): T = scope.get(key)
+
+  override fun getIfInScope(): T? = if (scope.inScope()) get() else null
 }

--- a/misk-api/api/misk-api.api
+++ b/misk-api/api/misk-api.api
@@ -47,10 +47,15 @@ public final class misk/client/NetworkInterceptorWrapper : okhttp3/Interceptor {
 public abstract interface class misk/scope/ActionScoped {
 	public static final field Companion Lmisk/scope/ActionScoped$Companion;
 	public abstract fun get ()Ljava/lang/Object;
+	public abstract fun getIfInScope ()Ljava/lang/Object;
 }
 
 public final class misk/scope/ActionScoped$Companion {
 	public final fun of (Ljava/lang/Object;)Lmisk/scope/ActionScoped;
+}
+
+public final class misk/scope/ActionScoped$DefaultImpls {
+	public static fun getIfInScope (Lmisk/scope/ActionScoped;)Ljava/lang/Object;
 }
 
 public abstract interface class misk/scope/ActionScopedProvider {

--- a/misk-api/build.gradle.kts
+++ b/misk-api/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("jvm")
@@ -18,4 +19,10 @@ configure<MavenPublishBaseExtension> {
   configure(
     KotlinJvm(javadocJar = Dokka("dokkaGfm"))
   )
+}
+
+tasks.getting(KotlinCompile::class) {
+  compilerOptions {
+    freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+  }
 }

--- a/misk-api/src/main/kotlin/misk/scope/ActionScoped.kt
+++ b/misk-api/src/main/kotlin/misk/scope/ActionScoped.kt
@@ -4,6 +4,8 @@ package misk.scope
 interface ActionScoped<out T> {
   fun get(): T
 
+  fun getIfInScope(): T? = get()
+
   companion object {
     /** @return an [ActionScoped] hard-coded to a specific value, useful for tests */
     fun <T> of(value: T) = object : ActionScoped<T> {


### PR DESCRIPTION
In a bunch of places across cash-app repos, we check `actionScope.inScope`, before using an ActionScoped value (or before calling `actionScope.get(key)`). I've added a new method to `ActionScoped`, to return null if not in scope and return the scoped value otherwise, to remove the need for this extra check we currently manually do.



