### PR TITLE
Revert "Bump com.datadoghq:dd-trace-ot from 1.23.0 to 1.29.0 (#3132)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,7 +150,7 @@ okHttpMockWebServer = { module = "com.squareup.okhttp3:mockwebserver", version =
 okio = { module = "com.squareup.okio:okio", version = "3.4.0" }
 openTracingApi = { module = "io.opentracing:opentracing-api", version = "0.33.0" }
 openTracingConcurrent = { module = "io.opentracing.contrib:opentracing-concurrent", version = "0.4.0" }
-openTracingDatadog = { module = "com.datadoghq:dd-trace-ot", version = "1.29.0" }
+openTracingDatadog = { module = "com.datadoghq:dd-trace-ot", version = "1.23.0" }
 openTracingJdbc = { module = "io.opentracing.contrib:opentracing-jdbc", version = "0.2.15" }
 openTracingMock = { module = "io.opentracing:opentracing-mock", version = "0.33.0" }
 openTracingOkHttp = { module = "io.opentracing.contrib:opentracing-okhttp3", version = "3.0.0" }


### PR DESCRIPTION
This reverts commit 0daf24e9e8f228044e25e9729d2d967e39b38726.

This bump caused traces to be lost for our services. Reverting until we can confirm the breaking changes between the versions. After this is merged, we plan to add a dependabot exclusion to prevent this dependency from automatically upgrading in the future (exclusion added [here](https://github.com/cashapp/misk/pull/3145)).