### PR TITLE
Remove unused `clock` parameter from `FakeJob` that causes  a breaking ABI change

### DIFF
--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -7,8 +7,8 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public static final field Companion Lmisk/jobqueue/FakeJob$Companion;
 	public static final field MAX_DELAY_DURATION J
 	public static final field MIN_DElAY_DURATION J
-	public fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;)V
-	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;)V
+	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acknowledge ()V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lmisk/jobqueue/FakeJob;)I
@@ -19,8 +19,8 @@ public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/J
 	public final fun component5 ()Ljava/util/Map;
 	public final fun component6 ()Ljava/time/Instant;
 	public final fun component7 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;)Lmisk/jobqueue/FakeJob;
-	public static synthetic fun copy$default (Lmisk/jobqueue/FakeJob;Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;Ljava/time/Clock;ILjava/lang/Object;)Lmisk/jobqueue/FakeJob;
+	public final fun copy (Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;)Lmisk/jobqueue/FakeJob;
+	public static synthetic fun copy$default (Lmisk/jobqueue/FakeJob;Lmisk/jobqueue/QueueName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/time/Instant;Ljava/time/Duration;ILjava/lang/Object;)Lmisk/jobqueue/FakeJob;
 	public fun deadLetter ()V
 	public fun delayWithBackoff ()V
 	public fun equals (Ljava/lang/Object;)Z

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
@@ -533,7 +533,7 @@ internal class FakeJobQueueTest {
     // Process an unknown job.
     assertThat(fakeJobQueue.peekJobs(GREEN_QUEUE)).hasSize(2)
     val unknownJob =
-      FakeJob(GREEN_QUEUE, "unknown", "idempotenceKey", "body", mapOf(), fakeClock.instant(), clock = fakeClock)
+      FakeJob(GREEN_QUEUE, "unknown", "idempotenceKey", "body", mapOf(), fakeClock.instant())
     assertThat(fakeJobQueue.handleJob(unknownJob)).isFalse()
     assertThat(logCollector.takeMessages(ExampleJobHandler::class)).isEmpty()
 

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueue.kt
@@ -102,7 +102,7 @@ class FakeJobQueue @Inject constructor(
     throwIfQueuedFailure(queueName)
     val id = tokenGenerator.generate("fakeJobQueue")
     val job =
-      FakeJob(queueName, id, idempotenceKey, body, attributes, clock.instant(), deliveryDelay, clock)
+      FakeJob(queueName, id, idempotenceKey, body, attributes, clock.instant(), deliveryDelay)
     jobQueues.getOrPut(queueName, ::PriorityBlockingQueue).add(job)
   }
 
@@ -279,7 +279,6 @@ data class FakeJob(
   override val attributes: Map<String, String>,
   val enqueuedAt: Instant,
   var deliveryDelay: Duration? = null,
-  private val clock: Clock,
 ) : Job, Comparable<FakeJob> {
   val deliverAt: Instant
     get() = when (deliveryDelay) {


### PR DESCRIPTION
The changes in #3252 introduced a new argument to `FakeJob` that is a breaking API/ABI change, but the argument was not actually being used. 

This change removes it again as it's blocking some dependency updates due to incompatible ABI errors. Note that this could be an breaking ABI change for any consumer that have updated to the new API already.