### PR TITLE
Disable concurrency_limiter by default

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -87,7 +87,7 @@ data class WebConfig @JvmOverloads constructor(
   val cors: Map<String, CorsConfig> = mapOf(),
 
   /** If true, disables automatic load shedding when degraded. */
-  val concurrency_limiter_disabled: Boolean = false,
+  val concurrency_limiter_disabled: Boolean = true,
 
   /** The level of log when concurrency shedding. */
   val concurrency_limiter_log_level: Level = Level.ERROR,

--- a/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
+++ b/misk/src/test/kotlin/misk/web/DegradedHealthStressTest.kt
@@ -139,6 +139,7 @@ internal class DegradedHealthStressTest {
       install(
         WebServerTestingModule(
           TESTING_WEB_CONFIG.copy(
+            concurrency_limiter_disabled = false,
             concurrency_limiter = ConcurrencyLimiterConfig(
               // We use VEGAS here to make testing easier (VEGAS cares about errors, GRADIENT2
               // doesn't). The main purpose of this test is to make sure we have everything wired

--- a/misk/src/test/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsStrategyTest.kt
+++ b/misk/src/test/kotlin/misk/web/concurrencylimits/ConcurrencyLimitsStrategyTest.kt
@@ -43,6 +43,7 @@ class ConcurrencyLimitsStrategyTest {
         MiskWebModule(
           WebConfig(
             port = 0,
+            concurrency_limiter_disabled = false,
             concurrency_limiter = ConcurrencyLimiterConfig(
               strategy = strategy,
               max_concurrency = maxConcurrency,


### PR DESCRIPTION
We have disabled concurrency_limiter in all environments for more than a week (using a feature flag). This PR disables it by default so we can remove the FF.