### PR TITLE
Add Metadata admin dashboard tab

### DIFF
--- a/misk-admin/api/misk-admin.api
+++ b/misk-admin/api/misk-admin.api
@@ -670,6 +670,16 @@ public final class misk/web/metadata/all/AllMetadataModule : misk/inject/KAbstra
 	public fun <init> ()V
 }
 
+public final class misk/web/metadata/all/AllMetadataTabAction : misk/web/actions/WebAction {
+	public static final field Companion Lmisk/web/metadata/all/AllMetadataTabAction$Companion;
+	public static final field PATH Ljava/lang/String;
+	public fun <init> (Lmisk/web/v2/DashboardPageLayout;Ljava/util/Map;)V
+	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class misk/web/metadata/all/AllMetadataTabAction$Companion {
+}
+
 public final class misk/web/metadata/config/ConfigMetadata : misk/web/metadata/Metadata {
 	public fun <init> (Ljava/util/Map;)V
 	public final fun component1 ()Ljava/util/Map;

--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataModule.kt
@@ -2,6 +2,9 @@ package misk.web.metadata.all
 
 import misk.inject.KAbstractModule
 import misk.web.WebActionModule
+import misk.web.dashboard.AdminDashboard
+import misk.web.dashboard.AdminDashboardAccess
+import misk.web.dashboard.DashboardModule
 import misk.web.metadata.MetadataModule
 import misk.web.metadata.config.ConfigMetadataProvider
 import misk.web.metadata.database.DatabaseHibernateMetadataProvider
@@ -25,5 +28,14 @@ class AllMetadataModule : KAbstractModule() {
     install(MetadataModule(ConfigMetadataProvider()))
     install(MetadataModule(DatabaseHibernateMetadataProvider()))
     install(MetadataModule(WebActionsMetadataProvider()))
+
+    // Install dashbaord tab
+    install(WebActionModule.create<AllMetadataTabAction>())
+    install(DashboardModule.createHotwireTab<AdminDashboard, AdminDashboardAccess>(
+      slug = "metadata",
+      urlPathPrefix = AllMetadataTabAction.PATH,
+      menuLabel = "Metadata",
+      menuCategory = "Container Admin"
+    ))
   }
 }

--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataTabAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataTabAction.kt
@@ -1,0 +1,82 @@
+package misk.web.metadata.all
+
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlinx.html.code
+import kotlinx.html.div
+import kotlinx.html.form
+import kotlinx.html.h1
+import kotlinx.html.id
+import kotlinx.html.label
+import kotlinx.html.onChange
+import kotlinx.html.option
+import kotlinx.html.pre
+import kotlinx.html.select
+import misk.web.Get
+import misk.web.QueryParam
+import misk.web.ResponseContentType
+import misk.web.actions.WebAction
+import misk.web.dashboard.AdminDashboardAccess
+import misk.web.mediatype.MediaTypes
+import misk.web.metadata.Metadata
+import misk.web.v2.DashboardPageLayout
+
+@Singleton
+class AllMetadataTabAction @Inject constructor(
+  private val dashboardPageLayout: DashboardPageLayout,
+  private val allMetadata: Map<String, Metadata>,
+) : WebAction {
+  @Get(PATH)
+  @ResponseContentType(MediaTypes.TEXT_HTML)
+  @AdminDashboardAccess
+  fun get(
+    /** Metadata id to show. */
+    @QueryParam q: String?
+  ): String = dashboardPageLayout
+    .newBuilder()
+    .build { appName, _, _ ->
+      val metadata = q?.let { allMetadata[it] }?.metadata?.toString()
+        // TODO properly optimistically serialize to JSON
+        ?.split("),")?.joinToString("),\n")
+        ?.split(",")?.joinToString(",\n")
+
+      div("container mx-auto p-8") {
+        h1 { +"""All Metadata""" }
+
+        div {
+          form {
+            action = "/_admin/metadata/"
+            select("mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6") {
+              id = "q"
+              name = "q"
+              onChange = "this.form.submit()"
+
+              allMetadata.keys.sorted().forEachIndexed { index, key ->
+                option {
+                  if ((q == null && index == 0) || q == key) {
+                    selected = true
+                  }
+                  value = key
+                  +key
+                }
+              }
+            }
+          }
+        }
+
+        // code pre of pretty metadata json
+        if (metadata != null || allMetadata[q] != null) {
+          pre {
+            code("text-wrap font-mono") {
+              +(metadata ?: "Metadata not found for $q")
+            }
+          }
+        }
+      }
+    }
+
+  companion object {
+    const val PATH = "/_admin/metadata/"
+
+  }
+}

--- a/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
+++ b/misk-tailwind/src/main/kotlin/misk/tailwind/pages/Navbar.kt
@@ -198,7 +198,7 @@ private fun TagConsumer<*>.NavMenu(menuSections: List<MenuSection>) {
             role = "list"
 
             li {
-              section.links.map { link ->
+              section.links.sortedBy { it.label }.map { link ->
                 ul("-mx-2 py-1") {
                   role = "list"
                   li {


### PR DESCRIPTION
This adds a basic read-only tab for all bound metadata. The dropdown select updates a query parameter which then reloads the page with the respective metadata.

<img width="1290" alt="Screenshot 2024-06-11 at 23 13 29" src="https://github.com/cashapp/misk/assets/8827217/5fc68bf0-56bf-4bf9-a068-e0d3e155e20c">

Remaining Tasks
---
- [ ] Serialize Metadata data classes to JSON, not just stringify
- [ ] Expose filterable metadata action API and use that directly (don't lookup metadata within tab action)
- [ ] Cleanup styling