### PR TITLE
Add metadata example to exemplar, make backwards compat

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataTabAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataTabAction.kt
@@ -92,7 +92,7 @@ class AllMetadataTabAction @Inject constructor(
 
             pre("bg-gray-100 p-4") {
               code("text-wrap font-mono") {
-                +(metadata?.formattedJsonString ?: "Metadata not found for $q")
+                +(metadata?.prettyPrint ?: "Metadata not found for $q")
               }
             }
           }

--- a/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigMetadata.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigMetadata.kt
@@ -7,16 +7,11 @@ import misk.resources.ResourceLoader
 import misk.web.metadata.Metadata
 import misk.web.metadata.MetadataProvider
 import misk.web.metadata.jvm.JvmMetadataAction
-import misk.web.metadata.toFormattedJson
 import wisp.deployment.Deployment
-import wisp.moshi.adapter
-import wisp.moshi.defaultKotlinMoshi
 
 data class ConfigMetadata(
   val resources: Map<String, String?>
-) : Metadata(metadata = resources, formattedJsonString = defaultKotlinMoshi
-  .adapter<Map<String, String?>>()
-  .toFormattedJson(resources))
+) : Metadata(metadata = resources, prettyPrint = resources.toString())
 
 class ConfigMetadataProvider : MetadataProvider<ConfigMetadata> {
   @Inject @AppName private lateinit var appName: String

--- a/misk-admin/src/main/kotlin/misk/web/metadata/database/DatabaseHibernateMetadata.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/database/DatabaseHibernateMetadata.kt
@@ -9,7 +9,7 @@ import wisp.moshi.defaultKotlinMoshi
 
 data class DatabaseHibernateMetadata(
   val hibernate: List<DatabaseQueryMetadata>
-) : Metadata(metadata = hibernate, formattedJsonString = defaultKotlinMoshi
+) : Metadata(metadata = hibernate, prettyPrint = defaultKotlinMoshi
   .adapter<List<DatabaseQueryMetadata>>()
   .toFormattedJson(hibernate))
 

--- a/misk-config/api/misk-config.api
+++ b/misk-config/api/misk-config.api
@@ -94,9 +94,11 @@ public final class misk/resources/TestingResourceLoaderModule : misk/inject/KAbs
 }
 
 public class misk/web/metadata/Metadata {
+	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
-	public final fun getFormattedJsonString ()Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMetadata ()Ljava/lang/Object;
+	public final fun getPrettyPrint ()Ljava/lang/String;
 }
 
 public final class misk/web/metadata/MetadataKt {

--- a/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
+++ b/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
@@ -1,21 +1,19 @@
 package misk.web.metadata
 
 import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonWriter
-import okio.Buffer
 
-open class Metadata(
+open class Metadata @JvmOverloads constructor(
   /** Metadata object, should be a data class for easy built-in serialization to JSON. */
   val metadata: Any,
 
-  /** JSON representation of the metadata. */
-  val formattedJsonString: String
+  /**
+   * Pretty Print representation of the metadata used in the admin dashboard.
+   * Most metadata should create a Moshi JSON adapter and use [toFormattedJson] to do this.
+   */
+  val prettyPrint: String = metadata.toString()
+    // Improves readability of default data class toString() for admin dashboard if JSON or custom prettyPrint isn't provided
+    .split("),").joinToString("),\n")
+    .split(",").joinToString(",\n")
 )
 
-fun <T> JsonAdapter<T>.toFormattedJson(value: T): String {
-  val buffer = Buffer()
-  val jsonWriter = JsonWriter.of(buffer)
-  this.serializeNulls().indent("  ").toJson(jsonWriter, value)
-  val json = buffer.readUtf8();
-  return json
-}
+fun <T> JsonAdapter<T>.toFormattedJson(value: T): String = serializeNulls().indent("  ").toJson(value)

--- a/misk-service/src/main/kotlin/misk/metadata/servicegraph/ServiceGraphMetadata.kt
+++ b/misk-service/src/main/kotlin/misk/metadata/servicegraph/ServiceGraphMetadata.kt
@@ -11,7 +11,7 @@ import wisp.moshi.defaultKotlinMoshi
 
 data class ServiceGraphMetadata(
   val builderMetadata: ServiceGraphBuilderMetadata,
-) : Metadata(metadata = builderMetadata, formattedJsonString = "Service Graph Ascii Visual\n\n${builderMetadata.asciiVisual}\n\nMetadata\n\n" + defaultKotlinMoshi
+) : Metadata(metadata = builderMetadata, prettyPrint = "Service Graph Ascii Visual\n\n${builderMetadata.asciiVisual}\n\nMetadata\n\n" + defaultKotlinMoshi
   .adapter<ServiceGraphBuilderMetadata>()
   .toFormattedJson(builderMetadata))
 

--- a/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionsMetadataProvider.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/webaction/WebActionsMetadataProvider.kt
@@ -12,7 +12,7 @@ import wisp.moshi.defaultKotlinMoshi
 
 data class WebActionsMetadata(
   val webActions: List<WebActionMetadata>
-) : Metadata(metadata = webActions, formattedJsonString = defaultKotlinMoshi
+) : Metadata(metadata = webActions, prettyPrint = defaultKotlinMoshi
   .adapter<List<WebActionMetadata>>()
   .toFormattedJson(webActions))
 

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarMetadataModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarMetadataModule.kt
@@ -2,12 +2,16 @@ package com.squareup.exemplar
 
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessAnnotationEntry
+import misk.web.metadata.Metadata
+import misk.web.metadata.MetadataModule
+import misk.web.metadata.MetadataProvider
 import misk.web.metadata.all.AllMetadataAccess
 import misk.web.metadata.all.AllMetadataModule
 
-class ExemplarMetadataModule: KAbstractModule() {
+class ExemplarMetadataModule : KAbstractModule() {
   override fun configure() {
     install(AllMetadataModule())
+    install(MetadataModule(DinoMetadataProvider()))
 
     multibind<AccessAnnotationEntry>().toInstance(
       AccessAnnotationEntry<AllMetadataAccess>(
@@ -18,3 +22,10 @@ class ExemplarMetadataModule: KAbstractModule() {
   }
 }
 
+class DinoMetadataProvider : MetadataProvider<Metadata> {
+  override val id: String = "dino"
+
+  override fun get() = Metadata(
+    metadata = listOf("t-rex", "stegosaurus", "triceratops")
+  )
+}


### PR DESCRIPTION
This fixes [#3303] which was backwards incompatible due to the new parameter added to the `Metadata` constructor. This renames and provides a default so existing callsites can roll forward automatically.