### PR TITLE
Downgrade logger.error to logger.warn in HibernateHealthCheck.

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
@@ -32,7 +32,7 @@ internal class HibernateHealthCheck(
         session.createNativeQuery("SELECT NOW()").uniqueResult() as Timestamp
       }.toInstant()
     } catch (e: Exception) {
-      logger.error(e) { "error performing hibernate health check" }
+      logger.warn(e) { "error performing hibernate health check" }
       return HealthStatus.unhealthy("Hibernate: failed to query ${qualifier.simpleName} database")
     }
 


### PR DESCRIPTION
In the context of the health check being executed, it seems unnecessary for exceptions here to be logged as an error.