### PR TITLE
Don't block .md PRs from merging -- part 2

### DIFF
--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -2,12 +2,12 @@ name: Linting
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 env:
   ENVIRONMENT: TESTING


### PR DESCRIPTION
An identical change to https://github.com/cashapp/misk/pull/3281, but for the `Linting.yml` file that I didn't realize existed until now