### PR TITLE
Update replica fallback logic

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -332,7 +332,6 @@ data class DataSourceConfig @JvmOverloads constructor(
   fun canRecoverOnReplica() = this.type in listOf(
     DataSourceType.COCKROACHDB,
     DataSourceType.TIDB,
-    DataSourceType.VITESS_MYSQL
   )
 
 }

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -51,12 +51,12 @@ class DataSourceService @JvmOverloads constructor(
     try {
       createDataSource(baseConfig)
     } catch (e: Exception) {
-      logger.error(e) { "Fail to start the data source, trying to do it with replica" }
       if (!baseConfig.canRecoverOnReplica()) {
+        logger.error(e) { "Failed to start the data source." }
         throw e
       }
+      logger.error(e) { "Failed to start the data source, trying to do it with replica." }
       createDataSource(baseConfig.asReplica())
-
     }
     logger.info("Started @${qualifier.simpleName} connection pool in $stopwatch")
   }


### PR DESCRIPTION
This PR does the following:
1. Removes Vitess from the `canRecoverOnReplica` path. This is currently causing an issue where a replica gets mistakenly used for performing writes.
3. Update error logs for when the data source fails to initialize. The current logs seem misleading since they indicate that a replica will always be attempted to fallback to, despite the fallback only applying to a subset of DB types.