### PR TITLE
Expose minMessageToCompress for GrpcClientModule

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6060,6 +6060,17 @@ acceptedBreaks:
       new: "method java.util.List<misk.web.WebUnixDomainSocketConfig> misk.web.WebConfig::getUnix_domain_sockets()"
       justification: "Changing the return type from Array to List. Barely anyone uses\
         \ this config at this point"
+  "2024.03.12.191907-bc64606":
+    com.squareup.misk:misk:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.client.GrpcClientProvider<T extends com.squareup.wire.Service,\
+        \ G extends T extends com.squareup.wire.Service>::<init>(kotlin.reflect.KClass<T>,\
+        \ kotlin.reflect.KClass<G>, java.lang.String, com.google.inject.Provider<okhttp3.OkHttpClient>)"
+      new: "method void misk.client.GrpcClientProvider<T extends com.squareup.wire.Service,\
+        \ G extends T extends com.squareup.wire.Service>::<init>(kotlin.reflect.KClass<T>,\
+        \ kotlin.reflect.KClass<G>, java.lang.String, com.google.inject.Provider<okhttp3.OkHttpClient>,\
+        \ long)"
+      justification: "Internal consturctor only called within misk."
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -448,7 +448,8 @@ public final class misk/client/GrpcClientModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/client/GrpcClientModule$Companion;
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/annotation/Annotation;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/annotation/Annotation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/annotation/Annotation;J)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/annotation/Annotation;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/client/GrpcClientModule$Companion {

--- a/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
+++ b/misk/src/main/kotlin/misk/client/GrpcClientModule.kt
@@ -22,7 +22,17 @@ class GrpcClientModule<T : Service, G : T> @JvmOverloads constructor(
   private val name: String,
 
   /** Qualifier annotation on the bound service. If null the service will be bound unannotated. */
-  private val annotation: Annotation? = null
+  private val annotation: Annotation? = null,
+
+  /**
+   * Sets the minimum outbound message size (in bytes) that will be compressed.
+   *
+   * Set this to 0 to enable compression for all outbound messages. Set to [Long.MAX_VALUE] to
+   * disable compression.
+   *
+   * This is 0 by default.
+   */
+  private val minMessageToCompress: Long = 0L
 ) : KAbstractModule() {
   private val httpClientAnnotation = annotation ?: Names.named(kclass.qualifiedName)
 
@@ -34,7 +44,7 @@ class GrpcClientModule<T : Service, G : T> @JvmOverloads constructor(
 
     val key = if (annotation == null) Key.get(kclass.java) else Key.get(kclass.java, annotation)
     bind(key)
-      .toProvider(GrpcClientProvider(kclass, grpcClientClass, name, httpClientProvider))
+      .toProvider(GrpcClientProvider(kclass, grpcClientClass, name, httpClientProvider, minMessageToCompress))
       .`in`(Singleton::class.java)
 
     // Initialize empty sets for our multibindings.

--- a/misk/src/main/kotlin/misk/client/GrpcClientProvider.kt
+++ b/misk/src/main/kotlin/misk/client/GrpcClientProvider.kt
@@ -50,7 +50,8 @@ internal class GrpcClientProvider<T : Service, G : T>(
   private val kclass: KClass<T>,
   private val grpcClientClass: KClass<G>,
   private val name: String,
-  private val httpClientProvider: Provider<OkHttpClient>
+  private val httpClientProvider: Provider<OkHttpClient>,
+  private val minMessageToCompress: Long
 ) : Provider<T> {
   /** Use a provider because we don't know the test client's URL until its test server starts. */
   @Inject private lateinit var httpClientsConfigProvider: Provider<HttpClientsConfig>
@@ -190,6 +191,7 @@ internal class GrpcClientProvider<T : Service, G : T>(
     val grpcClient = GrpcClient.Builder()
       .callFactory(callFactoryWrapped)
       .baseUrl(baseUrl)
+      .minMessageToCompress(minMessageToCompress)
       .build()
 
     // There should be *exactly one constructor* that takes in a grpcClient


### PR DESCRIPTION
This was added to wire gRPC clients in https://github.com/square/wire/pull/1956.
Without exposing this, wire gRPC clients default to compressing everything with
gRPC. Some gRPC server implementations don't support gzip, so this adds an
escape hatch (and also let's folks fine tune this setting for optimal performance,
should they want.)
