### PR TITLE
Fix ConfigMetadata prettyPrint to match Config tab

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigMetadata.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigMetadata.kt
@@ -11,7 +11,10 @@ import wisp.deployment.Deployment
 
 internal data class ConfigMetadata(
   val resources: Map<String, String?>
-) : Metadata(metadata = resources, prettyPrint = resources.toString())
+) : Metadata(metadata = resources, prettyPrint = resources.entries
+  .joinToString("\n\n") {
+    "${it.key}\n---\n${it.value?.removePrefix("---")?.removePrefix("\n")}"
+  })
 
 internal class ConfigMetadataProvider : MetadataProvider<ConfigMetadata> {
   @Inject @AppName private lateinit var appName: String


### PR DESCRIPTION
<img width="1239" alt="Screenshot 2024-06-18 at 00 32 29" src="https://github.com/cashapp/misk/assets/8827217/28d38333-988e-4cf2-b9da-405a7cd88009">
<img width="1237" alt="Screenshot 2024-06-18 at 00 32 54" src="https://github.com/cashapp/misk/assets/8827217/cbe3fd6f-a592-42fa-9bcd-bd5eef92218d">
