### PR TITLE
Fetch the max receive count from the redrive policy directly

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6241,6 +6241,32 @@ acceptedBreaks:
       new: "method void misk.jobqueue.sqs.SqsJob::delayForFailure()"
       justification: "{SqsJob is an internal class and there seem to be no references\
         \ to this function}"
+  "2024.04.12.171745-81ea336":
+    com.squareup.misk:misk-aws:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.jobqueue.sqs.QueueResolver::<init>(misk.cloud.aws.AwsRegion,\
+        \ misk.cloud.aws.AwsAccountId, com.amazonaws.services.sqs.AmazonSQS, java.util.Map<misk.cloud.aws.AwsRegion,\
+        \ ? extends com.amazonaws.services.sqs.AmazonSQS>, com.amazonaws.services.sqs.AmazonSQS,\
+        \ java.util.Map<misk.cloud.aws.AwsRegion, ? extends com.amazonaws.services.sqs.AmazonSQS>,\
+        \ java.util.Map<misk.jobqueue.QueueName, misk.jobqueue.sqs.AwsSqsQueueConfig>,\
+        \ misk.jobqueue.sqs.DeadLetterQueueProvider)"
+      new: "method void misk.jobqueue.sqs.QueueResolver::<init>(misk.cloud.aws.AwsRegion,\
+        \ misk.cloud.aws.AwsAccountId, com.amazonaws.services.sqs.AmazonSQS, java.util.Map<misk.cloud.aws.AwsRegion,\
+        \ ? extends com.amazonaws.services.sqs.AmazonSQS>, com.amazonaws.services.sqs.AmazonSQS,\
+        \ java.util.Map<misk.cloud.aws.AwsRegion, ? extends com.amazonaws.services.sqs.AmazonSQS>,\
+        \ java.util.Map<misk.jobqueue.QueueName, misk.jobqueue.sqs.AwsSqsQueueConfig>,\
+        \ misk.jobqueue.sqs.DeadLetterQueueProvider, com.squareup.moshi.Moshi)"
+      justification: "SQSJob is an internal class and is not exposed to the clients\
+        \ of Misk"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.jobqueue.sqs.ResolvedQueue::<init>(misk.jobqueue.QueueName,\
+        \ misk.jobqueue.QueueName, java.lang.String, misk.cloud.aws.AwsRegion, misk.cloud.aws.AwsAccountId,\
+        \ com.amazonaws.services.sqs.AmazonSQS)"
+      new: "method void misk.jobqueue.sqs.ResolvedQueue::<init>(misk.jobqueue.QueueName,\
+        \ misk.jobqueue.QueueName, java.lang.String, misk.cloud.aws.AwsRegion, misk.cloud.aws.AwsAccountId,\
+        \ com.amazonaws.services.sqs.AmazonSQS, int)"
+      justification: "SQSJob is an internal class and is not exposed to the clients\
+        \ of Misk"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6234,6 +6234,13 @@ acceptedBreaks:
         \ extends java.lang.annotation.Annotation>, java.util.List<java.lang.String>,\
         \ java.util.List<java.lang.String>, boolean, boolean)"
       justification: "New parameters are optional"
