### PR TITLE
Encapsulate pipelines in misk-redis client

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6094,6 +6094,11 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method misk.web.metadata.webaction.WebActionMetadataList misk.web.metadata.webaction.WebActionMetadataAction::getWebActionMetadataList()"
       justification: "Metadata actions and providers only have internal usage"
+    com.squareup.misk:misk-redis:
+    - code: "java.method.addedToInterface"
+      new: "method void misk.redis.Redis::pipelining(kotlin.jvm.functions.Function1<?\
+        \ super misk.redis.DeferredRedis, kotlin.Unit>)"
+      justification: "Adds proper support for pipelining Redis commands"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -1,3 +1,57 @@
+public abstract interface class misk/redis/DeferredRedis {
+	public abstract fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Ljava/util/function/Supplier;
+	public abstract fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public abstract fun close ()V
+	public abstract fun del (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun del ([Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun expire (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun expireAt (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun get (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun getDel (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hdel (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hget (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hgetAll (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun hlen (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun hrandField (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)Ljava/util/function/Supplier;
+	public abstract fun hset (Ljava/lang/String;Ljava/util/Map;)Ljava/util/function/Supplier;
+	public abstract fun incr (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun incrBy (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Ljava/util/function/Supplier;
+	public abstract fun lpop (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun lpop (Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public abstract fun lpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
+	public abstract fun lrange (Ljava/lang/String;JJ)Ljava/util/function/Supplier;
+	public abstract fun lrem (Ljava/lang/String;JLokio/ByteString;)Ljava/util/function/Supplier;
+	public abstract fun mget ([Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun mset ([Lokio/ByteString;)Ljava/util/function/Supplier;
+	public abstract fun pExpire (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun pExpireAt (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun rpop (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun rpop (Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public abstract fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
+	public abstract fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public abstract fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
+}
+
+public final class misk/redis/DeferredRedis$DefaultImpls {
+	public static synthetic fun set$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public static synthetic fun setnx$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public static synthetic fun zrange$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public static synthetic fun zrangeWithScores$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
+}
+
 public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public field clock Ljava/time/Clock;
 	public field random Lkotlin/random/Random;
@@ -38,6 +92,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun pipelining (Lkotlin/jvm/functions/Function1;)V
 	public fun publish (Ljava/lang/String;Ljava/lang/String;)V
 	public fun rpop (Ljava/lang/String;)Lokio/ByteString;
 	public fun rpop (Ljava/lang/String;I)Ljava/util/List;
@@ -114,6 +169,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun pipelining (Lkotlin/jvm/functions/Function1;)V
 	public fun publish (Ljava/lang/String;Ljava/lang/String;)V
 	public fun rpop (Ljava/lang/String;)Lokio/ByteString;
 	public fun rpop (Ljava/lang/String;I)Ljava/util/List;
@@ -136,6 +192,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 }
 
 public final class misk/redis/RealRedis$Companion {
+	public final fun getCharset ()Ljava/nio/charset/Charset;
 }
 
 public abstract interface class misk/redis/Redis {
@@ -173,6 +230,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun pExpire (Ljava/lang/String;J)Z
 	public abstract fun pExpireAt (Ljava/lang/String;J)Z
 	public abstract fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public abstract fun pipelining (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun publish (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun rpop (Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun rpop (Ljava/lang/String;I)Ljava/util/List;
@@ -201,6 +259,7 @@ public final class misk/redis/Redis$DefaultImpls {
 
 public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
 	public static final field CH Lmisk/redis/Redis$ZAddOptions;
+	public static final field Companion Lmisk/redis/Redis$ZAddOptions$Companion;
 	public static final field GT Lmisk/redis/Redis$ZAddOptions;
 	public static final field LT Lmisk/redis/Redis$ZAddOptions;
 	public static final field NX Lmisk/redis/Redis$ZAddOptions;
@@ -208,6 +267,10 @@ public final class misk/redis/Redis$ZAddOptions : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lmisk/redis/Redis$ZAddOptions;
 	public static fun values ()[Lmisk/redis/Redis$ZAddOptions;
+}
+
+public final class misk/redis/Redis$ZAddOptions$Companion {
+	public final fun getZAddParams ([Lmisk/redis/Redis$ZAddOptions;)Lredis/clients/jedis/params/ZAddParams;
 }
 
 public final class misk/redis/Redis$ZRangeIndexMarker : misk/redis/Redis$ZRangeMarker {
@@ -490,6 +553,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun pExpire (Ljava/lang/String;J)Z
 	public fun pExpireAt (Ljava/lang/String;J)Z
 	public fun pipelined ()Lredis/clients/jedis/Pipeline;
+	public fun pipelining (Lkotlin/jvm/functions/Function1;)V
 	public fun publish (Ljava/lang/String;Ljava/lang/String;)V
 	public fun rpop (Ljava/lang/String;)Lokio/ByteString;
 	public fun rpop (Ljava/lang/String;I)Ljava/util/List;
@@ -509,6 +573,54 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis {
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
+}
+
+public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/DeferredRedis {
+	public fun <init> (Lmisk/redis/testing/FakeRedis;)V
+	public fun blmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;D)Ljava/util/function/Supplier;
+	public fun brpoplpush (Ljava/lang/String;Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public fun close ()V
+	public fun del (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun del ([Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun expire (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun expireAt (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun get (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun getDel (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hget (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hgetAll (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun hlen (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun hrandField (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun hrandFieldWithValues (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun hset (Ljava/lang/String;Ljava/lang/String;Lokio/ByteString;)Ljava/util/function/Supplier;
+	public fun hset (Ljava/lang/String;Ljava/util/Map;)Ljava/util/function/Supplier;
+	public fun incr (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun incrBy (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun lmove (Ljava/lang/String;Ljava/lang/String;Lredis/clients/jedis/args/ListDirection;Lredis/clients/jedis/args/ListDirection;)Ljava/util/function/Supplier;
+	public fun lpop (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun lpop (Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public fun lpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
+	public fun lrange (Ljava/lang/String;JJ)Ljava/util/function/Supplier;
+	public fun lrem (Ljava/lang/String;JLokio/ByteString;)Ljava/util/function/Supplier;
+	public fun mget ([Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun mset ([Lokio/ByteString;)Ljava/util/function/Supplier;
+	public fun pExpire (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun pExpireAt (Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun rpop (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun rpop (Ljava/lang/String;I)Ljava/util/function/Supplier;
+	public fun rpoplpush (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
+	public fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -1,0 +1,145 @@
+package misk.redis
+
+import okio.ByteString
+import redis.clients.jedis.args.ListDirection
+import java.time.Duration
+import java.util.function.Supplier
+
+/**
+ * Like [Redis], but returns [Supplier]s to defer value retrieval.
+ * **Does not support transactions or pubsub.**
+ */
+interface DeferredRedis {
+  fun del(key: String): Supplier<Boolean>
+
+  fun del(vararg keys: String): Supplier<Int>
+
+  fun mget(vararg keys: String): Supplier<List<ByteString?>>
+
+  fun mset(vararg keyValues: ByteString): Supplier<Unit>
+
+  operator fun get(key: String): Supplier<ByteString?>
+
+  fun getDel(key: String): Supplier<ByteString?>
+
+  fun hdel(key: String, vararg fields: String): Supplier<Long>
+
+  fun hget(key: String, field: String): Supplier<ByteString?>
+
+  fun hgetAll(key: String): Supplier<Map<String, ByteString>?>
+
+  fun hlen(key: String): Supplier<Long>
+
+  fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>>
+
+  fun hincrBy(key: String, field: String, increment: Long): Supplier<Long>
+
+  fun hrandFieldWithValues(key: String, count: Long): Supplier<Map<String, ByteString>?>
+
+  fun hrandField(key: String, count: Long): Supplier<List<String>>
+
+  fun set(key: String, value: ByteString, expiryDuration: Duration? = null): Supplier<Unit>
+
+  fun setnx(key: String, value: ByteString, expiryDuration: Duration? = null): Supplier<Boolean>
+
+  fun hset(key: String, field: String, value: ByteString): Supplier<Long>
+
+  fun hset(key: String, hash: Map<String, ByteString>): Supplier<Long>
+
+  fun incr(key: String): Supplier<Long>
+
+  fun incrBy(key: String, increment: Long): Supplier<Long>
+
+  fun blmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection,
+    timeoutSeconds: Double
+  ): Supplier<ByteString?>
+
+  fun brpoplpush(
+    sourceKey: String,
+    destinationKey: String,
+    timeoutSeconds: Int
+  ): Supplier<ByteString?>
+
+  fun lmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection
+  ): Supplier<ByteString?>
+
+  fun lpush(key: String, vararg elements: ByteString): Supplier<Long>
+
+  fun rpush(key: String, vararg elements: ByteString): Supplier<Long>
+
+  fun lpop(key: String, count: Int): Supplier<List<ByteString?>>
+
+  fun lpop(key: String): Supplier<ByteString?>
+
+  fun rpop(key: String, count: Int): Supplier<List<ByteString?>>
+
+  fun rpop(key: String): Supplier<ByteString?>
+
+  fun lrange(key: String, start: Long, stop: Long): Supplier<List<ByteString?>>
+
+  fun lrem(key: String, count: Long, element: ByteString): Supplier<Long>
+
+  fun rpoplpush(sourceKey: String, destinationKey: String): Supplier<ByteString?>
+
+  fun expire(key: String, seconds: Long): Supplier<Boolean>
+
+  fun expireAt(key: String, timestampSeconds: Long): Supplier<Boolean>
+
+  fun pExpire(key: String, milliseconds: Long): Supplier<Boolean>
+
+  fun pExpireAt(key: String, timestampMilliseconds: Long): Supplier<Boolean>
+
+  fun close()
+
+  fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions
+  ): Supplier<Long>
+
+  fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions
+  ): Supplier<Long>
+
+  fun zscore(
+    key: String,
+    member: String
+  ): Supplier<Double?>
+
+  fun zrange(
+    key: String,
+    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean = false,
+    limit: Redis.ZRangeLimit? = null,
+  ): Supplier<List<ByteString?>>
+
+  fun zrangeWithScores(
+    key: String,
+    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean = false,
+    limit: Redis.ZRangeLimit? = null,
+  ): Supplier<List<Pair<ByteString?, Double>>>
+
+  fun zremRangeByRank(
+    key: String,
+    start: Redis.ZRangeRankMarker,
+    stop: Redis.ZRangeRankMarker,
+  ): Supplier<Long>
+
+  fun zcard(key: String): Supplier<Long>
+}

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -394,8 +394,13 @@ class FakeRedis : Redis {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
     throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun pipelining(block: DeferredRedis.() -> Unit) {
+    throw NotImplementedError("Use the fake from misk.redis.testing instead.")
   }
 
   override fun close() {

--- a/misk-redis/src/main/kotlin/misk/redis/JedisPipeline.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPipeline.kt
@@ -1,0 +1,78 @@
+package misk.redis
+
+import okio.Closeable
+import redis.clients.jedis.ClusterPipeline
+import redis.clients.jedis.Pipeline
+import redis.clients.jedis.Response
+import redis.clients.jedis.args.FlushMode
+import redis.clients.jedis.args.FunctionRestorePolicy
+import redis.clients.jedis.commands.PipelineBinaryCommands
+import redis.clients.jedis.commands.PipelineCommands
+
+internal sealed class JedisPipeline : Closeable, PipelineCommands, PipelineBinaryCommands {
+  class ClusterJedisPipeline(private val pipeline: ClusterPipeline) : JedisPipeline(),
+    Closeable by pipeline, PipelineCommands by pipeline, PipelineBinaryCommands by pipeline {
+
+    // The following methods must be overridden because the class inherits multiple implementations.
+
+    override fun functionDump(): Response<ByteArray> {
+      return pipeline.functionDump()
+    }
+
+    override fun functionKill(): Response<String> {
+      return pipeline.functionKill()
+    }
+
+    override fun functionFlush(): Response<String> {
+      return pipeline.functionFlush()
+    }
+
+    override fun functionFlush(mode: FlushMode?): Response<String> {
+      return pipeline.functionFlush(mode)
+    }
+
+    override fun functionRestore(serializedValue: ByteArray?): Response<String> {
+      return pipeline.functionRestore(serializedValue)
+    }
+
+    override fun functionRestore(
+      serializedValue: ByteArray?,
+      policy: FunctionRestorePolicy?
+    ): Response<String> {
+      return pipeline.functionRestore(serializedValue, policy)
+    }
+  }
+
+  class PooledPipeline(private val pipeline: Pipeline) : JedisPipeline(),
+    Closeable by pipeline, PipelineCommands by pipeline, PipelineBinaryCommands by pipeline {
+
+    // The following methods must be overridden because the class inherits multiple implementations.
+
+    override fun functionDump(): Response<ByteArray> {
+      return pipeline.functionDump()
+    }
+
+    override fun functionKill(): Response<String> {
+      return pipeline.functionKill()
+    }
+
+    override fun functionFlush(): Response<String> {
+      return pipeline.functionFlush()
+    }
+
+    override fun functionFlush(mode: FlushMode?): Response<String> {
+      return pipeline.functionFlush(mode)
+    }
+
+    override fun functionRestore(serializedValue: ByteArray?): Response<String> {
+      return pipeline.functionRestore(serializedValue)
+    }
+
+    override fun functionRestore(
+      serializedValue: ByteArray?,
+      policy: FunctionRestorePolicy?
+    ): Response<String> {
+      return pipeline.functionRestore(serializedValue, policy)
+    }
+  }
+}

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -1,0 +1,522 @@
+package misk.redis
+
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.params.SetParams
+import redis.clients.jedis.params.ZRangeParams
+import redis.clients.jedis.resps.Tuple
+import java.time.Duration
+import java.util.function.Supplier
+
+internal class RealPipelinedRedis(private val pipeline: JedisPipeline) : DeferredRedis {
+  override fun del(key: String): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.del(keyBytes)
+    return Supplier { response.get() == 1L }
+  }
+
+  override fun del(vararg keys: String): Supplier<Int> {
+    val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+    val response = pipeline.del(*keysBytes)
+    return Supplier { response.get().toInt() }
+  }
+
+  override fun mget(vararg keys: String): Supplier<List<ByteString?>> {
+    val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+    val response = pipeline.mget(*keysBytes)
+    return Supplier { response.get().map { it?.toByteString() } }
+  }
+
+  override fun mset(vararg keyValues: ByteString): Supplier<Unit> {
+    val keyValuePairs = keyValues.map { it.toByteArray() }.toTypedArray()
+    val response = pipeline.mset(*keyValuePairs)
+    return Supplier { response.get() }
+  }
+
+  override fun get(key: String): Supplier<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.get(keyBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun getDel(key: String): Supplier<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.getDel(keyBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun hdel(key: String, vararg fields: String): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val fieldsBytes = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val response = pipeline.hdel(keyBytes, *fieldsBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun hget(key: String, field: String): Supplier<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    val response = pipeline.hget(keyBytes, fieldBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun hgetAll(key: String): Supplier<Map<String, ByteString>?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.hgetAll(keyBytes)
+    return Supplier {
+      response.get()
+        ?.mapKeys { it.key.toString(charset) }
+        ?.mapValues { it.value.toByteString() }
+    }
+  }
+
+  override fun hlen(key: String): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.hlen(keyBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>> {
+    val keyBytes = key.toByteArray(charset)
+    val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val response = pipeline.hmget(keyBytes, *fieldsAsByteArrays)
+    return Supplier { response.get()?.map { it?.toByteString() } ?: emptyList() }
+  }
+
+  override fun hincrBy(key: String, field: String, increment: Long): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    val response = pipeline.hincrBy(keyBytes, fieldBytes, increment)
+    return Supplier { response.get() }
+  }
+
+  override fun hrandFieldWithValues(key: String, count: Long): Supplier<Map<String, ByteString>?> {
+    checkHrandFieldCount(count)
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.hrandfieldWithValues(keyBytes, count)
+    return Supplier {
+      response.get()
+        ?.mapKeys { it.key.toString(charset) }
+        ?.mapValues { it.value.toByteString() }
+    }
+  }
+
+  override fun hrandField(key: String, count: Long): Supplier<List<String>> {
+    checkHrandFieldCount(count)
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.hrandfield(keyBytes, count)
+    return Supplier { response.get()?.map { it.toString(charset) } ?: emptyList() }
+  }
+
+  override fun set(key: String, value: ByteString, expiryDuration: Duration?): Supplier<Unit> {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().apply {
+      if (expiryDuration != null) {
+        px(expiryDuration.toMillis())
+      }
+    }
+    val response = pipeline.set(keyBytes, valueBytes, params)
+    return Supplier { response.get() }
+  }
+
+  override fun setnx(key: String, value: ByteString, expiryDuration: Duration?): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().nx().apply {
+      if (expiryDuration != null) px(expiryDuration.toMillis())
+    }
+    val response = pipeline.set(keyBytes, valueBytes, params)
+    return Supplier { response.get() == "OK" }
+  }
+
+  override fun hset(key: String, field: String, value: ByteString): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val response = pipeline.hset(keyBytes, fieldBytes, valueBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun hset(key: String, hash: Map<String, ByteString>): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val hashBytes = hash.mapKeys { it.key.toByteArray(charset) }
+      .mapValues { it.value.toByteArray() }
+    val response = pipeline.hset(keyBytes, hashBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun incr(key: String): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.incr(keyBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun incrBy(key: String, increment: Long): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.incrBy(keyBytes, increment)
+    return Supplier { response.get() }
+  }
+
+  override fun blmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection,
+    timeoutSeconds: Double
+  ): Supplier<ByteString?> {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    val response = pipeline.blmove(sourceKeyBytes, destKeyBytes, from, to, timeoutSeconds)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun brpoplpush(
+    sourceKey: String,
+    destinationKey: String,
+    timeoutSeconds: Int
+  ): Supplier<ByteString?> {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    val response = pipeline.brpoplpush(sourceKeyBytes, destinationKeyBytes, timeoutSeconds)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun lmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection
+  ): Supplier<ByteString?> {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    val response = pipeline.lmove(sourceKeyBytes, destKeyBytes, from, to)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun lpush(key: String, vararg elements: ByteString): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    val response = pipeline.lpush(keyBytes, *byteArrays)
+    return Supplier { response.get() }
+  }
+
+  override fun rpush(key: String, vararg elements: ByteString): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    val response = pipeline.rpush(keyBytes, *byteArrays)
+    return Supplier { response.get() }
+  }
+
+  override fun lpop(key: String, count: Int): Supplier<List<ByteString?>> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.lpop(keyBytes, count)
+    return Supplier { response.get()?.map { it.toByteString() } ?: emptyList() }
+  }
+
+  override fun lpop(key: String): Supplier<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.lpop(keyBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun rpop(key: String, count: Int): Supplier<List<ByteString?>> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.rpop(keyBytes, count)
+    return Supplier { response.get()?.map { it.toByteString() } ?: emptyList() }
+  }
+
+  override fun rpop(key: String): Supplier<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.rpop(keyBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun lrange(key: String, start: Long, stop: Long): Supplier<List<ByteString?>> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.lrange(keyBytes, start, stop)
+    return Supplier { response.get()?.map { it.toByteString() } ?: emptyList() }
+  }
+
+  override fun lrem(key: String, count: Long, element: ByteString): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val elementBytes = element.toByteArray()
+    val response = pipeline.lrem(keyBytes, count, elementBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun rpoplpush(sourceKey: String, destinationKey: String): Supplier<ByteString?> {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    val response = pipeline.rpoplpush(sourceKeyBytes, destinationKeyBytes)
+    return Supplier { response.get()?.toByteString() }
+  }
+
+  override fun expire(key: String, seconds: Long): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.expire(keyBytes, seconds)
+    return Supplier { response.get() == 1L }
+  }
+
+  override fun expireAt(key: String, timestampSeconds: Long): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.expireAt(keyBytes, timestampSeconds)
+    return Supplier { response.get() == 1L }
+  }
+
+  override fun pExpire(key: String, milliseconds: Long): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.pexpire(keyBytes, milliseconds)
+    return Supplier { response.get() == 1L }
+  }
+
+  override fun pExpireAt(key: String, timestampMilliseconds: Long): Supplier<Boolean> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.pexpireAt(keyBytes, timestampMilliseconds)
+    return Supplier { response.get() == 1L }
+  }
+
+  override fun close() {
+    pipeline.close()
+  }
+
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions,
+  ): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val memberBytes = member.toByteArray(charset)
+    val params = Redis.ZAddOptions.getZAddParams(options)
+    val response = pipeline.zadd(keyBytes, score, memberBytes, params)
+    return Supplier { response.get() }
+  }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions,
+  ): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val scoreMembersBytes = scoreMembers.mapKeys { it.key.toByteArray(charset) }
+    val params = Redis.ZAddOptions.getZAddParams(options)
+    val response = pipeline.zadd(keyBytes, scoreMembersBytes, params)
+    return Supplier { response.get() }
+  }
+
+  override fun zscore(key: String, member: String): Supplier<Double?> {
+    val keyBytes = key.toByteArray(charset)
+    val memberBytes = member.toByteArray(charset)
+    val response = pipeline.zscore(keyBytes, memberBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun zrange(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): Supplier<List<ByteString?>> {
+    return Supplier {
+      zrangeBase(key, type, start, stop, reverse, false, limit)
+        .get().let { response ->
+          response?.noScore?.map { bytes ->
+            bytes?.toByteString()
+          } ?: listOf()
+        }
+    }
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): Supplier<List<Pair<ByteString?, Double>>> {
+    return Supplier {
+      zrangeBase(key, type, start, stop, reverse, true, limit)
+        .get().let { response ->
+          response?.withScore?.map { tuple ->
+            Pair(tuple.binaryElement?.toByteString(), tuple.score)
+          } ?: listOf()
+        }
+    }
+  }
+
+  override fun zremRangeByRank(
+    key: String,
+    start: Redis.ZRangeRankMarker,
+    stop: Redis.ZRangeRankMarker
+  ): Supplier<Long> {
+    val response = pipeline.zremrangeByRank(key, start.longValue, stop.longValue)
+    return Supplier { response.get() }
+  }
+
+  override fun zcard(key: String): Supplier<Long> {
+    val response = pipeline.zcard(key)
+    return Supplier { response.get() }
+  }
+
+  private fun zrangeBase(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: Redis.ZRangeLimit?,
+  ): Supplier<ZRangeResponse?> {
+    return when (type) {
+      Redis.ZRangeType.INDEX ->
+        zrangeByIndex(
+          key, start as Redis.ZRangeIndexMarker, stop as Redis.ZRangeIndexMarker, reverse,
+          withScore
+        )
+
+      Redis.ZRangeType.SCORE ->
+        zrangeByScore(
+          key, start as Redis.ZRangeScoreMarker, stop as Redis.ZRangeScoreMarker, reverse,
+          withScore, limit
+        )
+    }
+  }
+
+  private fun zrangeByIndex(
+    key: String,
+    start: Redis.ZRangeIndexMarker,
+    stop: Redis.ZRangeIndexMarker,
+    reverse: Boolean,
+    withScore: Boolean
+  ): Supplier<ZRangeResponse?> {
+    val params = ZRangeParams(
+      start.intValue,
+      stop.intValue
+    )
+    if (reverse) params.rev()
+
+    return Supplier {
+      if (withScore) {
+        ZRangeResponse.withScore(
+          pipeline.zrangeWithScores(
+            key.toByteArray(charset),
+            params
+          ).get()
+        )
+      } else {
+        ZRangeResponse.noScore(pipeline.zrange(key.toByteArray(charset), params).get())
+      }
+    }
+  }
+
+  private fun zrangeByScore(
+    key: String,
+    start: Redis.ZRangeScoreMarker,
+    stop: Redis.ZRangeScoreMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: Redis.ZRangeLimit?,
+  ): Supplier<ZRangeResponse?> {
+    val minString = start.toString()
+    val maxString = stop.toString()
+
+    return Supplier {
+      if (limit == null && !reverse && !withScore) {
+        ZRangeResponse.noScore(
+          pipeline.zrangeByScore(
+            key.toByteArray(charset),
+            minString.toByteArray(charset),
+            maxString.toByteArray(charset)
+          ).get()
+        )
+      } else if (limit == null && !reverse) {
+        ZRangeResponse.withScore(
+          pipeline.zrangeByScoreWithScores(
+            key.toByteArray(charset),
+            minString.toByteArray(charset),
+            maxString.toByteArray(charset)
+          ).get()
+        )
+      } else if (limit == null && !withScore) {
+        ZRangeResponse.noScore(
+          pipeline.zrevrangeByScore(
+            key.toByteArray(charset),
+            maxString.toByteArray(charset),
+            minString.toByteArray(charset)
+          ).get()
+        )
+      } else if (limit == null) {
+        ZRangeResponse.withScore(
+          pipeline.zrevrangeByScoreWithScores(
+            key.toByteArray(charset),
+            maxString.toByteArray(charset),
+            minString.toByteArray(charset)
+          ).get()
+        )
+      } else if (!reverse && !withScore) {
+        ZRangeResponse.noScore(
+          pipeline.zrangeByScore(
+            key.toByteArray(charset),
+            minString.toByteArray(charset),
+            maxString.toByteArray(charset),
+            limit.offset,
+            limit.count
+          ).get()
+        )
+      } else if (!reverse) {
+        ZRangeResponse.withScore(
+          pipeline.zrangeByScoreWithScores(
+            key.toByteArray(charset),
+            minString.toByteArray(charset),
+            maxString.toByteArray(charset),
+            limit.offset,
+            limit.count
+          ).get()
+        )
+      } else if (!withScore) {
+        ZRangeResponse.noScore(
+          pipeline.zrevrangeByScore(
+            key.toByteArray(charset),
+            maxString.toByteArray(charset),
+            minString.toByteArray(charset),
+            limit.offset,
+            limit.count
+          ).get()
+        )
+      } else {
+        ZRangeResponse.withScore(
+          pipeline.zrevrangeByScoreWithScores(
+            key.toByteArray(charset),
+            maxString.toByteArray(charset),
+            minString.toByteArray(charset),
+            limit.offset,
+            limit.count
+          ).get()
+        )
+      }
+    }
+  }
+
+  /**
+   * A wrapper class for handling response from zrange* methods.
+   */
+  private class ZRangeResponse private constructor(
+    val noScore: List<ByteArray?>?,
+    val withScore: List<Tuple>?
+  ) {
+    companion object {
+      fun noScore(ans: List<ByteArray?>): ZRangeResponse = ZRangeResponse(ans, null)
+
+      fun withScore(ans: List<Tuple>): ZRangeResponse = ZRangeResponse(null, ans)
+    }
+  }
+
+  companion object {
+    /** The charset used to convert String keys to ByteArrays for Jedis commands. */
+    private val charset = Charsets.UTF_8
+  }
+}

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -9,7 +9,6 @@ import misk.redis.Redis.ZRangeScoreMarker
 import misk.redis.Redis.ZRangeType
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
-import okio.use
 import redis.clients.jedis.ClusterPipeline
 import redis.clients.jedis.JedisCluster
 import redis.clients.jedis.JedisPooled
@@ -87,7 +86,9 @@ class RealRedis(
   }
 
   override fun mset(vararg keyValues: ByteString) {
-    require(keyValues.size % 2 == 0) { "Wrong number of arguments to mset" }
+    require(keyValues.size % 2 == 0) {
+      "Wrong number of arguments to mset (must be a multiple of 2, alternating keys and values)"
+    }
     when (unifiedJedis) {
       is JedisPooled -> {
         val byteArrays = keyValues.map { it.toByteArray() }.toTypedArray()

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -5,9 +5,21 @@ import redis.clients.jedis.JedisPubSub
 import redis.clients.jedis.Pipeline
 import redis.clients.jedis.Transaction
 import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.params.ZAddParams
 import java.time.Duration
+import java.util.function.Supplier
 
-/** A Redis client. */
+/**
+ * A Redis client.
+ *
+ * Note: special care must be taken if your Redis is running in cluster mode,
+ * as keys **must** belong to the same slot in a single command operation like [lmove].
+ * You can control which hash slot a key belongs to a certain degree by making use of
+ * `{hashtags}` in the key name.
+ *
+ * See the [Redis Cluster Spec](https://redis.io/docs/reference/cluster-spec/#hash-tags) for more
+ * information.
+ */
 interface Redis {
   /**
    * Deletes a single key.
@@ -254,9 +266,9 @@ interface Redis {
   fun brpoplpush(sourceKey: String, destinationKey: String, timeoutSeconds: Int): ByteString?
 
   /**
-   * Atomically returns and removes the first/last element (head/tail depending on the wherefrom
+   * Atomically returns and removes the first/last element (head/tail depending on the [from]
    * argument) of the list stored at source, and pushes the element at the first/last element
-   * (head/tail depending on the whereto argument) of the list stored at destination.
+   * (head/tail depending on the [to] argument) of the list stored at destination.
    *
    * For example: consider source holding the list a,b,c, and destination holding the list x,y,z.
    * Executing LMOVE source destination RIGHT LEFT results in source holding a,b and destination
@@ -265,7 +277,7 @@ interface Redis {
    * If source does not exist, the value nil is returned and no operation is performed. If source
    * and destination are the same, the operation is equivalent to removing the first/last element
    * from the list and pushing it as first/last element of the list, so it can be considered as a
-   * list rotation command (or a no-op if wherefrom is the same as whereto).
+   * list rotation command (or a no-op if [from] is the same as [to]).
    *
    * Throws an error if using Redis Cluster and source and destination are not in the same hash slot
    *
@@ -456,7 +468,18 @@ interface Redis {
   /**
    * Begin a pipeline operation to batch together several updates for optimal performance
    */
+  @Deprecated("Use pipelining instead.")
   fun pipelined(): Pipeline
+
+  /**
+   * Runs a block of Redis commands in a pipeline, for better performance.
+   * Pipelined command responses are not returned until the block completes.
+   * If you need to use the results of each command immediately, either save the [Supplier]s and call
+   * them later, or use non-pipelined operations.
+   *
+   * See [Redis pipelining](https://redis.io/docs/manual/pipelining/) for more information.
+   */
+  fun pipelining(block: DeferredRedis.() -> Unit)
 
   /**
    * Closes the client, so it may not be used further.
@@ -523,7 +546,7 @@ interface Redis {
   fun zscore(
     key: String,
     member: String
-  ) : Double?
+  ): Double?
 
   /**
    * Returns the specified range of elements in the sorted set stored at [key].
@@ -570,7 +593,7 @@ interface Redis {
    * Both start and stop are 0 -based indexes with 0 being the element with the lowest score.
    * These indexes can be negative numbers, where they indicate offsets starting at the element
    * with the highest score. For example: -1 is the element with the highest score, -2 the element
-   * with the second highest score and so forth.
+   * with the second-highest score and so forth.
    */
   fun zremRangeByRank(
     key: String,
@@ -627,12 +650,9 @@ interface Redis {
     val included: Boolean
   )
 
-  /**
-   *
-   */
   data class ZRangeRankMarker(
     val longValue: Long
-  ): ZRangeMarker(longValue, true)
+  ) : ZRangeMarker(longValue, true)
 
   /**
    * To be used when [ZRangeType] is [ZRangeType.INDEX].
@@ -640,7 +660,7 @@ interface Redis {
    */
   data class ZRangeIndexMarker(
     val intValue: Int
-  ): ZRangeMarker(intValue, true)
+  ) : ZRangeMarker(intValue, true)
 
   /**
    * To be used when [ZRangeType] is [ZRangeType.SCORE].
@@ -651,7 +671,7 @@ interface Redis {
   data class ZRangeScoreMarker(
     val doubleValue: Double,
     val isIncluded: Boolean = true,
-  ): ZRangeMarker(doubleValue, isIncluded) {
+  ) : ZRangeMarker(doubleValue, isIncluded) {
     override fun toString(): String {
       var ans = when (this.doubleValue) {
         Double.MAX_VALUE -> "+inf"
@@ -707,7 +727,26 @@ interface Redis {
      * in the command line having the same score as they had in the past are not counted.
      * Note: normally the return value of ZADD only counts the number of new elements added.
      */
-    CH
+    CH,
+    ;
+
+    companion object {
+      fun getZAddParams(options: Array<out ZAddOptions>): ZAddParams {
+        val params = ZAddParams()
+
+        options.forEach {
+          when (it) {
+            XX -> params.xx()
+            NX -> params.nx()
+            LT -> params.lt()
+            GT -> params.gt()
+            CH -> params.ch()
+          }
+        }
+
+        return params
+      }
+    }
   }
 }
 
@@ -729,3 +768,4 @@ inline fun checkHrandFieldCount(count: Long) {
     "You must request at least 1 field."
   }
 }
+

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -1332,15 +1332,15 @@ abstract class AbstractRedisTest {
         listOf(
           set("test key", "test value".encodeUtf8()),
           get("test key"),
+          del("test key"),
           setnx("keynx", "valuenx".encodeUtf8()),
           setnx("keynx", "valuenx2".encodeUtf8()),
+          get("keynx"),
+          getDel("keynx"),
           get("keynx"),
           incr("incr"),
           incrBy("incr", 3),
           get("incr"),
-          del("test key"),
-          getDel("keynx"),
-          get("keynx"),
         )
       )
     }
@@ -1348,14 +1348,14 @@ abstract class AbstractRedisTest {
       Unit,
       "test value".encodeUtf8(),
       true,
+      true,
       false,
       "valuenx".encodeUtf8(),
+      "valuenx".encodeUtf8(),
+      null,
       1L,
       4L,
       "4".encodeUtf8(),
-      true,
-      "valuenx".encodeUtf8(),
-      null,
     )
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -1373,6 +1373,7 @@ abstract class AbstractRedisTest {
             "mval2".encodeUtf8()
           ),
           mget("mkey1", "mkey2"),
+          del("mkey1", "mkey2"),
         )
       )
     }
@@ -1381,7 +1382,8 @@ abstract class AbstractRedisTest {
       listOf(
         "mval1".encodeUtf8(),
         "mval2".encodeUtf8(),
-      )
+      ),
+      2
     )
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -766,29 +766,6 @@ abstract class AbstractRedisTest {
     assertNull(redis["foo"])
   }
 
-  @Test
-  fun `pipelining works`() {
-    val suppliers = mutableListOf<Supplier<*>>()
-    redis.pipelining {
-      suppliers.addAll(
-        listOf(
-          set("key7", "value7".encodeUtf8()),
-          get("key7"),
-          hset("key8", "field8", "value8".encodeUtf8()),
-          hget("key8", "field8"),
-          hget("key8", "field9"),
-        )
-      )
-    }
-    assertThat(suppliers.map { it.get() }).containsExactly(
-      Unit,
-      "value7".encodeUtf8(),
-      1L,
-      "value8".encodeUtf8(),
-      null,
-      )
-  }
-
   @Test fun `zAdd no option or only CH tests`() {
     val aMember = "a"
     val bMember = "b"
@@ -921,7 +898,6 @@ abstract class AbstractRedisTest {
     assertEquals(1L, redis.zadd("bar", 1.0, cMember, LT, XX, CH))
     assertEquals(1.0, redis.zscore("bar", "c"))
 
-
     // GT XX
     // GT modifies existing if score is more than current. XX prevents adding new
 
@@ -988,8 +964,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - happy case`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair)
@@ -1003,8 +981,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - stop index exceeds the size`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1017,8 +997,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - start is greater than stop`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf<String, Double>()
     val expectedMapForReverse = mapOf<String, Double>()
@@ -1030,8 +1012,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - negative indices - get second last to last`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf(yy_6_7Pair, ad_9Pair)
     val expectedMapForReverse = mapOf(bz_2_3Pair, ba_2_3Pair)
@@ -1043,8 +1027,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - negative indices - get last 100 or as many as there are`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1058,8 +1044,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - mixed indices - get from second last to second`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf<String, Double>()
     val expectedMapForReverse = mapOf<String, Double>()
@@ -1071,8 +1059,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by index test - mixed indices - get from second to second last`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair)
@@ -1086,8 +1076,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - happy case`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1100,8 +1092,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - infinity cases`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1114,8 +1108,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - start score exceeds stop`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf<String, Double>()
     val expectedMapForReverse = mapOf<String, Double>()
@@ -1126,8 +1122,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - start included, stop included`() {
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf(bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair)
     val expectedMapForReverse = mapOf(yy_6_7Pair, c_5Pair, b_5Pair, bb_4_5Pair)
@@ -1138,8 +1136,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - start not included, stop included`() {
-    redis.zadd(key,
-          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf(b_5Pair, c_5Pair, yy_6_7Pair)
     val expectedMapForReverse = mapOf(yy_6_7Pair, c_5Pair, b_5Pair)
@@ -1150,8 +1150,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - start not included, stop not included`() {
-    redis.zadd(key,
-          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf(b_5Pair, c_5Pair)
     val expectedMapForReverse = mapOf(c_5Pair, b_5Pair)
@@ -1162,8 +1164,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - start included, stop not included`() {
-    redis.zadd(key,
-          mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedMapForNonReverse = mapOf(bb_4_5Pair, b_5Pair, c_5Pair)
     val expectedMapForReverse = mapOf(c_5Pair, b_5Pair, bb_4_5Pair)
@@ -1174,8 +1178,10 @@ abstract class AbstractRedisTest {
   }
 
   @Test fun `zrange by score test - limit cases`() {
-    redis.zadd(key,
-        mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val m2 = mapOf(bz_2_3Pair, bb_4_5Pair, b_5Pair)
     val m3 = mapOf(yy_6_7Pair, c_5Pair, b_5Pair)
@@ -1187,8 +1193,10 @@ abstract class AbstractRedisTest {
   @Test fun `zrange by score test - limit cases negative count`() {
 
     // The members with same score are lex arranged.
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val m2 = mapOf(b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
     val m3 = mapOf(b_5Pair, bb_4_5Pair, bz_2_3Pair, ba_2_3Pair)
@@ -1201,8 +1209,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - both ranks positive`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap = mapOf(b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
 
@@ -1211,8 +1221,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - start positive, stop negative`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap = mapOf(yy_6_7Pair, ad_9Pair)
 
@@ -1221,8 +1233,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - both rank negative`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap = mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair)
 
@@ -1231,8 +1245,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - start negative stop positive`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap = mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair)
 
@@ -1241,8 +1257,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - start rank after stop`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1255,8 +1273,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zremRangeByRank - multiple removes`() {
     // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
 
     val expectedZRangeMap1 =
       mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair)
@@ -1274,8 +1294,10 @@ abstract class AbstractRedisTest {
 
   @Test fun `zcard`() {
     assertEquals(0, redis.zcard(key))
-    redis.zadd(key,
-               mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+    redis.zadd(
+      key,
+      mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair)
+    )
     assertEquals(7, redis.zcard(key))
 
     redis.zadd("foo", 4.0, "d")
@@ -1300,6 +1322,201 @@ abstract class AbstractRedisTest {
 
     assertNull(redis[key])
     assertNull(redis.getDel(key))
+  }
+
+  @Test
+  fun `pipelining works - regular keys`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          set("test key", "test value".encodeUtf8()),
+          get("test key"),
+          setnx("keynx", "valuenx".encodeUtf8()),
+          setnx("keynx", "valuenx2".encodeUtf8()),
+          get("keynx"),
+          incr("incr"),
+          incrBy("incr", 3),
+          get("incr"),
+          del("test key"),
+          getDel("keynx"),
+          get("keynx"),
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      Unit,
+      "test value".encodeUtf8(),
+      true,
+      false,
+      "valuenx".encodeUtf8(),
+      1L,
+      4L,
+      "4".encodeUtf8(),
+      true,
+      "valuenx".encodeUtf8(),
+      null,
+    )
+  }
+
+  @Test
+  fun `pipelining works - multikey commands`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          mset(
+            "mkey1".encodeUtf8(),
+            "mval1".encodeUtf8(),
+            "mkey2".encodeUtf8(),
+            "mval2".encodeUtf8()
+          ),
+          mget("mkey1", "mkey2"),
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      Unit,
+      listOf(
+        "mval1".encodeUtf8(),
+        "mval2".encodeUtf8(),
+      )
+    )
+  }
+
+  @Test
+  fun `pipelining works - hash keys`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          hset("hkey", "f1", "v1".encodeUtf8()),
+          hget("hkey", "f1"),
+          hget("hkey", "f_dne"),
+          hgetAll("hkey"),
+          hlen("hkey"),
+          hmget("hkey", "f1", "f_dne"),
+          hincrBy("hkey", "f2", 3),
+          hdel("hkey", "f2"),
+          hrandField("hkey", 1),
+          hrandFieldWithValues("hkey", 1),
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      1L,
+      "v1".encodeUtf8(),
+      null,
+      mapOf("f1" to "v1".encodeUtf8()),
+      1L,
+      listOf("v1".encodeUtf8(), null),
+      3L,
+      1L,
+      listOf("f1"),
+      mapOf("f1" to "v1".encodeUtf8()),
+    )
+  }
+
+  @Test
+  fun `pipelining works - list keys`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          lpush("{same-slot-key}1", "lval1".encodeUtf8(), "lval2".encodeUtf8()),
+          rpush("{same-slot-key}1", "lval3".encodeUtf8(), "lval4".encodeUtf8()),
+          lrange("{same-slot-key}1", 0, -1),
+          lrem("{same-slot-key}1", 1, "lval1".encodeUtf8()),
+          lmove("{same-slot-key}1", "{same-slot-key}2", ListDirection.LEFT, ListDirection.RIGHT),
+          rpoplpush("{same-slot-key}1", "{same-slot-key}2"),
+          lpop("{same-slot-key}1"),
+          rpop("{same-slot-key}2"),
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      2L,
+      4L,
+      listOf(
+        "lval2".encodeUtf8(),
+        "lval1".encodeUtf8(),
+        "lval3".encodeUtf8(),
+        "lval4".encodeUtf8()
+      ),
+      1L,
+      "lval2".encodeUtf8(),
+      "lval4".encodeUtf8(),
+      "lval3".encodeUtf8(),
+      "lval2".encodeUtf8()
+    )
+  }
+
+  @Test
+  fun `pipelining works - sorted sets`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          zadd("zkey", 1.0, "a"),
+          zscore("zkey", "a"),
+          zrangeWithScores("zkey", start = ZRangeIndexMarker(0), stop = ZRangeIndexMarker(-1)),
+          zremRangeByRank("zkey", start = ZRangeRankMarker(0), stop = ZRangeRankMarker(-1)),
+          zcard("zkey")
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      1L,
+      1.0,
+      listOf("a".encodeUtf8() to 1.0),
+      1L,
+      0L,
+    )
+  }
+
+  @Test
+  fun `pipelining works - blocking operations`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          // Blocking operations work best under scenarios where there are multiple clients writing to the same key.
+          // This is really hard to test, so we just test the commands are accepted under situations where they are guaranteed
+          // not to block.
+          lpush("{same-slot-key}1", "lval1".encodeUtf8(), "lval2".encodeUtf8()),
+          lpush("{same-slot-key}2", "lval3".encodeUtf8(), "lval4".encodeUtf8()),
+          blmove("{same-slot-key}1", "{same-slot-key}2", ListDirection.LEFT, ListDirection.RIGHT, 0.0),
+          brpoplpush("{same-slot-key}1", "{same-slot-key}2", 0),
+        )
+      )
+    }
+
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      2L,
+      2L,
+      "lval2".encodeUtf8(),
+      "lval1".encodeUtf8()
+    )
+  }
+
+  @Test
+  fun `pipelining captures errors`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          set("string key", "string value".encodeUtf8()),
+          incr("string key"), // Not a number.
+        )
+      )
+    }
+    assertThat(suppliers.first().get()).isEqualTo(Unit)
+    assertThrows<RuntimeException> { suppliers.last().get() }
   }
 
   private fun checkZRemRangeByRankResponse(
@@ -1372,10 +1589,11 @@ abstract class AbstractRedisTest {
     stop: Double,
     limit: ZRangeLimit? = null
   ) {
-    checkZRangeScoreResponse(expectedMapForNonReverse, expectedMapForReverse,
-                             ZRangeScoreMarker(start), ZRangeScoreMarker(stop), limit)
+    checkZRangeScoreResponse(
+      expectedMapForNonReverse, expectedMapForReverse,
+      ZRangeScoreMarker(start), ZRangeScoreMarker(stop), limit
+    )
   }
-
 
   private fun checkZRangeScoreResponse(
     expectedMapForNonReverse: Map<String, Double>,
@@ -1481,12 +1699,12 @@ abstract class AbstractRedisTest {
     val key = "foo"
   }
 
-  private fun Map<String, Double>.toEncodedListOfPairs() : List<Pair<ByteString, Double>> =
+  private fun Map<String, Double>.toEncodedListOfPairs(): List<Pair<ByteString, Double>> =
     this.entries.map { Pair(it.key.encodeUtf8(), it.value) }.toList()
 
   private fun List<String>.encoded(): List<ByteString> = this.map { it.encodeUtf8() }.toList()
 
-  private fun Map<String, Double>.encodedKeys() : List<ByteString> =
+  private fun Map<String, Double>.encodedKeys(): List<ByteString> =
     this.entries.map { it.key.encodeUtf8() }.toList()
 
 }

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -27,12 +27,12 @@ class RealRedisTest : AbstractRedisTest() {
     }
   }
 
+  @Inject override lateinit var redis: Redis
+
   @BeforeEach
   fun setUp() {
     redis.flushAll()
   }
-
-  @Inject override lateinit var redis: Redis
 
   @Test
   fun `watch and unwatch succeeds`() {
@@ -70,5 +70,4 @@ class RealRedisTest : AbstractRedisTest() {
     assertThat(redis["key5"]).isEqualTo("value5".encodeUtf8())
     assertThat(redis["key6"]).isNull()
   }
-
 }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -13,6 +13,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import jakarta.inject.Inject
+import misk.redis.DeferredRedis
 import misk.redis.Redis.ZAddOptions.XX
 import misk.redis.Redis.ZAddOptions.NX
 import misk.redis.Redis.ZAddOptions.LT
@@ -27,6 +28,7 @@ import misk.redis.Redis.ZRangeType
 import okio.ByteString.Companion.encodeUtf8
 import redis.clients.jedis.exceptions.JedisDataException
 import java.util.SortedMap
+import java.util.function.Supplier
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
@@ -40,7 +42,7 @@ import kotlin.random.Random
  *  - You need fine-grained control over key-expiry in tests
  *
  * Caveats:
- *  - FakeRedis does not currently support [Redis.pipelined] requests or [Redis.multi] transactions
+ *  - FakeRedis does not currently support [Redis.multi] transactions
  */
 class FakeRedis @Inject constructor(
   private val clock: Clock,
@@ -426,8 +428,267 @@ class FakeRedis @Inject constructor(
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
-    throw NotImplementedError("Fake client not implemented for this operation")
+    throw NotImplementedError("Use pipelining instead.")
+  }
+
+  override fun pipelining(block: DeferredRedis.() -> Unit) {
+    FakePipelinedRedis().block()
+  }
+
+  /**
+   * A poor implementation of pipelining for testing purposes.
+   * Unlike a real pipeline, this does not queue commands.
+   */
+  inner class FakePipelinedRedis : DeferredRedis {
+    override fun del(key: String): Supplier<Boolean> = Supplier { this@FakeRedis.del(key) }
+
+    override fun del(vararg keys: String): Supplier<Int> = Supplier { this@FakeRedis.del(*keys) }
+
+    override fun mget(vararg keys: String): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.mget(*keys)
+    }
+
+    override fun mset(vararg keyValues: ByteString): Supplier<Unit> = Supplier {
+      this@FakeRedis.mset(*keyValues)
+    }
+
+    override fun get(key: String): Supplier<ByteString?> = Supplier { this@FakeRedis[key] }
+
+    override fun getDel(key: String): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.getDel(key)
+    }
+
+    override fun hdel(key: String, vararg fields: String): Supplier<Long> = Supplier {
+      this@FakeRedis.hdel(key, *fields)
+    }
+
+    override fun hget(key: String, field: String): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.hget(key, field)
+    }
+
+    override fun hgetAll(key: String): Supplier<Map<String, ByteString>?> = Supplier {
+      this@FakeRedis.hgetAll(key)
+    }
+
+    override fun hlen(key: String): Supplier<Long> = Supplier {
+      this@FakeRedis.hlen(key)
+    }
+
+    override fun hmget(
+      key: String,
+      vararg fields: String
+    ): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.hmget(key, *fields)
+    }
+
+    override fun hincrBy(
+      key: String,
+      field: String,
+      increment: Long
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.hincrBy(key, field, increment)
+    }
+
+    override fun hrandFieldWithValues(
+      key: String,
+      count: Long
+    ): Supplier<Map<String, ByteString>?> = Supplier {
+      this@FakeRedis.hrandFieldWithValues(key, count)
+    }
+
+    override fun hrandField(key: String, count: Long): Supplier<List<String>> = Supplier {
+      this@FakeRedis.hrandField(key, count)
+    }
+
+    override fun set(key: String, value: ByteString): Supplier<Unit> = Supplier {
+      this@FakeRedis[key] = value
+    }
+
+    override fun set(
+      key: String,
+      expiryDuration: Duration,
+      value: ByteString
+    ): Supplier<Unit> = Supplier {
+      this@FakeRedis[key, expiryDuration] = value
+    }
+
+    override fun setnx(key: String, value: ByteString): Supplier<Boolean> = Supplier {
+      this@FakeRedis.setnx(key, value)
+    }
+
+    override fun setnx(
+      key: String,
+      expiryDuration: Duration,
+      value: ByteString
+    ): Supplier<Boolean> = Supplier {
+      this@FakeRedis.setnx(key, expiryDuration, value)
+    }
+
+    override fun hset(key: String, field: String, value: ByteString): Supplier<Long> = Supplier {
+      this@FakeRedis.hset(key, field, value)
+    }
+
+    override fun hset(key: String, hash: Map<String, ByteString>): Supplier<Long> = Supplier {
+      this@FakeRedis.hset(key, hash)
+    }
+
+    override fun incr(key: String): Supplier<Long> = Supplier {
+      this@FakeRedis.incr(key)
+    }
+
+    override fun incrBy(key: String, increment: Long): Supplier<Long> = Supplier {
+      this@FakeRedis.incrBy(key, increment)
+    }
+
+    override fun blmove(
+      sourceKey: String,
+      destinationKey: String,
+      from: ListDirection,
+      to: ListDirection,
+      timeoutSeconds: Double
+    ): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.blmove(sourceKey, destinationKey, from, to, timeoutSeconds)
+    }
+
+    override fun brpoplpush(
+      sourceKey: String,
+      destinationKey: String,
+      timeoutSeconds: Int
+    ): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.brpoplpush(sourceKey, destinationKey, timeoutSeconds)
+    }
+
+    override fun lmove(
+      sourceKey: String,
+      destinationKey: String,
+      from: ListDirection,
+      to: ListDirection
+    ): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.lmove(sourceKey, destinationKey, from, to)
+    }
+
+    override fun lpush(key: String, vararg elements: ByteString): Supplier<Long> = Supplier {
+      this@FakeRedis.lpush(key, *elements)
+    }
+
+    override fun rpush(key: String, vararg elements: ByteString): Supplier<Long> = Supplier {
+      this@FakeRedis.rpush(key, *elements)
+    }
+
+    override fun lpop(key: String, count: Int): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.lpop(key, count)
+    }
+
+    override fun lpop(key: String): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.lpop(key)
+    }
+
+    override fun rpop(key: String, count: Int): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.rpop(key, count)
+    }
+
+    override fun rpop(key: String): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.rpop(key)
+    }
+
+    override fun lrange(
+      key: String,
+      start: Long,
+      stop: Long
+    ): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.lrange(key, start, stop)
+    }
+
+    override fun lrem(key: String, count: Long, element: ByteString): Supplier<Long> = Supplier {
+      this@FakeRedis.lrem(key, count, element)
+    }
+
+    override fun rpoplpush(
+      sourceKey: String,
+      destinationKey: String
+    ): Supplier<ByteString?> = Supplier {
+      this@FakeRedis.rpoplpush(sourceKey, destinationKey)
+    }
+
+    override fun expire(key: String, seconds: Long): Supplier<Boolean> = Supplier {
+      this@FakeRedis.expire(key, seconds)
+    }
+
+    override fun expireAt(key: String, timestampSeconds: Long): Supplier<Boolean> = Supplier {
+      this@FakeRedis.expireAt(key, timestampSeconds)
+    }
+
+    override fun pExpire(key: String, milliseconds: Long): Supplier<Boolean> = Supplier {
+      this@FakeRedis.pExpire(key, milliseconds)
+    }
+
+    override fun pExpireAt(
+      key: String,
+      timestampMilliseconds: Long
+    ): Supplier<Boolean> = Supplier {
+      this@FakeRedis.pExpireAt(key, timestampMilliseconds)
+    }
+
+    override fun close() {
+      // No-op.
+    }
+
+    override fun zadd(
+      key: String,
+      score: Double,
+      member: String,
+      vararg options: Redis.ZAddOptions
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zadd(key, score, member, *options)
+    }
+
+    override fun zadd(
+      key: String,
+      scoreMembers: Map<String, Double>,
+      vararg options: Redis.ZAddOptions
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zadd(key, scoreMembers, *options)
+    }
+
+    override fun zscore(key: String, member: String): Supplier<Double?> = Supplier {
+      this@FakeRedis.zscore(key, member)
+    }
+
+    override fun zrange(
+      key: String,
+      type: ZRangeType,
+      start: ZRangeMarker,
+      stop: ZRangeMarker,
+      reverse: Boolean,
+      limit: ZRangeLimit?
+    ): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.zrange(key, type, start, stop, reverse, limit)
+    }
+
+    override fun zrangeWithScores(
+      key: String,
+      type: ZRangeType,
+      start: ZRangeMarker,
+      stop: ZRangeMarker,
+      reverse: Boolean,
+      limit: ZRangeLimit?
+    ): Supplier<List<Pair<ByteString?, Double>>> = Supplier {
+      this@FakeRedis.zrangeWithScores(key, type, start, stop, reverse, limit)
+    }
+
+    override fun zremRangeByRank(
+      key: String,
+      start: ZRangeRankMarker,
+      stop: ZRangeRankMarker
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zremRangeByRank(key, start, stop)
+    }
+
+    override fun zcard(key: String): Supplier<Long> = Supplier {
+      this@FakeRedis.zcard(key)
+    }
   }
 
   override fun close() {
@@ -505,14 +766,14 @@ class FakeRedis @Inject constructor(
     score: Double,
     exists: Boolean,
     zaddOptions: Set<Redis.ZAddOptions>
-  ) : Boolean {
+  ): Boolean {
     val options = zaddOptions.filter { it != CH }
     // default without any options
     if (options.isEmpty()) return true
 
     // all valid single options.
     if ((options.size == 1)
-        && (((options[0] == XX) && exists)
+      && (((options[0] == XX) && exists)
         || ((options[0] == NX) && !exists)
         || ((options[0] == LT) && ((exists && score < currentScore!!) || !exists))
         || ((options[0] == GT) && ((exists && score > currentScore!!) || !exists)))
@@ -568,8 +829,7 @@ class FakeRedis @Inject constructor(
     scoreMembers: Map<String, Double>,
     vararg options: Redis.ZAddOptions
   ): Long {
-    return scoreMembers.entries.sumOf {
-      (member, score) ->
+    return scoreMembers.entries.sumOf { (member, score) ->
       zadd(key, score, member, options.toSet())
     }
   }
@@ -577,7 +837,7 @@ class FakeRedis @Inject constructor(
   override fun zscore(key: String, member: String): Double? {
     if (sortedSetKeyValueStore[key] == null) return null
 
-    var currentScore:Double? = null
+    var currentScore: Double? = null
     for (entries in sortedSetKeyValueStore[key]!!.data.entries) {
       if (entries.value.contains(member)) {
         currentScore = entries.key
@@ -597,7 +857,7 @@ class FakeRedis @Inject constructor(
     limit: ZRangeLimit?,
   ): List<ByteString?> {
     return zrangeWithScores(key, type, start, stop, reverse, limit)
-      .map { (member, _) ->  member }.toList()
+      .map { (member, _) -> member }.toList()
   }
 
   override fun zrangeWithScores(
@@ -610,7 +870,7 @@ class FakeRedis @Inject constructor(
   ): List<Pair<ByteString?, Double>> {
     val sortedSet = sortedSetKeyValueStore[key]?.data?.toSortedMap() ?: return listOf()
 
-    val ansWithScore = when(type) {
+    val ansWithScore = when (type) {
       ZRangeType.INDEX ->
         zrangeByIndex(
           sortedSet = sortedSet,
@@ -618,6 +878,7 @@ class FakeRedis @Inject constructor(
           stop = stop as ZRangeIndexMarker,
           reverse = reverse
         )
+
       ZRangeType.SCORE ->
         zrangeByScore(
           sortedSet = sortedSet,
@@ -646,7 +907,7 @@ class FakeRedis @Inject constructor(
     var ctr = 0
     var added = 0
 
-    val newSortedSet:SortedMap<Double, HashSet<String>> = sortedMapOf()
+    val newSortedSet: SortedMap<Double, HashSet<String>> = sortedMapOf()
 
     for (idx in scores.indices) {
       val score = scores[idx]
@@ -665,7 +926,7 @@ class FakeRedis @Inject constructor(
 
     sortedSetKeyValueStore[key] = Value(data = newSortedSet, expiryInstant = Instant.MAX)
 
-    return (length-added)
+    return (length - added)
   }
 
   override fun zcard(
@@ -681,7 +942,7 @@ class FakeRedis @Inject constructor(
     sortedSet: SortedMap<Double, HashSet<String>>,
     start: Long,
     stop: Long,
-  ) : Triple<Long, Long, Long> {
+  ): Triple<Long, Long, Long> {
     var min = start
     var max = stop
     var length = 0L
@@ -689,11 +950,11 @@ class FakeRedis @Inject constructor(
 
     if (min < -length) min = -length
     if (min < 0) min += length
-    if (min > length-1) min = length-1
+    if (min > length - 1) min = length - 1
 
     if (max < -length) max = -length
     if (max < 0) max += length
-    if (max > length-1) max = length-1
+    if (max > length - 1) max = length - 1
 
     return Triple(min, max, length)
   }
@@ -760,7 +1021,7 @@ class FakeRedis @Inject constructor(
       count = limit.count
     }
 
-    if  (count < 0) count = Int.MAX_VALUE
+    if (count < 0) count = Int.MAX_VALUE
 
     val filteredScores = scores.filter { it.cmp() }
 

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -502,28 +502,25 @@ class FakeRedis @Inject constructor(
       this@FakeRedis.hrandField(key, count)
     }
 
-    override fun set(key: String, value: ByteString): Supplier<Unit> = Supplier {
-      this@FakeRedis[key] = value
+    override fun set(key: String, value: ByteString, expiryDuration: Duration?): Supplier<Unit> = Supplier {
+      if (expiryDuration == null) {
+        this@FakeRedis[key] = value
+      } else {
+        this@FakeRedis[key, expiryDuration] = value
+      }
     }
 
-    override fun set(
-      key: String,
-      expiryDuration: Duration,
-      value: ByteString
-    ): Supplier<Unit> = Supplier {
-      this@FakeRedis[key, expiryDuration] = value
-    }
-
-    override fun setnx(key: String, value: ByteString): Supplier<Boolean> = Supplier {
-      this@FakeRedis.setnx(key, value)
-    }
 
     override fun setnx(
       key: String,
-      expiryDuration: Duration,
-      value: ByteString
+      value: ByteString,
+      expiryDuration: Duration?
     ): Supplier<Boolean> = Supplier {
-      this@FakeRedis.setnx(key, expiryDuration, value)
+      if (expiryDuration == null) {
+        this@FakeRedis.setnx(key, value)
+      } else {
+        this@FakeRedis.setnx(key, expiryDuration, value)
+      }
     }
 
     override fun hset(key: String, field: String, value: ByteString): Supplier<Long> = Supplier {


### PR DESCRIPTION
Add a `pipelining { }` method to misk redis, and deprecate the old `pipelined()` one.

**Why?**

1. `pipelined()` is broken in cluster-mode Redis, because the backing cluster implementation in Jedis does not return a `Pipeline`, it returns a `ClusterPipeline`, which are not compatible. Attempts to use `pipelined()` in a cluster-mode configuration will always result in a class cast exception.
2. `pipelined()` exposes the Jedis implementation details of misk-redis. This results in a subpar experience, as the Jedis APIs and misk-redis APIs are not compatible.

**How do I use this?**

Pipelining Redis commands can be done to improve efficiency, reducing round-trip time while talking to the redis server.

`DeferredRedis` commands always give back a Supplier, which can be read after the `pipelining` is complete.

```kt
val results = mutableListOf<Supplier<*>>
redis.piplining { 
  // This is a DeferredRedis. You can call all supported Redis commands on it.
  // Backing Jedis implementation details are 100% hidden in this scope.
  set("{customer:1}.name", "Luke SkyWalker")
  set("{customer:1}.team", "Light")
  incrBy("{customer:1}.movies_appearances", 9)
  results += mget("{customer:2}.name", "{customer:2}.team")
  // Note: It is an error to read the result of a command before the pipeline finishes.
  // ...
}
results.forEach { 
  it.get() 
  // Do something with a result.
  // Note that get() can throw, ex. if you do an incorrect operation on the wrong key type.
}
```

