### PR TITLE
Expose out DockerSqs

### DIFF
--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/DockerSqs.kt
@@ -20,7 +20,7 @@ import wisp.logging.getLogger
 /**
  * A test SQS Service. Tests can connect to the service at 127.0.0.1:[clientPort]
  */
-internal object DockerSqs : ExternalDependency {
+object DockerSqs : ExternalDependency {
 
   private val log = getLogger<DockerSqs>()
   private const val clientPort = 9324


### PR DESCRIPTION
`DockerSqs` is used internally by a Cash service that copies over the code directly, and this has resulted in code drift and some test issues. Exposing this class out will grant the ability to import an up-to-date version of this construct directly, and furtermore it may be of future use to other consumers who need to simulate local SQS testing.