### PR TITLE
Install the MetadataModule only once for cron metadata

### DIFF
--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -14,8 +14,6 @@ import java.time.ZoneId
 import jakarta.inject.Qualifier
 import misk.inject.KAbstractModule
 import misk.inject.KInstallOnceModule
-import misk.moshi.MoshiAdapterModule
-import misk.web.metadata.Metadata
 import misk.web.metadata.MetadataModule
 
 class CronModule @JvmOverloads constructor(
@@ -24,7 +22,6 @@ class CronModule @JvmOverloads constructor(
   private val dependencies: List<Key<out Service>> = listOf()
 ) : KInstallOnceModule() {
   override fun configure() {
-    install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class).dependsOn<ReadyService>())
     install(
       ServiceModule(

--- a/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronModule.kt
@@ -22,6 +22,7 @@ class CronModule @JvmOverloads constructor(
   private val dependencies: List<Key<out Service>> = listOf()
 ) : KInstallOnceModule() {
   override fun configure() {
+    install(FakeCronModule(zoneId, threadPoolSize, dependencies))
     install(ServiceModule<RepeatedTaskQueue>(ForMiskCron::class).dependsOn<ReadyService>())
     install(
       ServiceModule(
@@ -29,7 +30,6 @@ class CronModule @JvmOverloads constructor(
         dependsOn = dependencies,
       ).dependsOn<ReadyService>()
     )
-    install(MetadataModule(CronMetadataProvider()))
   }
 
   @Provides


### PR DESCRIPTION
It's being installed both from the real and fake cron modules, and for some reason the fake module is being installed by the real one, meaning any binding of the real module results in MetadataModule being installed twice and failing with a duplicate key error.  