### PR TITLE
Log evaluation reason when checkDefaultNotUsed fails

### DIFF
--- a/wisp/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/wisp/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -283,7 +283,9 @@ class LaunchDarklyFeatureFlags @JvmOverloads constructor(
       )
     }
 
-    throw IllegalStateException("Feature flag $feature is off but no off variation is specified")
+    throw IllegalStateException(
+      "Feature flag $feature is off but no off variation is specified, evaluation reason: ${detail.reason}"
+    )
   }
 
   private fun buildUser(feature: Feature, key: String, attributes: Attributes): LDUser {


### PR DESCRIPTION
This provides useful information to understand the specific error we got from LD.