### PR TITLE
Add `allowAnyService` and `allowAnyUser` to `AccessAnnotationEntry` inline function

### DIFF
--- a/misk/src/main/kotlin/misk/security/authz/AccessAnnotationEntry.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessAnnotationEntry.kt
@@ -49,9 +49,11 @@ data class AccessAnnotationEntry @JvmOverloads constructor(
 
 inline fun <reified T : Annotation> AccessAnnotationEntry(
   services: List<String> = listOf(),
-  capabilities: List<String> = listOf()
+  capabilities: List<String> = listOf(),
+  allowAnyService: Boolean = false,
+  allowAnyUser: Boolean = false
 ): AccessAnnotationEntry {
-  return AccessAnnotationEntry(T::class, services, capabilities)
+  return AccessAnnotationEntry(T::class, services, capabilities, allowAnyService, allowAnyUser)
 }
 
 /**


### PR DESCRIPTION
This PR updates the inline function for constructing an `AccessAnnotationEntry` to include `allowAnyService` and `allowAnyUser` boolean parameters, following a [recent change](https://github.com/cashapp/misk/pull/3244/files) that requires these over empty lists for services and capabilities. This simplifies `AccessAnnotationEntry` usage, eliminating the need for services to create custom constructors or modify the returned class, as the data constructor defaults the parameters to `false`.