### PR TITLE
Allow dashboard menu links with query parameters

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/dashboard/ValidWebEntry.kt
+++ b/misk-actions/src/main/kotlin/misk/web/dashboard/ValidWebEntry.kt
@@ -44,8 +44,12 @@ open class ValidWebEntry @JvmOverloads constructor(
 
     /** Valid URL path prefix must have correct form and not use any blocked prefixes. */
     private fun String.requireValidUrlPathPrefix() = apply {
-      // internal link url_path_prefix must start and end with '/'
-      require(this.startsWith("http") || this.matches(Regex("(/[^/]+)*/"))) {
+      require(this.startsWith("http") ||
+        // Internal link url_path_prefix must start and end with '/'
+        this.matches(Regex("(/[^/]+)*/")) ||
+        // Ignores any trailing query parameters for service local links like /_admin/metadata/?q=config but still enforces the trailing '/'
+        if (this.contains("?")) this.split("?").dropLast(1).joinToString("?").matches(Regex("(/[^/]+)*/")) else false
+      ) {
         "Invalid or unexpected [urlPathPrefix=$this]. " +
           "Must start with 'http' OR start and end with '/'."
       }

--- a/misk-actions/src/test/kotlin/misk/web/dashboard/ValidWebEntryTest.kt
+++ b/misk-actions/src/test/kotlin/misk/web/dashboard/ValidWebEntryTest.kt
@@ -73,4 +73,9 @@ class ValidWebEntryTest {
       classException.message
     )
   }
+
+  @Test fun `allows valid path with query parameters`() {
+    class TestWebEntry : ValidWebEntry(valid_slug = "test-slug", valid_url_path_prefix = "/test-slug/?q=abc123")
+    TestWebEntry()
+  }
 }


### PR DESCRIPTION
This anticipates the use case where for backwards compatability purposes we want to keep a menu link but point it to a local URL with a query parameter. For example, keeping a Config link but pointing it to `/_admin/metadata/?q=config`.