### PR TITLE
Add constructors to DontRetryException

### DIFF
--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -4,8 +4,8 @@ public abstract interface class misk/backoff/Backoff {
 }
 
 public final class misk/backoff/DontRetryException : java/lang/Exception {
+	public fun <init> (Ljava/lang/Exception;)V
 	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Exception;)V
 }
 

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -12,13 +12,10 @@ fun <A> retry(
   withBackoff: Backoff,
   onRetry: ((retryCount: Int, exception: Exception) -> Unit)? = null,
   block: (retryCount: Int) -> A,
-  ): A {
+): A {
   require(upTo > 0) { "must support at least one call" }
-
   withBackoff.reset()
-
   var lastException: Exception? = null
-
   for (i in 0 until upTo) {
     try {
       val result = block(i)
@@ -29,7 +26,6 @@ fun <A> retry(
     } catch (e: Exception) {
       onRetry?.invoke(i + 1, e)
       lastException = e
-
       if (i + 1 < upTo) {
         try {
           Thread.sleep(withBackoff.nextRetry().toMillis())
@@ -39,10 +35,12 @@ fun <A> retry(
       }
     }
   }
-
   throw lastException!!
 }
 
-class DontRetryException(message: String?, exception: Exception?) : Exception(message, exception) {
-  constructor(message: String? = null) : this(message, null)
+class DontRetryException : Exception {
+  constructor(message: String?) : super(message)
+  constructor(cause: Exception?) : super(cause)
+  constructor(message: String?, cause: Exception?) : super(message, cause)
 }
+

--- a/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
+++ b/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
@@ -81,4 +81,47 @@ internal class RetryTest {
 
     assertThat(retried).isEqualTo(2)
   }
+
+  @Test
+  fun throwsDontRetryExceptionWithMessage() {
+    val backoff = ExponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(100))
+    val customMessage = "Custom message for DontRetryException"
+    assertFailsWith<DontRetryException> {
+      retry(3, backoff) {
+        throw DontRetryException(customMessage)
+      }
+    }.also { exception ->
+      assertThat(exception.message).isEqualTo(customMessage)
+    }
+  }
+
+  @Test
+  fun throwsDontRetryExceptionWithCause() {
+    val backoff = ExponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(100))
+    val cause = IllegalStateException("Underlying exception")
+    assertFailsWith<DontRetryException> {
+      retry(3, backoff) {
+        throw DontRetryException(cause)
+      }
+    }.also { exception ->
+      assertThat(exception.cause).isEqualTo(cause)
+    }
+  }
+
+  @Test
+  fun throwsDontRetryExceptionWithMessageAndCause() {
+    val backoff = ExponentialBackoff(Duration.ofMillis(10), Duration.ofMillis(100))
+    val customMessage = "Custom message for DontRetryException"
+    val cause = IllegalStateException("Underlying exception")
+    assertFailsWith<DontRetryException> {
+      retry(3, backoff) {
+        throw DontRetryException(customMessage, cause)
+      }
+    }.also { exception ->
+      assertThat(exception.message).isEqualTo(customMessage)
+      assertThat(exception.cause).isEqualTo(cause)
+    }
+  }
+
+
 }


### PR DESCRIPTION
Changes
- Add new constructors to the DontRetryException class:
- The new constructors provide flexibility in creating instances of DontRetryException with specific error messages and underlying causes so you can also surface the underlying error

Motivation:
- I'd like to be able to pull out the underlying exception in cases where we get back non-retriable errors from endpoints