### PR TITLE
Replace synchronized with ReentrantLock in SynchronizedLazy

### DIFF
--- a/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
@@ -1,5 +1,8 @@
 package misk.scope
 
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
 private object UNINITIALIZED_VALUE
 
 internal class SynchronizedLazy(
@@ -8,13 +11,15 @@ internal class SynchronizedLazy(
   @Volatile
   private var _value: Any? = UNINITIALIZED_VALUE
 
+  private val lock = ReentrantLock()
+
   override val value: Any?
     get() {
       if (_value !== UNINITIALIZED_VALUE) {
         return _value
       }
 
-      return synchronized(this) {
+      return lock.withLock {
         val existingValue = _value
         if (existingValue != UNINITIALIZED_VALUE) {
           existingValue


### PR DESCRIPTION
Using a `synchronized` block can cause pinning when using virtual threads. We're better to use a proper `Lock` here instead, which doesn't really impact the code that much anyway.