### PR TITLE
Add generic marshaller for Unit response

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1984,6 +1984,13 @@ public final class misk/web/marshal/GenericMarshallers$ToNothing : misk/web/mars
 	public fun responseBody (Ljava/lang/Void;)Lmisk/web/ResponseBody;
 }
 
+public final class misk/web/marshal/GenericMarshallers$ToUnit : misk/web/marshal/Marshaller {
+	public fun <init> (Lokhttp3/MediaType;)V
+	public fun contentType ()Lokhttp3/MediaType;
+	public synthetic fun responseBody (Ljava/lang/Object;)Lmisk/web/ResponseBody;
+	public fun responseBody (Lkotlin/Unit;)Lmisk/web/ResponseBody;
+}
+
 public final class misk/web/marshal/GenericUnmarshallers {
 	public static final field INSTANCE Lmisk/web/marshal/GenericUnmarshallers;
 	public final fun canHandle (Ljava/lang/reflect/Type;)Z

--- a/misk/src/main/kotlin/misk/web/marshal/Generic.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Generic.kt
@@ -94,7 +94,7 @@ object GenericMarshallers {
 
   class ToUnit(private val contentType: MediaType?) : Marshaller<Unit> {
     override fun contentType(): MediaType? = contentType
-    override fun responseBody(o: Nothing) = object : ResponseBody {
+    override fun responseBody(o: Unit) = object : ResponseBody {
       override fun writeTo(sink: BufferedSink) {}
     }
   }

--- a/misk/src/main/kotlin/misk/web/marshal/Generic.kt
+++ b/misk/src/main/kotlin/misk/web/marshal/Generic.kt
@@ -58,7 +58,8 @@ object GenericMarshallers {
     String::class.java,
     ResponseBody::class.java,
     ByteString::class.java,
-    Nothing::class.java
+    Nothing::class.java,
+    Unit::class.java,
   )
 
   private class FromResponseBody(private val contentType: MediaType?) : Marshaller<ResponseBody> {
@@ -91,6 +92,13 @@ object GenericMarshallers {
     }
   }
 
+  class ToUnit(private val contentType: MediaType?) : Marshaller<Unit> {
+    override fun contentType(): MediaType? = contentType
+    override fun responseBody(o: Nothing) = object : ResponseBody {
+      override fun writeTo(sink: BufferedSink) {}
+    }
+  }
+
   fun from(contentType: MediaType?, returnType: KType): Marshaller<Any>? {
     @Suppress("UNCHECKED_CAST")
     return when (actualResponseType(returnType)) {
@@ -98,6 +106,7 @@ object GenericMarshallers {
       ByteString::class.java -> FromByteString(contentType)
       ResponseBody::class.java -> FromResponseBody(contentType)
       Nothing::class.java -> ToNothing(contentType)
+      Unit::class.java -> ToUnit(contentType)
       else -> null
     } as Marshaller<Any>?
   }

--- a/misk/src/test/kotlin/misk/web/marshal/UnitResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/UnitResponseTest.kt
@@ -1,0 +1,46 @@
+package misk.web.marshal
+
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.Get
+import misk.web.Response
+import misk.web.WebActionModule
+import misk.web.WebServerTestingModule
+import misk.web.WebTestClient
+import misk.web.actions.WebAction
+import okhttp3.ResponseBody
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+internal class UnitResponseTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject private lateinit var webTestClient: WebTestClient
+
+  @Test
+  fun returnUnitResponseBody() {
+    with(webTestClient.get("/response/as-unit-response-body")) {
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.headers.toMap()).doesNotContainKey("Content-Type")
+      assertThat(response.body!!.bytes()).isEmpty()
+    }
+  }
+
+  class ReturnAsUnitResponseBody @Inject constructor() : WebAction {
+    @Get("/response/as-unit-response-body")
+    fun call() = Response(Unit)
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<ReturnAsUnitResponseBody>())
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/marshal/UnitResponseTest.kt
+++ b/misk/src/test/kotlin/misk/web/marshal/UnitResponseTest.kt
@@ -7,12 +7,18 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.Get
 import misk.web.Response
+import misk.web.ResponseContentType
 import misk.web.WebActionModule
 import misk.web.WebServerTestingModule
 import misk.web.WebTestClient
 import misk.web.actions.WebAction
-import okhttp3.ResponseBody
+import misk.web.mediatype.MediaTypes
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
 
 @MiskTest(startService = true)
@@ -26,7 +32,25 @@ internal class UnitResponseTest {
   fun returnUnitResponseBody() {
     with(webTestClient.get("/response/as-unit-response-body")) {
       assertThat(response.code).isEqualTo(200)
-      assertThat(response.headers.toMap()).doesNotContainKey("Content-Type")
+      assertThat(response.headers["Content-Type"]).isNull()
+      assertThat(response.body!!.bytes()).isEmpty()
+    }
+  }
+
+  @Test
+  fun returnEmptyStringResponseBody() {
+    with(webTestClient.get("/response/as-no-response-content-type")) {
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.headers["Content-Type"]).isNull()
+      assertThat(response.body!!.bytes()).isEmpty()
+    }
+  }
+
+  @Test
+  fun returnWithContentType() {
+    with(webTestClient.get("/response/as-application-json")) {
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.headers["Content-Type"]).isEqualTo(MediaTypes.APPLICATION_JSON)
       assertThat(response.body!!.bytes()).isEmpty()
     }
   }
@@ -36,11 +60,24 @@ internal class UnitResponseTest {
     fun call() = Response(Unit)
   }
 
+  class ReturnAsEmptyStringResponseBody @Inject constructor() : WebAction {
+    @Get("/response/as-no-response-content-type")
+    fun call() = ""
+  }
+
+  class ReturnWithContentType @Inject constructor() : WebAction {
+    @Get("/response/as-application-json")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun call() = Response(Unit)
+  }
+
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(WebServerTestingModule())
       install(MiskTestingServiceModule())
       install(WebActionModule.create<ReturnAsUnitResponseBody>())
+      install(WebActionModule.create<ReturnAsEmptyStringResponseBody>())
+      install(WebActionModule.create<ReturnWithContentType>())
     }
   }
 }


### PR DESCRIPTION
For an endpoint that returns nothing — for instance if it always returns a redirect response — it's currently impossible to return an empty `Response` object without a response media type.

In `ResponseBodyMarshallerFactory` it would look for a generic marshaller that matches the return type [here](https://github.com/cashapp/misk/blob/447c6c984bff3a87473cd2650996a20a9bb1de80/misk/src/main/kotlin/misk/web/interceptors/ResponseBodyMarshallerFactory.kt#L19). This means that a response of type `Unit` would throw.

The workaround for that is to either add a `@ResponseContentType` annotation to force it to use a non-generic marshaller — even if the endpoint never actually returns that content type — or to change the response type to something like an empty string so that it can be handled by the generic `FromString` marshaller. While both of these approaches work I think a Unit response better represents what this kind of empty response actually means.