### PR TITLE
Remove deprecated admin dashboard BETA_PREFIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The Changelog consequently will not be updated regularly since releases only inc
 
 Major and breaking changes will still be documented in the Changelog.
 
+Version 2024.05.16
+---------------------------------
+Breaking changes:
+- Remove the deprecated `BETA_PREFIX` val which was used to gate development of the new v2 admin dashboard. It has been deprecated since 2023-06-30 when the v2 admin dashboard was promoted to `/_admin/`.
+
 Version 2024.05.14
 ---------------------------------
 Breaking changes:

--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -948,7 +948,6 @@ public final class misk/web/v2/DashboardIndexBlock {
 
 public final class misk/web/v2/DashboardPageLayout {
 	public static final field ADMIN_DASHBOARD_PATH Ljava/lang/String;
-	public static final field BETA_PREFIX Ljava/lang/String;
 	public static final field Companion Lmisk/web/v2/DashboardPageLayout$Companion;
 	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lwisp/deployment/Deployment;Lmisk/scope/ActionScoped;)V
 	public final fun build ()Ljava/lang/String;

--- a/misk-admin/src/main/kotlin/misk/web/v2/DashboardPageLayout.kt
+++ b/misk-admin/src/main/kotlin/misk/web/v2/DashboardPageLayout.kt
@@ -134,8 +134,5 @@ class DashboardPageLayout @Inject constructor(
 
   companion object {
     const val ADMIN_DASHBOARD_PATH = "/_admin"
-
-    @Deprecated("v2 dashboard is now available at /_admin/ so BETA_PREFIX variable will be removed in a future release")
-    const val BETA_PREFIX = "/v2"
   }
 }


### PR DESCRIPTION
All internal usages have been migrated and the val has been deprecated since 2023-06-30 so removal should be a safe breaking change and code cleanup.