### PR TITLE
build: centralize more build deps on the root.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
@@ -16,15 +15,18 @@ buildscript {
   }
 
   dependencies {
-    classpath(libs.kotlinAllOpenPlugin)
-    classpath(libs.kotlinGradlePlugin)
     classpath(libs.detektGradlePlugin)
     classpath(libs.dokkaGradlePlugin)
-    classpath(libs.kotlinNoArgPlugin)
-    classpath(libs.protobufGradlePlugin)
+    classpath(libs.flywayGradlePlugin)
     classpath(libs.jgit)
-    classpath(libs.wireGradlePlugin)
+    classpath(libs.jooqGradlePlugin)
+    classpath(libs.kotlinAllOpenPlugin)
+    classpath(libs.kotlinGradlePlugin)
+    classpath(libs.kotlinNoArgPlugin)
+    classpath(libs.mysql)
+    classpath(libs.protobufGradlePlugin)
     classpath(libs.sqldelightGradlePlugin)
+    classpath(libs.wireGradlePlugin)
   }
 }
 
@@ -175,12 +177,6 @@ subprojects {
 
   dependencies {
     add("detektPlugins", project(":detektive"))
-  }
-
-  buildscript {
-    repositories {
-      mavenCentral()
-    }
   }
 
   // Only apply if the project has the kotlin plugin added:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ buildscript {
   dependencies {
     classpath(libs.detektGradlePlugin)
     classpath(libs.dokkaGradlePlugin)
+    // TODO remove Flyway when Misk SchemaMigratorGradlePlugin merges
     classpath(libs.flywayGradlePlugin)
     classpath(libs.jgit)
     classpath(libs.jooqGradlePlugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 dependencyAnalysisPlugin = "1.29.0"
+flyway = "9.14.1"
 kotlin = "1.9.21"
 kotlinBinaryCompatibilityPlugin = "0.13.1"
 mavenPublish = "0.27.0"
@@ -45,6 +46,7 @@ dockerTransportCore = { module = "com.github.docker-java:docker-java-transport",
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 errorproneAnnotations = { module = "com.google.errorprone:error_prone_annotations", version = "2.20.0" }
 findbugsJsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
+flywayGradlePlugin = { module = "org.flywaydb:flyway-gradle-plugin", version.ref = "flyway" }
 gax = { module = "com.google.api:gax", version = "2.5.0" }
 gcpCloudCore = { module = "com.google.cloud:google-cloud-core", version = "1.95.4" }
 gcpCloudStorage = { module = "com.google.cloud:google-cloud-storage", version = "1.117.1" }
@@ -114,6 +116,7 @@ jettyWebsocketServer = { module = "org.eclipse.jetty.websocket:websocket-jetty-s
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version = "5.12.0.202106070339-r" }
 jnrUnixsocket = { module = "com.github.jnr:jnr-unixsocket", version = "0.38.20" }
 jooq = { module = "org.jooq:jooq", version = "3.18.2" }
+jooqGradlePlugin = { module = "nu.studer:gradle-jooq-plugin", version = "8.2" }
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.9.3" }
 junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.9.3" }
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.9.3" }
@@ -206,8 +209,8 @@ wireSchema = { module = "com.squareup.wire:wire-schema", version.ref = "wire" }
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryCompatibilityPlugin" }
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyAnalysisPlugin" }
-flyway = { id = "org.flywaydb.flyway", version = "9.14.1" }
-jooq = { id = "nu.studer.jooq", version = "8.2" }
+flyway = { id = "org.flywaydb.flyway" }
+jooq = { id = "nu.studer.jooq" }
 kotlinAllOpen = { id = "org.jetbrains.kotlin.plugin.allopen" }
 kotlinJpa = { id = "org.jetbrains.kotlin.plugin.jpa" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm" }

--- a/misk-jooq/README.md
+++ b/misk-jooq/README.md
@@ -20,15 +20,9 @@ jooq-code-gen to it. There's an example of how to do this in this
 a. Add the below lines to your build.gradle.kts
 
 ```
-buildscript {
-  dependencies {
-    classpath("org.flywaydb:flyway-gradle-plugin:7.15.0")
-    classpath(Dependencies.mysql)
-  }
-}
 plugins {
-  id("org.flywaydb.flyway") version "7.15.0"
-  id("nu.studer.jooq") version "5.2"
+  alias(libs.plugins.flyway)
+  alias(libs.plugins.jooq)
 }
 // We are using flyway here in order to run the migrations to create a schema. 
 // Ensure the migration directory is not called `migrations`. There's more details as to why below.

--- a/misk-jooq/build.gradle.kts
+++ b/misk-jooq/build.gradle.kts
@@ -1,16 +1,6 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 
-// TODO(tsr): it might be better to put these on the root build classpath, but I'm not sure if that
-//  will have other repercussions. Do in a follow-up.
-// Needed to generate jooq test db classes
-buildscript {
-  dependencies {
-    classpath("org.flywaydb:flyway-gradle-plugin:9.14.1")
-    classpath(libs.mysql)
-  }
-}
-
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublishBase)


### PR DESCRIPTION
Loading all plugins in the root classloader makes the build more maintainable and less fragile.