### PR TITLE
Add sorted set operations to misk-redis pipelines

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -36,11 +36,20 @@ public abstract interface class misk/redis/DeferredRedis {
 	public abstract fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
 	public abstract fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
 	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public abstract fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public abstract fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public abstract fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
 public final class misk/redis/DeferredRedis$DefaultImpls {
 	public static synthetic fun set$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
 	public static synthetic fun setnx$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public static synthetic fun zrange$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public static synthetic fun zrangeWithScores$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
 }
 
 public final class misk/redis/FakeRedis : misk/redis/Redis {
@@ -592,6 +601,13 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 	public fun rpush (Ljava/lang/String;[Lokio/ByteString;)Ljava/util/function/Supplier;
 	public fun set (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;Ljava/time/Duration;)Ljava/util/function/Supplier;
+	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public fun zadd (Ljava/lang/String;Ljava/util/Map;[Lmisk/redis/Redis$ZAddOptions;)Ljava/util/function/Supplier;
+	public fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
+	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {

--- a/misk-redis/build.gradle.kts
+++ b/misk-redis/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
   implementation(libs.guice)
   implementation(libs.okio)
   implementation(libs.prometheusClient)
+  implementation(project(":wisp:wisp-logging"))
   implementation(project(":wisp:wisp-deployment"))
   implementation(project(":misk-service"))
 

--- a/misk-redis/build.gradle.kts
+++ b/misk-redis/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
   implementation(libs.okio)
   implementation(libs.prometheusClient)
   implementation(project(":wisp:wisp-logging"))
+  implementation(libs.kotlinLogging)
   implementation(project(":wisp:wisp-deployment"))
   implementation(project(":misk-service"))
 

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -97,5 +97,49 @@ interface DeferredRedis {
 
   fun pExpireAt(key: String, timestampMilliseconds: Long): Supplier<Boolean>
 
+  fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions
+  ): Supplier<Long>
+
+  fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions
+  ): Supplier<Long>
+
+  fun zscore(
+    key: String,
+    member: String
+  ): Supplier<Double?>
+
+  fun zrange(
+    key: String,
+    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean = false,
+    limit: Redis.ZRangeLimit? = null,
+  ): Supplier<List<ByteString?>>
+
+  fun zrangeWithScores(
+    key: String,
+    type: Redis.ZRangeType = Redis.ZRangeType.INDEX,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean = false,
+    limit: Redis.ZRangeLimit? = null,
+  ): Supplier<List<Pair<ByteString?, Double>>>
+
+  fun zremRangeByRank(
+    key: String,
+    start: Redis.ZRangeRankMarker,
+    stop: Redis.ZRangeRankMarker,
+  ): Supplier<Long>
+
+  fun zcard(key: String): Supplier<Long>
+
   fun close()
 }

--- a/misk-redis/src/main/kotlin/misk/redis/JedisExtensions.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/JedisExtensions.kt
@@ -1,0 +1,26 @@
+package misk.redis
+
+import mu.KLogger
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisCluster
+import redis.clients.jedis.JedisPooled
+import redis.clients.jedis.UnifiedJedis
+
+internal fun UnifiedJedis.flushAllWithClusterSupport(logger: KLogger) {
+  when (this) {
+    is JedisPooled -> this.flushAll()
+    is JedisCluster -> {
+      // Note: flushAll cannot be broadcast to all nodes in a cluster. We need to flush each node individually.
+      this.clusterNodes.forEach { (node, pool) ->
+        pool.resource.use { conn ->
+          try {
+            Jedis(conn).use { jedis -> jedis.flushAll() }
+          } catch (e : Exception) {
+            logger.error(e) { "Error flushing node $node: + ${e.message}" }
+          }
+        }
+      }
+    }
+    else -> error("flushAll is not supported for UnifiedJedis implementation ${this.javaClass}")
+  }
+}

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -370,6 +370,184 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     return Supplier { response.get() == 1L }
   }
 
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions,
+  ): Supplier<Long> {
+    Redis.ZAddOptions.verify(options)
+    val keyBytes = key.toByteArray(charset)
+    val memberBytes = member.toByteArray(charset)
+    val params = Redis.ZAddOptions.getZAddParams(options)
+    val response = pipeline.zadd(keyBytes, score, memberBytes, params)
+    return Supplier { response.get() }
+  }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions,
+  ): Supplier<Long> {
+    Redis.ZAddOptions.verify(options)
+    val keyBytes = key.toByteArray(charset)
+    val scoreMembersBytes = scoreMembers.mapKeys { it.key.toByteArray(charset) }
+    val params = Redis.ZAddOptions.getZAddParams(options)
+    val response = pipeline.zadd(keyBytes, scoreMembersBytes, params)
+    return Supplier { response.get() }
+  }
+
+  override fun zscore(key: String, member: String): Supplier<Double?> {
+    val keyBytes = key.toByteArray(charset)
+    val memberBytes = member.toByteArray(charset)
+    val response = pipeline.zscore(keyBytes, memberBytes)
+    return Supplier { response.get() }
+  }
+
+  override fun zrange(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): Supplier<List<ByteString?>> {
+    val response = zrangeBase(key, type, start, stop, reverse, false, limit).noScore
+    return Supplier {
+      response?.get()?.map { bytes -> bytes?.toByteString() } ?: listOf()
+    }
+  }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): Supplier<List<Pair<ByteString?, Double>>> {
+    val response = zrangeBase(key, type, start, stop, reverse, true, limit).withScore
+    return Supplier {
+      response?.get()?.map { tuple -> Pair(tuple.binaryElement?.toByteString(), tuple.score) } ?: listOf()
+    }
+  }
+
+  override fun zremRangeByRank(
+    key: String,
+    start: Redis.ZRangeRankMarker,
+    stop: Redis.ZRangeRankMarker
+  ): Supplier<Long> {
+    val response = pipeline.zremrangeByRank(key, start.longValue, stop.longValue)
+    return Supplier { response.get() }
+  }
+
+  override fun zcard(key: String): Supplier<Long> {
+    val response = pipeline.zcard(key)
+    return Supplier { response.get() }
+  }
+
+  private fun zrangeBase(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: Redis.ZRangeLimit?,
+  ): ZRangeResponse {
+    return when (type) {
+      Redis.ZRangeType.INDEX ->
+        zrangeByIndex(
+          key = key,
+          start = start as Redis.ZRangeIndexMarker,
+          stop = stop as Redis.ZRangeIndexMarker,
+          reverse = reverse,
+          withScore = withScore
+        )
+
+      Redis.ZRangeType.SCORE ->
+        zrangeByScore(
+          key = key,
+          start = start as Redis.ZRangeScoreMarker,
+          stop = stop as Redis.ZRangeScoreMarker,
+          reverse = reverse,
+          withScore = withScore,
+          limit = limit
+        )
+    }
+  }
+
+  private fun zrangeByIndex(
+    key: String,
+    start: Redis.ZRangeIndexMarker,
+    stop: Redis.ZRangeIndexMarker,
+    reverse: Boolean,
+    withScore: Boolean
+  ): ZRangeResponse {
+    val params = ZRangeParams(
+      start.intValue,
+      stop.intValue
+    )
+    if (reverse) params.rev()
+
+    return if (withScore) {
+      ZRangeResponse.withScore(pipeline.zrangeWithScores(key.toByteArray(charset), params))
+    } else {
+      ZRangeResponse.noScore(pipeline.zrange(key.toByteArray(charset), params))
+    }
+  }
+
+  private fun zrangeByScore(
+    key: String,
+    start: Redis.ZRangeScoreMarker,
+    stop: Redis.ZRangeScoreMarker,
+    reverse: Boolean,
+    withScore: Boolean,
+    limit: Redis.ZRangeLimit?,
+  ): ZRangeResponse {
+    val min = start.toString().toByteArray(charset)
+    val max = stop.toString().toByteArray(charset)
+    val keyBytes = key.toByteArray(charset)
+
+    return if (limit == null && !reverse && !withScore) {
+      ZRangeResponse.noScore(pipeline.zrangeByScore(keyBytes, min, max))
+    } else if (limit == null && !reverse) {
+      ZRangeResponse.withScore(pipeline.zrangeByScoreWithScores(keyBytes, min, max))
+    } else if (limit == null && !withScore) {
+      ZRangeResponse.noScore(pipeline.zrevrangeByScore(keyBytes, max, min))
+    } else if (limit == null) {
+      ZRangeResponse.withScore(pipeline.zrevrangeByScoreWithScores(keyBytes, max, min))
+    } else if (!reverse && !withScore) {
+      ZRangeResponse.noScore(pipeline.zrangeByScore(keyBytes, min, max, limit.offset, limit.count))
+    } else if (!reverse) {
+      ZRangeResponse.withScore(
+        pipeline.zrangeByScoreWithScores(keyBytes, min, max, limit.offset, limit.count)
+      )
+    } else if (!withScore) {
+      ZRangeResponse.noScore(
+        pipeline.zrevrangeByScore(keyBytes, max, min, limit.offset, limit.count)
+      )
+    } else {
+      ZRangeResponse.withScore(
+        pipeline.zrevrangeByScoreWithScores(keyBytes, max, min, limit.offset, limit.count)
+      )
+    }
+  }
+
+  /**
+   * A wrapper class for handling response from zrange* methods.
+   */
+  private class ZRangeResponse private constructor(
+    val noScore: Response<List<ByteArray?>>?,
+    val withScore: Response<List<Tuple>>?
+  ) {
+    companion object {
+      fun noScore(ans: Response<List<ByteArray?>>?): ZRangeResponse = ZRangeResponse(ans, null)
+
+      fun withScore(ans: Response<List<Tuple>>?): ZRangeResponse = ZRangeResponse(null, ans)
+    }
+  }
+
   override fun close() {
     pipeline.close()
   }

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -9,6 +9,7 @@ import misk.redis.Redis.ZRangeScoreMarker
 import misk.redis.Redis.ZRangeType
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisCluster
 import redis.clients.jedis.JedisPooled
 import redis.clients.jedis.JedisPubSub
