### PR TITLE
fix: Add an ability for misk services to start under docker that uses RedisModule, this provides a way for those services to either start under docker or localhost

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
@@ -34,7 +34,7 @@ private class ConnectionFactoryWithMetrics(
   requiresPassword: Boolean = true,
 ) : ConnectionFactory(
   HostAndPort(
-    replicationGroupConfig.writer_endpoint.hostname,
+    replicationGroupConfig.writer_endpoint.hostname?.takeUnless { it.isNullOrBlank() } ?: System.getenv("REDIS_HOST") ?: "127.0.0.1",
     replicationGroupConfig.writer_endpoint.port
   ),
   createJedisClientConfig(replicationGroupConfig, ssl, requiresPassword),


### PR DESCRIPTION
Equivalent change to this PR https://github.com/cashapp/misk/pull/3170 but for RedisModule which underneath uses `JedisPooledWithMetrics`


More context:

Currently under orc, services can either only be started locally or under docker however for end to end integration tests we want services to be able to start under docker(to avoid host port conflicts, etc.) and also have the flexibility to run on localhost. Ideally it would be good if misk config loader was able to parse envars from the resource yaml file [as such](https://github.com/squareup/cash-p2p-index/blob/c3981f6ebe169800d94bfd1084d73b23312038c5/service/src/main/resources/data-source-clusters-development.yaml#L6), but given this isn't possible right now we're explicitly checking for REDIS_HOST envar in RedisClusterModule.

Some conversation regarding this in private channel https://cash.slack.com/archives/C05KAS86D0A/p1709501529157699

# Test
Tested this with cash-misk-exemplar-service change both with and without docker. https://github.com/squareup/cash-misk-exemplar-service/compare/main...nsherpa/redismodule_docker_testing