### PR TITLE
Support custom responses for 401s and 403s

### DIFF
--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -123,11 +123,7 @@ class ExceptionHandlingInterceptor(
     }
 
     // Fall back to a default mapping.
-    return when (th) {
-      is UnauthenticatedException -> UNAUTHENTICATED_RESPONSE
-      is UnauthorizedException -> UNAUTHORIZED_RESPONSE
-      else -> toInternalServerError(th)
-    }
+    return toInternalServerError(th)
   }
 
   private fun toGrpcResponse(th: Throwable): GrpcErrorResponse = when (th) {
@@ -165,18 +161,6 @@ class ExceptionHandlingInterceptor(
       "internal server error".toResponseBody(),
       listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap().toHeaders(),
       HttpURLConnection.HTTP_INTERNAL_ERROR
-    )
-
-    val UNAUTHENTICATED_RESPONSE = Response(
-      "unauthenticated".toResponseBody(),
-      listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap().toHeaders(),
-      HttpURLConnection.HTTP_UNAUTHORIZED
-    )
-
-    val UNAUTHORIZED_RESPONSE = Response(
-      "unauthorized".toResponseBody(),
-      listOf("Content-Type" to MediaTypes.TEXT_PLAIN_UTF8).toMap().toHeaders(),
-      HttpURLConnection.HTTP_FORBIDDEN
     )
   }
 }

--- a/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/exceptions/ExceptionHandlingInterceptor.kt
@@ -3,6 +3,7 @@ package misk.web.exceptions
 import com.google.common.util.concurrent.UncheckedExecutionException
 import com.squareup.wire.GrpcStatus
 import com.squareup.wire.ProtoAdapter
+import jakarta.inject.Inject
 import misk.Action
 import misk.exceptions.UnauthenticatedException
 import misk.exceptions.UnauthorizedException
@@ -14,7 +15,6 @@ import misk.web.NetworkChain
 import misk.web.NetworkInterceptor
 import misk.web.Response
 import misk.web.ResponseBody
-import misk.web.extractors.RequestBodyException
 import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
 import okhttp3.Headers.Companion.toHeaders
@@ -27,7 +27,6 @@ import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 import java.net.HttpURLConnection
 import java.util.Base64
-import jakarta.inject.Inject
 
 /**
  * Converts and logs application and component level dispatch exceptions into the appropriate
@@ -107,17 +106,28 @@ class ExceptionHandlingInterceptor(
     return buffer.readUtf8()
   }
 
-  private fun toResponse(th: Throwable, suppressLog: Boolean): Response<*> = when (th) {
-    is UnauthenticatedException -> UNAUTHENTICATED_RESPONSE
-    is UnauthorizedException -> UNAUTHORIZED_RESPONSE
-    is InvocationTargetException -> toResponse(th.targetException, suppressLog = suppressLog)
-    is UncheckedExecutionException -> toResponse(th.cause!!, suppressLog = suppressLog)
-    else -> mapperResolver.mapperFor(th)?.let {
+  private fun toResponse(th: Throwable, suppressLog: Boolean): Response<*> {
+    // If the exception is a reflection wrapper, unwrap first.
+    when (th) {
+      is InvocationTargetException -> return toResponse(th.targetException, suppressLog)
+      is UncheckedExecutionException -> return toResponse(th.cause!!, suppressLog)
+    }
+
+    // Prefer the mapper's response, if one exists.
+    val mapper = mapperResolver.mapperFor(th)
+    if (mapper != null) {
       if (!suppressLog) {
-        log.log(it.loggingLevel(th), th) { "exception dispatching to $actionName" }
+        log.log(mapper.loggingLevel(th), th) { "exception dispatching to $actionName" }
       }
-      it.toResponse(th)
-    } ?: toInternalServerError(th)
+      return mapper.toResponse(th)
+    }
+
+    // Fall back to a default mapping.
+    return when (th) {
+      is UnauthenticatedException -> UNAUTHENTICATED_RESPONSE
+      is UnauthorizedException -> UNAUTHORIZED_RESPONSE
+      else -> toInternalServerError(th)
+    }
   }
 
   private fun toGrpcResponse(th: Throwable): GrpcErrorResponse = when (th) {

--- a/misk/src/test/kotlin/misk/web/exceptions/CustomExceptionMapperTest.kt
+++ b/misk/src/test/kotlin/misk/web/exceptions/CustomExceptionMapperTest.kt
@@ -1,0 +1,103 @@
+package misk.web.exceptions
+
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.exceptions.UnauthenticatedException
+import misk.exceptions.UnauthorizedException
+import misk.inject.KAbstractModule
+import misk.logging.LogCollectorModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.Response
+import misk.web.ResponseContentType
+import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import misk.web.toResponseBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+internal class CustomExceptionMapperTest {
+
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject
+  lateinit var jettyService: JettyService
+
+  @Test
+  fun customizeUnauthenticated() {
+    val response = get("/unauthenticated")
+    assertThat(response.code).isEqualTo(misk.client.HTTP_UNAUTHORIZED)
+    assertThat(response.body?.string()).isEqualTo("custom unauthenticated response!")
+  }
+
+  @Test
+  fun customizeUnauthorized() {
+    val response = get("/unauthorized")
+    assertThat(response.code).isEqualTo(misk.client.HTTP_FORBIDDEN)
+    assertThat(response.body?.string()).isEqualTo("custom unauthorized response!")
+  }
+
+  fun get(path: String): okhttp3.Response {
+    val httpClient = OkHttpClient()
+    val request = Request.Builder()
+      .get()
+      .url(jettyService.httpServerUrl.newBuilder()
+        .encodedPath(path)
+        .build()
+      )
+      .build()
+    return httpClient.newCall(request).execute()
+  }
+
+  class ThrowsUnauthenticated @Inject constructor() : WebAction {
+    @Get("/unauthenticated")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun throwsUnauthenticated(): String {
+      throw UnauthenticatedException()
+    }
+  }
+
+  class ThrowsUnauthorized @Inject constructor() : WebAction {
+    @Get("/unauthorized")
+    @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8)
+    fun throwsUnauthorized(): String {
+      throw UnauthorizedException()
+    }
+  }
+
+  class CustomUnauthorizedMapper @Inject constructor(
+  ) : ExceptionMapper<UnauthorizedException> {
+    override fun toResponse(th: UnauthorizedException) = Response(
+      statusCode = 403,
+      body = "custom unauthorized response!".toResponseBody(),
+    )
+  }
+
+  class CustomUnauthenticatedMapper @Inject constructor(
+  ) : ExceptionMapper<UnauthenticatedException> {
+    override fun toResponse(th: UnauthenticatedException) = Response(
+      statusCode = 401,
+      body = "custom unauthenticated response!".toResponseBody(),
+    )
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<ThrowsUnauthenticated>())
+      install(WebActionModule.create<ThrowsUnauthorized>())
+      install(ExceptionMapperModule.create<UnauthenticatedException, CustomUnauthenticatedMapper>())
+      install(ExceptionMapperModule.create<UnauthorizedException, CustomUnauthorizedMapper>())
+      install(LogCollectorModule())
+    }
+  }
+}


### PR DESCRIPTION
For internal tools its nice to return a page with a link to the role the caller is missing.