### PR TITLE
Don't block .md PRs from merging

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -2,12 +2,12 @@ name: Build
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 env:
   ENVIRONMENT: TESTING


### PR DESCRIPTION
It is a [known problem](https://github.com/orgs/community/discussions/49124) that using `paths-ignore` to skip a workflow step will block a PR from ever merging if that workflow step is required. The step will just be pending forever.

The official guidance from GH is to create a separate workflow that targets the inverse of `paths-ignore` and just does nothing to complete the required steps. That sounds like a terrible workaround to me; I think it's better if we just remove the ignore rule and eat the unnecessary build cost.

Completely independent of the problem described above, I think we **should** use `paths-ignore` on the master branch push rule, that way we can skip unnecessary master builds for .md changes.