### PR TITLE
CronModule to be install once module

### DIFF
--- a/misk-cron/api/misk-cron.api
+++ b/misk-cron/api/misk-cron.api
@@ -34,7 +34,7 @@ public final class misk/cron/CronManager$CronEntry {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class misk/cron/CronModule : misk/inject/KAbstractModule {
+public final class misk/cron/CronModule : misk/inject/KInstallOnceModule {
 	public fun <init> (Ljava/time/ZoneId;)V
 	public fun <init> (Ljava/time/ZoneId;I)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V
@@ -46,7 +46,7 @@ public abstract interface annotation class misk/cron/CronPattern : java/lang/ann
 	public abstract fun pattern ()Ljava/lang/String;
 }
 
-public final class misk/cron/FakeCronModule : misk/inject/KAbstractModule {
+public final class misk/cron/FakeCronModule : misk/inject/KInstallOnceModule {
 	public fun <init> (Ljava/time/ZoneId;)V
 	public fun <init> (Ljava/time/ZoneId;I)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V

--- a/misk-cron/api/misk-cron.api
+++ b/misk-cron/api/misk-cron.api
@@ -46,7 +46,7 @@ public abstract interface annotation class misk/cron/CronPattern : java/lang/ann
 	public abstract fun pattern ()Ljava/lang/String;
 }
 
-public final class misk/cron/FakeCronModule : misk/inject/KInstallOnceModule {
+public final class misk/cron/FakeCronModule : misk/inject/KAbstractModule {
 	public fun <init> (Ljava/time/ZoneId;)V
 	public fun <init> (Ljava/time/ZoneId;I)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -12,6 +12,7 @@ import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
 import java.time.ZoneId
 import jakarta.inject.Qualifier
+import misk.inject.KAbstractModule
 import misk.inject.KInstallOnceModule
 
 class CronModule @JvmOverloads constructor(
@@ -41,7 +42,7 @@ class FakeCronModule @JvmOverloads constructor(
   private val zoneId: ZoneId,
   private val threadPoolSize: Int = 10,
   private val dependencies: List<Key<out Service>> = listOf()
-) : KInstallOnceModule() {
+) : KAbstractModule() {
   override fun configure() {
     bind<ZoneId>().annotatedWith<ForMiskCron>().toInstance(zoneId)
     install(

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -7,18 +7,18 @@ import jakarta.inject.Singleton
 import misk.ReadyService
 import misk.ServiceModule
 import misk.concurrent.ExecutorServiceModule
-import misk.inject.KAbstractModule
 import misk.inject.toKey
 import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueFactory
 import java.time.ZoneId
 import jakarta.inject.Qualifier
+import misk.inject.KInstallOnceModule
 
 class CronModule @JvmOverloads constructor(
   private val zoneId: ZoneId,
   private val threadPoolSize: Int = 10,
   private val dependencies: List<Key<out Service>> = listOf()
-) : KAbstractModule() {
+) : KInstallOnceModule() {
   override fun configure() {
     install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class).dependsOn<ReadyService>())
@@ -41,7 +41,7 @@ class FakeCronModule @JvmOverloads constructor(
   private val zoneId: ZoneId,
   private val threadPoolSize: Int = 10,
   private val dependencies: List<Key<out Service>> = listOf()
-) : KAbstractModule() {
+) : KInstallOnceModule() {
   override fun configure() {
     bind<ZoneId>().annotatedWith<ForMiskCron>().toInstance(zoneId)
     install(

--- a/misk-cron/src/test/kotlin/misk/cron/FakeCronModuleTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/FakeCronModuleTest.kt
@@ -21,7 +21,7 @@ import jakarta.inject.Singleton
 import misk.clustering.weights.FakeClusterWeightModule
 
 @MiskTest(startService = true)
-class CronModuleTest {
+class FakeCronModuleTest {
   @Suppress("unused")
   @MiskTestModule
   val module = object : KAbstractModule() {
@@ -29,15 +29,12 @@ class CronModuleTest {
       install(FakeLeaseModule())
       install(MiskTestingServiceModule())
       install(LogCollectorModule())
+
       install(ServiceModule<DependentService>().enhancedBy<ReadyService>())
       install(FakeClusterWeightModule())
       install(
-        CronModule(ZoneId.of("America/Toronto"),
-          dependencies = listOf(DependentService::class.toKey())
-        )
-      )
-      install(
-        CronModule(ZoneId.of("America/Toronto"),
+        FakeCronModule(
+          ZoneId.of("America/Toronto"),
           dependencies = listOf(DependentService::class.toKey())
         )
       )
@@ -48,7 +45,7 @@ class CronModuleTest {
   @Inject private lateinit var logCollector: LogCollector
 
   @Test fun dependentServicesStartUpBeforeCron() {
-    assertThat(logCollector.takeMessages()).contains(
+    assertThat(logCollector.takeMessages()).containsExactly(
       "DependentService started",
       "Starting ready service",
       "CronService started",


### PR DESCRIPTION
* CronModule might be installed multiple times (for example once in a service, and once in a library which is dependent by the service). Change it to extend KInstallOnceModule so that this module is only installed once by Guice.
* Also added a test, which tests CronModule.
* Renamed the original CronModuleTest to FakeCronModuleTest, since it doesn't really test the CronModule