### PR TITLE
Distribute cron tasks

### DIFF
--- a/misk-cron/README.md
+++ b/misk-cron/README.md
@@ -1,6 +1,5 @@
 ## misk-cron
 This module gives Misk services a way to run scheduled tasks using [cron](https://en.wikipedia.org/wiki/Cron) syntax. [Leases](https://github.com/cashapp/wisp/tree/main/wisp-lease) are used to ensure that only one instance of the service executes the schedule at a time.
-
 Note that there are **not** strong guarantees on task execution; tasks can be delayed or missed entirely for many reasons, including if the instance currently holding the lease is degraded or if it dies completely while executing the task. This module is not a good choice for highly sensitive, business critical needs.
 
 ## Usage
@@ -23,3 +22,10 @@ Note that there are **not** strong guarantees on task execution; tasks can be de
       }
     }
     ```
+## Cron Task Distribution
+Please keep in mind that the current behavior of the leases is that a single instance of the service runs all the ready cron tasks. 
+
+If you wish to distribute the tasks across the fleet of pods, you would need to do the following:
+- Update the `cronLeaseBehavior` within the `CronModule` to be equal to `ONE_LEASE_PER_CRON`
+
+Note that there are **no** strong guarantees on lease distribution if you take this approach: **all leases for tasks could end up on a single pod**.

--- a/misk-cron/build.gradle.kts
+++ b/misk-cron/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
   testImplementation(libs.assertj)
   testImplementation(libs.junitApi)
+  testImplementation(libs.junitParams)
   testImplementation(libs.logbackClassic)
   testImplementation(project(":wisp:wisp-logging-testing"))
   testImplementation(project(":wisp:wisp-time-testing"))

--- a/misk-cron/src/main/kotlin/misk/cron/CronManager.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronManager.kt
@@ -98,12 +98,10 @@ class CronManager @Inject constructor() {
   }
 
   fun tryToRunCrons(lastRun: Instant) {
-    if (cronLeaseBehavior == CronLeaseBehavior.ONE_LEASE_PER_CLUSTER) {
-      tryAcquireSingleLeaseAndRunCrons(lastRun)
-      return
+    when(cronLeaseBehavior) {
+      CronLeaseBehavior.ONE_LEASE_PER_CRON -> tryAcquireLeasePerCronAndRunCrons(lastRun)
+      CronLeaseBehavior.ONE_LEASE_PER_CLUSTER -> tryAcquireSingleLeaseAndRunCrons(lastRun)
     }
-
-    tryAcquireLeasePerCronAndRunCrons(lastRun)
   }
 
   fun tryAcquireSingleLeaseAndRunCrons(lastRun: Instant) {

--- a/misk-cron/src/main/kotlin/misk/cron/CronService.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronService.kt
@@ -9,11 +9,10 @@ import wisp.logging.getLogger
 
 @Singleton
 internal class CronService @Inject constructor(
-  private val injector: Injector
+  private val injector: Injector,
 ) : AbstractIdleService() {
   @Inject private lateinit var cronManager: CronManager
   @Inject private lateinit var cronRunnableEntries: List<CronRunnableEntry>
-  @Inject private lateinit var leaseManager: LeaseManager
 
   override fun startUp() {
     logger.info { "CronService started" }
@@ -26,7 +25,7 @@ internal class CronService @Inject constructor(
 
       val runnable = injector.getProvider(cronRunnable.runnableClass.java).get()
       cronManager.addCron(name, cronPattern.pattern, runnable)
-
+      // We want to request an interest in holding a lease as soon as the service starts up
       cronManager.buildTaskLease(cronRunnable.runnableClass)
     }
   }

--- a/misk-cron/src/main/kotlin/misk/cron/CronService.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronService.kt
@@ -2,9 +2,10 @@ package misk.cron
 
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.inject.Injector
-import wisp.logging.getLogger
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import wisp.lease.LeaseManager
+import wisp.logging.getLogger
 
 @Singleton
 internal class CronService @Inject constructor(
@@ -12,6 +13,7 @@ internal class CronService @Inject constructor(
 ) : AbstractIdleService() {
   @Inject private lateinit var cronManager: CronManager
   @Inject private lateinit var cronRunnableEntries: List<CronRunnableEntry>
+  @Inject private lateinit var leaseManager: LeaseManager
 
   override fun startUp() {
     logger.info { "CronService started" }
@@ -24,6 +26,8 @@ internal class CronService @Inject constructor(
 
       val runnable = injector.getProvider(cronRunnable.runnableClass.java).get()
       cronManager.addCron(name, cronPattern.pattern, runnable)
+
+      cronManager.buildTaskLease(cronRunnable.runnableClass)
     }
   }
 

--- a/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
@@ -26,9 +26,8 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
         return@scheduleWithBackoff Status.OK
       }
 
-      val now = clock.instant()
-      cronManager.runReadyCrons(lastRun)
-      lastRun = now
+      cronManager.tryToRunCrons(lastRun)
+      lastRun = clock.instant()
       Status.OK
     }
   }
@@ -40,8 +39,6 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
 
   companion object {
     val INTERVAL: Duration = Duration.ofSeconds(60L)
-    private const val CRON_CLUSTER_LEASE_NAME = "misk.cron.lease"
-
     private val logger = getLogger<CronTask>()
   }
 }


### PR DESCRIPTION
Currently Cron tasks are governed by a single lease, so all tasks are executed on whichever pod takes that lease. This change adds a new `CronLeaseBehavior` parameter to `CronModule`, making it possible to take out a lease per-cron-task and distribute the tasks across the deployment. The default behavior remains to take out a single lease