@@ -21,6 +22,7 @@ import redis.clients.jedis.params.SetParams
 import redis.clients.jedis.params.ZRangeParams
 import redis.clients.jedis.resps.Tuple
 import redis.clients.jedis.util.JedisClusterCRC16
+import wisp.logging.getLogger
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -390,7 +392,7 @@ class RealRedis(
   }
 
   override fun flushAll() {
-    unifiedJedis.flushAll()
+    unifiedJedis.flushAllWithClusterSupport(logger)
   }
 
   override fun zadd(
@@ -660,5 +662,7 @@ class RealRedis(
 
   companion object {
     val charset = charset("UTF-8")
+
+    private val logger = getLogger<RealRedis>()
   }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
@@ -1,0 +1,102 @@
+package misk.redis
+
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import redis.clients.jedis.args.ListDirection
+import redis.clients.jedis.exceptions.JedisClusterOperationException
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+abstract class AbstractRedisClusterTest : AbstractRedisTest() {
+  /**
+   * Using keys that belong to different slots https://redis.io/docs/reference/cluster-spec/
+   * If the key contains a "{...}" pattern, only the substring between { and } is hashed
+   * therefore {k}1 and {k}2 are in the same slot
+   */
+  private val keys =
+    listOf("{k}1", "{t}1", "{k}2", "{m}1", "{m}2", "{k}3", "{t}2")
+
+  @Test
+  fun `batch get and set for keys not in the same slot`() {
+
+    // mget returns null for all keys
+    assertThat(redis.mget(*keys.toTypedArray())).isEqualTo(
+      listOf(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      )
+    )
+
+    // Set values as the key using mset
+    val keyValues = keys.flatMap { listOf(it.encodeUtf8(), it.encodeUtf8()) }.toTypedArray()
+    redis.mset(*keyValues)
+
+    // mget should return the correct values in the right order
+    val values = redis.mget(*keys.toTypedArray())
+    assertThat(values).isEqualTo(keys.map { it.encodeUtf8() })
+
+  }
+
+  @Test
+  fun `batch delete for keys not in the same slot`() {
+    val keysToInsert = keys.toTypedArray()
+    val nonExistentKey = "nonExistentKey"
+    val value = "value".encodeUtf8()
+
+    // Set all keys except nonExistentKey
+    keysToInsert.forEach { redis[it] = value }
+    keysToInsert.forEach { assertEquals(value, redis[it], "Key should have been set") }
+    assertNull(redis[nonExistentKey], "Key should not have been set")
+
+    // Try deleting all three keys, only 2 should actually get deleted
+    assertEquals(
+      keys.size,
+      redis.del(*keysToInsert, nonExistentKey),
+      "${keys.size} keys should have been deleted"
+    )
+
+    // Keys should be deleted
+    listOf(*keysToInsert, nonExistentKey).forEach {
+      assertNull(
+        redis[it],
+        "Key should have been deleted"
+      )
+    }
+  }
+
+  @Test
+  fun `atomic rpoplpush throws cross-cluster error for keys not in the same slot`() {
+
+    assertFailsOnKeysInNotSameSlot {
+      redis.rpoplpush(
+        sourceKey = "{pop}1",
+        destinationKey = "{push}1",
+      )
+    }
+  }
+
+  @Test
+  fun `atomic lmove throws cross-cluster error for keys not in the same slot`() {
+    assertFailsOnKeysInNotSameSlot {
+      redis.lmove(
+        sourceKey = "{k}1",
+        destinationKey = "{t}1",
+        from = ListDirection.RIGHT,
+        to = ListDirection.LEFT,
+      )
+    }
+  }
+
+  private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
+    assertThatThrownBy { block() }
+      .isInstanceOf(JedisClusterOperationException::class.java)
+      .hasMessage("Keys must belong to same hashslot.")
+  }
+}

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
@@ -4,6 +4,7 @@ import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import redis.clients.jedis.args.ListDirection
 import redis.clients.jedis.exceptions.JedisClusterOperationException
 import kotlin.test.assertEquals
@@ -95,8 +96,8 @@ abstract class AbstractRedisClusterTest : AbstractRedisTest() {
   }
 
   private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
-    assertThatThrownBy { block() }
-      .isInstanceOf(JedisClusterOperationException::class.java)
-      .hasMessage("Keys must belong to same hashslot.")
+    val ex = assertThrows<IllegalStateException>(block)
+    assertThat(ex.message)
+      .matches("When using clustered Redis, keys used by one (.+) command must always map to the same slot, but mapped to slots .+")
   }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisClusterTest.kt
