### PR TITLE
(DNM) Revert "Simplify misk-redis implementation (#3198)"

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6192,38 +6192,6 @@ acceptedBreaks:
       old: "parameter void misk.redis.RealPipelinedRedis::<init>(===misk.redis.JedisPipeline===)"
       new: "parameter void misk.redis.RealPipelinedRedis::<init>(===redis.clients.jedis.AbstractPipeline===)"
       justification: "RealPipelinedRedis is internal"
-  "2024.03.26.112919-01b20b7":
-    com.squareup.misk:misk-redis:
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.lang.Double> misk.redis.DeferredRedis::zscore(java.lang.String,\
-        \ java.lang.String)"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.lang.Long> misk.redis.DeferredRedis::zadd(java.lang.String,\
-        \ double, java.lang.String, misk.redis.Redis.ZAddOptions[])"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.lang.Long> misk.redis.DeferredRedis::zadd(java.lang.String,\
-        \ java.util.Map<java.lang.String, java.lang.Double>, misk.redis.Redis.ZAddOptions[])"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.lang.Long> misk.redis.DeferredRedis::zcard(java.lang.String)"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.lang.Long> misk.redis.DeferredRedis::zremRangeByRank(java.lang.String,\
-        \ misk.redis.Redis.ZRangeRankMarker, misk.redis.Redis.ZRangeRankMarker)"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.util.List<kotlin.Pair<okio.ByteString,\
-        \ java.lang.Double>>> misk.redis.DeferredRedis::zrangeWithScores(java.lang.String,\
-        \ misk.redis.Redis.ZRangeType, misk.redis.Redis.ZRangeMarker, misk.redis.Redis.ZRangeMarker,\
-        \ boolean, misk.redis.Redis.ZRangeLimit)"
-      justification: "Additive change only"
-    - code: "java.method.addedToInterface"
-      new: "method java.util.function.Supplier<java.util.List<okio.ByteString>> misk.redis.DeferredRedis::zrange(java.lang.String,\
-        \ misk.redis.Redis.ZRangeType, misk.redis.Redis.ZRangeMarker, misk.redis.Redis.ZRangeMarker,\
-        \ boolean, misk.redis.Redis.ZRangeLimit)"
-      justification: "Additive change only"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -36,20 +36,11 @@ public abstract interface class misk/redis/DeferredRedis {
 	public abstract fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
 	public abstract fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
 	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
-	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
-	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
-	public abstract fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
-	public abstract fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
-	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
-	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
-	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
 public final class misk/redis/DeferredRedis$DefaultImpls {
 	public static synthetic fun set$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
 	public static synthetic fun setnx$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
-	public static synthetic fun zrange$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
-	public static synthetic fun zrangeWithScores$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
 }
 
 public final class misk/redis/FakeRedis : misk/redis/Redis {
@@ -601,13 +592,6 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 	public fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
 	public fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
-	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
-	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
-	public fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
-	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
-	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
-	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
-	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -97,49 +97,5 @@ interface DeferredRedis {
 
   fun pExpireAt(key: String, timestampMilliseconds: Long): Supplier<Boolean>
 
-  fun zadd(
-    key: String,
-    score: Double,
-    member: String,
-    vararg options: Redis.ZAddOptions
-  ): Supplier<Long>
-
-  fun zadd(
-    key: String,
-    scoreMembers: Map<String, Double>,
-    vararg options: Redis.ZAddOptions
-  ): Supplier<Long>
-
-  fun zscore(
-    key: String,
-    member: String
-  ): Supplier<Double?>
-
-  fun zrange(
-    key: String,
-    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
-    start: Redis.ZRangeMarker,
-    stop: Redis.ZRangeMarker,
-    reverse: Boolean = false,
-    limit: Redis.ZRangeLimit? = null,
-  ): Supplier<List<ByteString?>>
-
-  fun zrangeWithScores(
-    key: String,
-    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
-    start: Redis.ZRangeMarker,
-    stop: Redis.ZRangeMarker,
-    reverse: Boolean = false,
-    limit: Redis.ZRangeLimit? = null,
-  ): Supplier<List<Pair<ByteString?, Double>>>
-
-  fun zremRangeByRank(
-    key: String,
-    start: Redis.ZRangeRankMarker,
-    stop: Redis.ZRangeRankMarker,
-  ): Supplier<Long>
-
-  fun zcard(key: String): Supplier<Long>
-
   fun close()
 }

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -4,7 +4,9 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import redis.clients.jedis.AbstractPipeline
 import redis.clients.jedis.ClusterPipeline
+import redis.clients.jedis.Jedis
 import redis.clients.jedis.Pipeline
+import redis.clients.jedis.PipelineBase
 import redis.clients.jedis.Response
 import redis.clients.jedis.args.ListDirection
 import redis.clients.jedis.params.SetParams
@@ -25,7 +27,7 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     } else {
       RuntimeException(
         """
-          |When using clustered Redis, keys used by one $op command must always map to the same slot, but mapped to slots $slots.
+          |When using clustered Redis, keys used by one $op command in a pipeline must always map to the same slot, but mapped to slots $slots.
           |You can use {hashtags} in your key name to control how Redis hashes keys to slots.
           |For example, keys: `{customer9001}.contacts` and `{customer9001}.payments` will  hash to the same slot.
           |
@@ -52,7 +54,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
             pipeline.del(*slottedKeys.toTypedArray())
           }
       }
-
       else -> error("Unknown pipeline type: $pipeline")
     }
     return Supplier {
@@ -70,7 +71,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
         val response = pipeline.mget(*keysBytes)
         Supplier { response.get().map { it?.toByteString() } }
       }
-
       is ClusterPipeline -> {
         val responses = keysBytes.groupBy { JedisClusterCRC16.getSlot(it) }
           .mapValues { (_, slottedKeys) ->
@@ -90,7 +90,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
           keys.map { keyToValueMap[it] }
         }
       }
-
       else -> error("Unknown pipeline type: $pipeline")
     }
   }
@@ -110,7 +109,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
             pipeline.mset(*slottedKeyValues.flatten().toTypedArray())
           }
       }
-
       else -> error("Unknown pipeline type: $pipeline")
     }
     return Supplier { responses.map { it.get() } }
@@ -370,188 +368,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     val keyBytes = key.toByteArray(charset)
     val response = pipeline.pexpireAt(keyBytes, timestampMilliseconds)
     return Supplier { response.get() == 1L }
-  }
-
-  override fun zadd(
-    key: String,
-    score: Double,
-    member: String,
-    vararg options: Redis.ZAddOptions,
-  ): Supplier<Long> {
-    Redis.ZAddOptions.verify(options)
-    val keyBytes = key.toByteArray(charset)
-    val memberBytes = member.toByteArray(charset)
-    val params = Redis.ZAddOptions.getZAddParams(options)
-    val response = pipeline.zadd(keyBytes, score, memberBytes, params)
-    return Supplier { response.get() }
-  }
-
-  override fun zadd(
-    key: String,
-    scoreMembers: Map<String, Double>,
-    vararg options: Redis.ZAddOptions,
-  ): Supplier<Long> {
-    Redis.ZAddOptions.verify(options)
-    val keyBytes = key.toByteArray(charset)
-    val scoreMembersBytes = scoreMembers.mapKeys { it.key.toByteArray(charset) }
-    val params = Redis.ZAddOptions.getZAddParams(options)
-    val response = pipeline.zadd(keyBytes, scoreMembersBytes, params)
-    return Supplier { response.get() }
-  }
-
-  override fun zscore(key: String, member: String): Supplier<Double?> {
-    val keyBytes = key.toByteArray(charset)
-    val memberBytes = member.toByteArray(charset)
-    val response = pipeline.zscore(keyBytes, memberBytes)
-    return Supplier { response.get() }
-  }
-
-  override fun zrange(
-    key: String,
-    type: Redis.ZRangeType,
-    start: Redis.ZRangeMarker,
-    stop: Redis.ZRangeMarker,
-    reverse: Boolean,
-    limit: Redis.ZRangeLimit?
-  ): Supplier<List<ByteString?>> {
-    val response = zrangeBase(key, type, start, stop, reverse, false, limit).noScore
-    return Supplier {
-      response?.get()?.map { bytes -> bytes?.toByteString() } ?: listOf()
-    }
-  }
-
-  override fun zrangeWithScores(
-    key: String,
-    type: Redis.ZRangeType,
-    start: Redis.ZRangeMarker,
-    stop: Redis.ZRangeMarker,
-    reverse: Boolean,
-    limit: Redis.ZRangeLimit?
-  ): Supplier<List<Pair<ByteString?, Double>>> {
-    val response = zrangeBase(key, type, start, stop, reverse, true, limit).withScore
-    return Supplier {
-      response?.get()?.map { tuple -> Pair(tuple.binaryElement?.toByteString(), tuple.score) } ?: listOf()
-    }
-  }
-
-  override fun zremRangeByRank(
-    key: String,
-    start: Redis.ZRangeRankMarker,
-    stop: Redis.ZRangeRankMarker
-  ): Supplier<Long> {
-    val response = pipeline.zremrangeByRank(key, start.longValue, stop.longValue)
-    return Supplier { response.get() }
-  }
-
-  override fun zcard(key: String): Supplier<Long> {
-    val response = pipeline.zcard(key)
-    return Supplier { response.get() }
-  }
-
-  private fun zrangeBase(
-    key: String,
-    type: Redis.ZRangeType,
-    start: Redis.ZRangeMarker,
-    stop: Redis.ZRangeMarker,
-    reverse: Boolean,
-    withScore: Boolean,
-    limit: Redis.ZRangeLimit?,
-  ): ZRangeResponse {
-    return when (type) {
-      Redis.ZRangeType.INDEX ->
-        zrangeByIndex(
-          key = key,
-          start = start as Redis.ZRangeIndexMarker,
-          stop = stop as Redis.ZRangeIndexMarker,
-          reverse = reverse,
-          withScore = withScore
-        )
-
-      Redis.ZRangeType.SCORE ->
-        zrangeByScore(
-          key = key,
-          start = start as Redis.ZRangeScoreMarker,
-          stop = stop as Redis.ZRangeScoreMarker,
-          reverse = reverse,
-          withScore = withScore,
-          limit = limit
-        )
-    }
-  }
-
-  private fun zrangeByIndex(
-    key: String,
-    start: Redis.ZRangeIndexMarker,
-    stop: Redis.ZRangeIndexMarker,
-    reverse: Boolean,
-    withScore: Boolean
-  ): ZRangeResponse {
-    val params = ZRangeParams(
-      start.intValue,
-      stop.intValue
-    )
-    if (reverse) params.rev()
-
-    return if (withScore) {
-      ZRangeResponse.withScore(pipeline.zrangeWithScores(key.toByteArray(charset), params))
-    } else {
-      ZRangeResponse.noScore(pipeline.zrange(key.toByteArray(charset), params))
-    }
-  }
-
-  private fun zrangeByScore(
-    key: String,
-    start: Redis.ZRangeScoreMarker,
-    stop: Redis.ZRangeScoreMarker,
-    reverse: Boolean,
-    withScore: Boolean,
-    limit: Redis.ZRangeLimit?,
-  ): ZRangeResponse {
-    val min = start.toString().toByteArray(charset)
-    val max = stop.toString().toByteArray(charset)
-    val keyBytes = key.toByteArray(charset)
-
-    return if (limit == null && !reverse && !withScore) {
-      ZRangeResponse.noScore(pipeline.zrangeByScore(keyBytes, min, max))
-    } else if (limit == null && !reverse) {
-      ZRangeResponse.withScore(pipeline.zrangeByScoreWithScores(keyBytes, min, max)
-      )
-    } else if (limit == null && !withScore) {
-      ZRangeResponse.noScore(pipeline.zrevrangeByScore(keyBytes, max, min)
-      )
-    } else if (limit == null) {
-      ZRangeResponse.withScore(pipeline.zrevrangeByScoreWithScores(keyBytes, max, min)
-      )
-    } else if (!reverse && !withScore) {
-      ZRangeResponse.noScore(pipeline.zrangeByScore(keyBytes, min, max, limit.offset, limit.count)
-      )
-    } else if (!reverse) {
-      ZRangeResponse.withScore(
-        pipeline.zrangeByScoreWithScores(keyBytes, min, max, limit.offset, limit.count)
-      )
-    } else if (!withScore) {
-      ZRangeResponse.noScore(
-        pipeline.zrevrangeByScore(keyBytes, max, min, limit.offset, limit.count)
-      )
-    } else {
-      ZRangeResponse.withScore(
-        pipeline.zrevrangeByScoreWithScores(keyBytes, max, min, limit.offset, limit.count)
-      )
-    }
-  }
-
-  /**
-   * A wrapper class for handling response from zrange* methods.
-   */
-  private class ZRangeResponse private constructor(
-    val noScore: Response<List<ByteArray?>>?,
-    val withScore: Response<List<Tuple>>?
-  ) {
-    companion object {
-      fun noScore(ans: Response<List<ByteArray?>>?): ZRangeResponse = ZRangeResponse(ans, null)
-
-      fun withScore(ans: Response<List<Tuple>>?): ZRangeResponse = ZRangeResponse(null, ans)
-    }
   }
 
   override fun close() {

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -1,79 +1,156 @@
 package misk.redis
 
 import misk.redis.Redis.ZAddOptions
+import misk.redis.Redis.ZRangeIndexMarker
 import misk.redis.Redis.ZRangeLimit
 import misk.redis.Redis.ZRangeMarker
 import misk.redis.Redis.ZRangeRankMarker
+import misk.redis.Redis.ZRangeScoreMarker
 import misk.redis.Redis.ZRangeType
 import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import redis.clients.jedis.JedisCluster
 import redis.clients.jedis.JedisPooled
 import redis.clients.jedis.JedisPubSub
 import redis.clients.jedis.Pipeline
 import redis.clients.jedis.Transaction
 import redis.clients.jedis.UnifiedJedis
 import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.commands.JedisBinaryCommands
+import redis.clients.jedis.params.SetParams
+import redis.clients.jedis.params.ZRangeParams
+import redis.clients.jedis.resps.Tuple
+import redis.clients.jedis.util.JedisClusterCRC16
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 import java.time.Duration
+import kotlin.reflect.cast
 
 /**
- * A Redis client implementation with metrics. Supports pooled connections and clustered Redis.
- *
- * Install this to your service using the [RedisModule], and configure it with a [RedisConfig].
- *
- * Note: To keep the implementation simple, this client always defers to [RealPipelinedRedis],
- * even if there is only one command.
- *
- * If you have to issue multiple commands in a row, use [pipelining] to batch them together.
+ * For each command, a Jedis instance is retrieved from the pool and returned once the command has
+ * been issued.
  */
 class RealRedis(
   private val unifiedJedis: UnifiedJedis,
   private val clientMetrics: RedisClientMetrics,
 ) : Redis {
-  override fun del(key: String): Boolean = withMetrics("del") {
-    runPipeline { del(key) }.get()
+  override fun del(key: String): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { del(keyBytes) == 1L }
   }
 
-  override fun del(vararg keys: String): Int = withMetrics("del") {
-    runPipeline { del(*keys) }.get()
+  override fun del(vararg keys: String): Int {
+    return when (unifiedJedis) {
+      is JedisPooled -> {
+        val keysAsBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+        jedis { unifiedJedis.del(*keysAsBytes) }.toInt()
+      }
+
+      is JedisCluster -> {
+        // JedisCluster does not support multi-key del, so we need to group by slot and perform del for each slot
+        keys.groupBy { JedisClusterCRC16.getSlot(it) }
+          .map { (_, slotKeys) -> jedis { unifiedJedis.del(*slotKeys.toTypedArray()) } }
+          .sumOf { it.toInt() }
+      }
+
+      else -> throw RuntimeException("Unsupported UnifiedJedis implementation ${unifiedJedis.javaClass}")
+    }
   }
 
-  override fun mget(vararg keys: String): List<ByteString?> = withMetrics("mget") {
-    runPipeline { mget(*keys) }.get()
+  override fun mget(vararg keys: String): List<ByteString?> {
+    return when (unifiedJedis) {
+      is JedisPooled -> {
+        val keysAsBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
+        jedis { unifiedJedis.mget(*keysAsBytes) }.map { it?.toByteString() }
+      }
+
+      is JedisCluster -> {
+        // JedisCluster does not support multi-key mget, so we need to group by slot and perform mget for each slot
+        val keyToValueMap = mutableMapOf<String, ByteString?>()
+        keys.groupBy { JedisClusterCRC16.getSlot(it) }
+          .flatMap { (_, slotKeys) ->
+            val result = jedis { unifiedJedis.mget(*slotKeys.toTypedArray()) }
+            slotKeys.zip(result)
+          }.forEach { (key, value) ->
+            keyToValueMap[key] = value?.toByteArray(charset)?.toByteString()
+          }
+        keys.map { keyToValueMap[it] }
+      }
+
+      else -> throw RuntimeException("Unsupported UnifiedJedis implementation ${unifiedJedis.javaClass}")
+    }
+
   }
 
-  override fun mset(vararg keyValues: ByteString) = withMetrics("mset") {
-    runPipeline { mset(*keyValues) }.get()
+  override fun mset(vararg keyValues: ByteString) {
+    require(keyValues.size % 2 == 0) {
+      "Wrong number of arguments to mset (must be a multiple of 2, alternating keys and values)"
+    }
+    when (unifiedJedis) {
+      is JedisPooled -> {
+        val byteArrays = keyValues.map { it.toByteArray() }.toTypedArray()
+        return jedis { unifiedJedis.mset(*byteArrays) }
+      }
+
+      is JedisCluster -> {
+        // JedisCluster does not support multi-key mset, so we need to group by slot and perform mset for each slot
+        keyValues.toList().chunked(2).groupBy { JedisClusterCRC16.getSlot(it[0].toByteArray()) }
+          .forEach { (_, slotKeys) ->
+            jedis { unifiedJedis.mset(*slotKeys.flatten().map { it.toByteArray() }.toTypedArray()) }
+          }
+      }
+
+      else -> throw RuntimeException("Unsupported UnifiedJedis implementation ${unifiedJedis.javaClass}")
+    }
   }
 
-  override fun get(key: String): ByteString? = withMetrics("get") {
-    runPipeline { get(key) }.get()
+  override fun get(key: String): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { get(keyBytes) }?.toByteString()
   }
 
-  override fun getDel(key: String): ByteString? = withMetrics("getDel") {
-    runPipeline { getDel(key) }.get()
+  override fun getDel(key: String): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { getDel(keyBytes) }?.toByteString()
   }
 
-  override fun hdel(key: String, vararg fields: String): Long = withMetrics("hdel") {
-    runPipeline { hdel(key, *fields) }.get()
+  override fun hdel(key: String, vararg fields: String): Long {
+    val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hdel(keyBytes, *fieldsAsByteArrays) }
   }
 
-  override fun hgetAll(key: String): Map<String, ByteString>? = withMetrics("hgetAll") {
-    runPipeline { hgetAll(key) }.get()
+  override fun hgetAll(key: String): Map<String, ByteString>? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hgetAll(keyBytes) }
+      ?.mapKeys { it.key.toString(charset) }
+      ?.mapValues { it.value.toByteString() }
   }
 
-  override fun hlen(key: String): Long = withMetrics("hlen") {
-    runPipeline { hlen(key) }.get()
+  override fun hlen(key: String): Long {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hlen(keyBytes) }
   }
 
-  override fun hmget(key: String, vararg fields: String): List<ByteString?> = withMetrics("hmget") {
-    runPipeline { hmget(key, *fields) }.get()
+  override fun hmget(key: String, vararg fields: String): List<ByteString?> {
+    val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hmget(keyBytes, *fieldsAsByteArrays) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
-  override fun hget(key: String, field: String): ByteString? = withMetrics("hget") {
-    runPipeline { hget(key, field) }.get()
+  override fun hget(key: String, field: String): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    return jedis { hget(keyBytes, fieldBytes) }?.toByteString()
   }
 
-  override fun hincrBy(key: String, field: String, increment: Long): Long = withMetrics("hincrBy") {
-    runPipeline { hincrBy(key, field, increment) }.get()
+  override fun hincrBy(key: String, field: String, increment: Long): Long {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    return jedis { hincrBy(keyBytes, fieldBytes, increment) }
   }
 
   /**
@@ -81,11 +158,11 @@ class RealRedis(
    *
    * See [misk.redis.Redis.hrandFieldWithValues].
    */
-  override fun hrandFieldWithValues(
-    key: String,
-    count: Long
-  ): Map<String, ByteString>? = withMetrics("hrandFieldWithValues") {
-    runPipeline { hrandFieldWithValues(key, count) }.get()
+  override fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>? {
+    checkHrandFieldCount(count)
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hrandfieldWithValues(keyBytes, count) }
+      .associate { it.key.toString(charset) to it.value.toByteString() }
   }
 
   /**
@@ -93,44 +170,59 @@ class RealRedis(
    *
    * See [misk.redis.Redis.hrandField].
    */
-  override fun hrandField(key: String, count: Long): List<String> = withMetrics("hrandField") {
-    runPipeline { hrandField(key, count) }.get()
+  override fun hrandField(key: String, count: Long): List<String> {
+    checkHrandFieldCount(count)
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hrandfield(keyBytes, count) }
+      .map { it.toString(charset) }
   }
 
-  override fun set(key: String, value: ByteString) = withMetrics("set") {
-    runPipeline { set(key, value) }.get()
+  override fun set(key: String, value: ByteString) {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    jedis { set(keyBytes, valueBytes) }
   }
 
-  override fun set(key: String, expiryDuration: Duration, value: ByteString) = withMetrics("set") {
-    runPipeline { set(key, value, expiryDuration) }.get()
+  override fun set(key: String, expiryDuration: Duration, value: ByteString) {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    jedis { setex(keyBytes, expiryDuration.seconds, valueBytes) }
   }
 
-  override fun setnx(key: String, value: ByteString): Boolean = withMetrics("setnx") {
-    runPipeline { setnx(key, value) }.get()
+  override fun setnx(key: String, value: ByteString): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    return jedis { setnx(keyBytes, valueBytes) == 1L }
   }
 
-  override fun setnx(
-    key: String,
-    expiryDuration: Duration,
-    value: ByteString
-  ): Boolean = withMetrics("setnx") {
-    runPipeline { setnx(key, value, expiryDuration) }.get()
+  override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    val params = SetParams().nx().px(expiryDuration.toMillis())
+    return jedis { set(keyBytes, valueBytes, params) == "OK" }
   }
 
-  override fun hset(key: String, field: String, value: ByteString): Long = withMetrics("hset") {
-    runPipeline { hset(key, field, value) }.get()
+  override fun hset(key: String, field: String, value: ByteString): Long {
+    val keyBytes = key.toByteArray(charset)
+    val fieldBytes = field.toByteArray(charset)
+    val valueBytes = value.toByteArray()
+    return jedis { hset(keyBytes, fieldBytes, valueBytes) }
   }
 
-  override fun hset(key: String, hash: Map<String, ByteString>): Long = withMetrics("hset") {
-    runPipeline { hset(key, hash) }.get()
+  override fun hset(key: String, hash: Map<String, ByteString>): Long {
+    val hashBytes = hash.entries.associate { it.key.toByteArray(charset) to it.value.toByteArray() }
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hset(keyBytes, hashBytes) }
   }
 
-  override fun incr(key: String): Long = withMetrics("incr") {
-    runPipeline { incr(key) }.get()
+  override fun incr(key: String): Long {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { incr(keyBytes) }
   }
 
-  override fun incrBy(key: String, increment: Long): Long = withMetrics("incrBy") {
-    runPipeline { incrBy(key, increment) }.get()
+  override fun incrBy(key: String, increment: Long): Long {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { incrBy(keyBytes, increment) }
   }
 
   override fun blmove(
@@ -139,16 +231,20 @@ class RealRedis(
     from: ListDirection,
     to: ListDirection,
     timeoutSeconds: Double
-  ): ByteString? = withMetrics("blmove") {
-    runPipeline { blmove(sourceKey, destinationKey, from, to, timeoutSeconds) }.get()
+  ): ByteString? {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { blmove(sourceKeyBytes, destKeyBytes, from, to, timeoutSeconds) }?.toByteString()
   }
 
   override fun brpoplpush(
     sourceKey: String,
     destinationKey: String,
     timeoutSeconds: Int
-  ): ByteString? = withMetrics("brpoplpush") {
-    runPipeline { brpoplpush(sourceKey, destinationKey, timeoutSeconds) }.get()
+  ): ByteString? {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { brpoplpush(sourceKeyBytes, destinationKeyBytes, timeoutSeconds) }?.toByteString()
   }
 
   override fun lmove(
@@ -156,127 +252,82 @@ class RealRedis(
     destinationKey: String,
     from: ListDirection,
     to: ListDirection
-  ): ByteString? = withMetrics("lmove") {
-    runPipeline { lmove(sourceKey, destinationKey, from, to) }.get()
+  ): ByteString? {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { lmove(sourceKeyBytes, destKeyBytes, from, to) }?.toByteString()
   }
 
-  override fun lpush(key: String, vararg elements: ByteString): Long = withMetrics("lpush") {
-    runPipeline { lpush(key, *elements) }.get()
+  override fun lpush(key: String, vararg elements: ByteString): Long {
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    return jedis { lpush(keyBytes, *byteArrays) }
   }
 
-  override fun rpush(key: String, vararg elements: ByteString): Long = withMetrics("rpush") {
-    runPipeline { rpush(key, *elements) }.get()
+  override fun rpush(key: String, vararg elements: ByteString): Long {
+    val keyBytes = key.toByteArray(charset)
+    val byteArrays = elements.map { it.toByteArray() }.toTypedArray()
+    return jedis { rpush(keyBytes, *byteArrays) }
   }
 
-  override fun lpop(key: String, count: Int): List<ByteString?> = withMetrics("lpop") {
-    runPipeline { lpop(key, count) }.get()
+  override fun lpop(key: String, count: Int): List<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lpop(keyBytes, count) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
-  override fun lpop(key: String): ByteString? = withMetrics("lpop") {
-    runPipeline { lpop(key) }.get()
+  override fun lpop(key: String): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lpop(keyBytes) }?.toByteString()
   }
 
-  override fun rpop(key: String, count: Int): List<ByteString?> = withMetrics("rpop") {
-    runPipeline { rpop(key, count) }.get()
+  override fun rpop(key: String, count: Int): List<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { rpop(keyBytes, count) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
-  override fun rpop(key: String): ByteString? = withMetrics("rpop") {
-    runPipeline { rpop(key) }.get()
+  override fun rpop(key: String): ByteString? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { rpop(keyBytes) }?.toByteString()
   }
 
-  override fun lrange(
-    key: String,
-    start: Long,
-    stop: Long
-  ): List<ByteString?> = withMetrics("lrange") {
-    runPipeline { lrange(key, start, stop) }.get()
+  override fun lrange(key: String, start: Long, stop: Long): List<ByteString?> {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { lrange(keyBytes, start, stop) ?: emptyList() }
+      .map { it?.toByteString() }
   }
 
-  override fun lrem(key: String, count: Long, element: ByteString): Long = withMetrics("lrem") {
-    runPipeline { lrem(key, count, element) }.get()
+  override fun lrem(key: String, count: Long, element: ByteString): Long {
+    val keyBytes = key.toByteArray(charset)
+    val elementBytes = element.toByteArray()
+    return jedis { lrem(keyBytes, count, elementBytes) }
   }
 
-  override fun rpoplpush(
-    sourceKey: String,
-    destinationKey: String
-  ): ByteString? = withMetrics("rpoplpush") {
-    runPipeline { rpoplpush(sourceKey, destinationKey) }.get()
+  override fun rpoplpush(sourceKey: String, destinationKey: String): ByteString? {
+    val sourceKeyBytes = sourceKey.toByteArray(charset)
+    val destinationKeyBytes = destinationKey.toByteArray(charset)
+    return jedis { rpoplpush(sourceKeyBytes, destinationKeyBytes) }?.toByteString()
   }
 
-  override fun expire(key: String, seconds: Long): Boolean = withMetrics("expire") {
-    runPipeline { expire(key, seconds) }.get()
+  override fun expire(key: String, seconds: Long): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { expire(keyBytes, seconds) == 1L }
   }
 
-  override fun expireAt(key: String, timestampSeconds: Long): Boolean = withMetrics("expireAt") {
-    runPipeline { expireAt(key, timestampSeconds) }.get()
+  override fun expireAt(key: String, timestampSeconds: Long): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { expireAt(keyBytes, timestampSeconds) == 1L }
   }
 
-  override fun pExpire(key: String, milliseconds: Long): Boolean = withMetrics("pExpire") {
-    runPipeline { pExpire(key, milliseconds) }.get()
+  override fun pExpire(key: String, milliseconds: Long): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { pexpire(keyBytes, milliseconds) == 1L }
   }
 
-  override fun pExpireAt(
-    key: String,
-    timestampMilliseconds: Long
-  ): Boolean = withMetrics("pExpireAt") {
-    runPipeline { pExpireAt(key, timestampMilliseconds) }.get()
-  }
-
-  override fun zadd(
-    key: String,
-    score: Double,
-    member: String,
-    vararg options: ZAddOptions,
-  ): Long = withMetrics("zadd") {
-    runPipeline { zadd(key, score, member, *options) }.get()
-  }
-
-  override fun zadd(
-    key: String,
-    scoreMembers: Map<String, Double>,
-    vararg options: ZAddOptions,
-  ): Long = withMetrics("zadd") {
-    runPipeline { zadd(key, scoreMembers, *options) }.get()
-  }
-
-  override fun zscore(key: String, member: String): Double? = withMetrics("zscore") {
-    runPipeline { zscore(key, member) }.get()
-  }
-
-  override fun zrange(
-    key: String,
-    type: ZRangeType,
-    start: ZRangeMarker,
-    stop: ZRangeMarker,
-    reverse: Boolean,
-    limit: ZRangeLimit?,
-  ): List<ByteString?> = withMetrics("zrange") {
-    runPipeline { zrange(key, type, start, stop, reverse, limit) }.get()
-  }
-
-  override fun zrangeWithScores(
-    key: String,
-    type: ZRangeType,
-    start: ZRangeMarker,
-    stop: ZRangeMarker,
-    reverse: Boolean,
-    limit: ZRangeLimit?,
-  ): List<Pair<ByteString?, Double>> = withMetrics("zrangeWithScores") {
-    runPipeline { zrangeWithScores(key, type, start, stop, reverse, limit) }.get()
-  }
-
-  override fun zremRangeByRank(
-    key: String,
-    start: ZRangeRankMarker,
-    stop: ZRangeRankMarker
-  ): Long = withMetrics("zremRangeByRank") {
-    runPipeline { zremRangeByRank(key, start, stop) }.get()
-  }
-
-  override fun zcard(
-    key: String
-  ): Long = withMetrics("zcard") {
-    runPipeline { zcard(key) }.get()
+  override fun pExpireAt(key: String, timestampMilliseconds: Long): Boolean {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { pexpireAt(keyBytes, timestampMilliseconds) == 1L }
   }
 
   override fun watch(vararg keys: String) {
@@ -300,28 +351,30 @@ class RealRedis(
   }
 
   // Transactions do not get client histogram metrics right now.
+  // multi() returns the jedis to the pool, despite returning a Transaction that holds a reference.
+  // This is a bug, and will be fixed in a follow-up.
   override fun multi(): Transaction {
     return unifiedJedis.multi() as? Transaction ?: error("Transactions aren't supported in misk-redis with ${unifiedJedis.javaClass} at this time.")
   }
 
+  // Pipelined requests do not get client histogram metrics right now.
+  // pipelined() returns the jedis to the pool, despite returning a Pipeline that holds a reference
+  // to the borrowed jedis connection.
+  // This is a bug, and will be fixed in a follow-up.
   @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
-    return unifiedJedis.pipelined() as? Pipeline ?: error("pipelined() isn't supported in misk-redis with ${unifiedJedis.javaClass}. Use pipelining instead.")
+    return unifiedJedis.pipelined() as Pipeline
   }
 
-  private fun <T> runPipeline(block: DeferredRedis.() -> T): T = withMetrics("pipelining") {
-    unifiedJedis.pipelined().use { pipeline ->
+  override fun pipelining(block: DeferredRedis.() -> Unit) {
+      unifiedJedis.pipelined().use { pipeline ->
       block(RealPipelinedRedis(pipeline))
     }
   }
 
-  override fun pipelining(block: DeferredRedis.() -> Unit) {
-    runPipeline(block)
-  }
-
   /** Closes the connection to Redis. */
   override fun close() {
-    unifiedJedis.close()
+    return unifiedJedis.close()
   }
 
   override fun subscribe(jedisPubSub: JedisPubSub, channel: String) {
@@ -336,16 +389,261 @@ class RealRedis(
     unifiedJedis.flushAll()
   }
 
-  private fun <T> withMetrics(commandName: String, op: () -> T): T {
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: ZAddOptions,
+  ): Long {
+    ZAddOptions.verify(options)
+
+    return unifiedJedis.zadd(
+      key.toByteArray(charset),
+      score,
+      member.toByteArray(charset),
+      ZAddOptions.getZAddParams(options)
+    )
+  }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: ZAddOptions,
+  ): Long {
+    val params = ZAddOptions.getZAddParams(options)
+    val keyBytes = key.toByteArray(charset)
+    val scoreMembersBytes =
+      scoreMembers.entries.associate { it.key.toByteArray(charset) to it.value }
+    return unifiedJedis.zadd(
+      keyBytes,
+      scoreMembersBytes,
+      params
+    )
+  }
+
+  override fun zscore(key: String, member: String): Double? {
+    return unifiedJedis.zscore(
+      key.toByteArray(charset),
+      member.toByteArray(charset)
+    )
+  }
+
+  override fun zrange(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<ByteString?> {
+    return zrangeBase(key, type, start, stop, reverse, false, limit)
+      .noScore?.map { it?.toByteString() } ?: listOf()
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    limit: ZRangeLimit?,
+  ): List<Pair<ByteString?, Double>> {
+    return zrangeBase(key, type, start, stop, reverse, true, limit)
+      .withScore?.map { Pair(it.binaryElement?.toByteString(), it.score) } ?: listOf()
+  }
+
+  override fun zremRangeByRank(
+    key: String,
+    start: ZRangeRankMarker,
+    stop: ZRangeRankMarker
+  ): Long {
+    return unifiedJedis.zremrangeByRank(key, start.longValue, stop.longValue)
+  }
+
+  override fun zcard(
+    key: String
+  ): Long {
+    return unifiedJedis.zcard(key)
+  }
+
+  private fun zrangeBase(
+    key: String,
+    type: ZRangeType,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: ZRangeLimit?,
+  ): ZRangeResponse {
+    return when (type) {
+      ZRangeType.INDEX ->
+        zrangeByIndex(
+          key, start as ZRangeIndexMarker, stop as ZRangeIndexMarker, reverse,
+          withScore
+        )
+
+      ZRangeType.SCORE ->
+        zrangeByScore(
+          key, start as ZRangeScoreMarker, stop as ZRangeScoreMarker, reverse,
+          withScore, limit
+        )
+    }
+  }
+
+  private fun zrangeByScore(
+    key: String,
+    start: ZRangeScoreMarker,
+    stop: ZRangeScoreMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: ZRangeLimit?,
+  ): ZRangeResponse {
+    val minString = start.toString()
+    val maxString = stop.toString()
+
+    return if (limit == null && !reverse && !withScore) {
+      ZRangeResponse.noScore(
+        unifiedJedis.zrangeByScore(
+          key.toByteArray(charset),
+          minString.toByteArray(charset),
+          maxString.toByteArray(charset)
+        )
+      )
+    } else if (limit == null && !reverse) {
+      ZRangeResponse.withScore(
+        unifiedJedis.zrangeByScoreWithScores(
+          key.toByteArray(charset),
+          minString.toByteArray(charset),
+          maxString.toByteArray(charset)
+        )
+      )
+    } else if (limit == null && !withScore) {
+      ZRangeResponse.noScore(
+        unifiedJedis.zrevrangeByScore(
+          key.toByteArray(charset),
+          maxString.toByteArray(charset),
+          minString.toByteArray(charset)
+        )
+      )
+    } else if (limit == null) {
+      ZRangeResponse.withScore(
+        unifiedJedis.zrevrangeByScoreWithScores(
+          key.toByteArray(charset),
+          maxString.toByteArray(charset),
+          minString.toByteArray(charset)
+        )
+      )
+    } else if (!reverse && !withScore) {
+      ZRangeResponse.noScore(
+        unifiedJedis.zrangeByScore(
+          key.toByteArray(charset),
+          minString.toByteArray(charset),
+          maxString.toByteArray(charset),
+          limit.offset,
+          limit.count
+        )
+      )
+    } else if (!reverse) {
+      ZRangeResponse.withScore(
+        unifiedJedis.zrangeByScoreWithScores(
+          key.toByteArray(charset),
+          minString.toByteArray(charset),
+          maxString.toByteArray(charset),
+          limit.offset,
+          limit.count
+        )
+      )
+    } else if (!withScore) {
+      ZRangeResponse.noScore(
+        unifiedJedis.zrevrangeByScore(
+          key.toByteArray(charset),
+          maxString.toByteArray(charset),
+          minString.toByteArray(charset),
+          limit.offset,
+          limit.count
+        )
+      )
+    } else {
+      ZRangeResponse.withScore(
+        unifiedJedis.zrevrangeByScoreWithScores(
+          key.toByteArray(charset),
+          maxString.toByteArray(charset),
+          minString.toByteArray(charset),
+          limit.offset,
+          limit.count
+        )
+      )
+    }
+  }
+
+  /**
+   * A wrapper class for handling response from zrange* methods.
+   */
+  private class ZRangeResponse private constructor(
+    val noScore: List<ByteArray?>?,
+    val withScore: List<Tuple>?
+  ) {
+    companion object {
+      fun noScore(ans: List<ByteArray?>): ZRangeResponse = ZRangeResponse(ans, null)
+
+      fun withScore(ans: List<Tuple>): ZRangeResponse = ZRangeResponse(null, ans)
+    }
+  }
+
+  private fun zrangeByIndex(
+    key: String,
+    start: ZRangeIndexMarker,
+    stop: ZRangeIndexMarker,
+    reverse: Boolean,
+    withScore: Boolean
+  ): ZRangeResponse {
+    val params = ZRangeParams(
+      start.intValue,
+      stop.intValue
+    )
+    if (reverse) params.rev()
+
+    return if (withScore) {
+      ZRangeResponse.withScore(unifiedJedis.zrangeWithScores(key.toByteArray(charset), params))
+    } else {
+      ZRangeResponse.noScore(unifiedJedis.zrange(key.toByteArray(charset), params))
+    }
+  }
+
+  // Gets a Jedis instance from the pool, and times the requested method invocations.
+  private fun <T> jedis(op: JedisBinaryCommands.() -> T): T {
     updateMetrics()
-    return clientMetrics.timed(commandName, op)
-      .also { updateMetrics() }
+    val invocationHandler = JedisTimedInvocationHandler(unifiedJedis, clientMetrics)
+    val timedProxy = JedisBinaryCommands::class.cast(
+      Proxy.newProxyInstance(
+        ClassLoader.getSystemClassLoader(),
+        arrayOf(JedisBinaryCommands::class.java),
+        invocationHandler
+      )
+    )
+    val response = timedProxy.op()
+    updateMetrics()
+    return response
   }
 
   private fun updateMetrics() {
     when (unifiedJedis) {
       is JedisPooled -> clientMetrics.setActiveIdleConnectionMetrics(unifiedJedis.pool)
     }
+  }
+
+  private class JedisTimedInvocationHandler(
+    private val jedisCommand: JedisBinaryCommands,
+    private val clientMetrics: RedisClientMetrics,
+  ) : InvocationHandler {
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any?>?): Any? =
+      try {
+        clientMetrics.timed(method.name) {
+          method.invoke(jedisCommand, *(args ?: arrayOf()))
+        }
+      } catch (e: InvocationTargetException) {
+        throw e.cause!!
+      }
   }
 
   companion object {

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -5,6 +5,7 @@ import redis.clients.jedis.JedisPubSub
 import redis.clients.jedis.Pipeline
 import redis.clients.jedis.Transaction
 import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.exceptions.JedisDataException
 import redis.clients.jedis.params.ZAddParams
 import java.time.Duration
 import java.util.function.Supplier
@@ -449,95 +450,6 @@ interface Redis {
   fun pExpireAt(key: String, timestampMilliseconds: Long): Boolean
 
   /**
-   * Adds the specified [member] with the specified [score] to the sorted set at the [key].
-   * If a specified [member] is already a member of the sorted set, the [score] is updated and the
-   * element reinserted at the right position to ensure the correct ordering.
-   *
-   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
-   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
-   * an error is returned.
-   *
-   * ZADD supports a list of [options], specified after the name of the key and before the first
-   * score argument. The complete list of options can be found in [ZAddOptions].
-   */
-  fun zadd(key: String, score: Double, member: String, vararg options: ZAddOptions): Long
-
-  /**
-   * Adds all the specified members with the specified scores in [scoreMembers] to the sorted set
-   * at the [key]. If a specified [member] is already a member of the sorted set, the [score] is
-   * updated and the element reinserted at the right position to ensure the correct ordering.
-   *
-   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
-   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
-   * an error is returned.
-   *
-   * ZADD supports a list of [options], specified after the name of the key and before the first
-   * score argument. The complete list of options can be found in [ZAddOptions]
-   */
-  fun zadd(key: String, scoreMembers: Map<String, Double>, vararg options: ZAddOptions): Long
-
-  /**
-   * Returns the score of [member] in the sorted set at [key].
-   *
-   * If [member] does not exist in the sorted set, or [key] does not exist, nil is returned.
-   */
-  fun zscore(key: String, member: String): Double?
-
-  /**
-   * Returns the specified range of elements in the sorted set stored at [key].
-   *
-   * ZRANGE can perform different [type]s of range queries: by index (rank), by the score, or by
-   * lexicographical order. Currently only index and score type range queries are supported.
-   * See [ZRangeType] for different types of range queries.
-   *
-   * You can specify the [start] and [stop] of the range you want to filter by.
-   * Depending on the [type] you will have to use the appropriate type of [ZRangeMarker].
-   *
-   * The order of elements is from the lowest to the highest score.
-   * Elements with the same score are ordered lexicographically.
-   *
-   * Setting [reverse] reverses the ordering, so elements are ordered from highest to lowest score,
-   * and score ties are resolved by reverse lexicographical ordering.
-   *
-   * The [limit] argument can be used to obtain a sub-range from the matching elements.
-   * See [ZRangeLimit] for more info.
-   */
-  fun zrange(
-    key: String,
-    type: ZRangeType = ZRangeType.INDEX,
-    start: ZRangeMarker,
-    stop: ZRangeMarker,
-    reverse: Boolean = false,
-    limit: ZRangeLimit? = null,
-  ): List<ByteString?>
-
-  /**
-   * This is similar to [zrange] but returns the scores along with the members.
-   */
-  fun zrangeWithScores(
-    key: String,
-    type: ZRangeType = ZRangeType.INDEX,
-    start: ZRangeMarker,
-    stop: ZRangeMarker,
-    reverse: Boolean = false,
-    limit: ZRangeLimit? = null,
-  ): List<Pair<ByteString?, Double>>
-
-  /**
-   * Removes all elements in the sorted set stored at [key] with rank between [start] and [stop].
-   * Both start and stop are 0 -based indexes with 0 being the element with the lowest score.
-   * These indexes can be negative numbers, where they indicate offsets starting at the element
-   * with the highest score. For example: -1 is the element with the highest score, -2 the element
-   * with the second-highest score and so forth.
-   */
-  fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long
-
-  /**
-   * Returns the sorted set cardinality (number of elements) of the sorted set stored at [key]
-   */
-  fun zcard(key: String): Long
-
-  /**
    * Marks the given keys to be watched for conditional execution of a transaction.
    */
   fun watch(vararg keys: String)
@@ -589,6 +501,113 @@ interface Redis {
    * Flushes all keys from all databases.
    */
   fun flushAll()
+
+  /**
+   * Adds the specified [member] with the specified [score] to the sorted set at the [key].
+   * If a specified [member] is already a member of the sorted set, the [score] is updated and the
+   * element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. The complete list of options can be found in [ZAddOptions].
+   */
+  fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: ZAddOptions
+  ): Long
+
+  /**
+   * Adds all the specified members with the specified scores in [scoreMembers] to the sorted set
+   * at the [key]. If a specified [member] is already a member of the sorted set, the [score] is
+   * updated and the element reinserted at the right position to ensure the correct ordering.
+   *
+   * If [key] does not exist, a new sorted set with the specified [member] as sole member is
+   * created, like if the sorted set was empty. If the [key] exists but does not hold a sorted set,
+   * an error is returned.
+   *
+   * ZADD supports a list of [options], specified after the name of the key and before the first
+   * score argument. The complete list of options can be found in [ZAddOptions]
+   */
+  fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: ZAddOptions
+  ): Long
+
+  /**
+   * Returns the score of [member] in the sorted set at [key].
+   *
+   * If [member] does not exist in the sorted set, or [key] does not exist, nil is returned.
+   */
+  fun zscore(
+    key: String,
+    member: String
+  ): Double?
+
+  /**
+   * Returns the specified range of elements in the sorted set stored at [key].
+   *
+   * ZRANGE can perform different [type]s of range queries: by index (rank), by the score, or by
+   * lexicographical order. Currently only index and score type range queries are supported.
+   * See [ZRangeType] for different types of range queries.
+   *
+   * You can specify the [start] and [stop] of the range you want to filter by.
+   * Depending on the [type] you will have to use the appropriate type of [ZRangeMarker].
+   *
+   * The order of elements is from the lowest to the highest score.
+   * Elements with the same score are ordered lexicographically.
+   *
+   * Setting [reverse] reverses the ordering, so elements are ordered from highest to lowest score,
+   * and score ties are resolved by reverse lexicographical ordering.
+   *
+   * The [limit] argument can be used to obtain a sub-range from the matching elements.
+   * See [ZRangeLimit] for more info.
+   */
+  fun zrange(
+    key: String,
+    type: ZRangeType = ZRangeType.INDEX,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean = false,
+    limit: ZRangeLimit? = null,
+  ): List<ByteString?>
+
+  /**
+   * This is similar to [zrange] but returns the scores along with the members.
+   */
+  fun zrangeWithScores(
+    key: String,
+    type: ZRangeType = ZRangeType.INDEX,
+    start: ZRangeMarker,
+    stop: ZRangeMarker,
+    reverse: Boolean = false,
+    limit: ZRangeLimit? = null,
+  ): List<Pair<ByteString?, Double>>
+
+  /**
+   * Removes all elements in the sorted set stored at [key] with rank between [start] and [stop].
+   * Both start and stop are 0 -based indexes with 0 being the element with the lowest score.
+   * These indexes can be negative numbers, where they indicate offsets starting at the element
+   * with the highest score. For example: -1 is the element with the highest score, -2 the element
+   * with the second-highest score and so forth.
+   */
+  fun zremRangeByRank(
+    key: String,
+    start: ZRangeRankMarker,
+    stop: ZRangeRankMarker,
+  ): Long
+
+  /**
+   * Returns the sorted set cardinality (number of elements) of the sorted set stored at [key]
+   */
+  fun zcard(
+    key: String
+  ): Long
 
   /**
    * Different types of range queries.

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -75,6 +75,44 @@ abstract class AbstractRedisTest {
     assertThat(redis[unknownKey]).isNull()
   }
 
+  @Test
+  fun batchGetAndSetPipelined()  {
+    val key = "key"
+    val key2 = "key2"
+    val firstValue = "firstValue".encodeUtf8()
+    val value = "value".encodeUtf8()
+    val value2 = "value2".encodeUtf8()
+    val unknownKey = "this key doesn't exist"
+
+    val suppliers = mutableListOf<Supplier<*>>()
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          mget(key),
+          mget(key, key2),
+          mset(key.encodeUtf8(), firstValue),
+          mget(key),
+          mset(key.encodeUtf8(), value, key2.encodeUtf8(), value2),
+          mget(key),
+          mget(key, key2),
+          mget(key2, key),
+          mget(key, unknownKey, key2, key),
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      listOf(null),
+      listOf(null, null),
+      Unit,
+      listOf(firstValue),
+      Unit,
+      listOf(value),
+      listOf(value, value2),
+      listOf(value2, value),
+      listOf(value, null, value2, value),
+    )
+  }
+
   @Test fun hsetReturnsCorrectValues() {
     val key = "prehistoric_life"
     // Add one get one.
@@ -1453,30 +1491,6 @@ abstract class AbstractRedisTest {
       "lval4".encodeUtf8(),
       "lval3".encodeUtf8(),
       "lval2".encodeUtf8()
-    )
-  }
-
-  @Test
-  fun `pipelining works - sorted sets`() {
-    val suppliers = mutableListOf<Supplier<*>>()
-
-    redis.pipelining {
-      suppliers.addAll(
-        listOf(
-          zadd("zkey", 1.0, "a"),
-          zscore("zkey", "a"),
-          zrangeWithScores("zkey", start = ZRangeIndexMarker(0), stop = ZRangeIndexMarker(-1)),
-          zremRangeByRank("zkey", start = ZRangeRankMarker(0), stop = ZRangeRankMarker(-1)),
-          zcard("zkey")
-        )
-      )
-    }
-    assertThat(suppliers.map { it.get() }).containsExactly(
-      1L,
-      1.0,
-      listOf("a".encodeUtf8() to 1.0),
-      1L,
-      0L,
     )
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
@@ -103,7 +103,7 @@ class RealRedisClusterTest : AbstractRedisTest() {
   @Test
   fun `atomic rpoplpush throws cross-cluster error for keys not in the same slot`() {
 
-    assertFailsOnKeysInNotSameSlot("RPOPLPUSH") {
+    assertFailsOnKeysInNotSameSlot {
       redis.rpoplpush(
         sourceKey = "{pop}1",
         destinationKey = "{push}1",
@@ -113,7 +113,7 @@ class RealRedisClusterTest : AbstractRedisTest() {
 
   @Test
   fun `atomic lmove throws cross-cluster error for keys not in the same slot`() {
-    assertFailsOnKeysInNotSameSlot("LMOVE") {
+    assertFailsOnKeysInNotSameSlot {
       redis.lmove(
         sourceKey = "{k}1",
         destinationKey = "{t}1",
@@ -123,10 +123,10 @@ class RealRedisClusterTest : AbstractRedisTest() {
     }
   }
 
-  private fun assertFailsOnKeysInNotSameSlot(command: String, block: () -> Unit) {
+  private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
     assertThatThrownBy { block() }
-      .isInstanceOf(RuntimeException::class.java)
-      .hasMessageStartingWith("When using clustered Redis, keys used by one $command command must always map to the same slot, but mapped to slots [")
+      .isInstanceOf(JedisClusterOperationException::class.java)
+      .hasMessage("Keys must belong to same hashslot.")
   }
 
 }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -627,62 +627,6 @@ class FakeRedis @Inject constructor(
       this@FakeRedis.pExpireAt(key, timestampMilliseconds)
     }
 
-
-    override fun zadd(
-      key: String,
-      score: Double,
-      member: String,
-      vararg options: Redis.ZAddOptions
-    ): Supplier<Long> = Supplier {
-      this@FakeRedis.zadd(key, score, member, *options)
-    }
-
-    override fun zadd(
-      key: String,
-      scoreMembers: Map<String, Double>,
-      vararg options: Redis.ZAddOptions
-    ): Supplier<Long> = Supplier {
-      this@FakeRedis.zadd(key, scoreMembers, *options)
-    }
-
-    override fun zscore(key: String, member: String): Supplier<Double?> = Supplier {
-      this@FakeRedis.zscore(key, member)
-    }
-
-    override fun zrange(
-      key: String,
-      type: ZRangeType,
-      start: ZRangeMarker,
-      stop: ZRangeMarker,
-      reverse: Boolean,
-      limit: ZRangeLimit?
-    ): Supplier<List<ByteString?>> = Supplier {
-      this@FakeRedis.zrange(key, type, start, stop, reverse, limit)
-    }
-
-    override fun zrangeWithScores(
-      key: String,
-      type: ZRangeType,
-      start: ZRangeMarker,
-      stop: ZRangeMarker,
-      reverse: Boolean,
-      limit: ZRangeLimit?
-    ): Supplier<List<Pair<ByteString?, Double>>> = Supplier {
-      this@FakeRedis.zrangeWithScores(key, type, start, stop, reverse, limit)
-    }
-
-    override fun zremRangeByRank(
-      key: String,
-      start: ZRangeRankMarker,
-      stop: ZRangeRankMarker
-    ): Supplier<Long> = Supplier {
-      this@FakeRedis.zremRangeByRank(key, start, stop)
-    }
-
-    override fun zcard(key: String): Supplier<Long> = Supplier {
-      this@FakeRedis.zcard(key)
-    }
-
     override fun close() {
       // No-op.
     }


### PR DESCRIPTION
This reverts commit d3fad45e48488f1915e1fef94095fca897aff108.

We're seeing some unexpected Jedis connection pool issues which are resolved by rolling back this dependency upgrade.

---

UPDATE: I think it's probable that this change was not compatible when Jedis is configured to have a single connection in its pool. The default Jedis pool configurations support a default value of up to 8 maximum connections.