+  "2024.04.10.210352-9854ef3":
+    com.squareup.misk:misk-aws:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void misk.jobqueue.sqs.SqsJob::delayForFailure(int)"
+      new: "method void misk.jobqueue.sqs.SqsJob::delayForFailure()"
+      justification: "{SqsJob is an internal class and there seem to be no references\
+        \ to this function}"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
@@ -14,7 +14,7 @@ internal class ResolvedQueue(
   val region: AwsRegion,
   val accountId: AwsAccountId,
   val client: AmazonSQS,
-  val maxRetries: Int,
+  val maxRetries: Int = 10,
 ) {
 
   val queueName: String

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
@@ -13,7 +13,8 @@ internal class ResolvedQueue(
   val url: String,
   val region: AwsRegion,
   val accountId: AwsAccountId,
-  val client: AmazonSQS
+  val client: AmazonSQS,
+  val maxRetries: Int,
 ) {
 
   val queueName: String

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -10,7 +10,6 @@ import misk.jobqueue.QueueName
 import misk.moshi.adapter
 import misk.time.timed
 import java.math.BigInteger
-import kotlin.math.pow
 import kotlin.random.Random
 
 internal class SqsJob(
@@ -65,10 +64,11 @@ internal class SqsJob(
    *  that duration. With every subsequent retry the duration becomes longer until it hits the max
    *  value of 10hrs.
    */
-   fun delayForFailure(maxRetryCount: Int = 10) {
+  fun delayForFailure() {
+    val maxReceiveCount = queue.maxRetries
     val visibilityTime = calculateVisibilityTimeOut(
       currentReceiveCount = attributes[RECEIVE_COUNT]?.toInt()  ?: 1,
-      maxReceiveCount = maxRetryCount,
+      maxReceiveCount = maxReceiveCount,
     )
 
     queue.call { client ->

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -1,8 +1,9 @@
 package misk.jobqueue.sqs
 
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest
 import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.QueueAttributeName
 import misk.clustering.fake.lease.FakeLeaseManager
 import misk.feature.testing.FakeFeatureFlags
 import misk.jobqueue.Job
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import jakarta.inject.Inject
 import kotlin.test.assertFailsWith
+import com.squareup.moshi.Moshi
 
 @MiskTest(startService = true)
 internal class SqsJobQueueTest {
@@ -44,10 +46,11 @@ internal class SqsJobQueueTest {
   @Inject @ForSqsHandling lateinit var taskQueue: RepeatedTaskQueue
   @Inject private lateinit var fakeFeatureFlags: FakeFeatureFlags
   @Inject private lateinit var fakeLeaseManager: FakeLeaseManager
-  @Inject private lateinit var queueResolver: QueueResolver
+  @Inject private lateinit var moshi: Moshi
 
   private lateinit var queueName: QueueName
   private lateinit var deadLetterQueueName: QueueName
+
 
   /**
    * Make sure all tests pass regardless of the receiver policy.
@@ -183,6 +186,107 @@ internal class SqsJobQueueTest {
     assertThat(sqsMetrics.handlerFailures.labels(queueName.value, queueName.value).get()).isEqualTo(
       0.0
     )
+  }
+
+  private fun createDeadLetterQueue(queueName: String): String?{
+    val dlqName = "${queueName}_dlq"
+
+    val createQueueRequest = CreateQueueRequest()
+      .withQueueName(dlqName)
+      .withAttributes(mapOf(
+        "MessageRetentionPeriod" to "10"
+      ))
+
+    val dlqUrl = sqs.createQueue(createQueueRequest).queueUrl
+    return sqs.getQueueAttributes(dlqUrl, listOf("QueueArn")).attributes["QueueArn"]
+  }
+  @TestAllReceiverPolicies
+  fun usingRedrivePolicyTheMaxNumberOfReceivesCouldBeAchieved(receiverPolicy: String) {
+    setupReceiverPolicy(receiverPolicy)
+    val handledJobs = CopyOnWriteArrayList<Job>()
+
+    val queueNameWithRedrive = QueueName("sqs_job_queue_test_redrive")
+    val maxReceiveCount = 2
+    val deadLetterQueueArn = createDeadLetterQueue(queueNameWithRedrive.value)
+
+    assertThat(deadLetterQueueArn).isNotNull()
+
+    val redrivePolicyQueueUrl = sqs.createQueue(
+      CreateQueueRequest()
+        .withQueueName(queueNameWithRedrive.value)
+        .withAttributes(
+          mapOf(
+            // 1 second visibility timeout
+            "VisibilityTimeout" to 1.toString(),
+            "RedrivePolicy" to """{"maxReceiveCount":"$maxReceiveCount", "deadLetterTargetArn":"$deadLetterQueueArn"}"""
+          )
+        )
+    ).queueUrl
+
+    queue.enqueue(queueNameWithRedrive, "this is my job")
+
+    val jobsReceived = AtomicInteger()
+    val allJobsCompleted = CountDownLatch(2)
+    consumer.subscribe(queueNameWithRedrive) {
+      val sqsJob = it as SqsJob
+      handledJobs.add(sqsJob)
+      // Only acknowledge third attempt
+      if (jobsReceived.getAndIncrement() == 1) sqsJob.acknowledge()
+      else sqsJob.delayForFailure()
+
+      allJobsCompleted.countDown()
+    }
+
+    assertThat(allJobsCompleted.await(10, TimeUnit.SECONDS)).isTrue()
+
+    // Should have processed the same job twice
+    val messageId = handledJobs[0].id
+    assertThat(handledJobs.map { it.body }).containsExactly("this is my job", "this is my job")
+    assertThat(handledJobs).allSatisfy { assertThat(it.id).isEqualTo(messageId) }
+
+    // Confirm metrics
+    assertThat(
+      sqsMetrics.jobsEnqueued.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()
+    ).isEqualTo(1.0)
+    assertThat(
+      sqsMetrics.jobEnqueueFailures.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()
+    ).isEqualTo(0.0)
+    assertThat(sqsMetrics.sqsSendTime.count(queueNameWithRedrive.value, queueNameWithRedrive.value)).isEqualTo(1)
+
+    assertThat(
+      sqsMetrics.jobsReceived.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()
+    ).isEqualTo(2.0)
+    // Can't predict how many times we'll receive have since consumers may get 0 messages and retry, or may get many
+    // messages in varying batches
+    assertThat(sqsMetrics.sqsReceiveTime.count(queueNameWithRedrive.value, queueNameWithRedrive.value)).isNotZero()
+
+    // Since we are using jitter, we can't predict what would be the exact timeout time assigned
+    assertThat(sqsMetrics.visibilityTime.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()).isGreaterThanOrEqualTo(1.0)
+
+    assertThat(
+      sqsMetrics.jobsAcknowledged.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()
+    ).isEqualTo(1.0)
+    assertThat(sqsMetrics.sqsDeleteTime.count(queueNameWithRedrive.value, queueNameWithRedrive.value)).isEqualTo(1)
+    assertThat(sqsMetrics.queueProcessingLag.count(queueNameWithRedrive.value, queueNameWithRedrive.value)).isEqualTo(1)
+
+    assertThat(sqsMetrics.handlerFailures.labels(queueNameWithRedrive.value, queueNameWithRedrive.value).get()).isEqualTo(
+      0.0
+    )
+
+    // now assert the redrive policy has been applied correctly
+    val redrivePolicyJson = sqs.getQueueAttributes(
+      GetQueueAttributesRequest()
+        .withQueueUrl(redrivePolicyQueueUrl)
+        .withAttributeNames(
+          QueueAttributeName.RedrivePolicy
+        )
+    ).attributes["RedrivePolicy"]
+
+    assertThat(redrivePolicyJson).isNotNull()
+
+    // assert that the redrive policy has been applied correctly
+    val redrivePolicyAdapter = moshi.adapter(QueueResolver.RedrivePolicy::class.java)
+    assertThat(redrivePolicyAdapter.fromJson(redrivePolicyJson!!)?.maxReceiveCount).isEqualTo(2)
   }
 
   @TestAllReceiverPolicies

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -275,7 +275,6 @@ data class FakeJob(
   override fun deadLetter() {
     deadLettered = true
   }
-
   override fun compareTo(other: FakeJob): Int {
     val result = deliverAt.compareTo(other.deliverAt)
     if (result == 0) {


### PR DESCRIPTION
Instead of allowing the clients to pass-in the max retry count, fetch the retry count directly from the queue itself.