### PR TITLE
Partial revert of config change in #3203

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisPooledWithMetrics.kt
@@ -34,7 +34,10 @@ private class ConnectionFactoryWithMetrics(
   requiresPassword: Boolean = true,
 ) : ConnectionFactory(
   HostAndPort(
-    replicationGroupConfig.writer_endpoint.hostname?.takeUnless { it.isBlank() } ?: System.getenv("REDIS_HOST") ?: "127.0.0.1",
+    replicationGroupConfig.writer_endpoint.hostname?.takeUnless {
+      @Suppress("UselessCallOnNotNull")
+      it.isNullOrBlank() // This might actually be nullable?
+    } ?: System.getenv("REDIS_HOST") ?: "127.0.0.1",
     replicationGroupConfig.writer_endpoint.port
   ),
   createJedisClientConfig(replicationGroupConfig, ssl, requiresPassword),


### PR DESCRIPTION
Getting some reports of errors related to redis `writer_endpoint` config after this change landed, so reverting this back to `isNullOrBlank` out of precaution.