### PR TITLE
Make AwsSqsJobHandlerSubscriptionService public...

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -72,7 +72,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
 }
 
 @Singleton
-internal class AwsSqsJobHandlerSubscriptionService @Inject constructor(
+class AwsSqsJobHandlerSubscriptionService @Inject internal constructor(
   private val attributeImporter: AwsSqsQueueAttributeImporter,
   private val consumer: SqsJobConsumer,
   private val consumerMapping: Map<QueueName, JobHandler>,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
@@ -11,7 +11,7 @@ import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 import jakarta.inject.Inject
 
-internal class AwsSqsQueueAttributeImporter @Inject constructor(
+class AwsSqsQueueAttributeImporter @Inject internal constructor(
   private val config: AwsSqsJobQueueConfig,
   private val leaseManager: LeaseManager,
   private val metrics: SqsMetrics,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueResolver.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/QueueResolver.kt
@@ -13,7 +13,7 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 
 @Singleton
-internal class QueueResolver @Inject internal constructor(
+class QueueResolver @Inject internal constructor(
   private val currentRegion: AwsRegion,
   private val currentAccount: AwsAccountId,
   private val defaultSQS: AmazonSQS,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/ResolvedQueue.kt
@@ -7,7 +7,7 @@ import misk.cloud.aws.AwsRegion
 import misk.jobqueue.QueueName
 
 /** [ResolvedQueue] provides information needed to reach an SQS queue */
-internal class ResolvedQueue(
+class ResolvedQueue internal constructor(
   val name: QueueName,
   val sqsQueueName: QueueName,
   val url: String,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobConsumer.kt
@@ -31,7 +31,7 @@ import com.google.inject.Provider
 import jakarta.inject.Singleton
 
 @Singleton
-internal class SqsJobConsumer @Inject internal constructor(
+class SqsJobConsumer @Inject internal constructor(
   @ForSqsHandling private val handlingThreads: ExecutorService,
   @ForSqsHandling private val taskQueue: RepeatedTaskQueue,
   @ForSqsReceiving private val receivingThreads: ExecutorService,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsMetrics.kt
@@ -11,7 +11,7 @@ import jakarta.inject.Singleton
  * for queues both client-side and on SQS with the same label.
  */
 @Singleton
-internal class SqsMetrics @Inject internal constructor(metrics: Metrics) {
+class SqsMetrics @Inject internal constructor(metrics: Metrics) {
   val jobsEnqueued = metrics.counter(
     "jobs_enqueued_total",
     "total # of jobs sent to a queueName",


### PR DESCRIPTION
... to allow usage in the service dependency graph

Users may wish to let other Services depend on the AWS JobHandler Subscription service in cases where you want to ensure that SQS job handling has begun before your service has started.

As an alternative to making all these classes `open`, we could do something like this:

```kotlin
val sqsJobHandlerSubscriptionServiceKey: Key<out Service> = Key.get(AwsSqsJobHandlerSubscriptionService::class.java)
```

And leave the `AwsSqsJobHandlerSubscriptionService` and all the rest of the classes marked as `internal`. Not sure if this would actually work and we'd wanna test this further but from our small injector test it seemed to pass.