### PR TITLE
Add requireRequestNotNull

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -51,6 +51,7 @@ public class misk/exceptions/ConflictException : misk/exceptions/WebActionExcept
 
 public final class misk/exceptions/ExceptionsKt {
 	public static final fun requireRequest (ZLkotlin/jvm/functions/Function0;)V
+	public static final fun requireRequestNotNull (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public class misk/exceptions/GatewayTimeoutException : misk/exceptions/WebActionException {

--- a/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
+++ b/misk-actions/src/main/kotlin/misk/exceptions/Exceptions.kt
@@ -12,6 +12,8 @@ import java.net.HttpURLConnection.HTTP_NOT_FOUND
 import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 import java.net.HttpURLConnection.HTTP_UNAVAILABLE
 import java.net.HttpURLConnection.HTTP_UNSUPPORTED_TYPE
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 /**
  * Even though all kotlin exceptions are runtime exceptions.
@@ -124,6 +126,20 @@ open class UnsupportedMediaTypeException @JvmOverloads constructor(message: Stri
 /** Similar to [kotlin.require], but throws [BadRequestException] if the check fails */
 inline fun requireRequest(check: Boolean, lazyMessage: () -> String) {
   if (!check) throw BadRequestException(lazyMessage())
+}
+
+/** Similar to [kotlin.requireNotNull], but throws [BadRequestException] if the check fails */
+@OptIn(ExperimentalContracts::class)
+public inline fun <T : Any> requireRequestNotNull(value: T?, lazyMessage: () -> String): T {
+  contract {
+    returns() implies (value != null)
+  }
+
+  if (value == null) {
+    throw BadRequestException(lazyMessage())
+  } else {
+    return value
+  }
 }
 
 private val GrpcStatus.isGrpcServerCode

--- a/misk-actions/src/test/kotlin/misk/exceptions/ExceptionsTest.kt
+++ b/misk-actions/src/test/kotlin/misk/exceptions/ExceptionsTest.kt
@@ -1,0 +1,39 @@
+package misk.exceptions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ExceptionsTest {
+  @Test
+  fun `requireRequestNotNull throws if value is null`() {
+    var exception: BadRequestException? = null
+    try {
+      @Suppress("IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
+      requireRequestNotNull(null) { "lazy message" }
+    } catch (e: BadRequestException) {
+      exception = e
+    }
+
+    assertNotNull(exception)
+    assertEquals("lazy message", exception.message)
+  }
+
+  @Test
+  fun `requireRequestNotNull returns non-null value and contractually implies value is non-null`() {
+    // don't let the kotlin compiler infer this is non-null
+    val value: String? = lazy {
+      if (true) {
+        "value"
+      } else {
+        null
+      }
+    }.value
+
+    val theValue = requireRequestNotNull(value) { "message" }
+    assertEquals("value", theValue)
+
+    // note: this is not value!!.length - the contract from the check implies this is non-null
+    assertEquals("value".length, value.length)
+  }
+}


### PR DESCRIPTION
This is inspired directly from kotlin.requireNotNull and meant to simplify
usages of requireRequest in code. The intent is before you have code that looks
like this

```kotlin
requireRequest(request.parameter != null) { "parameter must not be null" }

// later, safe do because of previous null check
request.parameter!!
```

becomes

```kotlin
requireRequestNotNull(request.parameter) { "parameter must not be null" }

// later - no need for !!
request.parameter
```
