### PR TITLE
Re-add DontRetryException default constructor to fix backwards compat

### DIFF
--- a/misk-core/api/misk-core.api
+++ b/misk-core/api/misk-core.api
@@ -6,6 +6,7 @@ public abstract interface class misk/backoff/Backoff {
 public final class misk/backoff/DontRetryException : java/lang/Exception {
 	public fun <init> (Ljava/lang/Exception;)V
 	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Exception;)V
 }
 

--- a/misk-core/src/main/kotlin/misk/backoff/Retries.kt
+++ b/misk-core/src/main/kotlin/misk/backoff/Retries.kt
@@ -39,8 +39,7 @@ fun <A> retry(
 }
 
 class DontRetryException : Exception {
-  constructor(message: String?) : super(message)
+  constructor(message: String? = null) : super(message)
   constructor(cause: Exception?) : super(cause)
   constructor(message: String?, cause: Exception?) : super(message, cause)
 }
-

--- a/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
+++ b/misk-core/src/test/kotlin/misk/backoff/RetryTest.kt
@@ -1,6 +1,8 @@
 package misk.backoff
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import kotlin.test.assertFailsWith
@@ -123,5 +125,12 @@ internal class RetryTest {
     }
   }
 
+  @Test
+fun dontRetryExceptionCanBeInstantiatedWithNoMessage() {
+    // needed to ensure backwards compat with 2 services
+    val exception = DontRetryException()
+    assertNotNull(exception)
+    assertNull(exception.message)
+}
 
 }


### PR DESCRIPTION
Changes:
* Implemented DontRetryException in misk-core, with a default constructor overloads for variability
* Updated tests in RetryTest.kt to include checks for the DontRetryException being thrown and correctly instantiated with a null message.

Related Issues/Purpose:

* This change addresses an issue of breaking backward compatibility due to the DontRetryException's null constructor removal in #3243)