### PR TITLE
Revert "Fallback to action scope key subtypes, if a requested key is missing

### DIFF
--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -183,20 +183,6 @@ class ActionScope @Inject internal constructor(
       return cachedValue as T
     }
 
-    // Search for any subtype of this key
-    // For example, given `HttpCall` extends `HttpRequest`, the value for `HttpCall` key
-    // will be returned when `HttpRequest` is requested (only if a `HttpRequest` key is not set)
-    val keyClass = key.typeLiteral.rawType
-    val subtypesThreadState = threadState.filterKeys {
-      it.annotation == key.annotation && keyClass.isAssignableFrom(it.typeLiteral.rawType)
-    }
-    if (subtypesThreadState.isNotEmpty()) {
-      val subtypeCachedValue = subtypesThreadState.values.toList()[0]
-      threadState[key] = subtypeCachedValue // cache this value
-      @Suppress("UNCHECKED_CAST")
-      return subtypeCachedValue as T
-    }
-
     val value = providerFor(key as Key<*>).get()
     threadState[key] = value
 

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -19,6 +19,7 @@ import okhttp3.MediaType
 import org.slf4j.MDC
 import java.util.regex.Matcher
 import com.google.inject.Provider
+import misk.api.HttpRequest
 import javax.servlet.http.HttpServletRequest
 import kotlin.reflect.KType
 
@@ -110,6 +111,7 @@ internal class BoundAction<A : WebAction>(
     val initialSeedData = mapOf<Key<*>, Any?>(
       keyOf<HttpServletRequest>() to request,
       keyOf<HttpCall>() to httpCall,
+      keyOf<HttpRequest>() to httpCall,
       keyOf<Action>() to action,
     )
     val seedData =


### PR DESCRIPTION
This reverts commit 880e488fb0dd114c4630143d340a57489d3ccbc9.

This totally breaks on generics and isn't backwards compatible.