### PR TITLE
Fix NullPointerException in ReflectionQuery.SelectMethodHandler#toValue

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -536,7 +536,7 @@ internal class ReflectionQuery<T : DbEntity<T>>(
           val args = row as Array<*>
           // If we got back an array of null values, which can't be assigned to the constructor,
           // then we should return null.
-          if (args.all { it == null } && !constructor.parameters.all { it.type.isMarkedNullable } ) return null
+          if (args.all { it == null } && constructor.parameters.none { it.type.isMarkedNullable } ) return null
           // Otherwise, we should check if we *can* assign the null values to the constructor.
           checkNullability(constructor, args)
           // Now it's (probably!) safe to call the constructor.

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -528,8 +528,9 @@ internal class ReflectionQuery<T : DbEntity<T>>(
       }
     }.toTypedArray())
 
-    private fun toValue(row: Any): Any? {
+    private fun toValue(row: Any?): Any? {
       return when {
+        row == null -> null
         constructor == null -> row
         properties.size == 1 -> constructor.call(row)
         else -> constructor.call(*(row as Array<*>))

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -556,7 +556,7 @@ internal class ReflectionQuery<T : DbEntity<T>>(
       if (errors.isNotEmpty()) {
         throw IllegalArgumentException(
           "There were problems with your Projection class:\n" +
-            errors.joinToString("\n")
+            errors.joinToString("\n", prefix = "  ")
         )
       }
     }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
@@ -223,6 +223,18 @@ class AggregationQueryTest {
     )
   }
 
+  @Test fun `aggregations work when there are no matching rows`() {
+    primitiveTransacter.transaction {session ->
+      queryFactory.newQuery<PrimitiveTourQuery>()
+        .delete(session)
+    }
+    primitiveTransacter.transaction { session ->
+      queryFactory.newQuery<PrimitiveTourQuery>()
+        .averageI64(session)
+        .let { assertThat(it).isNull() }
+    }
+  }
+
   private fun seedData() {
     movieTransacter.transaction { session ->
       val dbRocky = session.save(rocky).let { session.load(it) }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/AggregationQueryTest.kt
@@ -232,6 +232,10 @@ class AggregationQueryTest {
       queryFactory.newQuery<PrimitiveTourQuery>()
         .averageI64(session)
         .let { assertThat(it).isNull() }
+
+      queryFactory.newQuery<PrimitiveTourQuery>()
+        .listI1C16AndMaxI8(session)
+        .let { assertThat(it).isEmpty()}
     }
   }
 

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/DbPrimitiveTour.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/DbPrimitiveTour.kt
@@ -30,7 +30,10 @@ class DbPrimitiveTour(
   var f32: Float = 0.0f,
 
   @Column(nullable = false)
-  var f64: Double = 0.0
+  var f64: Double = 0.0,
+
+  @Column(nullable = true)
+  var maybe_i1: Boolean? = null,
 
 ) : DbUnsharded<DbPrimitiveTour> {
   @javax.persistence.Id @GeneratedValue

--- a/misk-hibernate/src/test/resources/misk/hibernate/primitivecolumns-migrations/v1__primitive_tours.sql
+++ b/misk-hibernate/src/test/resources/misk/hibernate/primitivecolumns-migrations/v1__primitive_tours.sql
@@ -7,5 +7,6 @@ CREATE TABLE primitive_tours (
     i64 bigint NOT NULL,
     c16 char(1) NOT NULL,
     f32 float NOT NULL,
-    f64 double NOT NULL
+    f64 double NOT NULL,
+    maybe_i1 tinyint(1) DEFAULT NULL
 );


### PR DESCRIPTION
There's a bug in projected queries where an NPE can be thrown if there are no matching rows. This is because we incorrectly pass an `Any?` into a method that wants `Any`. Oops!

This affected both single value projections and data class projection queries.