### PR TITLE
Configure dynamo cluster watch task logging

### DIFF
--- a/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterConfig.kt
+++ b/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterConfig.kt
@@ -7,4 +7,5 @@ data class DynamoClusterConfig @JvmOverloads constructor(
   var table_name: String = "$appName.misk-cluster-members",
   val update_frequency_seconds: Long = 30,
   val stale_threshold_seconds: Long = 60,
+  val log_updates: Boolean = true,
 ) : Config

--- a/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterWatcherTask.kt
+++ b/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterWatcherTask.kt
@@ -66,7 +66,9 @@ internal class DynamoClusterWatcherTask @Inject constructor(
       table.putItem(member)
     }
 
-    logger.info { "Updated dynamodb with my information in ${duration.toMillis()}ms" }
+    if (dynamoClusterConfig.log_updates) {
+      logger.info { "Updated dynamodb with my information in ${duration.toMillis()}ms" }
+    }
   }
 
   internal fun recordCurrentDynamoCluster() {
@@ -91,7 +93,9 @@ internal class DynamoClusterWatcherTask @Inject constructor(
       prevMembers = members
     }
 
-    logger.info { "Updated cluster information from dynamodb in ${duration.toMillis()}ms" }
+    if (dynamoClusterConfig.log_updates) {
+      logger.info { "Updated cluster information from dynamodb in ${duration.toMillis()}ms" }
+    }
   }
 
   override fun shutDown() {}


### PR DESCRIPTION
## What?

- Adds a config attribute to silence info logs

## Why?

- As a service owner/operator, these logs are noisy.

Alternatively, we could remove the logs entirely. If the latencies are important, they could also be reported as metrics, too, for platform owners to monitor themselves.