### PR TITLE
Make MiskMdc a public object 

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -645,6 +645,10 @@ acceptedBreaks:
         \ interceptor}"
   "2024.02.14.033633-b653902":
     com.squareup.misk:misk:
+    - code: "java.annotation.removed"
+      old: "method void misk.logging.MiskMdc::<init>()"
+      new: "method void misk.logging.MiskMdc::<init>()"
+      justification: "Not used anywhere"
     - code: "java.method.numberOfParametersChanged"
       old: "method misk.web.WebConfig misk.web.WebConfig::copy(int, long, int, java.lang.String,\
         \ misk.web.WebSslConfig, misk.web.WebUnixDomainSocketConfig, boolean, java.lang.Integer,\
@@ -661,6 +665,10 @@ acceptedBreaks:
         \ int, java.lang.Integer, java.lang.Integer, java.lang.Long, int, int, boolean,\
         \ boolean, java.lang.Integer, java.lang.Integer, java.lang.Integer, boolean)"
       justification: "new parameter has a default value"
+    - code: "java.method.visibilityReduced"
+      old: "method void misk.logging.MiskMdc::<init>()"
+      new: "method void misk.logging.MiskMdc::<init>()"
+      justification: "Not used anywhere yet"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -835,6 +835,13 @@ public final class misk/jvm/JvmManagementFactoryModule : misk/inject/KInstallOnc
 	public final fun provideRuntimeMxBean ()Ljava/lang/management/RuntimeMXBean;
 }
 
+public final class misk/logging/MiskMdc : misk/logging/Mdc {
+	public static final field INSTANCE Lmisk/logging/MiskMdc;
+	public fun clear ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+}
+
 public final class misk/monitoring/JvmMetrics {
 	public fun <init> (Ljava/lang/management/RuntimeMXBean;Lmisk/metrics/v2/Metrics;)V
 }

--- a/misk/src/main/kotlin/misk/logging/MdcModule.kt
+++ b/misk/src/main/kotlin/misk/logging/MdcModule.kt
@@ -1,11 +1,10 @@
 package misk.logging
 
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 
 internal class MdcModule : KAbstractModule() {
 
   override fun configure() {
-    bind<Mdc>().to<MiskMdc>().asSingleton()
+    bind<Mdc>().toInstance(MiskMdc)
   }
 }

--- a/misk/src/main/kotlin/misk/logging/MiskMdc.kt
+++ b/misk/src/main/kotlin/misk/logging/MiskMdc.kt
@@ -1,11 +1,8 @@
 package misk.logging
 
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 import org.slf4j.MDC
 
-@Singleton
-internal class MiskMdc @Inject constructor(): Mdc {
+object MiskMdc : Mdc {
 
   override fun put(key: String, value: String?) {
     MDC.put(key, value)


### PR DESCRIPTION
Follow-up PR from:
https://github.com/cashapp/misk/pull/3146

This lets us use `MiskMdc` in places where `MDC` is statically used in a backwards compatible way.