### PR TITLE
chore: add opentracing span to starting docker composer in tests

### DIFF
--- a/wisp/wisp-containers-testing/build.gradle.kts
+++ b/wisp/wisp-containers-testing/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(libs.dockerTransport)
     implementation(libs.dockerTransportCore)
     implementation(project(":wisp:wisp-logging"))
+    implementation(libs.openTracing)
+    implementation(libs.openTracingUtil)
     runtimeOnly(libs.logbackClassic)
 
     testImplementation(libs.junitApi)


### PR DESCRIPTION
This allows us to trace tests and see how much of test execution time is spent on starting the Containers, assuming the datadog test visibility is enabled