### PR TITLE
fix: Add a way to provide different redis host depending on if it is running inside docker or localhost.

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
@@ -18,6 +18,6 @@ data class RedisReplicationGroupConfig @JvmOverloads constructor(
 )
 
 data class RedisNodeConfig(
-  val hostname: String,
+  val hostname: String = System.getenv("REDIS_HOST"),
   val port: Int
 )

--- a/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
@@ -18,6 +18,6 @@ data class RedisReplicationGroupConfig @JvmOverloads constructor(
 )
 
 data class RedisNodeConfig(
-  val hostname: String = System.getenv("REDIS_HOST")?: "127.0.0.1",
+  val hostname: String,
   val port: Int
 )

--- a/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RedisConfig.kt
@@ -18,6 +18,6 @@ data class RedisReplicationGroupConfig @JvmOverloads constructor(
 )
 
 data class RedisNodeConfig(
-  val hostname: String = System.getenv("REDIS_HOST"),
+  val hostname: String = System.getenv("REDIS_HOST")?: "127.0.0.1",
   val port: Int
 )


### PR DESCRIPTION
Currently services that use RedisModule can only be run one way locally. where you set [this host](https://github.com/squareup/cash-misk-exemplar-service/blob/e4b3638b405b0d9db6779f7809060b9d9be4aa6c/service/src/main/resources/cash-misk-exemplar-service-orc.yaml#L12) field explicitly. But during local development we want to be able to  run the service either inside docker or localhost and we don't want to be update this config file everytime. So this provides a way to pass in the `REDIS_HOST` accordingly to be either set to `localhost` or `"host.docker.internal"`. If the host itself is provided explicitly the config will unfurl to use the provide host from the config resource.

Tested this with locally running https://github.com/squareup/cash-misk-exemplar-service inside docker and passing `REDIS_HOST` in the envar when running orc. Also tested it with explicitly setting this `host` in the [resources file](https://github.com/squareup/cash-misk-exemplar-service/blob/main/service/src/main/resources/cash-misk-exemplar-service-orc.yaml#L12) and also passing it as an envar during service startup and checking the resources file takes precedence  