### PR TITLE
Fix Metadata tab overflow scrolling

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/MetadataTabIndexAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/MetadataTabIndexAction.kt
@@ -91,7 +91,7 @@ internal class MetadataTabIndexAction @Inject constructor(
               }
             }
 
-            pre("bg-gray-100 p-4") {
+            pre("bg-gray-100 p-4 overflow-x-scroll rounded-lg") {
               code("text-wrap font-mono") {
                 +(metadata?.prettyPrint ?: "Metadata not found for $q")
               }


### PR DESCRIPTION
Before
---

<img width="1238" alt="Screenshot 2024-06-18 at 13 05 34" src="https://github.com/cashapp/misk/assets/8827217/9c3eb448-d158-4a3f-97c0-9d4ec05b5b6b">

After
---

<img width="1235" alt="Screenshot 2024-06-18 at 13 04 54" src="https://github.com/cashapp/misk/assets/8827217/aa73aacb-7631-4a7d-a71c-cd7174473ace">
