### PR TITLE
Only allow providers to be called at-most once per action scope

### DIFF
--- a/misk-action-scopes/api/misk-action-scopes.api
+++ b/misk-action-scopes/api/misk-action-scopes.api
@@ -18,6 +18,7 @@ public final class misk/scope/ActionScope : java/lang/AutoCloseable {
 	public static final field Companion Lmisk/scope/ActionScope$Companion;
 	public final fun asContextElement ()Lkotlin/coroutines/CoroutineContext$Element;
 	public fun close ()V
+	public final fun create (Ljava/util/Map;)Lmisk/scope/ActionScope$Instance;
 	public final fun enter (Ljava/util/Map;)Lmisk/scope/ActionScope;
 	public final fun get (Lcom/google/inject/Key;)Ljava/lang/Object;
 	public final fun inScope ()Z
@@ -27,9 +28,16 @@ public final class misk/scope/ActionScope : java/lang/AutoCloseable {
 	public final fun runBlocking (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public final fun runBlocking (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public final fun snapshotActionScope ()Ljava/util/Map;
+	public final fun snapshotActionScopeInstance ()Lmisk/scope/ActionScope$Instance;
 }
 
 public final class misk/scope/ActionScope$Companion {
+}
+
+public final class misk/scope/ActionScope$Instance : java/lang/AutoCloseable {
+	public fun close ()V
+	public final fun enter ()V
+	public final fun inScope (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public abstract class misk/scope/ActionScopedProviderModule : misk/inject/KAbstractModule {

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -2,12 +2,12 @@ package misk.scope
 
 import com.google.inject.Key
 import com.google.inject.Provider
-import kotlinx.coroutines.asContextElement
-import java.util.UUID
-import java.util.concurrent.Callable
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asContextElement
+import java.util.UUID
+import java.util.concurrent.Callable
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -24,7 +24,7 @@ class ActionScope @Inject internal constructor(
   private val providers: @JvmSuppressWildcards Map<Key<*>, Provider<ActionScopedProvider<*>>>
 ) : AutoCloseable {
   companion object {
-    private val threadLocalScope = ThreadLocal<LinkedHashMap<Key<*>, Any?>>()
+    private val threadLocalInstance = ThreadLocal<Instance>()
     private val threadLocalUUID = ThreadLocal<UUID>()
   }
 
@@ -59,35 +59,65 @@ class ActionScope @Inject internal constructor(
    * Example usage:
    * ```
    *  scope.enter(seedData).use {
-        runBlocking(scope.asContextElement()) {
-          async(Dispatchers.IO) {
-            tester.fooValue()
-          }.await()
-        }
-      }
+   *    runBlocking(scope.asContextElement()) {
+   *      async(Dispatchers.IO) {
+   *        tester.fooValue()
+   *      }.await()
+   *    }
+   *  }
    * ```
    *
    */
   fun asContextElement(): CoroutineContext.Element {
     check(inScope()) { "not running within an ActionScope" }
 
-    val currentScopedData = threadLocalScope.get()
+    val instance = threadLocalInstance.get()
 
-    return threadLocalScope.asContextElement(currentScopedData)
+    return threadLocalInstance.asContextElement(instance)
   }
 
+  @Deprecated(
+    "Use snapshotActionScopeInstance instead",
+    ReplaceWith("this.snapshotActionScopeInstance()"),
+  )
   fun snapshotActionScope(): Map<Key<*>, Any?> {
-    check(inScope()) { "not running within an ActionScope" }
-    return threadLocalScope.get().toMap()
+    return snapshotActionScopeInstance().asImmediateValues()
   }
 
-  /** Starts the scope on a thread with the provided seed data */
+  fun snapshotActionScopeInstance(): Instance {
+    check(inScope()) { "not running within an ActionScope" }
+    return threadLocalInstance.get()
+  }
+
+  @Deprecated("Use create() instead and then call inScope() to enter the scope")
+    /** Starts the scope on a thread with the provided seed data */
   fun enter(seedData: Map<Key<*>, Any?>): ActionScope {
+    create(seedData).enter()
+    return this
+  }
+
+  /** Creates a new scope on the current thread with the provided seed data */
+  fun create(seedData: Map<Key<*>, Any?>): Instance {
+    check(!inScope()) {
+      "cannot create an ActionScope.Instance on a thread that is already running in an action scope"
+    }
+
+    val immediateValues = seedData.mapValues { (_, value) -> ImmediateLazy(value) }
+
+    val lazyValues = providers.mapValues { (key, _) ->
+      SynchronizedLazy(providerFor(key))
+    }
+
+    return Instance(lazyValues + immediateValues, this)
+  }
+
+  /** Starts the scope on a thread with the provided instance */
+  internal fun enter(instance: Instance): ActionScope {
     check(!inScope()) {
       "cannot begin an ActionScope on a thread that is already running in an action scope"
     }
 
-    threadLocalScope.set(LinkedHashMap(seedData))
+    threadLocalInstance.set(instance)
 
     // If an action scope had previously been entered on the thread, re-use its UUID.
     // Otherwise, generate a new one.
@@ -99,7 +129,7 @@ class ActionScope @Inject internal constructor(
   }
 
   override fun close() {
-    threadLocalScope.remove()
+    threadLocalInstance.remove()
 
     // Explicitly NOT removing threadLocalUUID because we want to retain the thread's UUID if
     // the action scope is re-entered on the same thread.
@@ -108,7 +138,7 @@ class ActionScope @Inject internal constructor(
   }
 
   /** Returns true if currently in the scope */
-  fun inScope(): Boolean = threadLocalScope.get() != null
+  fun inScope(): Boolean = threadLocalInstance.get() != null
 
   /**
    * Wraps a [Callable] that will be called on another thread, propagating the current
@@ -117,7 +147,7 @@ class ActionScope @Inject internal constructor(
   fun <T> propagate(c: Callable<T>): Callable<T> {
     check(inScope()) { "not running within an ActionScope" }
 
-    val currentScopedData = threadLocalScope.get().toMap()
+    val currentInstance = threadLocalInstance.get()
     val currentThreadUUID = threadLocalUUID.get()
 
     return Callable {
@@ -126,7 +156,7 @@ class ActionScope @Inject internal constructor(
       if (inScope() && currentThreadUUID == threadLocalUUID.get()) {
         c.call()
       } else {
-        enter(currentScopedData).use {
+        currentInstance.inScope {
           c.call()
         }
       }
@@ -140,9 +170,9 @@ class ActionScope @Inject internal constructor(
   fun <T> propagate(f: KFunction<T>): KFunction<T> {
     check(inScope()) { "not running within an ActionScope" }
 
-    val currentScopedData = threadLocalScope.get().toMap()
+    val currentInstance = threadLocalInstance.get()
     val currentThreadUUID = threadLocalUUID.get()
-    return WrappedKFunction(currentScopedData, this, f, currentThreadUUID)
+    return WrappedKFunction(currentInstance, this, f, currentThreadUUID)
   }
 
   /**
@@ -152,7 +182,7 @@ class ActionScope @Inject internal constructor(
   fun <T> propagate(f: () -> T): () -> T {
     check(inScope()) { "not running within an ActionScope" }
 
-    val currentScopedData = threadLocalScope.get().toMap()
+    val currentInstance = threadLocalInstance.get()
     val currentThreadUUID = threadLocalUUID.get()
 
     return {
@@ -161,9 +191,7 @@ class ActionScope @Inject internal constructor(
       if (inScope() && currentThreadUUID == threadLocalUUID.get()) {
         f.invoke()
       } else {
-        enter(currentScopedData).use {
-          f.invoke()
-        }
+        currentInstance.inScope(f)
       }
     }
   }
@@ -171,34 +199,43 @@ class ActionScope @Inject internal constructor(
   /** Returns the action scoped value for the given key */
   fun <T> get(key: Key<T>): T {
     check(inScope()) { "not running within an ActionScope" }
-
-    // NB(mmihic): We don't use computeIfAbsent because computing the value of this
-    // key might require computing the values of keys on which we depend, which would
-    // cause recursive calls to computeIfAbsent which is unsupported (and explicitly
-    // detected in JDK 9+)
-    val threadState = threadLocalScope.get()
-    val cachedValue = threadState[key]
-    if (cachedValue != null) {
-      @Suppress("UNCHECKED_CAST")
-      return cachedValue as T
-    }
-
-    val value = providerFor(key as Key<*>).get()
-    threadState[key] = value
-
-    @Suppress("UNCHECKED_CAST")
-    return value as T
+    return threadLocalInstance.get()[key]
   }
 
-  @Suppress("UNCHECKED_CAST")
   private fun providerFor(key: Key<*>): ActionScopedProvider<*> {
     return requireNotNull(providers[key]?.get()) {
       "no ActionScopedProvider available for $key"
     }
   }
 
+  class Instance internal constructor(
+    private val lazyValues: Map<Key<*>, Lazy<*>>,
+    private val scope: ActionScope,
+  ) : AutoCloseable by scope {
+    internal operator fun <T> get(key: Key<T>): T {
+      @Suppress("UNCHECKED_CAST")
+      return lazyValues.getValue(key).value as T
+    }
+
+    internal fun asImmediateValues(): Map<Key<*>, Any?> {
+      return lazyValues
+        .filterValues { it.isInitialized() }
+        .mapValues { it.value.value }
+    }
+
+    fun <T> inScope(block: () -> T): T {
+      return scope.enter(this).use {
+        block()
+      }
+    }
+
+    fun enter() {
+      scope.enter(this)
+    }
+  }
+
   private class WrappedKFunction<T>(
-    val seedData: Map<Key<*>, Any?>,
+    val instance: Instance,
     val scope: ActionScope,
     val wrapped: KFunction<T>,
     val threadUUID: UUID
@@ -209,7 +246,7 @@ class ActionScope @Inject internal constructor(
       return if (scope.inScope() && threadUUID == threadLocalUUID.get()) {
         wrapped.call(*args)
       } else {
-        scope.enter(seedData).use {
+        instance.inScope {
           wrapped.call(*args)
         }
       }
@@ -219,9 +256,9 @@ class ActionScope @Inject internal constructor(
       // If the original thread is the same as the thread that calls the KFunction and we are already
       // in scope, then there is no need to re-enter the scope.
       return if (scope.inScope() && threadUUID == threadLocalUUID.get()) {
-       wrapped.callBy(args)
+        wrapped.callBy(args)
       } else {
-        scope.enter(seedData).use {
+        instance.inScope {
           wrapped.callBy(args)
         }
       }

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ImmediateLazy.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ImmediateLazy.kt
@@ -1,0 +1,5 @@
+package misk.scope
+
+internal class ImmediateLazy(override val value: Any?) : Lazy<Any?> {
+  override fun isInitialized(): Boolean = true
+}

--- a/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
@@ -1,0 +1,31 @@
+package misk.scope
+
+private object UNINITIALIZED_VALUE
+
+internal class SynchronizedLazy(
+  private val provider: ActionScopedProvider<*>,
+) : Lazy<Any?> {
+  @Volatile
+  private var _value: Any? = UNINITIALIZED_VALUE
+
+  override val value: Any?
+    get() {
+      if (_value !== UNINITIALIZED_VALUE) {
+        return _value
+      }
+
+      return synchronized(this) {
+        val existingValue = _value
+        if (existingValue != UNINITIALIZED_VALUE) {
+          existingValue
+        } else {
+          _value = provider.get()
+          _value
+        }
+      }
+    }
+
+  override fun isInitialized(): Boolean {
+    return _value != UNINITIALIZED_VALUE
+  }
+}

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -5,7 +5,7 @@ import com.google.inject.Key
 import com.google.inject.TypeLiteral
 import com.google.inject.name.Named
 import com.google.inject.name.Names
-import kotlin.concurrent.thread
+import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import misk.inject.keyOf
 import misk.inject.toKey
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.Optional
-import jakarta.inject.Inject
+import kotlin.concurrent.thread
 import kotlin.test.assertFailsWith
 
 internal class ActionScopedTest {
@@ -38,6 +38,9 @@ internal class ActionScopedTest {
 
   @Inject @Named("constant")
   private lateinit var optionalConstantString: ActionScoped<Optional<String>>
+
+  @Inject @Named("counting")
+  private lateinit var countingString: ActionScoped<String>
 
   @Inject private lateinit var scope: ActionScope
 
@@ -224,6 +227,66 @@ internal class ActionScopedTest {
         }
       }.join()
       assertThat(thrown).isNull()
+    }
+  }
+
+  @Test
+  fun `allow getting scope things from scope`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(
+      keyOf<String>(Names.named("from-seed")) to "seed-value"
+    )
+
+    // exhibit A: trying to access scoped things in a new thread results in exceptions
+    scope.enter(seedData).use { _ ->
+      var thrown: Throwable? = null
+
+      thread {
+        try {
+          assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+        } catch (t: Throwable) {
+          thrown = t
+        }
+      }.join()
+      assertThat(thrown).isNotNull
+    }
+
+    // exhibit B: trying to access scoped things in a new thread can work, if you take
+    // a snapshot of the scope and use it to instantiate a scope in the new thread.
+    scope.enter(seedData).use { actionScope ->
+      var thrown: Throwable? = null
+
+      val instance = actionScope.snapshotActionScopeInstance()
+      thread {
+        try {
+          actionScope.enter(instance).use {
+            assertThat(foo.get()).isEqualTo("seed-value and bar and foo!")
+          }
+        } catch (t: Throwable) {
+          thrown = t
+        }
+      }.join()
+      assertThat(thrown).isNull()
+    }
+  }
+
+  @Test
+  fun `providers are only called once per scope regardless of how many threads it propagates to`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    scope.create(mapOf()).inScope {
+      val instance = scope.snapshotActionScopeInstance()
+      repeat(3) {
+        thread {
+          instance.inScope {
+            assertThat(countingString.get()).isEqualTo("Called CountingProvider 1 time(s)")
+          }
+        }.join()
+      }
+      assertThat(countingString.get()).isEqualTo("Called CountingProvider 1 time(s)")
     }
   }
 }

--- a/misk-action-scopes/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/TestActionScopedProviderModule.kt
@@ -3,8 +3,8 @@ package misk.scope
 import com.google.inject.TypeLiteral
 import com.google.inject.name.Named
 import com.google.inject.name.Names
-import java.util.Optional
 import jakarta.inject.Inject
+import java.util.Optional
 
 internal class TestActionScopedProviderModule : ActionScopedProviderModule() {
   override fun configureProviders() {
@@ -25,6 +25,7 @@ internal class TestActionScopedProviderModule : ActionScopedProviderModule() {
       nullableStringTypeLiteral, NullableBasedOnFooProvider::class,
       Names.named("nullable-based-on-foo")
     )
+    bindProvider(String::class, CountingProvider::class, Names.named(("counting")))
   }
 
   class BarProvider @Inject internal constructor(
@@ -76,6 +77,11 @@ internal class TestActionScopedProviderModule : ActionScopedProviderModule() {
     override fun get(): String? {
       return nullableFoo.get()?.let { "from foo $it" }
     }
+  }
+
+  class CountingProvider @Inject internal constructor() : ActionScopedProvider<String> {
+    private var callCount = 0
+    override fun get(): String = "Called CountingProvider ${++callCount} time(s)"
   }
 
   companion object {


### PR DESCRIPTION
This changes the behavior of action-scoped providers, so that they are invoked at most once per scope. The current behavior propagates the ThreadLocal that contains key/values that have already been computed. However, if a provider hadn't been called yet then the value cannot be propagated to a new thread. Then the provider would get called once per thread, instead of once per original scope.

This propagates the already computed values, as well as the providers to new threads as a `Lazy`. This ensures that no matter how many threads the scope is propagated to, each provider is only called once. This behavior is tested [here](https://github.com/cashapp/misk/pull/3182/files#diff-812244514535aba81342e2e9cb42c660605e24537f91acc0d8cd530701e71c95R276).

There is also a subtle but beneficial change to an undocumented behavior. Because values are cached in a `Map`, if a provider returns null it cannot be cached, and will be called repeatedly until a non-null value is provided. With this change, that behavior no longer happens because the values are wrapped in a `Lazy`. The previously null value would now be stored correctly in the `Map` as a `Lazy(null)`. This means that a provider method will only be called at-most once, even if it returns a null value. I believe this is a beneficial change, and actually solves a pain point that we had to work around at Faire, which involved wrapping results in `Optional`.