@@ -96,8 +96,9 @@ abstract class AbstractRedisClusterTest : AbstractRedisTest() {
   }
 
   private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
-    val ex = assertThrows<IllegalStateException>(block)
+    val ex = assertThrows<RuntimeException>(block)
     assertThat(ex.message)
-      .matches("When using clustered Redis, keys used by one (.+) command must always map to the same slot, but mapped to slots .+")
+      .contains("When using clustered Redis, keys used by one",
+        "command must always map to the same slot, but mapped to slots [")
   }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -78,44 +78,6 @@ abstract class AbstractRedisTest {
     assertThat(redis[unknownKey]).isNull()
   }
 
-  @Test
-  fun batchGetAndSetPipelined()  {
-    val key = "key"
-    val key2 = "key2"
-    val firstValue = "firstValue".encodeUtf8()
-    val value = "value".encodeUtf8()
-    val value2 = "value2".encodeUtf8()
-    val unknownKey = "this key doesn't exist"
-
-    val suppliers = mutableListOf<Supplier<*>>()
-    redis.pipelining {
-      suppliers.addAll(
-        listOf(
-          mget(key),
-          mget(key, key2),
-          mset(key.encodeUtf8(), firstValue),
-          mget(key),
-          mset(key.encodeUtf8(), value, key2.encodeUtf8(), value2),
-          mget(key),
-          mget(key, key2),
-          mget(key2, key),
-          mget(key, unknownKey, key2, key),
-        )
-      )
-    }
-    assertThat(suppliers.map { it.get() }).containsExactly(
-      listOf(null),
-      listOf(null, null),
-      Unit,
-      listOf(firstValue),
-      Unit,
-      listOf(value),
-      listOf(value, value2),
-      listOf(value2, value),
-      listOf(value, null, value2, value),
-    )
-  }
-
   @Test fun hsetReturnsCorrectValues() {
     val key = "prehistoric_life"
     // Add one get one.
@@ -1520,6 +1482,30 @@ abstract class AbstractRedisTest {
       2L,
       "lval2".encodeUtf8(),
       "lval1".encodeUtf8()
+    )
+  }
+
+  @Test
+  fun `pipelining works - sorted sets`() {
+    val suppliers = mutableListOf<Supplier<*>>()
+
+    redis.pipelining {
+      suppliers.addAll(
+        listOf(
+          zadd("zkey", 1.0, "a"),
+          zscore("zkey", "a"),
+          zrangeWithScores("zkey", start = ZRangeIndexMarker(0), stop = ZRangeIndexMarker(-1)),
+          zremRangeByRank("zkey", start = ZRangeRankMarker(0), stop = ZRangeRankMarker(-1)),
+          zcard("zkey")
+        )
+      )
+    }
+    assertThat(suppliers.map { it.get() }).containsExactly(
+      1L,
+      1.0,
+      listOf("a".encodeUtf8() to 1.0),
+      1L,
+      0L,
     )
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -15,10 +15,10 @@ import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import redis.clients.jedis.args.ListDirection
-import redis.clients.jedis.exceptions.JedisDataException
 import java.util.function.Supplier
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -28,6 +28,9 @@ import kotlin.test.assertTrue
 
 abstract class AbstractRedisTest {
   abstract var redis: Redis
+
+  @BeforeEach
+  fun setUp() = redis.flushAll()
 
   @Test
   fun simpleStringSetGet() {

--- a/misk-redis/src/test/kotlin/misk/redis/AlwaysPipelined.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AlwaysPipelined.kt
@@ -1,0 +1,8 @@
+package misk.redis
+
+import jakarta.inject.Qualifier
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AlwaysPipelined

--- a/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisClusterTest.kt
@@ -13,7 +13,6 @@ import misk.testing.MiskTestModule
 import redis.clients.jedis.ConnectionPoolConfig
 import redis.clients.jedis.UnifiedJedis
 import wisp.deployment.TESTING
-import javax.inject.Provider
 
 /**
  * Provides test coverage/parity for pipelined operations on a Redis cluster.
@@ -29,9 +28,9 @@ class PipelinedRedisClusterTest : AbstractRedisTest() {
       install(DeploymentModule(TESTING))
 
       val jedisProvider = getProvider(UnifiedJedis::class.java)
-      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider(Provider {
+      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider {
         TestAlwaysPipelinedRedis(jedisProvider.get())
-      }).asSingleton()
+      }.asSingleton()
     }
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisClusterTest.kt
@@ -1,0 +1,43 @@
+package misk.redis
+
+import com.google.inject.Module
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.redis.testing.DockerRedisCluster
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.UnifiedJedis
+import wisp.deployment.TESTING
+import javax.inject.Provider
+
+/**
+ * Provides test coverage/parity for pipelined operations on a Redis cluster.
+ */
+@MiskTest
+class PipelinedRedisClusterTest : AbstractRedisTest() {
+  @Suppress("unused")
+  @MiskTestModule
+  private val module: Module = object : KAbstractModule() {
+    override fun configure() {
+      install(RedisClusterModule(DockerRedisCluster.config, ConnectionPoolConfig(), useSsl = false))
+      install(MiskTestingServiceModule())
+      install(DeploymentModule(TESTING))
+
+      val jedisProvider = getProvider(UnifiedJedis::class.java)
+      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider(Provider {
+        TestAlwaysPipelinedRedis(jedisProvider.get())
+      }).asSingleton()
+    }
+  }
+
+  @Suppress("unused")
+  @MiskExternalDependency
+  private val dockerRedisCluster = DockerRedisCluster
+
+  @Inject @AlwaysPipelined override lateinit var redis: Redis
+}

--- a/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisTest.kt
@@ -1,0 +1,38 @@
+package misk.redis
+
+import com.google.inject.Module
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.redis.testing.DockerRedis
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.UnifiedJedis
+import wisp.deployment.TESTING
+import javax.inject.Provider
+
+/**
+ * Provides test coverage/parity for pipelined operations on a connection-pooled Redis client.
+ */
+@MiskTest
+class PipelinedRedisTest : AbstractRedisTest() {
+  @Suppress("unused")
+  @MiskTestModule
+  private val module: Module = object : KAbstractModule() {
+    override fun configure() {
+      install(RedisModule(DockerRedis.config, ConnectionPoolConfig(), useSsl = false))
+      install(MiskTestingServiceModule())
+      install(DeploymentModule(TESTING))
+
+      val jedisProvider = getProvider(UnifiedJedis::class.java)
+      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider(Provider {
+        TestAlwaysPipelinedRedis(jedisProvider.get())
+      }).asSingleton()
+    }
+  }
+
+  @Inject @AlwaysPipelined override lateinit var redis: Redis
+}

--- a/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/PipelinedRedisTest.kt
@@ -1,6 +1,7 @@
 package misk.redis
 
 import com.google.inject.Module
+import com.google.inject.Provider
 import jakarta.inject.Inject
 import misk.MiskTestingServiceModule
 import misk.environment.DeploymentModule
@@ -12,7 +13,6 @@ import misk.testing.MiskTestModule
 import redis.clients.jedis.ConnectionPoolConfig
 import redis.clients.jedis.UnifiedJedis
 import wisp.deployment.TESTING
-import javax.inject.Provider
 
 /**
  * Provides test coverage/parity for pipelined operations on a connection-pooled Redis client.
@@ -28,9 +28,9 @@ class PipelinedRedisTest : AbstractRedisTest() {
       install(DeploymentModule(TESTING))
 
       val jedisProvider = getProvider(UnifiedJedis::class.java)
-      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider(Provider {
+      bind<Redis>().annotatedWith<AlwaysPipelined>().toProvider {
         TestAlwaysPipelinedRedis(jedisProvider.get())
-      }).asSingleton()
+      }.asSingleton()
     }
   }
 

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisClusterTest.kt
@@ -21,8 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @MiskTest
-class RealRedisClusterTest : AbstractRedisTest() {
-
+class RealRedisClusterTest : AbstractRedisClusterTest() {
   @Suppress("unused")
   @MiskTestModule
   private val module: Module = object : KAbstractModule() {
@@ -37,96 +36,5 @@ class RealRedisClusterTest : AbstractRedisTest() {
   @MiskExternalDependency
   private val dockerRedisCluster = DockerRedisCluster
 
-  /**
-   * Using keys that belong to different slots https://redis.io/docs/reference/cluster-spec/
-   * If the key contains a "{...}" pattern, only the substring between { and } is hashed
-   * therefore {k}1 and {k}2 are in the same slot
-   */
-  private val keys =
-    listOf("{k}1", "{t}1", "{k}2", "{m}1", "{m}2", "{k}3", "{t}2")
-
   @Inject override lateinit var redis: Redis
-
-  @Test
-  fun `batch get and set for keys not in the same slot`() {
-
-    // mget returns null for all keys
-    assertThat(redis.mget(*keys.toTypedArray())).isEqualTo(
-      listOf(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      )
-    )
-
-    // Set values as the key using mset
-    val keyValues = keys.flatMap { listOf(it.encodeUtf8(), it.encodeUtf8()) }.toTypedArray()
-    redis.mset(*keyValues)
-
-    // mget should return the correct values in the right order
-    val values = redis.mget(*keys.toTypedArray())
-    assertThat(values).isEqualTo(keys.map { it.encodeUtf8() })
-
-  }
-
-  @Test
-  fun `batch delete for keys not in the same slot`() {
-    val keysToInsert = keys.toTypedArray()
-    val nonExistentKey = "nonExistentKey"
-    val value = "value".encodeUtf8()
-
-    // Set all keys except nonExistentKey
-    keysToInsert.forEach { redis[it] = value }
-    keysToInsert.forEach { assertEquals(value, redis[it], "Key should have been set") }
-    assertNull(redis[nonExistentKey], "Key should not have been set")
-
-    // Try deleting all three keys, only 2 should actually get deleted
-    assertEquals(
-      keys.size,
-      redis.del(*keysToInsert, nonExistentKey),
-      "${keys.size} keys should have been deleted"
-    )
-
-    // Keys should be deleted
-    listOf(*keysToInsert, nonExistentKey).forEach {
-      assertNull(
-        redis[it],
-        "Key should have been deleted"
-      )
-    }
-  }
-
-  @Test
-  fun `atomic rpoplpush throws cross-cluster error for keys not in the same slot`() {
-
-    assertFailsOnKeysInNotSameSlot {
-      redis.rpoplpush(
-        sourceKey = "{pop}1",
-        destinationKey = "{push}1",
-      )
-    }
-  }
-
-  @Test
-  fun `atomic lmove throws cross-cluster error for keys not in the same slot`() {
-    assertFailsOnKeysInNotSameSlot {
-      redis.lmove(
-        sourceKey = "{k}1",
-        destinationKey = "{t}1",
-        from = ListDirection.RIGHT,
-        to = ListDirection.LEFT,
-      )
-    }
-  }
-
-  private fun assertFailsOnKeysInNotSameSlot(block: () -> Unit) {
-    assertThatThrownBy { block() }
-      .isInstanceOf(JedisClusterOperationException::class.java)
-      .hasMessage("Keys must belong to same hashslot.")
-  }
-
 }

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -10,7 +10,6 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import redis.clients.jedis.ConnectionPoolConfig
 import wisp.deployment.TESTING
@@ -29,10 +28,10 @@ class RealRedisTest : AbstractRedisTest() {
 
   @Inject override lateinit var redis: Redis
 
-  @BeforeEach
-  fun setUp() {
-    redis.flushAll()
-  }
+  // The following tests are not part of the AbstractRedisTest because as implemented right now,
+  // Redis transactions are not supported in Cluster mode. This is because the Redis interface
+  // leaks Jedis implementation details, and exposes the wrong type for Transactions when
+  // Jedis is configured to use a cluster.
 
   @Test
   fun `watch and unwatch succeeds`() {

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -7,6 +7,7 @@ import redis.clients.jedis.Pipeline
 import redis.clients.jedis.Transaction
 import redis.clients.jedis.UnifiedJedis
 import redis.clients.jedis.args.ListDirection
+import wisp.logging.getLogger
 import java.time.Duration
 import java.util.function.Supplier
 
@@ -169,7 +170,7 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(
   }
 
   override fun flushAll() {
-    unifiedJedis.flushAll()
+    unifiedJedis.flushAllWithClusterSupport(logger)
   }
 
   override fun zadd(
@@ -214,4 +215,8 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(
   ): Long = runPipeline { zremRangeByRank(key, start, stop) }
 
   override fun zcard(key: String): Long = runPipeline { zcard(key) }
+
+  companion object {
+    private val logger = getLogger<TestAlwaysPipelinedRedis>()
+  }
 }

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -1,0 +1,217 @@
+package misk.redis
+
+import jakarta.inject.Inject
+import okio.ByteString
+import redis.clients.jedis.JedisPubSub
+import redis.clients.jedis.Pipeline
+import redis.clients.jedis.Transaction
+import redis.clients.jedis.UnifiedJedis
+import redis.clients.jedis.args.ListDirection
+import java.time.Duration
+import java.util.function.Supplier
+
+internal class TestAlwaysPipelinedRedis @Inject constructor(
+  private val unifiedJedis: UnifiedJedis,
+) : Redis {
+
+  private fun <T> runPipeline(block: DeferredRedis.() -> Supplier<T>): T {
+    return unifiedJedis.pipelined().use { pipeline ->
+      block(RealPipelinedRedis(pipeline))
+    }.get()
+  }
+
+  override fun del(key: String): Boolean = runPipeline { del(key) }
+
+  override fun del(vararg keys: String): Int = runPipeline { del(*keys) }
+
+  override fun mget(vararg keys: String): List<ByteString?> = runPipeline { mget(*keys) }
+
+  override fun mset(vararg keyValues: ByteString) = runPipeline { mset(*keyValues) }
+
+  override fun get(key: String): ByteString? = runPipeline { get(key) }
+
+  override fun getDel(key: String): ByteString? = runPipeline { getDel(key) }
+
+  override fun hdel(key: String, vararg fields: String): Long =
+    runPipeline { hdel(key, *fields) }
+
+  override fun hget(key: String, field: String): ByteString? =
+    runPipeline { hget(key, field) }
+
+  override fun hgetAll(key: String): Map<String, ByteString>? = runPipeline { hgetAll(key) }
+
+  override fun hlen(key: String): Long = runPipeline { hlen(key) }
+
+  override fun hmget(key: String, vararg fields: String): List<ByteString?> =
+    runPipeline { hmget(key, *fields) }
+
+  override fun hincrBy(key: String, field: String, increment: Long): Long =
+    runPipeline { hincrBy(key, field, increment) }
+
+  override fun hrandFieldWithValues(key: String, count: Long): Map<String, ByteString>? =
+    runPipeline { hrandFieldWithValues(key, count) }
+
+  override fun hrandField(key: String, count: Long): List<String> =
+    runPipeline { hrandField(key, count) }
+
+  override fun set(key: String, value: ByteString) = runPipeline { set(key, value) }
+
+  override fun set(key: String, expiryDuration: Duration, value: ByteString) =
+    runPipeline { set(key, value, expiryDuration) }
+
+  override fun setnx(key: String, value: ByteString): Boolean =
+    runPipeline { setnx(key, value) }
+
+  override fun setnx(key: String, expiryDuration: Duration, value: ByteString): Boolean =
+    runPipeline { setnx(key, value, expiryDuration) }
+
+  override fun hset(key: String, field: String, value: ByteString): Long =
+    runPipeline { hset(key, field, value) }
+
+  override fun hset(key: String, hash: Map<String, ByteString>): Long =
+    runPipeline { hset(key, hash) }
+
+  override fun incr(key: String): Long = runPipeline { incr(key) }
+
+  override fun incrBy(key: String, increment: Long): Long =
+    runPipeline { incrBy(key, increment) }
+
+  override fun blmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection,
+    timeoutSeconds: Double
+  ): ByteString? = runPipeline { blmove(sourceKey, destinationKey, from, to, timeoutSeconds) }
+
+  override fun brpoplpush(
+    sourceKey: String,
+    destinationKey: String,
+    timeoutSeconds: Int
+  ): ByteString? = runPipeline { brpoplpush(sourceKey, destinationKey, timeoutSeconds) }
+
+  override fun lmove(
+    sourceKey: String,
+    destinationKey: String,
+    from: ListDirection,
+    to: ListDirection
+  ): ByteString? = runPipeline { lmove(sourceKey, destinationKey, from, to) }
+
+  override fun lpush(key: String, vararg elements: ByteString): Long =
+    runPipeline { lpush(key, *elements) }
+
+  override fun rpush(key: String, vararg elements: ByteString): Long =
+    runPipeline { rpush(key, *elements) }
+
+  override fun lpop(key: String, count: Int): List<ByteString?> =
+    runPipeline { lpop(key, count) }
+
+  override fun lpop(key: String): ByteString? = runPipeline { lpop(key) }
+
+  override fun rpop(key: String, count: Int): List<ByteString?> =
+    runPipeline { rpop(key, count) }
+
+  override fun rpop(key: String): ByteString? = runPipeline { rpop(key) }
+
+  override fun lrange(key: String, start: Long, stop: Long): List<ByteString?> =
+    runPipeline { lrange(key, start, stop) }
+
+  override fun lrem(key: String, count: Long, element: ByteString): Long =
+    runPipeline { lrem(key, count, element) }
+
+  override fun rpoplpush(sourceKey: String, destinationKey: String): ByteString? =
+    runPipeline { rpoplpush(sourceKey, destinationKey) }
+
+  override fun expire(key: String, seconds: Long): Boolean =
+    runPipeline { expire(key, seconds) }
+
+  override fun expireAt(key: String, timestampSeconds: Long): Boolean =
+    runPipeline { expireAt(key, timestampSeconds) }
+
+  override fun pExpire(key: String, milliseconds: Long): Boolean =
+    runPipeline { pExpire(key, milliseconds) }
+
+  override fun pExpireAt(key: String, timestampMilliseconds: Long): Boolean =
+    runPipeline { pExpireAt(key, timestampMilliseconds) }
+
+  override fun watch(vararg keys: String) {
+    error("watch is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  override fun unwatch(vararg keys: String) {
+    error("unwatch is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  override fun multi(): Transaction {
+    error("multi is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  @Deprecated("Use pipelining instead.")
+  override fun pipelined(): Pipeline {
+    error("pipelined is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  override fun pipelining(block: DeferredRedis.() -> Unit): Unit = runPipeline {
+    block(this)
+    Supplier { }
+  }
+
+  override fun close() {
+    unifiedJedis.close()
+  }
+
+  override fun subscribe(jedisPubSub: JedisPubSub, channel: String) {
+    error("subscribe is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  override fun publish(channel: String, message: String) {
+    error("publish is not supported in TestAlwaysPipelinedRedis")
+  }
+
+  override fun flushAll() {
+    unifiedJedis.flushAll()
+  }
+
+  override fun zadd(
+    key: String,
+    score: Double,
+    member: String,
+    vararg options: Redis.ZAddOptions
+  ): Long = runPipeline { zadd(key, score, member, *options) }
+
+  override fun zadd(
+    key: String,
+    scoreMembers: Map<String, Double>,
+    vararg options: Redis.ZAddOptions
+  ): Long = runPipeline { zadd(key, scoreMembers, *options) }
+
+  override fun zscore(key: String, member: String): Double? =
+    runPipeline { zscore(key, member) }
+
+  override fun zrange(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): List<ByteString?> = runPipeline { zrange(key, type, start, stop, reverse, limit) }
+
+  override fun zrangeWithScores(
+    key: String,
+    type: Redis.ZRangeType,
+    start: Redis.ZRangeMarker,
+    stop: Redis.ZRangeMarker,
+    reverse: Boolean,
+    limit: Redis.ZRangeLimit?
+  ): List<Pair<ByteString?, Double>> =
+    runPipeline { zrangeWithScores(key, type, start, stop, reverse, limit) }
+
+  override fun zremRangeByRank(
+    key: String,
+    start: Redis.ZRangeRankMarker,
+    stop: Redis.ZRangeRankMarker
+  ): Long = runPipeline { zremRangeByRank(key, start, stop) }
+
+  override fun zcard(key: String): Long = runPipeline { zcard(key) }
+}

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -627,6 +627,61 @@ class FakeRedis @Inject constructor(
       this@FakeRedis.pExpireAt(key, timestampMilliseconds)
     }
 
+    override fun zadd(
+      key: String,
+      score: Double,
+      member: String,
+      vararg options: Redis.ZAddOptions
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zadd(key, score, member, *options)
+    }
+
+    override fun zadd(
+      key: String,
+      scoreMembers: Map<String, Double>,
+      vararg options: Redis.ZAddOptions
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zadd(key, scoreMembers, *options)
+    }
+
+    override fun zscore(key: String, member: String): Supplier<Double?> = Supplier {
+      this@FakeRedis.zscore(key, member)
+    }
+
+    override fun zrange(
+      key: String,
+      type: ZRangeType,
+      start: ZRangeMarker,
+      stop: ZRangeMarker,
+      reverse: Boolean,
+      limit: ZRangeLimit?
+    ): Supplier<List<ByteString?>> = Supplier {
+      this@FakeRedis.zrange(key, type, start, stop, reverse, limit)
+    }
+
+    override fun zrangeWithScores(
+      key: String,
+      type: ZRangeType,
+      start: ZRangeMarker,
+      stop: ZRangeMarker,
+      reverse: Boolean,
+      limit: ZRangeLimit?
+    ): Supplier<List<Pair<ByteString?, Double>>> = Supplier {
+      this@FakeRedis.zrangeWithScores(key, type, start, stop, reverse, limit)
+    }
+
+    override fun zremRangeByRank(
+      key: String,
+      start: ZRangeRankMarker,
+      stop: ZRangeRankMarker
+    ): Supplier<Long> = Supplier {
+      this@FakeRedis.zremRangeByRank(key, start, stop)
+    }
+
+    override fun zcard(key: String): Supplier<Long> = Supplier {
+      this@FakeRedis.zcard(key)
+    }
+
     override fun close() {
       // No-op.
     }

--- a/samples/exemplar/src/test/kotlin/com/squareup/exemplar/ExemplarTestModule.kt
+++ b/samples/exemplar/src/test/kotlin/com/squareup/exemplar/ExemplarTestModule.kt
@@ -3,11 +3,8 @@ package com.squareup.exemplar
 import misk.MiskTestingServiceModule
 import misk.environment.DeploymentModule
 import misk.inject.KAbstractModule
-import misk.ratelimiting.bucket4j.redis.RedisBucket4jRateLimiterModule
-import misk.redis.testing.DockerRedis
 import misk.time.FakeClockModule
 import misk.tokens.FakeTokenGeneratorModule
-import redis.clients.jedis.JedisPoolConfig
 import wisp.deployment.TESTING
 
 class ExemplarTestModule : KAbstractModule() {


### PR DESCRIPTION
Essentially reimplements the reverted changes #3198, but in an additive-only way which is much less disruptive.

1. Introduces a **test-sources-only** redis client implementation which always delegates to pipelining operations. This allows us to ensure that RealPipelinedRedis always has test parity with RealRedis.
   - This provides a path forward for non-disruptively attempting to reproduce and diagnose connection/client configuration issues that may have been caused by just pipelining everything by default (as was done in #3198).
2. Reintroduces sorted-set operations to pipelines. This is safe to do, since we have upgraded to Jedis 5 (see #3198 for the reasoning why this was introduced and removed, before being re-introduced due to bugs in Jedis).