### PR TITLE
Pretty-print the service graph upon start-up

### DIFF
--- a/misk-service/api/misk-service.api
+++ b/misk-service/api/misk-service.api
@@ -27,6 +27,7 @@ public final class misk/ServiceManagerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/ServiceManagerModule$Companion;
 	public fun <init> ()V
 	public fun <init> (Lmisk/ServiceManagerConfig;)V
+	public synthetic fun <init> (Lmisk/ServiceManagerConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/ServiceManagerModule$Companion {

--- a/misk-service/api/misk-service.api
+++ b/misk-service/api/misk-service.api
@@ -10,9 +10,23 @@ public final class misk/ReadyService : com/google/common/util/concurrent/Abstrac
 public final class misk/ReadyService$Companion {
 }
 
+public final class misk/ServiceManagerConfig : wisp/config/Config {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lmisk/ServiceManagerConfig;
+	public static synthetic fun copy$default (Lmisk/ServiceManagerConfig;ZILjava/lang/Object;)Lmisk/ServiceManagerConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDebug_service_graph ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class misk/ServiceManagerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/ServiceManagerModule$Companion;
 	public fun <init> ()V
+	public fun <init> (Lmisk/ServiceManagerConfig;)V
 }
 
 public final class misk/ServiceManagerModule$Companion {

--- a/misk-service/build.gradle.kts
+++ b/misk-service/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
   api(libs.guice)
   api(libs.jakartaInject)
   api(project(":misk-inject"))
+  api(project(":wisp:wisp-config"))
   implementation(libs.kotlinLogging)
   implementation(libs.kotlinStdLibJdk8)
-  implementation(project(":wisp:wisp-config"))
   implementation(project(":wisp:wisp-logging"))
 
   testImplementation(libs.assertj)

--- a/misk-service/build.gradle.kts
+++ b/misk-service/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   api(project(":misk-inject"))
   implementation(libs.kotlinLogging)
   implementation(libs.kotlinStdLibJdk8)
+  implementation(project(":wisp:wisp-config"))
   implementation(project(":wisp:wisp-logging"))
 
   testImplementation(libs.assertj)

--- a/misk-service/src/main/kotlin/misk/CoordinatedService.kt
+++ b/misk-service/src/main/kotlin/misk/CoordinatedService.kt
@@ -5,8 +5,8 @@ import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.Service.Listener
 import com.google.common.util.concurrent.Service.State
-import java.util.concurrent.atomic.AtomicBoolean
 import com.google.inject.Provider
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class CoordinatedService(
   private val serviceProvider: Provider<out Service>

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -72,7 +72,7 @@ internal class ServiceGraphBuilder {
    */
   private fun linkDependencies() {
     for ((key, service) in serviceMap) {
-      val dependencies = dependencyMap[key]?.map { serviceMap[it]!! } ?: listOf()
+      val dependencies = dependencyMap[key].map { serviceMap[it]!! }
       service.addDependentServices(*dependencies.toTypedArray())
     }
   }

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -15,7 +15,7 @@ internal class ServiceGraphBuilder {
   private val serviceMap = mutableMapOf<Key<*>, CoordinatedService>()
   private val serviceNames = mutableMapOf<Key<*>, String>()
 
-  // A map of downstream services -> their upstreams.
+  /** A map of downstream services -> their upstreams. */
   private val dependencyMap = LinkedHashMultimap.create<Key<*>, Key<*>>()
 
   /**

--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -12,7 +12,10 @@ import com.google.inject.Provider
  * services are ready.
  */
 internal class ServiceGraphBuilder {
-  private var serviceMap = mutableMapOf<Key<*>, CoordinatedService>()
+  private val serviceMap = mutableMapOf<Key<*>, CoordinatedService>()
+  private val serviceNames = mutableMapOf<Key<*>, String>()
+
+  // A map of downstream services -> their upstreams.
   private val dependencyMap = LinkedHashMultimap.create<Key<*>, Key<*>>()
 
   /**
@@ -22,14 +25,15 @@ internal class ServiceGraphBuilder {
    * Keys must be unique. If a key is reused, then the original key-service pair will be replaced.
    */
   fun addService(key: Key<*>, service: Service) {
-    addService(key) { service }
+    addService(key, service::class.qualifiedName) { service }
   }
 
-  fun addService(key: Key<*>, serviceProvider: Provider<out Service>) {
+  fun addService(key: Key<*>, serviceName: String?, serviceProvider: Provider<out Service>) {
     check(serviceMap[key] == null) {
       "Service $key cannot be registered more than once"
     }
     serviceMap[key] = CoordinatedService(serviceProvider)
+    serviceNames[key] = serviceName ?: "Anonymous Service(${key.typeLiteral.type.typeName})"
   }
 
   /**
@@ -99,5 +103,54 @@ internal class ServiceGraphBuilder {
         "$stringBuilder requires $service but no such service was registered with the builder"
       }
     }
+  }
+
+  override fun toString(): String = buildString {
+    val visited = mutableSetOf<Key<*>>()
+    val allServices = serviceMap.keys
+    val serviceRoots = allServices.filterNot { it in dependencyMap.keys() }
+
+    for (root in serviceRoots) {
+      if (root !in visited) {
+        depthFirst(serviceKey = root, visited = visited, prefix = "", isLast = true, isRoot = true)
+      }
+    }
+  }
+
+  private fun StringBuilder.depthFirst(
+    serviceKey: Key<*>,
+    visited: MutableSet<Key<*>>,
+    prefix: String,
+    isLast: Boolean,
+    isRoot: Boolean
+  ) {
+    if (serviceKey in visited) return
+
+    if (!isRoot) {
+      append(prefix)
+      append(if (isLast) " \\__ " else "|__ ")
+    }
+    append(serviceNameOf(serviceKey))
+    append("\n")
+    visited.add(serviceKey)
+
+    val downstreamServices = dependencyMap.asMap().filter { it.value.contains(serviceKey) }.keys.toList()
+    for ((index, downstreamService) in downstreamServices.withIndex()) {
+      val newPrefix = prefix + if (isLast) "    " else "|   "
+      depthFirst(
+        serviceKey = downstreamService,
+        visited = visited,
+        prefix = newPrefix,
+        isLast = (index == downstreamServices.size - 1),
+        isRoot = false
+      )
+    }
+  }
+
+  private fun serviceNameOf(key: Key<*>): String = buildString {
+    if (key.annotation != null) {
+      append("${key.annotation} ")
+    }
+    append(serviceNames[key])
   }
 }

--- a/misk-service/src/main/kotlin/misk/ServiceManagerConfig.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerConfig.kt
@@ -1,0 +1,12 @@
+package misk
+
+import wisp.config.Config
+
+@Suppress("PropertyName")
+data class ServiceManagerConfig(
+  /**
+   * If true, writes the full graph of [ServiceModule] services and their dependencies to info-level
+   * logs.
+   */
+  val debug_service_graph: Boolean = false
+): Config

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -11,9 +11,9 @@ import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import wisp.logging.getLogger
 
-class ServiceManagerModule(private val serviceManagerConfig: ServiceManagerConfig) : KAbstractModule() {
-
-  constructor(): this(ServiceManagerConfig())
+class ServiceManagerModule @JvmOverloads constructor(
+  private val serviceManagerConfig: ServiceManagerConfig = ServiceManagerConfig()
+) : KAbstractModule() {
 
   companion object {
     private val log = getLogger<ServiceManagerModule>()

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -11,7 +11,10 @@ import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import wisp.logging.getLogger
 
-class ServiceManagerModule : KAbstractModule() {
+class ServiceManagerModule(private val serviceManagerConfig: ServiceManagerConfig) : KAbstractModule() {
+
+  constructor(): this(ServiceManagerConfig())
+
   companion object {
     private val log = getLogger<ServiceManagerModule>()
   }
@@ -73,7 +76,9 @@ class ServiceManagerModule : KAbstractModule() {
     }
 
     val serviceManager = builder.build()
-    log.info { "Starting misk services. Service dependency graph:\n$builder" }
+    if (serviceManagerConfig.debug_service_graph) {
+      log.info { "Service dependency graph:\n$builder" }
+    }
     listeners.forEach { serviceManager.addListener(it, directExecutor()) }
     return serviceManager
   }

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -53,7 +53,7 @@ class ServiceManagerModule : KAbstractModule() {
       if (!Scopes.isSingleton(injector.getBinding(entry.key))) {
         invalidServices += entry.key.typeLiteral.type.typeName
       }
-      builder.addService(entry.key, injector.getProvider(entry.key))
+      builder.addService(entry.key, entry.key.typeLiteral.toString(), injector.getProvider(entry.key))
     }
     for (edge in dependencies) {
       builder.addDependency(dependent = edge.dependent, dependsOn = edge.dependsOn)
@@ -76,6 +76,7 @@ class ServiceManagerModule : KAbstractModule() {
     }
 
     val serviceManager = builder.build()
+    log.info { "Starting misk services. Service dependency graph:\n$builder" }
     listeners.forEach { serviceManager.addListener(it, directExecutor()) }
     return serviceManager
   }

--- a/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceManagerModule.kt
@@ -6,11 +6,10 @@ import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.Injector
 import com.google.inject.Provides
 import com.google.inject.Scopes
+import jakarta.inject.Singleton
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import wisp.logging.getLogger
-import com.google.inject.Provider
-import jakarta.inject.Singleton
 
 class ServiceManagerModule : KAbstractModule() {
   companion object {
@@ -21,15 +20,13 @@ class ServiceManagerModule : KAbstractModule() {
     newMultibinder<Service>()
     newMultibinder<ServiceManager.Listener>()
 
-    multibind<ServiceManager.Listener>().toProvider(
-      Provider<ServiceManager.Listener> {
-        object : ServiceManager.Listener() {
-          override fun failure(service: Service) {
-            log.error(service.failureCause()) { "Service $service failed" }
-          }
+    multibind<ServiceManager.Listener>().toProvider {
+      object : ServiceManager.Listener() {
+        override fun failure(service: Service) {
+          log.error(service.failureCause()) { "Service $service failed" }
         }
       }
-    ).asSingleton()
+    }.asSingleton()
     newMultibinder<ServiceEntry>()
     newMultibinder<DependencyEdge>()
     newMultibinder<EnhancementEdge>()

--- a/misk-service/src/main/kotlin/misk/ServiceModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceModule.kt
@@ -87,7 +87,7 @@ class ServiceModule(
     key: Key<out Service>,
     dependsOn: List<Key<out Service>> = listOf(),
     enhancedBy: List<Key<out Service>> = listOf(),
-    enhances: Key<out Service>? = null
+    @Suppress("UNUSED_PARAMETER") enhances: Key<out Service>? = null
   ) : this(
     key = key,
     dependsOn = dependsOn,

--- a/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
+++ b/misk-service/src/test/kotlin/misk/CoordinatedServiceTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 import kotlin.test.assertFailsWith
 
 class CoordinatedServiceTest {

--- a/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -318,16 +318,9 @@ class ServiceGraphBuilderTest {
     val builder = newBuilderWithServices(target, listOf(keyA))
     val serviceManager = builder.build()
     serviceManager.startAsync()
-    val badEnhancer = CoordinatedService(
-      Provider<Service> {
-        AppendingService(target, "bad enhancement")
-      }
-    )
-    val badDependency = CoordinatedService(
-      Provider<Service> {
-        AppendingService(target, "bad dependency")
-      }
-    )
+    val badDependency = CoordinatedService {
+      AppendingService(target, "bad dependency")
+    }
 
     serviceManager.awaitHealthy()
 

--- a/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -16,6 +16,8 @@ class ServiceGraphBuilderTest {
   private val keyC = key("Service C")
   private val keyD = key("Service D")
   private val keyE = key("Service E")
+  private val keyF = key("Service F")
+  private val keyG = key("Service G")
   private val unregistered = key("Unregistered Service")
   private val enhancementA = key("Enhancement A")
 
@@ -366,6 +368,36 @@ class ServiceGraphBuilderTest {
         |stopping Service D
         |stopping Service A
         |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun canPrettyPrintTheGraphForDebugging() {
+    val graph = ServiceGraphBuilder().apply {
+      addService(keyA, AppendingService(StringBuilder(), keyA.name))
+      addService(keyB, AppendingService(StringBuilder(), keyB.name))
+      addService(keyC, AppendingService(StringBuilder(), keyC.name))
+      addService(keyD, AppendingService(StringBuilder(), keyD.name))
+      addService(keyE, AppendingService(StringBuilder(), keyE.name))
+      addService(keyF, AppendingService(StringBuilder(), keyF.name))
+      addService(keyG, AppendingService(StringBuilder(), keyG.name))
+      addDependency(keyA, keyB)
+      addDependency(keyB, keyC)
+      addDependency(keyB, keyD)
+      addDependency(keyD, keyE)
+      addDependency(keyA, keyF)
+    }.toString()
+
+    assertThat(graph).isEqualTo(
+      """
+      |@com.google.inject.name.Named("Service A") misk.ServiceGraphBuilderTest.AppendingService
+      |    |__ @com.google.inject.name.Named("Service B") misk.ServiceGraphBuilderTest.AppendingService
+      |    |   |__ @com.google.inject.name.Named("Service C") misk.ServiceGraphBuilderTest.AppendingService
+      |    |    \__ @com.google.inject.name.Named("Service D") misk.ServiceGraphBuilderTest.AppendingService
+      |    |        \__ @com.google.inject.name.Named("Service E") misk.ServiceGraphBuilderTest.AppendingService
+      |     \__ @com.google.inject.name.Named("Service F") misk.ServiceGraphBuilderTest.AppendingService
+      |@com.google.inject.name.Named("Service G") misk.ServiceGraphBuilderTest.AppendingService
+      |""".trimMargin()
     )
   }
 

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -102,7 +102,7 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
       if (context.startService()) {
         serviceManager.stopAsync()
       }
-      serviceManager.awaitStopped(20, TimeUnit.SECONDS)
+      serviceManager.awaitStopped(30, TimeUnit.SECONDS)
     }
   }
 

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -309,11 +309,13 @@ public abstract class misk/MiskCommand : java/lang/Runnable {
 public final class misk/MiskCommonServiceModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 	public fun <init> (Lmisk/ServiceManagerConfig;)V
+	public synthetic fun <init> (Lmisk/ServiceManagerConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/MiskRealServiceModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 	public fun <init> (Lmisk/ServiceManagerConfig;)V
+	public synthetic fun <init> (Lmisk/ServiceManagerConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/client/BackwardsCompatibleClientsConfig {

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -308,10 +308,12 @@ public abstract class misk/MiskCommand : java/lang/Runnable {
 
 public final class misk/MiskCommonServiceModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	public fun <init> (Lmisk/ServiceManagerConfig;)V
 }
 
 public final class misk/MiskRealServiceModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	public fun <init> (Lmisk/ServiceManagerConfig;)V
 }
 
 public final class misk/client/BackwardsCompatibleClientsConfig {

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   api(project(":misk-core"))
   api(project(":misk-inject"))
   api(project(":misk-metrics"))
+  api(project(":misk-service"))
   implementation(libs.jCommander)
   implementation(libs.jettyAlpnServer)
   implementation(libs.jettyHttp)
@@ -69,7 +70,6 @@ dependencies {
   implementation(project(":wisp:wisp-tracing"))
   implementation(project(":misk-prometheus"))
   implementation(project(":misk-proto"))
-  implementation(project(":misk-service"))
   runtimeOnly(libs.jettyAlpnServerJava)
 
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -21,7 +21,11 @@ import misk.tokens.TokenGeneratorModule
  * with [MiskTestingServiceModule]. Only bindings that are not suitable for a unit testing
  * environment belong here.
  */
-class MiskRealServiceModule : KAbstractModule() {
+class MiskRealServiceModule(
+  private val serviceManagerConfig: ServiceManagerConfig,
+) : KAbstractModule() {
+  constructor(): this(ServiceManagerConfig())
+
   override fun configure() {
     install(ResourceLoaderModule())
     install(RealEnvVarModule())
@@ -29,20 +33,23 @@ class MiskRealServiceModule : KAbstractModule() {
     install(SleeperModule())
     install(TickerModule())
     install(TokenGeneratorModule())
-    install(MiskCommonServiceModule())
+    install(MiskCommonServiceModule(serviceManagerConfig))
   }
 }
 
 /**
  * This module has common bindings for all environments (both real and testing).
  */
-class MiskCommonServiceModule : KAbstractModule() {
+class MiskCommonServiceModule(
+  private val serviceManagerConfig: ServiceManagerConfig,
+) : KAbstractModule() {
+  constructor(): this(ServiceManagerConfig())
   override fun configure() {
     binder().disableCircularProxies()
     binder().requireExactBindingAnnotations()
     install(MdcModule())
     install(ExecutorsModule())
-    install(ServiceManagerModule())
+    install(ServiceManagerModule(serviceManagerConfig))
     install(PrometheusMetricsClientModule())
     install(MoshiModule(useWireToRead = true, useWireToWrite = true))
     install(JvmManagementFactoryModule())

--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -21,11 +21,9 @@ import misk.tokens.TokenGeneratorModule
  * with [MiskTestingServiceModule]. Only bindings that are not suitable for a unit testing
  * environment belong here.
  */
-class MiskRealServiceModule(
-  private val serviceManagerConfig: ServiceManagerConfig,
+class MiskRealServiceModule @JvmOverloads constructor(
+  private val serviceManagerConfig: ServiceManagerConfig = ServiceManagerConfig(),
 ) : KAbstractModule() {
-  constructor(): this(ServiceManagerConfig())
-
   override fun configure() {
     install(ResourceLoaderModule())
     install(RealEnvVarModule())
@@ -40,10 +38,9 @@ class MiskRealServiceModule(
 /**
  * This module has common bindings for all environments (both real and testing).
  */
-class MiskCommonServiceModule(
-  private val serviceManagerConfig: ServiceManagerConfig,
+class MiskCommonServiceModule @JvmOverloads constructor(
+  private val serviceManagerConfig: ServiceManagerConfig = ServiceManagerConfig(),
 ) : KAbstractModule() {
-  constructor(): this(ServiceManagerConfig())
   override fun configure() {
     binder().disableCircularProxies()
     binder().requireExactBindingAnnotations()

--- a/samples/exemplar/build.gradle.kts
+++ b/samples/exemplar/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation(project(":misk-inject"))
   implementation(project(":misk-hotwire"))
   implementation(project(":misk-prometheus"))
+  implementation(project(":misk-service"))
 
   testImplementation(libs.assertj)
   testImplementation(libs.awsDynamodb)

--- a/samples/exemplarchat/build.gradle.kts
+++ b/samples/exemplarchat/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation(project(":misk-inject"))
   implementation(project(":misk-prometheus"))
   implementation(project(":misk-redis"))
+  implementation(project(":misk-service"))
   implementation(libs.guice)
   implementation(libs.jedis)
   implementation(libs.logbackClassic)


### PR DESCRIPTION
It can at times be difficult to reason about what the dependency graph is in larger misk services. This change logs the ServiceGraph when the ServiceManager is created during service start-up, in order to allow service operators to better understand their constituent service dependencies.

By default, no graph is printed on service start-up, but this can be opted into by passing a `ServiceManagerConfig` to `MiskRealServiceModule`.