### PR TITLE
CCPOKR-13542 | Issue Fix: Dynamodb table "misk-cluster-members" is not deleting any records

### DIFF
--- a/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DyClusterMember.kt
+++ b/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DyClusterMember.kt
@@ -15,4 +15,8 @@ internal class DyClusterMember {
 
   @get:DynamoDbAttribute("pod_name")
   var pod_name: String? = null
+
+  // Stored as epoch sec
+  @get:DynamoDbAttribute("expires_at")
+  var expires_at: Long? = null
 }

--- a/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterWatcherTask.kt
+++ b/misk-clustering-dynamodb/src/main/kotlin/misk/clustering/dynamo/DynamoClusterWatcherTask.kt
@@ -62,6 +62,8 @@ internal class DynamoClusterWatcherTask @Inject constructor(
       val member = DyClusterMember()
       member.name = self
       member.updated_at = clock.instant().toEpochMilli()
+      // TTL should be in seconds
+      member.expires_at = clock.instant().plus(Duration.ofDays(1)).toEpochMilli() / 1000
       podName?.let { member.pod_name = it }
       table.putItem(member)
     }

--- a/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
+++ b/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
@@ -86,6 +86,7 @@ class DynamoClusterTest {
       val member = DyClusterMember()
       member.name = "pod-${i}"
       member.updated_at = clock.instant().toEpochMilli()
+      member.expires_at = clock.instant().plus(Duration.ofDays(1)).toEpochMilli() / 1000
       table.putItem(member)
     }
     waitFor { dynamoClusterWatcherTask.run() }

--- a/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
+++ b/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
@@ -96,7 +96,6 @@ class DynamoClusterTest {
 
   @Test
   fun inspectAddedRecords() {
-    // Testing pagination
     val enhancedClient = DynamoDbEnhancedClient.builder()
       .dynamoDbClient(ddb)
       .build()

--- a/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
+++ b/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
@@ -102,15 +102,8 @@ class DynamoClusterTest {
       .build()
     val table = enhancedClient.table("$TEST_SERVICE_NAME.misk-cluster-members", DynamoClusterWatcherTask.TABLE_SCHEMA)
 
-    for (i in 0..5) {
-      val member = DyClusterMember()
-      member.name = "pod-${i}"
-      member.updated_at = clock.instant().toEpochMilli()
-      member.expires_at = clock.instant().plus(Duration.ofDays(1)).toEpochMilli() / 1000
-      table.putItem(member)
-    }
     waitFor { dynamoClusterWatcherTask.run() }
-    assertThat(cluster.snapshot.readyMembers).hasSize(7)
+    assertThat(cluster.snapshot.readyMembers).hasSize(1)
 
     val expiredTimeUnit = clock.instant().plus(Duration.ofDays(1)).toEpochMilli() / 1000
 

--- a/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
+++ b/misk-clustering-dynamodb/src/test/kotlin/misk/clustering/DynamoClusterTest.kt
@@ -100,7 +100,10 @@ class DynamoClusterTest {
     val enhancedClient = DynamoDbEnhancedClient.builder()
       .dynamoDbClient(ddb)
       .build()
-    val table = enhancedClient.table("$TEST_SERVICE_NAME.misk-cluster-members", DynamoClusterWatcherTask.TABLE_SCHEMA)
+    val table = enhancedClient.table(
+      "$TEST_SERVICE_NAME.misk-cluster-members",
+      DynamoClusterWatcherTask.TABLE_SCHEMA
+    )
 
     waitFor { dynamoClusterWatcherTask.run() }
     assertThat(cluster.snapshot.readyMembers).hasSize(1)
@@ -108,7 +111,9 @@ class DynamoClusterTest {
     val expiredTimeUnit = clock.instant().plus(Duration.ofDays(1)).toEpochMilli() / 1000
 
     // Verify that all records expire in 24 hours!
-    assertTrue(table.scan().items().all { m -> m.expires_at!! <= expiredTimeUnit })
+    assertTrue(
+      table.scan().items()
+        .all { m -> m.expires_at!! <= expiredTimeUnit && m.expires_at!! > m.updated_at!! / 1000 })
   }
 
   @Test


### PR DESCRIPTION
RCA: Currently TTL field was set to `updated_at` field which was set to `ms` granularity. It should be at `seconds` granularity. Added a new field to use as TTL. 