### PR TITLE
Add default implementation for attributes to strongly typed feature flags

### DIFF
--- a/wisp/wisp-feature-testing/src/test/kotlin/wisp/feature/testing/FakeFeatureFlagsTest.kt
+++ b/wisp/wisp-feature-testing/src/test/kotlin/wisp/feature/testing/FakeFeatureFlagsTest.kt
@@ -12,6 +12,7 @@ import wisp.config.ConfigSource
 import wisp.config.WispConfig
 import wisp.config.addWispConfigSources
 import wisp.feature.Attributes
+import wisp.feature.BooleanFeatureFlag
 import wisp.feature.Feature
 import wisp.feature.getEnum
 import wisp.feature.getJson
@@ -20,6 +21,13 @@ internal class FakeFeatureFlagsTest {
     val FEATURE = Feature("foo")
     val OTHER_FEATURE = Feature("bar")
     val TOKEN = "cust_abcdef123"
+
+    data class TestNoAttributeBooleanFlag(
+      val username: String = "test-boolean-username",
+    ) : BooleanFeatureFlag {
+      override val feature = Feature("test-boolean-default-attributes-flag")
+      override val key = username
+    }
 
     lateinit var subject: FakeFeatureFlags
 
@@ -353,6 +361,16 @@ internal class FakeFeatureFlagsTest {
 
         assertThat(subject.getInt(Feature("foo1"))).isEqualTo(1)
         assertThat(subject.getJson<JsonFeature>(Feature("fooJson")).optional).isEqualTo("value")
+    }
+
+    @Test
+    fun `strongly typed feature flags do not need to override attributes`() {
+      val booleanFlag = TestNoAttributeBooleanFlag("username")
+      subject.strongFeatureFlags.override<TestNoAttributeBooleanFlag>(true) { flag ->
+        flag.attributes == Attributes()
+      }
+      assertThat(subject.strongFeatureFlags.get(booleanFlag))
+        .isEqualTo(true)
     }
 
     /**

--- a/wisp/wisp-feature/api/wisp-feature.api
+++ b/wisp/wisp-feature/api/wisp-feature.api
@@ -22,7 +22,15 @@ public class wisp/feature/Attributes {
 public abstract interface class wisp/feature/BooleanFeatureFlag : wisp/feature/FeatureFlag {
 }
 
+public final class wisp/feature/BooleanFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/BooleanFeatureFlag;)Lwisp/feature/Attributes;
+}
+
 public abstract interface class wisp/feature/DoubleFeatureFlag : wisp/feature/FeatureFlag {
+}
+
+public final class wisp/feature/DoubleFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/DoubleFeatureFlag;)Lwisp/feature/Attributes;
 }
 
 public abstract interface class wisp/feature/DynamicConfig {
@@ -45,6 +53,10 @@ public abstract interface class wisp/feature/EnumFeatureFlag : wisp/feature/Feat
 	public abstract fun getReturnType ()Ljava/lang/Class;
 }
 
+public final class wisp/feature/EnumFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/EnumFeatureFlag;)Lwisp/feature/Attributes;
+}
+
 public class wisp/feature/Feature {
 	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -57,6 +69,10 @@ public abstract interface class wisp/feature/FeatureFlag {
 	public abstract fun getAttributes ()Lwisp/feature/Attributes;
 	public abstract fun getFeature ()Lwisp/feature/Feature;
 	public abstract fun getKey ()Ljava/lang/String;
+}
+
+public final class wisp/feature/FeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/FeatureFlag;)Lwisp/feature/Attributes;
 }
 
 public final class wisp/feature/FeatureFlagValidation {
@@ -86,8 +102,16 @@ public final class wisp/feature/FeatureFlags$DefaultImpls {
 public abstract interface class wisp/feature/IntFeatureFlag : wisp/feature/FeatureFlag {
 }
 
+public final class wisp/feature/IntFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/IntFeatureFlag;)Lwisp/feature/Attributes;
+}
+
 public abstract interface class wisp/feature/JsonFeatureFlag : wisp/feature/FeatureFlag {
 	public abstract fun getReturnType ()Ljava/lang/Class;
+}
+
+public final class wisp/feature/JsonFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/JsonFeatureFlag;)Lwisp/feature/Attributes;
 }
 
 public abstract interface class wisp/feature/LegacyFeatureFlags {
@@ -156,6 +180,10 @@ public final class wisp/feature/MoshiExtKt {
 }
 
 public abstract interface class wisp/feature/StringFeatureFlag : wisp/feature/FeatureFlag {
+}
+
+public final class wisp/feature/StringFeatureFlag$DefaultImpls {
+	public static fun getAttributes (Lwisp/feature/StringFeatureFlag;)Lwisp/feature/Attributes;
 }
 
 public abstract interface class wisp/feature/StrongFeatureFlags {

--- a/wisp/wisp-feature/src/main/kotlin/wisp/feature/FeatureFlag.kt
+++ b/wisp/wisp-feature/src/main/kotlin/wisp/feature/FeatureFlag.kt
@@ -15,6 +15,7 @@ sealed interface FeatureFlag<T : Any> {
      * The attributes of this feature flag, provided during flag evaluation
      */
     val attributes: Attributes
+      get() = Attributes()
 }
 
 interface StringFeatureFlag : FeatureFlag<String>


### PR DESCRIPTION
This makes it so subclasses don't have to override with empty attributes,
which is a common use case of these feature flags.
