### PR TITLE
Add aggregation support in select queries

### DIFF
--- a/misk-hibernate/api/misk-hibernate.api
+++ b/misk-hibernate/api/misk-hibernate.api
@@ -1,3 +1,16 @@
+public final class misk/hibernate/AggregationType : java/lang/Enum {
+	public static final field AVG Lmisk/hibernate/AggregationType;
+	public static final field COUNT Lmisk/hibernate/AggregationType;
+	public static final field COUNT_DISTINCT Lmisk/hibernate/AggregationType;
+	public static final field MAX Lmisk/hibernate/AggregationType;
+	public static final field MIN Lmisk/hibernate/AggregationType;
+	public static final field NONE Lmisk/hibernate/AggregationType;
+	public static final field SUM Lmisk/hibernate/AggregationType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/hibernate/AggregationType;
+	public static fun values ()[Lmisk/hibernate/AggregationType;
+}
+
 public final class misk/hibernate/BindPolicy : java/lang/Enum {
 	public static final field APPEND Lmisk/hibernate/BindPolicy;
 	public static final field PREPEND Lmisk/hibernate/BindPolicy;
@@ -50,6 +63,7 @@ public abstract interface class misk/hibernate/DbUnsharded : misk/hibernate/DbEn
 }
 
 public abstract interface annotation class misk/hibernate/Fetch : java/lang/annotation/Annotation {
+	public abstract fun forProjection ()Z
 	public abstract fun joinType ()Ljavax/persistence/criteria/JoinType;
 	public abstract fun path ()Ljava/lang/String;
 }
@@ -73,6 +87,10 @@ public final class misk/hibernate/GidGenerator : org/hibernate/id/AbstractPostIn
 	public fun <init> ()V
 	public fun configure (Lorg/hibernate/type/Type;Ljava/util/Properties;Lorg/hibernate/service/ServiceRegistry;)V
 	public fun getInsertGeneratedIdentifierDelegate (Lorg/hibernate/id/PostInsertIdentityPersister;Lorg/hibernate/dialect/Dialect;Z)Lorg/hibernate/id/insert/InsertGeneratedIdentifierDelegate;
+}
+
+public abstract interface annotation class misk/hibernate/Group : java/lang/annotation/Annotation {
+	public abstract fun paths ()[Ljava/lang/String;
 }
 
 public abstract class misk/hibernate/HibernateEntityModule : misk/inject/KAbstractModule {
@@ -200,6 +218,7 @@ public abstract interface class misk/hibernate/Projection {
 }
 
 public abstract interface annotation class misk/hibernate/Property : java/lang/annotation/Annotation {
+	public abstract fun aggregation ()Lmisk/hibernate/AggregationType;
 	public abstract fun path ()Ljava/lang/String;
 }
 
@@ -256,6 +275,7 @@ public abstract interface annotation class misk/hibernate/SecretColumn : java/la
 }
 
 public abstract interface annotation class misk/hibernate/Select : java/lang/annotation/Annotation {
+	public abstract fun aggregation ()Lmisk/hibernate/AggregationType;
 	public abstract fun path ()Ljava/lang/String;
 }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Projection.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Projection.kt
@@ -1,12 +1,15 @@
 package misk.hibernate
 
-/** Marker interface for query projections. */
 interface Projection
 
 /**
  * Annotates a parameter of a [Projection] data class to indicate which column (or path of columns)
  * to populate the parameter with.
+ *
+ * Properties may be created from an [aggregation] function, which will be applied to the column.
+ * By default, no aggregation is applied.
  */
 annotation class Property(
-  val path: String
+  val path: String,
+  val aggregation: AggregationType = AggregationType.NONE
 )

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Projection.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Projection.kt
@@ -1,5 +1,21 @@
 package misk.hibernate
 
+/**
+ * Marker interface for query projections.
+ *
+ * Projections are used to define the shape of the result set of a query, often as a subset of
+ * the properties of the entity or entities being queried.
+ *
+ * For example, if we have a `DbMovie` entity with a `name`, `release_date`, and other properties
+ * we could use a projection to only select the `name` and `release_date` properties:
+ *
+ * ```
+ * data class NameAndReleaseDate(
+ *  @Property("name") var name: String,
+ *  @Property("release_date") var releaseDate: LocalDate?
+ * ) : Projection
+ * ```
+ */
 interface Projection
 
 /**

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -150,6 +150,19 @@ fun <T, Q : Query<T>> Q.queryHint(hint: String): Q {
 /**
  * Annotates a function on a subinterface of [Query] to indicate which column (or path of columns)
  * it constrains and using which operator.
+ *
+ * You can think of Constraints as the rules used to build the `where` clause of a SQL query.
+ *
+ * For example, you can query movies by title with a method like this:
+ * ```
+ * @Constraint(path = "name")
+ * fun matchesTitle(title: String): MovieQuery
+ * ```
+ * Or query for movies released after a certain date with a method like this:
+ * ```
+ * @Constraint(path = "release_date", operator = Operator.GT)
+ * fun releasedAfter(date: LocalDate): MovieQuery
+ * ```
  */
 annotation class Constraint(
   val path: String,
@@ -192,9 +205,11 @@ enum class Operator {
 }
 
 /**
- * Annotates a function on a subinterface of [Query] to execute a `SELECT` query. Functions with
+ * Annotates a function on a [Query] interface to execute a `SELECT` query. Functions with
  * this annotation must return a `List` to fetch multiple rows results, or a regular type to fetch
  * a unique result.
+ *
+ * [Select] annotated methods may return single column values, or [Projection]s of multiple columns.
  */
 annotation class Select(
   val path: String = "",
@@ -202,8 +217,8 @@ annotation class Select(
 )
 
 /**
- * Annotates a function on a subinterface of [Query] to indicate which columns to order the
- * the selected columns.
+ * Annotates a function on a [Query] interface to indicate by which columns to order the
+ * results. Defaults to ascending order.
  */
 annotation class Order(
   val path: String,
@@ -211,9 +226,9 @@ annotation class Order(
 )
 
 /**
- * Annotates a function on a subinterface of [Query] to specify that the association at
- * the given `path` should be fetched in a single query. The type of join used will be
- * specified by `joinType`.
+ * Annotates a function on a [Query] interface to specify that the association at
+ * the given [path] should be fetched in a single query. The type of join used will be
+ * specified by [joinType].
  */
 annotation class Fetch(
   val path: String = "",

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -229,10 +229,15 @@ annotation class Order(
  * Annotates a function on a [Query] interface to specify that the association at
  * the given [path] should be fetched in a single query. The type of join used will be
  * specified by [joinType].
+ *
+ * If the query is a projection, and does not need to get the entire entity graph, set
+ * [forProjection] to true. This will make the query operate as a regular JOIN query, instead
+ * of a JOIN FETCH query.
  */
 annotation class Fetch(
   val path: String = "",
-  val joinType: JoinType = LEFT
+  val joinType: JoinType = LEFT,
+  val forProjection: Boolean = false,
 )
 
 /**

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -236,6 +236,14 @@ annotation class Fetch(
 )
 
 /**
+ * Annotates a function on a subinterface of [Query] to indicate that the results should be
+ * grouped by the given [paths].
+ */
+annotation class Group(
+  val paths: Array<String> = []
+)
+
+/**
  * Available aggregations which can be applied to a single value [Select] query,
  * or a [Property] of a projection.
  */

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -197,7 +197,8 @@ enum class Operator {
  * a unique result.
  */
 annotation class Select(
-  val path: String = ""
+  val path: String = "",
+  val aggregation: AggregationType = AggregationType.NONE
 )
 
 /**
@@ -218,3 +219,24 @@ annotation class Fetch(
   val path: String = "",
   val joinType: JoinType = LEFT
 )
+
+/**
+ * Available aggregations which can be applied to a single value [Select] query,
+ * or a [Property] of a projection.
+ */
+enum class AggregationType {
+  /** No aggregation is applied. Like `select column`. */
+  NONE,
+  /** Like `select avg(column)`. */
+  AVG,
+  /** Like `select count(column)`. */
+  COUNT,
+  /** Like `select count(distinct column)`. */
+  COUNT_DISTINCT,
+  /** Like `select max(column)`. */
+  MAX,
+  /** Like `select min(column)`. */
+  MIN,
+  /** Like `select sum(column)`. */
+  SUM,
+}

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Query.kt
@@ -148,14 +148,14 @@ fun <T, Q : Query<T>> Q.queryHint(hint: String): Q {
 }
 
 /**
- * Annotates a function on a subinterface of [Query] to indicate which column (or path of columns)
- * it constrains and using which operator.
+ * Annotates a function on a [Query] interface to indicate which column (or path of columns)
+ * it constrains and using which [Operator].
  *
  * You can think of Constraints as the rules used to build the `where` clause of a SQL query.
  *
  * For example, you can query movies by title with a method like this:
  * ```
- * @Constraint(path = "name")
+ * @Constraint(path = "name") // Uses EQ as the default operator.
  * fun matchesTitle(title: String): MovieQuery
  * ```
  * Or query for movies released after a certain date with a method like this:
@@ -228,9 +228,9 @@ annotation class Order(
 /**
  * Annotates a function on a [Query] interface to specify that the association at
  * the given [path] should be fetched in a single query. The type of join used will be
- * specified by [joinType].
+ * specified by [joinType], and defaults to a LEFT JOIN.
  *
- * If the query is a projection, and does not need to get the entire entity graph, set
+ * If the query will result in a [Projection], and does not need to get the entire entity graph, set
  * [forProjection] to true. This will make the query operate as a regular JOIN query, instead
  * of a JOIN FETCH query.
  */
@@ -241,8 +241,8 @@ annotation class Fetch(
 )
 
 /**
- * Annotates a function on a subinterface of [Query] to indicate that the results should be
- * grouped by the given [paths].
+ * Annotates a function on a [Query] interface to indicate that the results should be
+ * grouped by the given [paths]. This is most useful with [Projection]s and aggregations.
  */
 annotation class Group(
   val paths: Array<String> = []

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -678,7 +678,11 @@ internal class ReflectionQuery<T : DbEntity<T>>(
         result[javaMethod] = object : QueryMethodHandler {
           override fun invoke(reflectionQuery: ReflectionQuery<*>, args: Array<out Any>): Any? {
             return reflectionQuery.addFetch { root ->
-              root.fetch<Any?, Any?>(fetch.path, fetch.joinType)
+              if (fetch.forProjection) {
+                root.join<Any?, Any?>(fetch.path, fetch.joinType)
+              } else {
+                root.fetch<Any?, Any?>(fetch.path, fetch.joinType)
+              }
             }
           }
         }
@@ -1100,7 +1104,7 @@ private typealias OrderFactory =
 
 private typealias GroupFactory = (root: Root<*>, criteriaBuilder: CriteriaBuilder) -> List<Expression<*>>
 
-private typealias FetchFactory = (root: Root<*>) -> javax.persistence.criteria.Fetch<*, *>
+private typealias FetchFactory = (root: Root<*>) -> javax.persistence.criteria.FetchParent<*, *>
 
 private val PATH_PATTERN = Regex("""\w+(\.\w+)*""")
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -542,6 +542,13 @@ internal class ReflectionQuery<T : DbEntity<T>>(
     fun invoke(reflectionQuery: ReflectionQuery<*>, args: Array<out Any>): Any?
 
     companion object {
+      // Primitives are special. We have to ensure we are using the boxed types.
+      private val doubleType = Double::class.createType(nullable = true).typeLiteral().rawType
+      private val longType = Long::class.createType(nullable = true).typeLiteral().rawType
+      private val numberType = Number::class.createType(nullable = true).typeLiteral().rawType
+
+      private fun typeToString(type: Class<*>): String = "${type.simpleName}?"
+
       fun create(
         errors: MutableList<String>,
         function: KFunction<*>,
@@ -947,13 +954,6 @@ internal class ReflectionQuery<T : DbEntity<T>>(
         elementType: TypeLiteral<*>,
         propertyName: String,
       ) : MutableList<String> {
-        // Primitives are special. We have to ensure we are using the boxed types.
-        val doubleType = Double::class.createType(nullable = true).typeLiteral().rawType
-        val longType = Long::class.createType(nullable = true).typeLiteral().rawType
-        val numberType = Number::class.createType(nullable = true).typeLiteral().rawType
-
-        fun typeToString(type: Class<*>): String = "${type.simpleName}?"
-
         val errors = mutableListOf<String>()
         when (aggregation) {
           AggregationType.AVG -> {

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -812,6 +812,45 @@ internal class ReflectionQuery<T : DbEntity<T>>(
           errors.add("${function.name}() return type must be a non-null List or a nullable value")
           return
         }
+        if (select.aggregation != AggregationType.NONE) {
+          val nullableDouble = Double::class.createType(nullable = true).typeLiteral().rawType
+          val nullableLong = Long::class.createType(nullable = true).typeLiteral().rawType
+          val nullableNumber = Number::class.createType(nullable = true).typeLiteral().rawType
+          when (select.aggregation) {
+            AggregationType.AVG -> {
+              if (!nullableDouble.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be Double? for AVG aggregations, but was $elementType")
+              }
+            }
+            AggregationType.COUNT -> {
+              if (!nullableLong.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be Long? for COUNT aggregations, but was $elementType")
+              }
+            }
+            AggregationType.COUNT_DISTINCT -> {
+              if (!nullableLong.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be Long? for COUNT_DISTINCT aggregations, but was $elementType")
+              }
+            }
+            AggregationType.MAX -> {
+              if (!Comparable::class.java.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be out Comparable? for MAX aggregations, but was $elementType")
+              }
+            }
+            AggregationType.MIN -> {
+              if (!Comparable::class.java.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be out Comparable? for MIN aggregations, but was $elementType")
+              }
+            }
+            AggregationType.SUM -> {
+              if (!nullableNumber.isAssignableFrom(elementType.rawType)) {
+                errors.add("${function.name}() return element type must be out Number? for SUM aggregations, but was $elementType")
+              }
+            }
+            else -> error("Unexpected AggregationType: ${select.aggregation} on ${function.name}()")
+          }
+          if (errors.isNotEmpty()) return
+        }
 
         val isProjection = Projection::class.java.isAssignableFrom(elementType.rawType)
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
@@ -1,0 +1,117 @@
+package misk.hibernate
+
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.config.MiskConfig
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.jdbc.DataSourceClusterConfig
+import misk.jdbc.JdbcTestingModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import wisp.deployment.TESTING
+import java.time.LocalDate
+
+@MiskTest(startService = true)
+class AggregationQueryTest {
+  @MiskTestModule val module = AggregationQueryTestModule()
+
+  @Inject @PrimitivesDb lateinit var primitiveTransacter: Transacter
+  @Inject @Movies lateinit var movieTransacter: Transacter
+  @Inject lateinit var queryFactory: Query.Factory
+
+  private val jurassicPark = DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9))
+  private val rocky = DbMovie("Rocky", LocalDate.of(1976, 11, 21))
+  private val starWars = DbMovie("Star Wars", LocalDate.of(1977, 5, 25))
+
+  @Test fun aggregationInQueries() {
+    seedData()
+
+    // Find the average of some numbers (AVG).
+
+    // Find the count of movies (COUNT).
+
+    // Find the count of distinct movie titles (COUNT_DISTINCT).
+
+    // Find the latest movie (MAX).
+    val latestMovieReleaseDate = movieTransacter.transaction { session ->
+      queryFactory.newQuery<OperatorsMovieQuery>()
+        .allowFullScatter().allowTableScan()
+        .releaseDateMax(session)
+    }
+    Assertions.assertThat(latestMovieReleaseDate).isEqualTo(LocalDate.of(1993, 6, 9))
+
+    // Find the oldest movie (MIN).
+
+    // Find the sum of all movie ids (SUM). [Useless query but demonstrates the concept.]
+
+  }
+
+  @Test fun aggregationInProjections() {
+    seedData()
+
+    // Find the average movie id (AVG). [Useless query but demonstrates the concept.]
+
+    // Find the count of movies (COUNT).
+
+    // Find the count of distinct movie titles (COUNT_DISTINCT).
+
+    // Find the latest movie (MAX).
+    val latestMovie = movieTransacter.transaction { session ->
+      queryFactory.newQuery<OperatorsMovieQuery>()
+        .latestReleasedMovie(session)
+    }
+    Assertions.assertThat(latestMovie).isEqualTo(LatestReleasedMovie(jurassicPark.name, jurassicPark.release_date!!))
+
+    // Find the oldest movie (MIN).
+
+    // Find the sum of all movie ids (SUM). [Useless query but demonstrates the concept.]
+  }
+
+  private fun seedData() {
+    movieTransacter.transaction { session ->
+      session.save(jurassicPark)
+      session.save(rocky)
+      session.save(starWars)
+    }
+    primitiveTransacter.transaction { session ->
+      session.save(DbPrimitiveTour(false, 9, 8, 7, 6, '5', 4.0f, 3.0))
+      session.save(DbPrimitiveTour(true, 2, 3, 4, 5, '6', 7.0f, 8.0))
+      session.save(DbPrimitiveTour(true, 2, 3, 4, 5, '6', 7.0f, 8.0))
+    }
+  }
+}
+
+class AggregationQueryTestModule : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(DeploymentModule(TESTING))
+
+    val primitivesConfig = MiskConfig.load<RootConfig>("primitivecolumns", TESTING)
+    install(JdbcTestingModule(PrimitivesDb::class))
+    install(HibernateModule(PrimitivesDb::class, primitivesConfig.data_source))
+    install(object : HibernateEntityModule(PrimitivesDb::class) {
+      override fun configureHibernate() {
+        addEntities(DbPrimitiveTour::class)
+      }
+    })
+
+    val moviesConfig = MiskConfig.load<MoviesConfig>("moviestestmodule", TESTING)
+    val dataSourceConfig = moviesConfig.vitess_mysql_data_source
+    install(JdbcTestingModule(Movies::class, scaleSafetyChecks = false))
+    install(
+      HibernateModule(
+        Movies::class, MoviesReader::class,
+        DataSourceClusterConfig(writer = dataSourceConfig, reader = dataSourceConfig)
+      )
+    )
+    install(object : HibernateEntityModule(Movies::class) {
+      override fun configureHibernate() {
+        addEntities(DbMovie::class, DbActor::class, DbCharacter::class)
+      }
+    })
+  }
+}
+

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbCharacter.kt
@@ -103,6 +103,15 @@ interface CharacterQuery : Query<DbCharacter> {
 
   @Fetch(path = "actor")
   fun withActor(): CharacterQuery
+
+  @Fetch(path = "actor", forProjection = true)
+  fun withActorForProjection(): CharacterQuery
+
+  @Group(paths = ["actor.name"])
+  fun groupByActorName(): CharacterQuery
+
+  @Select
+  fun listAsActorAndCharacterCount(session: Session): List<ActorAndCharacterCount>
 }
 
 data class NameAndReleaseDate(
@@ -113,4 +122,9 @@ data class NameAndReleaseDate(
 data class ActorAndReleaseDate(
   @Property("actor.name") var actorName: String,
   @Property("movie.release_date") var movieReleaseDate: LocalDate?
+) : Projection
+
+data class ActorAndCharacterCount(
+  @Property("actor.name") var actorName: String,
+  @Property("name", aggregation = AggregationType.COUNT) var characterCount: Long?
 ) : Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbPrimitiveTour.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbPrimitiveTour.kt
@@ -1,0 +1,38 @@
+package misk.hibernate
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Table
+
+@Entity
+@Table(name = "primitive_tours")
+class DbPrimitiveTour(
+  @Column(nullable = false)
+  var i1: Boolean = false,
+
+  @Column(nullable = false)
+  var i8: Byte = 0,
+
+  @Column(nullable = false)
+  var i16: Short = 0,
+
+  @Column(nullable = false)
+  var i32: Int = 0,
+
+  @Column(nullable = false)
+  var i64: Long = 0,
+
+  @Column(nullable = false)
+  var c16: Char = '\u0000',
+
+  @Column(nullable = false)
+  var f32: Float = 0.0f,
+
+  @Column(nullable = false)
+  var f64: Double = 0.0
+
+) : DbUnsharded<DbPrimitiveTour> {
+  @javax.persistence.Id @GeneratedValue
+  override lateinit var id: Id<DbPrimitiveTour>
+}

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/MoviesTestModule.kt
@@ -52,7 +52,7 @@ class MoviesTestModule(
     install(entitiesModule)
   }
 
-  private fun selectDataSourceConfig(config: MoviesConfig): DataSourceConfig {
+  internal fun selectDataSourceConfig(config: MoviesConfig): DataSourceConfig {
     return when (type) {
       DataSourceType.VITESS_MYSQL -> config.vitess_mysql_data_source
       DataSourceType.MYSQL -> config.mysql_data_source

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
@@ -74,6 +74,12 @@ interface OperatorsMovieQuery : Query<DbMovie> {
 
   @Select
   fun oldestReleasedMovie(session: Session): OldestReleaseDate?
+
+  @Group(paths = ["release_date"])
+  fun groupByReleaseDate(): OperatorsMovieQuery
+
+  @Select
+  fun datesWithReleaseCount(session: Session): List<DateWithReleaseCount>
 }
 
 data class LatestReleaseDate(
@@ -84,4 +90,11 @@ data class LatestReleaseDate(
 data class OldestReleaseDate(
   @Property(path = "release_date", aggregation = AggregationType.MIN)
   val release_date: LocalDate
+): Projection
+
+data class DateWithReleaseCount(
+  @Property(path = "release_date")
+  val release_date: LocalDate,
+  @Property(path = "name", aggregation = AggregationType.COUNT)
+  val count: Long
 ): Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
@@ -63,13 +63,25 @@ interface OperatorsMovieQuery : Query<DbMovie> {
   @Select(path = "release_date", aggregation = AggregationType.MAX)
   fun releaseDateMax(session: Session): LocalDate?
 
+  @Select(path = "release_date", aggregation = AggregationType.MIN)
+  fun releaseDateMin(session: Session): LocalDate?
+
+  @Select(path = "name", aggregation = AggregationType.COUNT_DISTINCT)
+  fun distinctMovieTitles(session: Session): Long?
+
   @Select
-  fun latestReleasedMovie(session: Session): LatestReleasedMovie?
+  fun latestReleasedMovie(session: Session): LatestReleaseDate?
+
+  @Select
+  fun oldestReleasedMovie(session: Session): OldestReleaseDate?
 }
 
-data class LatestReleasedMovie(
-  @Property(path = "name")
-  val name: String,
+data class LatestReleaseDate(
   @Property(path = "release_date", aggregation = AggregationType.MAX)
+  val release_date: LocalDate
+): Projection
+
+data class OldestReleaseDate(
+  @Property(path = "release_date", aggregation = AggregationType.MIN)
   val release_date: LocalDate
 ): Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
@@ -96,5 +96,5 @@ data class DateWithReleaseCount(
   @Property(path = "release_date")
   val release_date: LocalDate,
   @Property(path = "name", aggregation = AggregationType.COUNT)
-  val count: Long
+  val count: Long?
 ): Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/OperatorsMovieQuery.kt
@@ -59,4 +59,17 @@ interface OperatorsMovieQuery : Query<DbMovie> {
 
   @Select("name")
   fun listAsNames(session: Session): List<String>
+
+  @Select(path = "release_date", aggregation = AggregationType.MAX)
+  fun releaseDateMax(session: Session): LocalDate?
+
+  @Select
+  fun latestReleasedMovie(session: Session): LatestReleasedMovie?
 }
+
+data class LatestReleasedMovie(
+  @Property(path = "name")
+  val name: String,
+  @Property(path = "release_date", aggregation = AggregationType.MAX)
+  val release_date: LocalDate
+): Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveColumnsTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveColumnsTest.kt
@@ -1,27 +1,15 @@
 package misk.hibernate
 
-import misk.MiskTestingServiceModule
-import misk.config.MiskConfig
-import misk.environment.DeploymentModule
-import misk.inject.KAbstractModule
-import misk.jdbc.DataSourceConfig
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import wisp.config.Config
-import wisp.deployment.TESTING
 import jakarta.inject.Inject
-import jakarta.inject.Qualifier
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Table
 
 @MiskTest(startService = true)
 class PrimitiveColumnsTest {
   @MiskTestModule
-  val module = TestModule()
+  val module = PrimitivesDbTestModule()
 
   @Inject @PrimitivesDb lateinit var transacter: Transacter
   @Inject lateinit var queryFactory: Query.Factory
@@ -37,79 +25,9 @@ class PrimitiveColumnsTest {
         .allowTableScan()
         .i1(true)
         .listAsPrimitiveTour(session)
-      assertThat(primitiveTour).containsExactly(PrimitiveTour(true, 2, 3, 4, 5, '6', 7.0f, 8.0))
+      assertThat(primitiveTour).containsExactly(
+        PrimitiveTour(true, 2, 3, 4, 5, '6', 7.0f, 8.0)
+      )
     }
-  }
-
-  class TestModule : KAbstractModule() {
-    override fun configure() {
-      install(MiskTestingServiceModule())
-      install(DeploymentModule(TESTING))
-
-      val config = MiskConfig.load<RootConfig>("primitivecolumns", TESTING)
-      install(HibernateTestingModule(PrimitivesDb::class, config.data_source))
-      install(HibernateModule(PrimitivesDb::class, config.data_source))
-      install(object : HibernateEntityModule(PrimitivesDb::class) {
-        override fun configureHibernate() {
-          addEntities(DbPrimitiveTour::class)
-        }
-      })
-    }
-  }
-
-  @Qualifier
-  @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
-  annotation class PrimitivesDb
-
-  data class RootConfig(val data_source: DataSourceConfig) : Config
-
-  @Entity
-  @Table(name = "primitive_tours")
-  class DbPrimitiveTour(
-    @Column(nullable = false)
-    var i1: Boolean = false,
-
-    @Column(nullable = false)
-    var i8: Byte = 0,
-
-    @Column(nullable = false)
-    var i16: Short = 0,
-
-    @Column(nullable = false)
-    var i32: Int = 0,
-
-    @Column(nullable = false)
-    var i64: Long = 0,
-
-    @Column(nullable = false)
-    var c16: Char = '\u0000',
-
-    @Column(nullable = false)
-    var f32: Float = 0.0f,
-
-    @Column(nullable = false)
-    var f64: Double = 0.0
-
-  ) : DbUnsharded<DbPrimitiveTour> {
-    @javax.persistence.Id @GeneratedValue override lateinit var id: Id<DbPrimitiveTour>
-  }
-
-  data class PrimitiveTour(
-    @Property("i1") var i1: Boolean,
-    @Property("i8") var i8: Byte,
-    @Property("i16") var i16: Short,
-    @Property("i32") var i32: Int,
-    @Property("i64") var i64: Long,
-    @Property("c16") var c16: Char,
-    @Property("f32") var f32: Float,
-    @Property("f64") var f64: Double
-  ) : Projection
-
-  interface PrimitiveTourQuery : Query<DbPrimitiveTour> {
-    @Constraint(path = "i1")
-    fun i1(i1: Boolean): PrimitiveTourQuery
-
-    @Select
-    fun listAsPrimitiveTour(session: Session): List<PrimitiveTour>
   }
 }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
@@ -42,6 +42,12 @@ interface PrimitiveTourQuery : Query<DbPrimitiveTour> {
 
   @Select
   fun sumAll(session: Session): SumPrimitiveTour?
+
+  @Group(paths = ["i1", "c16"])
+  fun groupByI1AndC16(): PrimitiveTourQuery
+
+  @Select
+  fun listI1C16AndMaxI8(session: Session): List<I1C16AndMaxI8>
 }
 
 data class PrimitiveTour(
@@ -115,4 +121,11 @@ data class SumPrimitiveTour(
   @Property("i64", aggregation = AggregationType.SUM) var i64: Long,
   @Property("f32", aggregation = AggregationType.SUM) var f32: Double,
   @Property("f64", aggregation = AggregationType.SUM) var f64: Double
+) : Projection
+
+
+data class I1C16AndMaxI8(
+  @Property("i1") var i1: Boolean,
+  @Property("c16") var c16: Char,
+  @Property("i8", aggregation = AggregationType.MAX) var i8: Long
 ) : Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
@@ -62,70 +62,70 @@ data class PrimitiveTour(
 ) : Projection
 
 data class AveragePrimitiveTour(
-  @Property("i8", aggregation = AggregationType.AVG) var i8: Double,
-  @Property("i16", aggregation = AggregationType.AVG) var i16: Double,
-  @Property("i32", aggregation = AggregationType.AVG) var i32: Double,
-  @Property("i64", aggregation = AggregationType.AVG) var i64: Double,
-  @Property("f32", aggregation = AggregationType.AVG) var f32: Double,
-  @Property("f64", aggregation = AggregationType.AVG) var f64: Double
+  @Property("i8", aggregation = AggregationType.AVG) var i8: Double?,
+  @Property("i16", aggregation = AggregationType.AVG) var i16: Double?,
+  @Property("i32", aggregation = AggregationType.AVG) var i32: Double?,
+  @Property("i64", aggregation = AggregationType.AVG) var i64: Double?,
+  @Property("f32", aggregation = AggregationType.AVG) var f32: Double?,
+  @Property("f64", aggregation = AggregationType.AVG) var f64: Double?,
 ) : Projection
 
 data class CountPrimitiveTour(
-  @Property("i1", aggregation = AggregationType.COUNT) var i1: Long,
-  @Property("i8", aggregation = AggregationType.COUNT) var i8: Long,
-  @Property("i16", aggregation = AggregationType.COUNT) var i16: Long,
-  @Property("i32", aggregation = AggregationType.COUNT) var i32: Long,
-  @Property("i64", aggregation = AggregationType.COUNT) var i64: Long,
-  @Property("c16", aggregation = AggregationType.COUNT) var c16: Long,
-  @Property("f32", aggregation = AggregationType.COUNT) var f32: Long,
-  @Property("f64", aggregation = AggregationType.COUNT) var f64: Long
+  @Property("i1", aggregation = AggregationType.COUNT) var i1: Long?,
+  @Property("i8", aggregation = AggregationType.COUNT) var i8: Long?,
+  @Property("i16", aggregation = AggregationType.COUNT) var i16: Long?,
+  @Property("i32", aggregation = AggregationType.COUNT) var i32: Long?,
+  @Property("i64", aggregation = AggregationType.COUNT) var i64: Long?,
+  @Property("c16", aggregation = AggregationType.COUNT) var c16: Long?,
+  @Property("f32", aggregation = AggregationType.COUNT) var f32: Long?,
+  @Property("f64", aggregation = AggregationType.COUNT) var f64: Long?,
 ) : Projection
 
 data class CountDistinctPrimitiveTour(
-  @Property("i1", aggregation = AggregationType.COUNT_DISTINCT) var i1: Long,
-  @Property("i8", aggregation = AggregationType.COUNT_DISTINCT) var i8: Long,
-  @Property("i16", aggregation = AggregationType.COUNT_DISTINCT) var i16: Long,
-  @Property("i32", aggregation = AggregationType.COUNT_DISTINCT) var i32: Long,
-  @Property("i64", aggregation = AggregationType.COUNT_DISTINCT) var i64: Long,
-  @Property("c16", aggregation = AggregationType.COUNT_DISTINCT) var c16: Long,
-  @Property("f32", aggregation = AggregationType.COUNT_DISTINCT) var f32: Long,
-  @Property("f64", aggregation = AggregationType.COUNT_DISTINCT) var f64: Long
+  @Property("i1", aggregation = AggregationType.COUNT_DISTINCT) var i1: Long?,
+  @Property("i8", aggregation = AggregationType.COUNT_DISTINCT) var i8: Long?,
+  @Property("i16", aggregation = AggregationType.COUNT_DISTINCT) var i16: Long?,
+  @Property("i32", aggregation = AggregationType.COUNT_DISTINCT) var i32: Long?,
+  @Property("i64", aggregation = AggregationType.COUNT_DISTINCT) var i64: Long?,
+  @Property("c16", aggregation = AggregationType.COUNT_DISTINCT) var c16: Long?,
+  @Property("f32", aggregation = AggregationType.COUNT_DISTINCT) var f32: Long?,
+  @Property("f64", aggregation = AggregationType.COUNT_DISTINCT) var f64: Long?,
 ) : Projection
 
 data class MaxPrimitiveTour(
   @Property("i1") var i1: Boolean,
-  @Property("i8", aggregation = AggregationType.MAX) var i8: Byte,
-  @Property("i16", aggregation = AggregationType.MAX) var i16: Short,
-  @Property("i32", aggregation = AggregationType.MAX) var i32: Int,
-  @Property("i64", aggregation = AggregationType.MAX) var i64: Long,
-  @Property("c16", aggregation = AggregationType.MAX) var c16: Char,
-  @Property("f32", aggregation = AggregationType.MAX) var f32: Float,
-  @Property("f64", aggregation = AggregationType.MAX) var f64: Double
+  @Property("i8", aggregation = AggregationType.MAX) var i8: Byte?,
+  @Property("i16", aggregation = AggregationType.MAX) var i16: Short?,
+  @Property("i32", aggregation = AggregationType.MAX) var i32: Int?,
+  @Property("i64", aggregation = AggregationType.MAX) var i64: Long?,
+  @Property("c16", aggregation = AggregationType.MAX) var c16: Char?,
+  @Property("f32", aggregation = AggregationType.MAX) var f32: Float?,
+  @Property("f64", aggregation = AggregationType.MAX) var f64: Double?
 ) : Projection
 
 data class MinPrimitiveTour(
   @Property("i1") var i1: Boolean,
-  @Property("i8", aggregation = AggregationType.MIN) var i8: Byte,
-  @Property("i16", aggregation = AggregationType.MIN) var i16: Short,
-  @Property("i32", aggregation = AggregationType.MIN) var i32: Int,
-  @Property("i64", aggregation = AggregationType.MIN) var i64: Long,
-  @Property("c16", aggregation = AggregationType.MIN) var c16: Char,
-  @Property("f32", aggregation = AggregationType.MIN) var f32: Float,
-  @Property("f64", aggregation = AggregationType.MIN) var f64: Double
+  @Property("i8", aggregation = AggregationType.MIN) var i8: Byte?,
+  @Property("i16", aggregation = AggregationType.MIN) var i16: Short?,
+  @Property("i32", aggregation = AggregationType.MIN) var i32: Int?,
+  @Property("i64", aggregation = AggregationType.MIN) var i64: Long?,
+  @Property("c16", aggregation = AggregationType.MIN) var c16: Char?,
+  @Property("f32", aggregation = AggregationType.MIN) var f32: Float?,
+  @Property("f64", aggregation = AggregationType.MIN) var f64: Double?,
 ) : Projection
 
 data class SumPrimitiveTour(
-  @Property("i8", aggregation = AggregationType.SUM) var i8: Long,
-  @Property("i16", aggregation = AggregationType.SUM) var i16: Long,
-  @Property("i32", aggregation = AggregationType.SUM) var i32: Long,
-  @Property("i64", aggregation = AggregationType.SUM) var i64: Long,
-  @Property("f32", aggregation = AggregationType.SUM) var f32: Double,
-  @Property("f64", aggregation = AggregationType.SUM) var f64: Double
+  @Property("i8", aggregation = AggregationType.SUM) var i8: Long?,
+  @Property("i16", aggregation = AggregationType.SUM) var i16: Long?,
+  @Property("i32", aggregation = AggregationType.SUM) var i32: Long?,
+  @Property("i64", aggregation = AggregationType.SUM) var i64: Long?,
+  @Property("f32", aggregation = AggregationType.SUM) var f32: Double?,
+  @Property("f64", aggregation = AggregationType.SUM) var f64: Double?,
 ) : Projection
 
 
 data class I1C16AndMaxI8(
   @Property("i1") var i1: Boolean,
   @Property("c16") var c16: Char,
-  @Property("i8", aggregation = AggregationType.MAX) var i8: Long
+  @Property("i8", aggregation = AggregationType.MAX) var i8: Byte?,
 ) : Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
@@ -6,6 +6,42 @@ interface PrimitiveTourQuery : Query<DbPrimitiveTour> {
 
   @Select
   fun listAsPrimitiveTour(session: Session): List<PrimitiveTour>
+
+  @Select(path = "i64", aggregation = AggregationType.AVG)
+  fun averageI64(session: Session): Double?
+
+  @Select(path = "i64", aggregation = AggregationType.COUNT)
+  fun countI64(session: Session): Long?
+
+  @Select(path = "i64", aggregation = AggregationType.COUNT_DISTINCT)
+  fun countDistinctI64(session: Session): Long?
+
+  @Select(path = "i64", aggregation = AggregationType.MAX)
+  fun maxI64(session: Session): Long?
+
+  @Select(path = "i64", aggregation = AggregationType.MIN)
+  fun minI64(session: Session): Long?
+
+  @Select(path = "i64", aggregation = AggregationType.SUM)
+  fun sumI64(session: Session): Long?
+
+  @Select
+  fun averageAll(session: Session): AveragePrimitiveTour?
+
+  @Select
+  fun countAll(session: Session): CountPrimitiveTour?
+
+  @Select
+  fun countDistinctAll(session: Session): CountDistinctPrimitiveTour?
+
+  @Select
+  fun maxAll(session: Session): MaxPrimitiveTour?
+
+  @Select
+  fun minAll(session: Session): MinPrimitiveTour?
+
+  @Select
+  fun sumAll(session: Session): SumPrimitiveTour?
 }
 
 data class PrimitiveTour(
@@ -17,4 +53,66 @@ data class PrimitiveTour(
   @Property("c16") var c16: Char,
   @Property("f32") var f32: Float,
   @Property("f64") var f64: Double
+) : Projection
+
+data class AveragePrimitiveTour(
+  @Property("i8", aggregation = AggregationType.AVG) var i8: Double,
+  @Property("i16", aggregation = AggregationType.AVG) var i16: Double,
+  @Property("i32", aggregation = AggregationType.AVG) var i32: Double,
+  @Property("i64", aggregation = AggregationType.AVG) var i64: Double,
+  @Property("f32", aggregation = AggregationType.AVG) var f32: Double,
+  @Property("f64", aggregation = AggregationType.AVG) var f64: Double
+) : Projection
+
+data class CountPrimitiveTour(
+  @Property("i1", aggregation = AggregationType.COUNT) var i1: Long,
+  @Property("i8", aggregation = AggregationType.COUNT) var i8: Long,
+  @Property("i16", aggregation = AggregationType.COUNT) var i16: Long,
+  @Property("i32", aggregation = AggregationType.COUNT) var i32: Long,
+  @Property("i64", aggregation = AggregationType.COUNT) var i64: Long,
+  @Property("c16", aggregation = AggregationType.COUNT) var c16: Long,
+  @Property("f32", aggregation = AggregationType.COUNT) var f32: Long,
+  @Property("f64", aggregation = AggregationType.COUNT) var f64: Long
+) : Projection
+
+data class CountDistinctPrimitiveTour(
+  @Property("i1", aggregation = AggregationType.COUNT_DISTINCT) var i1: Long,
+  @Property("i8", aggregation = AggregationType.COUNT_DISTINCT) var i8: Long,
+  @Property("i16", aggregation = AggregationType.COUNT_DISTINCT) var i16: Long,
+  @Property("i32", aggregation = AggregationType.COUNT_DISTINCT) var i32: Long,
+  @Property("i64", aggregation = AggregationType.COUNT_DISTINCT) var i64: Long,
+  @Property("c16", aggregation = AggregationType.COUNT_DISTINCT) var c16: Long,
+  @Property("f32", aggregation = AggregationType.COUNT_DISTINCT) var f32: Long,
+  @Property("f64", aggregation = AggregationType.COUNT_DISTINCT) var f64: Long
+) : Projection
+
+data class MaxPrimitiveTour(
+  @Property("i1") var i1: Boolean,
+  @Property("i8", aggregation = AggregationType.MAX) var i8: Byte,
+  @Property("i16", aggregation = AggregationType.MAX) var i16: Short,
+  @Property("i32", aggregation = AggregationType.MAX) var i32: Int,
+  @Property("i64", aggregation = AggregationType.MAX) var i64: Long,
+  @Property("c16", aggregation = AggregationType.MAX) var c16: Char,
+  @Property("f32", aggregation = AggregationType.MAX) var f32: Float,
+  @Property("f64", aggregation = AggregationType.MAX) var f64: Double
+) : Projection
+
+data class MinPrimitiveTour(
+  @Property("i1") var i1: Boolean,
+  @Property("i8", aggregation = AggregationType.MIN) var i8: Byte,
+  @Property("i16", aggregation = AggregationType.MIN) var i16: Short,
+  @Property("i32", aggregation = AggregationType.MIN) var i32: Int,
+  @Property("i64", aggregation = AggregationType.MIN) var i64: Long,
+  @Property("c16", aggregation = AggregationType.MIN) var c16: Char,
+  @Property("f32", aggregation = AggregationType.MIN) var f32: Float,
+  @Property("f64", aggregation = AggregationType.MIN) var f64: Double
+) : Projection
+
+data class SumPrimitiveTour(
+  @Property("i8", aggregation = AggregationType.SUM) var i8: Long,
+  @Property("i16", aggregation = AggregationType.SUM) var i16: Long,
+  @Property("i32", aggregation = AggregationType.SUM) var i32: Long,
+  @Property("i64", aggregation = AggregationType.SUM) var i64: Long,
+  @Property("f32", aggregation = AggregationType.SUM) var f32: Double,
+  @Property("f64", aggregation = AggregationType.SUM) var f64: Double
 ) : Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitiveTourQuery.kt
@@ -1,0 +1,20 @@
+package misk.hibernate
+
+interface PrimitiveTourQuery : Query<DbPrimitiveTour> {
+  @Constraint(path = "i1")
+  fun i1(i1: Boolean): PrimitiveTourQuery
+
+  @Select
+  fun listAsPrimitiveTour(session: Session): List<PrimitiveTour>
+}
+
+data class PrimitiveTour(
+  @Property("i1") var i1: Boolean,
+  @Property("i8") var i8: Byte,
+  @Property("i16") var i16: Short,
+  @Property("i32") var i32: Int,
+  @Property("i64") var i64: Long,
+  @Property("c16") var c16: Char,
+  @Property("f32") var f32: Float,
+  @Property("f64") var f64: Double
+) : Projection

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitivesDbTestModule.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/PrimitivesDbTestModule.kt
@@ -1,0 +1,34 @@
+package misk.hibernate
+
+import jakarta.inject.Qualifier
+import misk.MiskTestingServiceModule
+import misk.config.MiskConfig
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.jdbc.DataSourceConfig
+import wisp.config.Config
+import wisp.deployment.TESTING
+
+class PrimitivesDbTestModule : KAbstractModule() {
+  override fun configure() {
+    install(MiskTestingServiceModule())
+    install(DeploymentModule(TESTING))
+
+    val config = MiskConfig.load<RootConfig>("primitivecolumns", TESTING)
+    install(HibernateTestingModule(PrimitivesDb::class, config.data_source))
+    install(HibernateModule(PrimitivesDb::class, config.data_source))
+    install(object : HibernateEntityModule(PrimitivesDb::class) {
+      override fun configureHibernate() {
+        addEntities(DbPrimitiveTour::class)
+      }
+    })
+  }
+}
+
+data class RootConfig(val data_source: DataSourceConfig) : Config
+
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class PrimitivesDb
+

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryTest.kt
@@ -1211,40 +1211,6 @@ class ReflectionQueryFactoryTest {
       }
     }
   }
-
-  @Test
-  fun aggregationInQueries() {
-    transacter.transaction { session ->
-      session.save(DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9)))
-      session.save(DbMovie("Rocky", LocalDate.of(1976, 11, 21)))
-      session.save(DbMovie("Star Wars", LocalDate.of(1977, 5, 25)))
-    }
-    // Find the latest movie.
-    val latestMovieReleaseDate = transacter.transaction { session ->
-      queryFactory.newQuery<OperatorsMovieQuery>()
-        .allowFullScatter().allowTableScan()
-        .releaseDateMax(session)
-    }
-    assertThat(latestMovieReleaseDate).isEqualTo(LocalDate.of(1993, 6, 9))
-  }
-
-  @Test
-  fun aggregationInProjections() {
-    val jurassicPark = DbMovie("Jurassic Park", LocalDate.of(1993, 6, 9))
-    val rocky = DbMovie("Rocky", LocalDate.of(1976, 11, 21))
-    val starWars = DbMovie("Star Wars", LocalDate.of(1977, 5, 25))
-    transacter.transaction { session ->
-      session.save(jurassicPark)
-      session.save(rocky)
-      session.save(starWars)
-    }
-    // Find the latest movie.
-    val latestMovie = transacter.transaction { session ->
-      queryFactory.newQuery<OperatorsMovieQuery>()
-        .latestReleasedMovie(session)
-    }
-    assertThat(latestMovie).isEqualTo(LatestReleasedMovie(jurassicPark.name, jurassicPark.release_date!!))
-  }
 }
 
 inline fun withSqlLogging(work: () -> Unit) {

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/ReflectionQueryFactoryValidationTest.kt
@@ -64,7 +64,7 @@ class ReflectionQueryFactoryValidationTest {
     ).hasMessage(
       """
         |Query class ${AnnotationRequiredOnQuery::class.java.name} has problems:
-        |  name() must be annotated @Constraint, @Fetch, @Order, or @Select""".trimMargin()
+        |  name() must be annotated @Constraint, @Fetch, @Order, @Group, or @Select""".trimMargin()
     )
   }
 


### PR DESCRIPTION
Previously, it's possible to perform aggregations with `dynamicUniqueResult` or `dynamicList` by operating on the `root` and `criteriaBuilder`, however grouping is not exposed without access to the `CritieriaQuery` itself. This forces anyone who wants to do relatively common projected, grouped, and aggregated queries to operate on the `session.hibernateSession,` leading to more complicated code.

This change adds top-level support for aggregations and group by in misk.hibernate.Query interfaces.

Notably, this allows one to specify an `AggregationType` on `@Select` annotated methods, and adds a `@Group` annotation (similar to the existing `@Order`).

**How do I use this?**

Let's say you want to find the number of movies that were released on each date in your movies database. You might want to run a SQL query like `select release_date, count(name) from movies group by release_date`. Here's how you do that now with misk.hibernate.Query interfaces:

```kt
interface MovieQuery: Query<DbMovie> {
  @Select 
  fun datesAndCounts(session: Session): List<DateAndCount>
  
  @Group(paths = ["release_date"])
  fun groupByDate(): MovieQuery
}

data class DateAndCount(
  @Property(path = "release_date")
  val date: LocalDate,
  @Property(path = "name", aggregation = AggregationType.COUNT) 
  val count: Long?,
): Projection

transacter.transaction { session ->
  queryFactory.newQuery<MovieQuery>()
    .groupByDate()
    .datesAndCounts()
}
```

You'll get back a list of `DateAndCount` which have correctly counted the number of movie titles released on each date in the database.

| ⚠️ Warning |
| :-- |
| Forgetting to call the `groupByDate()` method on the above query will give a wrong result! Without the grouping, mySQL will give you back a date and count of all rows. This can lead to bugs! It's basically impossible to check for this though, since you might want to (for example) find the max of all columns without any grouping, etc. Testing your queries is necessary! |


`@Group` annotations accept multiple paths, since it's often useful to group aggregated results by multiple columns.

If either the Query class or the Projection are malformed, `ReflectionQuery` will type-check and complain with exactly the issue to avoid cryptic "Could not extract ResultSet" errors from hibernate.

We also now support joins in projections, by setting `@Fetch(path, forProjection = true)`, which allows for grouped aggregations across tables. For example, see b7f348a1cd4aa6f43ddb191ba89e8c34008ac2a6.