### PR TITLE
Remove ActionScope.threadLocalUUID

### DIFF
--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -6,7 +6,6 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asContextElement
-import java.util.UUID
 import java.util.concurrent.Callable
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KFunction
@@ -25,7 +24,6 @@ class ActionScope @Inject internal constructor(
 ) : AutoCloseable {
   companion object {
     private val threadLocalInstance = ThreadLocal<Instance>()
-    private val threadLocalUUID = ThreadLocal<UUID>()
   }
 
   /**
@@ -119,22 +117,11 @@ class ActionScope @Inject internal constructor(
 
     threadLocalInstance.set(instance)
 
-    // If an action scope had previously been entered on the thread, re-use its UUID.
-    // Otherwise, generate a new one.
-    if (threadLocalUUID.get() == null) {
-      threadLocalUUID.set(UUID.randomUUID())
-    }
-
     return this
   }
 
   override fun close() {
     threadLocalInstance.remove()
-
-    // Explicitly NOT removing threadLocalUUID because we want to retain the thread's UUID if
-    // the action scope is re-entered on the same thread.
-    // The only way in which threadLocalUUID is removed is through garbage collection, which occurs
-    // when the thread is no longer alive.
   }
 
   /** Returns true if currently in the scope */
@@ -148,12 +135,11 @@ class ActionScope @Inject internal constructor(
     check(inScope()) { "not running within an ActionScope" }
 
     val currentInstance = threadLocalInstance.get()
-    val currentThreadUUID = threadLocalUUID.get()
 
     return Callable {
-      // If the original thread is the same as the thread that calls the Callable and we are already
+      // If the original scope is the same as the scope that calls the KFunction and we are already
       // in scope, then there is no need to re-enter the scope.
-      if (inScope() && currentThreadUUID == threadLocalUUID.get()) {
+      if (inScope() && currentInstance === threadLocalInstance.get()) {
         c.call()
       } else {
         currentInstance.inScope {
@@ -171,8 +157,7 @@ class ActionScope @Inject internal constructor(
     check(inScope()) { "not running within an ActionScope" }
 
     val currentInstance = threadLocalInstance.get()
-    val currentThreadUUID = threadLocalUUID.get()
-    return WrappedKFunction(currentInstance, this, f, currentThreadUUID)
+    return WrappedKFunction(currentInstance, this, f)
   }
 
   /**
@@ -183,12 +168,11 @@ class ActionScope @Inject internal constructor(
     check(inScope()) { "not running within an ActionScope" }
 
     val currentInstance = threadLocalInstance.get()
-    val currentThreadUUID = threadLocalUUID.get()
 
     return {
-      // If the original thread is the same as the thread that calls the KFunction and we are already
+      // If the original scope is the same as the scope that calls the KFunction and we are already
       // in scope, then there is no need to re-enter the scope.
-      if (inScope() && currentThreadUUID == threadLocalUUID.get()) {
+      if (inScope() && currentInstance === threadLocalInstance.get()) {
         f.invoke()
       } else {
         currentInstance.inScope(f)
@@ -238,12 +222,11 @@ class ActionScope @Inject internal constructor(
     val instance: Instance,
     val scope: ActionScope,
     val wrapped: KFunction<T>,
-    val threadUUID: UUID
   ) : KFunction<T> {
     override fun call(vararg args: Any?): T {
-      // If the original thread is the same as the thread that calls the KFunction and we are already
+      // If the original scope is the same as the scope that calls the KFunction and we are already
       // in scope, then there is no need to re-enter the scope.
-      return if (scope.inScope() && threadUUID == threadLocalUUID.get()) {
+      return if (scope.inScope() && instance === threadLocalInstance.get()) {
         wrapped.call(*args)
       } else {
         instance.inScope {
@@ -253,9 +236,9 @@ class ActionScope @Inject internal constructor(
     }
 
     override fun callBy(args: Map<KParameter, Any?>): T {
-      // If the original thread is the same as the thread that calls the KFunction and we are already
+      // If the original scope is the same as the scope that calls the KFunction and we are already
       // in scope, then there is no need to re-enter the scope.
-      return if (scope.inScope() && threadUUID == threadLocalUUID.get()) {
+      return if (scope.inScope() && instance === threadLocalInstance.get()) {
         wrapped.callBy(args)
       } else {
         instance.inScope {

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopePropagationTest.kt
@@ -34,11 +34,13 @@ internal class ActionScopePropagationTest {
       keyOf<String>(Names.named("from-seed")) to "my seed data"
     )
 
-    val callable = scope.enter(seedData).use {
+    val actionScopeInstance = scope.create(seedData)
+
+    val callable = actionScopeInstance.inScope {
       scope.propagate(Callable { tester.fooValue() })
     }
 
-    scope.enter(seedData).use {
+    actionScopeInstance.inScope {
       // Submit to same thread after we've already entered the scope
       val result = directExecutor.submit(callable).get()
       assertThat(result).isEqualTo("my seed data and bar and foo!")
@@ -55,7 +57,9 @@ internal class ActionScopePropagationTest {
       keyOf<String>(Names.named("from-seed")) to "my seed data"
     )
 
-    val callable = scope.enter(seedData).use {
+    val actionScopeInstance = scope.create(seedData)
+
+    val callable = actionScopeInstance.inScope {
       scope.propagate(Callable { tester.fooValue() })
     }
 
@@ -74,13 +78,15 @@ internal class ActionScopePropagationTest {
       keyOf<String>(Names.named("from-seed")) to "my seed data"
     )
 
+    val actionScopeInstance = scope.create(seedData)
+
     // Propagate on the the KCallable directly
     val f: KFunction<String> = tester::fooValue
-    val callable = scope.enter(seedData).use {
+    val callable = actionScopeInstance.inScope {
       scope.propagate(f)
     }
 
-    scope.enter(seedData).use {
+    scope.enter(actionScopeInstance).use {
       // Submit to same thread after we've already entered the scope
       val result = directExecutor.submit(
         Callable {
@@ -126,12 +132,14 @@ internal class ActionScopePropagationTest {
       keyOf<String>(Names.named("from-seed")) to "my seed data"
     )
 
+    val actionScopeInstance = scope.create(seedData)
+
     // Propagate on a lambda directly
-    val function = scope.enter(seedData).use {
+    val function = actionScopeInstance.inScope {
       scope.propagate { tester.fooValue() }
     }
 
-    scope.enter(seedData).use {
+    actionScopeInstance.inScope {
       // Submit to same thread after we've already entered the scope
       val result = directExecutor.submit(Callable { function() }).get()
       assertThat(result).isEqualTo("my seed data and bar and foo!")


### PR DESCRIPTION
*This shouldn't be merged until the deprecated `ActionScope::enter` method is deleted. Otherwise it will break existing callers who use a direct executor*

This removes the ThreadLocal UUID and simplifies the code, fixing what I believe is an unintended behavior and a footgun. Currently you can overwrite your ActionScope seed data if you propagate an ActionScope to a "new" thread using a DirectExecutor. Because the UUID will match, it won't complain about being in an action scope and happily overwrite the thread local with the newly supplied seed data. Now that we have ActionScope.Instance, we can check for object equality and provide the safer guarantee that the scope you're propagating is the same as the current scope.