### PR TITLE
Update Job interface to expose delay functionality

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6301,6 +6301,10 @@ acceptedBreaks:
       old: "method java.lang.String misk.web.metadata.Metadata::getId()"
       justification: "API is unused so change is safe"
   "2024.05.07.104226-502a4b6":
+    com.squareup.misk:misk-aws:
+    - code: "java.method.removed"
+      old: "method void misk.jobqueue.sqs.SqsJob::delayForFailure()"
+      justification: "updating job interface to include backoff function"
     com.squareup.misk:misk-jobqueue:
     - code: "java.method.addedToInterface"
       new: "method void misk.jobqueue.Job::delayWithBackoff()"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -6300,6 +6300,11 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method java.lang.String misk.web.metadata.Metadata::getId()"
       justification: "API is unused so change is safe"
+  "2024.05.07.104226-502a4b6":
+    com.squareup.misk:misk-jobqueue:
+    - code: "java.method.addedToInterface"
+      new: "method void misk.jobqueue.Job::delayWithBackoff()"
+      justification: "updating job interface to include backoff"
   misk-0.18.0:
     com.squareup.misk:misk-gcp:
     - code: "java.method.numberOfParametersChanged"

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -64,7 +64,7 @@ internal class SqsJob(
    *  that duration. With every subsequent retry the duration becomes longer until it hits the max
    *  value of 10hrs.
    */
-  override fun backOffDelay() {
+  override fun delayWithBackoff() {
     val maxReceiveCount = queue.maxRetries
     val visibilityTime = calculateVisibilityTimeOut(
       currentReceiveCount = attributes[RECEIVE_COUNT]?.toInt()  ?: 1,

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJob.kt
@@ -64,7 +64,7 @@ internal class SqsJob(
    *  that duration. With every subsequent retry the duration becomes longer until it hits the max
    *  value of 10hrs.
    */
-  fun delayForFailure() {
+  override fun backOffDelay() {
     val maxReceiveCount = queue.maxRetries
     val visibilityTime = calculateVisibilityTimeOut(
       currentReceiveCount = attributes[RECEIVE_COUNT]?.toInt()  ?: 1,

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -232,7 +232,7 @@ internal class SqsJobQueueTest {
       handledJobs.add(sqsJob)
       // Only acknowledge third attempt
       if (jobsReceived.getAndIncrement() == 1) sqsJob.acknowledge()
-      else sqsJob.backOffDelay()
+      else sqsJob.delayWithBackoff()
 
       allJobsCompleted.countDown()
     }
@@ -314,7 +314,7 @@ internal class SqsJobQueueTest {
       handledJobs.add(sqsJob)
       // Only acknowledge third attempt
       if (jobsReceived.getAndIncrement() == 2) sqsJob.acknowledge()
-      else sqsJob.backOffDelay()
+      else sqsJob.delayWithBackoff()
 
       allJobsCompleted.countDown()
     }

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTest.kt
@@ -232,7 +232,7 @@ internal class SqsJobQueueTest {
       handledJobs.add(sqsJob)
       // Only acknowledge third attempt
       if (jobsReceived.getAndIncrement() == 1) sqsJob.acknowledge()
-      else sqsJob.delayForFailure()
+      else sqsJob.backOffDelay()
 
       allJobsCompleted.countDown()
     }
@@ -314,7 +314,7 @@ internal class SqsJobQueueTest {
       handledJobs.add(sqsJob)
       // Only acknowledge third attempt
       if (jobsReceived.getAndIncrement() == 2) sqsJob.acknowledge()
-      else sqsJob.delayForFailure()
+      else sqsJob.backOffDelay()
 
       allJobsCompleted.countDown()
     }

--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -19,7 +19,6 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public final fun component5 ()Ljava/util/Map;
 	public final fun component6 ()Ljava/time/Instant;
 	public final fun component7 ()Ljava/time/Duration;
-	public final fun component8 ()Ljava/time/Clock;
 	public final fun copy (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;)Lmisk/jobqueue/FakeJob;
 	public static synthetic fun copy$default (Lmisk/jobqueue/FakeJob;Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;ILjava/lang/Object;)Lmisk/jobqueue/FakeJob;
 	public fun deadLetter ()V
@@ -28,7 +27,6 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public final fun getAcknowledged ()Z
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getBody ()Ljava/lang/String;
-	public final fun getClock ()Ljava/time/Clock;
 	public final fun getDeadLettered ()Z
 	public final fun getDelayDuration ()Ljava/lang/Long;
 	public final fun getDelayedForBackoff ()Z

--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -4,8 +4,11 @@ public final class misk/jobqueue/DevelopmentJobProcessorModule : misk/inject/KAb
 }
 
 public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/Job {
-	public fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;)V
-	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Lmisk/jobqueue/FakeJob$Companion;
+	public static final field MAX_DELAY_DURATION J
+	public static final field MIN_DElAY_DURATION J
+	public fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;)V
+	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acknowledge ()V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lmisk/jobqueue/FakeJob;)I
@@ -16,14 +19,19 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public final fun component5 ()Ljava/util/Map;
 	public final fun component6 ()Ljava/time/Instant;
 	public final fun component7 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;)Lmisk/jobqueue/FakeJob;
-	public static synthetic fun copy$default (Lmisk/jobqueue/FakeJob;Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;ILjava/lang/Object;)Lmisk/jobqueue/FakeJob;
+	public final fun component8 ()Ljava/time/Clock;
+	public final fun copy (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;)Lmisk/jobqueue/FakeJob;
+	public static synthetic fun copy$default (Lmisk/jobqueue/FakeJob;Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;ILjava/lang/Object;)Lmisk/jobqueue/FakeJob;
 	public fun deadLetter ()V
+	public fun delayWithBackoff ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcknowledged ()Z
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getBody ()Ljava/lang/String;
+	public final fun getClock ()Ljava/time/Clock;
 	public final fun getDeadLettered ()Z
+	public final fun getDelayDuration ()Ljava/lang/Long;
+	public final fun getDelayedForBackoff ()Z
 	public final fun getDeliverAt ()Ljava/time/Instant;
 	public final fun getDeliveryDelay ()Ljava/time/Duration;
 	public final fun getEnqueuedAt ()Ljava/time/Instant;
@@ -31,7 +39,11 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public fun getIdempotenceKey ()Ljava/lang/String;
 	public fun getQueueName ()Lmisk/jobqueue/QueueName;
 	public fun hashCode ()I
+	public final fun setDeliveryDelay (Ljava/time/Duration;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/jobqueue/FakeJob$Companion {
 }
 
 public final class misk/jobqueue/FakeJobHandlerModule : misk/inject/KAbstractModule {
@@ -75,6 +87,7 @@ public final class misk/jobqueue/FakeJobQueueModule : misk/inject/KAbstractModul
 public abstract interface class misk/jobqueue/Job {
 	public abstract fun acknowledge ()V
 	public abstract fun deadLetter ()V
+	public abstract fun delayWithBackoff ()V
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getBody ()Ljava/lang/String;
 	public abstract fun getId ()Ljava/lang/String;

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -29,4 +29,7 @@ interface Job {
 
   /** Moves the job from the main queue onto the associated dead letter queue. May perform an RPC */
   fun deadLetter()
+
+  /** Assign a visibility timeout for the job that increases with exp. backoff */
+  fun backOffDelay()
 }

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/Job.kt
@@ -30,6 +30,9 @@ interface Job {
   /** Moves the job from the main queue onto the associated dead letter queue. May perform an RPC */
   fun deadLetter()
 
-  /** Assign a visibility timeout for the job that increases with exp. backoff */
-  fun backOffDelay()
+  /**
+   * Assigns and applies a visibility timeout for the job by making it unreachable for some time duration.
+   * The timeout increases after each retry. May perform an RPC.
+   * */
+  fun delayWithBackoff()
 }

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
@@ -346,6 +346,35 @@ internal class FakeJobQueueTest {
   }
 
   @Test
+  fun jobsDoNotStartUntilBackoffDelayElapses() {
+    assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).isEmpty()
+
+    // Setup jobs.
+    exampleJobEnqueuer.enqueueGreen("J1:0s")
+    exampleJobEnqueuer.enqueueGreen("J2:0s + 1s", hint = ExampleJobHint.DELAY_ONCE)
+    exampleJobEnqueuer.enqueueGreen("J3:0s")
+    exampleJobEnqueuer.enqueueGreen("J4:0s + 5s", Duration.ofSeconds(5))
+    exampleJobEnqueuer.enqueueGreen("J5:0s + 5s + 1s", Duration.ofSeconds(5), hint = ExampleJobHint.DELAY_ONCE)
+
+    fakeClock.add(Duration.ofMillis(500))
+    val jobs = fakeJobQueue.handleJobs(GREEN_QUEUE, considerDelays = true, retries = 2, assertAcknowledged = false)
+    assertThat(jobs.size).isEqualTo(2)
+
+    // there are still 3 jobs that are yet to be processed
+    assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(3)
+    // Repeating processing does not change anything.
+    fakeJobQueue.handleJobs(considerDelays = true)
+    assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(3)
+
+    fakeClock.add(Duration.ofMillis(5000))
+    val jobsAfter5s = fakeJobQueue.handleJobs(GREEN_QUEUE, considerDelays = true, retries = 2, assertAcknowledged = false)
+    assertThat(jobsAfter5s.size).isEqualTo(2)
+
+    // there are still 3 jobs that are yet to be processed
+    assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(1)
+  }
+
+  @Test
   fun jobsStartOnDeliveryDelayPassed() {
     assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).isEmpty()
 
@@ -504,7 +533,7 @@ internal class FakeJobQueueTest {
     // Process an unknown job.
     assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(2)
     val unknownJob =
-      FakeJob(GREEN_QUEUE, "unknown", "idempotenceKey", "body", mapOf(), fakeClock.instant())
+      FakeJob(GREEN_QUEUE, "unknown", "idempotenceKey", "body", mapOf(), fakeClock.instant(), clock = fakeClock)
     assertThat(fakeJobQueue.handleJob(unknownJob)).isFalse()
     assertThat(logCollector.takeMessages(ExampleJobHandler::class)).isEmpty()
 
@@ -539,7 +568,7 @@ internal enum class Color {
   GREEN
 }
 
-internal class ColorException : Throwable()
+internal class ColorException : Exception()
 
 internal data class ExampleJob(
   val color: Color,
@@ -552,7 +581,8 @@ internal enum class ExampleJobHint {
   THROW,
   THROW_ONCE,
   DEAD_LETTER,
-  DEAD_LETTER_ONCE
+  DEAD_LETTER_ONCE,
+  DELAY_ONCE,
 }
 
 internal class ExampleJobEnqueuer @Inject private constructor(
@@ -617,6 +647,10 @@ internal class ExampleJobHandler @Inject private constructor(moshi: Moshi) : Job
       }
       ExampleJobHint.THROW -> throw ColorException()
       ExampleJobHint.THROW_ONCE -> if (!jobExecutedBefore) {
+        throw ColorException()
+      }
+      ExampleJobHint.DELAY_ONCE -> if (!jobExecutedBefore) {
+        job.backOffDelay()
         throw ColorException()
       }
       else -> Unit

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
@@ -366,11 +366,11 @@ internal class FakeJobQueueTest {
     fakeJobQueue.handleJobs(considerDelays = true)
     assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(3)
 
-    fakeClock.add(Duration.ofMillis(5000))
+    fakeClock.add(Duration.ofSeconds(5))
     val jobsAfter5s = fakeJobQueue.handleJobs(GREEN_QUEUE, considerDelays = true, retries = 2, assertAcknowledged = false)
     assertThat(jobsAfter5s.size).isEqualTo(2)
 
-    // there are still 3 jobs that are yet to be processed
+    // there is only 1 job that is yet to be processed
     assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(1)
   }
 
@@ -650,7 +650,7 @@ internal class ExampleJobHandler @Inject private constructor(moshi: Moshi) : Job
         throw ColorException()
       }
       ExampleJobHint.DELAY_ONCE -> if (!jobExecutedBefore) {
-        job.backOffDelay()
+        job.delayWithBackoff()
         throw ColorException()
       }
       else -> Unit

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -192,7 +192,7 @@ class FakeJobQueue @Inject constructor(
   ): List<FakeJob> {
     val jobHandlers = jobHandlers.get()
     val resultedJobs = mutableListOf<FakeJob>()
-    val jobsToQueueBack = mutableListOf<FakeJob>()
+    val jobsToQueueBack = mutableSetOf<FakeJob>()
     // Used to prevent an infinite loop by mistake in supplier.
     val touchedJobs = mutableSetOf<FakeJob>()
     while (true) {
@@ -221,7 +221,7 @@ class FakeJobQueue @Inject constructor(
         throw e
       }
       // validate that the job has been added to jobsToQueueBack
-      if (job.backoffDelayedTime != null && job.backoffDelayedTime!!.isAfter(clock.instant())) {
+      if (jobsToQueueBack.contains(job)) {
         continue
       } else {
         resultedJobs += job

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -279,7 +279,7 @@ data class FakeJob(
   override val attributes: Map<String, String>,
   val enqueuedAt: Instant,
   var deliveryDelay: Duration? = null,
-  val clock: Clock,
+  private val clock: Clock,
 ) : Job, Comparable<FakeJob> {
   val deliverAt: Instant
     get() = when (deliveryDelay) {


### PR DESCRIPTION
Context: https://cash.slack.com/archives/C01M5M297T7/p1714144374605119
Summary: We want to expose backOffDelay() functionality to all users of Misk. In order to do that we need to update the Job interface and update FakeJobQueue.
