### PR TITLE
Deprecate Config tab in admin dashboard menu

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigDashboardTabModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/config/ConfigDashboardTabModule.kt
@@ -6,6 +6,7 @@ import misk.web.WebActionModule
 import misk.web.dashboard.AdminDashboard
 import misk.web.dashboard.AdminDashboardAccess
 import misk.web.dashboard.DashboardModule
+import misk.web.metadata.all.MetadataTabIndexAction
 import misk.web.metadata.config.ConfigMetadataAction.ConfigTabMode.SAFE
 import misk.web.metadata.jvm.JvmMetadata
 import misk.web.metadata.jvm.JvmMetadataProvider
@@ -31,12 +32,21 @@ class ConfigDashboardTabModule @JvmOverloads constructor(
     install(WebActionModule.create<ConfigMetadataAction>())
 
     install(
+      DashboardModule.createMenuLink<AdminDashboard, AdminDashboardAccess>(
+        label = "Config",
+        url = MetadataTabIndexAction.PATH + "?q=config",
+        category = "Container Admin",
+      )
+    )
+
+    // TODO delete the old Misk-Web tab after testing in real environments to confirm Metadata tab is sufficient drop-in replacement
+    install(
       DashboardModule.createMiskWebTab<AdminDashboard, AdminDashboardAccess>(
         isDevelopment = isDevelopment,
         slug = "config",
         urlPathPrefix = "/_admin/config/",
         developmentWebProxyUrl = "http://localhost:3200/",
-        menuLabel = "Config",
+        menuLabel = "Config v1",
         menuCategory = "Container Admin"
       )
     )


### PR DESCRIPTION
Old Config tab still accessible via `Config v1`
---
<img width="1315" alt="Screenshot 2024-06-19 at 10 02 37" src="https://github.com/cashapp/misk/assets/8827217/dfcd5498-b2d3-4381-a3d4-41f0d0001362">

New config link jumps straight into the Metadata tab
---
<img width="1315" alt="Screenshot 2024-06-19 at 10 02 52" src="https://github.com/cashapp/misk/assets/8827217/b5293234-e088-49ad-8908-f82afed53e19">
