### PR TITLE
Print repeat subtrees in the service graph

### DIFF
--- a/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceGraphBuilder.kt
@@ -106,40 +106,32 @@ internal class ServiceGraphBuilder {
   }
 
   override fun toString(): String = buildString {
-    val visited = mutableSetOf<Key<*>>()
     val allServices = serviceMap.keys
     val serviceRoots = allServices.filterNot { it in dependencyMap.keys() }
-
     for (root in serviceRoots) {
-      if (root !in visited) {
-        depthFirst(serviceKey = root, visited = visited, prefix = "", isLast = true, isRoot = true)
-      }
+      depthFirst(serviceKey = root, prefix = "", isLast = true, isRoot = true)
     }
   }
 
   private fun StringBuilder.depthFirst(
     serviceKey: Key<*>,
-    visited: MutableSet<Key<*>>,
     prefix: String,
     isLast: Boolean,
     isRoot: Boolean
   ) {
-    if (serviceKey in visited) return
-
     if (!isRoot) {
       append(prefix)
-      append(if (isLast) " \\__ " else "|__ ")
+      append(if (isLast) "\\__ " else "|__ ")
     }
     append(serviceNameOf(serviceKey))
     append("\n")
-    visited.add(serviceKey)
 
-    val downstreamServices = dependencyMap.asMap().filter { it.value.contains(serviceKey) }.keys.toList()
+    val downstreamServices =
+      dependencyMap.asMap().filter { it.value.contains(serviceKey) }.keys.toList()
     for ((index, downstreamService) in downstreamServices.withIndex()) {
       val newPrefix = prefix + if (isLast) "    " else "|   "
       depthFirst(
         serviceKey = downstreamService,
-        visited = visited,
         prefix = newPrefix,
         isLast = (index == downstreamServices.size - 1),
         isRoot = false

--- a/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
+++ b/misk-service/src/test/kotlin/misk/ServiceGraphBuilderTest.kt
@@ -386,10 +386,33 @@ class ServiceGraphBuilderTest {
       |@com.google.inject.name.Named("Service A") misk.ServiceGraphBuilderTest.AppendingService
       |    |__ @com.google.inject.name.Named("Service B") misk.ServiceGraphBuilderTest.AppendingService
       |    |   |__ @com.google.inject.name.Named("Service C") misk.ServiceGraphBuilderTest.AppendingService
-      |    |    \__ @com.google.inject.name.Named("Service D") misk.ServiceGraphBuilderTest.AppendingService
-      |    |        \__ @com.google.inject.name.Named("Service E") misk.ServiceGraphBuilderTest.AppendingService
-      |     \__ @com.google.inject.name.Named("Service F") misk.ServiceGraphBuilderTest.AppendingService
+      |    |   \__ @com.google.inject.name.Named("Service D") misk.ServiceGraphBuilderTest.AppendingService
+      |    |       \__ @com.google.inject.name.Named("Service E") misk.ServiceGraphBuilderTest.AppendingService
+      |    \__ @com.google.inject.name.Named("Service F") misk.ServiceGraphBuilderTest.AppendingService
       |@com.google.inject.name.Named("Service G") misk.ServiceGraphBuilderTest.AppendingService
+      |""".trimMargin()
+    )
+  }
+
+  @Test fun `debug graph shows all dependencies, including repeated subtrees`() {
+    val graph = ServiceGraphBuilder().apply {
+      addService(keyA, AppendingService(StringBuilder(), keyA.name))
+      addService(keyB, AppendingService(StringBuilder(), keyB.name))
+      addService(keyC, AppendingService(StringBuilder(), keyC.name))
+      addService(keyD, AppendingService(StringBuilder(), keyD.name))
+      addDependency(keyA, keyB)
+      addDependency(keyA, keyD)
+      addDependency(keyB, keyC)
+      addDependency(keyD, keyC)
+    }.toString()
+
+    assertThat(graph).isEqualTo(
+      """
+      |@com.google.inject.name.Named("Service A") misk.ServiceGraphBuilderTest.AppendingService
+      |    |__ @com.google.inject.name.Named("Service B") misk.ServiceGraphBuilderTest.AppendingService
+      |    |   \__ @com.google.inject.name.Named("Service C") misk.ServiceGraphBuilderTest.AppendingService
+      |    \__ @com.google.inject.name.Named("Service D") misk.ServiceGraphBuilderTest.AppendingService
+      |        \__ @com.google.inject.name.Named("Service C") misk.ServiceGraphBuilderTest.AppendingService
       |""".trimMargin()
     )
   }


### PR DESCRIPTION
Follow-on for #3285.

The previous implementation was overly restrictive and did not print repeat nodes in the service dependency tree. I thought this was fine before, but there can be similar (but different) subtrees, which need to be printed to get a full picture of the service.

This change stops tracking the visited nodes in each tree, and traverses them all anyway. This is safe to do, because we guarantee at this point that the graph is acyclic.

Note: This change will make the debug tree output much longer, and more verbose. We could probably try to be clever to detect identical subtrees to make the output more concise, but I don't feel like that is worth the effort at this time.