### PR TITLE
Add Guice Metadata that shows DI bindings

### DIFF
--- a/misk/src/main/kotlin/misk/MiskServiceModule.kt
+++ b/misk/src/main/kotlin/misk/MiskServiceModule.kt
@@ -13,6 +13,8 @@ import misk.resources.ResourceLoaderModule
 import misk.time.ClockModule
 import misk.time.TickerModule
 import misk.tokens.TokenGeneratorModule
+import misk.web.metadata.MetadataModule
+import misk.web.metadata.guice.GuiceMetadataProvider
 
 /**
  * Install this module in real environments.
@@ -53,5 +55,6 @@ class MiskCommonServiceModule @JvmOverloads constructor(
     // Initialize empty sets for our multibindings.
     newMultibinder<HealthCheck>()
     install(ServiceModule<ReadyService>())
+    install(MetadataModule(GuiceMetadataProvider()))
   }
 }

--- a/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
@@ -3,6 +3,11 @@ package misk.web.metadata.guice
 import com.google.inject.Binding
 import com.google.inject.Injector
 import com.google.inject.Key
+import com.google.inject.spi.ConstructorBinding
+import com.google.inject.spi.InstanceBinding
+import com.google.inject.spi.LinkedKeyBinding
+import com.google.inject.spi.ProviderInstanceBinding
+import com.google.inject.spi.ProviderKeyBinding
 import jakarta.inject.Inject
 import misk.web.metadata.Metadata
 import misk.web.metadata.MetadataProvider
@@ -10,34 +15,32 @@ import misk.web.metadata.toFormattedJson
 import wisp.moshi.adapter
 import wisp.moshi.defaultKotlinMoshi
 
-data class GuiceMetadata(
-  val allBindings: Map<String, String>
+internal data class GuiceMetadata(
+  val guice: GuiceMetadataProvider.Metadata
 ) : Metadata(
-  metadata = allBindings,
-  prettyPrint = defaultKotlinMoshi
-    .adapter<Map<String, String>>()
-    .toFormattedJson(allBindings),
-  descriptionString = "Guice bindings."
+  metadata = guice,
+  prettyPrint = "Total Bindings: ${guice.all.size}\n\n" + defaultKotlinMoshi
+    .adapter<Map<String, Map<String, String>>>()
+    .toFormattedJson(guice.grouped),
+  descriptionString = "Direct injection bindings, powered by Guice. This metadata is work-in-progress."
 )
 
-class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
+internal class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
   @Inject lateinit var injector: Injector
 
   override val id = "guice"
 
-  override fun get(): GuiceMetadata {
-    val allBindings = injector.allBindings
+  internal data class Metadata(
+    val all: Map<String, String>,
+    val grouped: Map<String, Map<String, String>>,
+  )
 
-    return GuiceMetadata(
-      allBindings = allBindings
-        .map { it.key.prettyPrint(injector.allBindings) to it.value.prettyPrint() }
-        .toMap()
-        .toSortedMap()
-    )
+  val allBindings by lazy {
+    injector.allBindings
   }
 
-  fun Key<*>.prettyPrint(allBindings: MutableMap<Key<*>, Binding<*>>): String {
-    val ambiguousNames = allBindings.keys
+  val ambiguousNames by lazy {
+    allBindings.keys
       .groupBy { it.typeLiteral.rawType.simpleName }
       .map { entry ->
         entry.key to entry.value
@@ -46,13 +49,61 @@ class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
       }
       .filter { it.second.size > 1 }
       .toMap()
+  }
 
-    val unambiguousPackages = allBindings.filter { it.key.typeLiteral.rawType.simpleName !in ambiguousNames.keys }
+  val unambiguousPackages by lazy {
+    allBindings.filter { it.key.typeLiteral.rawType.simpleName !in ambiguousNames.keys }
       .keys
       .map { it.typeLiteral.rawType.packageName }
       .toSet()
+  }
 
+  override fun get(): GuiceMetadata {
+    val raw = allBindings
+      .map { it.key.prettyPrint() to it.value.prettyPrint() }
+      .toMap()
+      .toSortedMap()
+
+    val all = raw.entries.groupBy {
+      if (it.key.contains(" / ")) it.key.split(" / ").first() else "default"
+    }.map {
+      it.key to it.value.associate { it.key.split(" / ").last() to it.value }
+    }.toMap()
+
+    return GuiceMetadata(
+      Metadata(
+        all = allBindings.map { it.key.toString() to it.value.toString() }.toMap(),
+        grouped = all
+      )
+    )
+  }
+
+  fun Key<*>.prettyPrint(): String {
     var pretty = typeLiteral.toString()
+
+    pretty = pretty.stripAmbiguousPackages()
+
+    return if (annotation != null) {
+      if (annotation.annotationClass.qualifiedName == "com.google.inject.internal.Element") {
+        if (annotation.toString().contains("type=MULTIBINDER")) {
+          "Multibinder / List<$pretty>"
+        } else if (annotation.toString().contains("type=MAPBINDER")) {
+          var keyType = annotation.toString().split("keyType=").last().removeSuffix(")")
+          keyType = keyType.stripAmbiguousPackages()
+          "Mapbinder / Map<$keyType,$pretty>"
+        } else {
+          "$pretty, annotation=$annotation"
+        }
+      } else {
+        "$pretty, annotation=$annotation"
+      }
+    } else {
+      pretty
+    }
+  }
+
+  private fun String.stripAmbiguousPackages(): String {
+    var pretty = this
 
     // Protect ambiguous packages by changing . to - in package names
     ambiguousNames.forEach {
@@ -61,7 +112,7 @@ class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
       }
     }
 
-    // Cleanup unambiguous packages
+    // Strip unambiguous packages
     unambiguousPackages.forEach {
       pretty = pretty.replace("$it.", "")
     }
@@ -73,16 +124,52 @@ class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
       }
     }
 
-    pretty = pretty
-      .replace("? extends Map${"$"}Entry", "Entry")
-      .replace("Map${"$"}Entry", "Entry")
+    // Strip specific groups that don't need to be unambiguous (ie. javax vs jakarta vs google inject annotations)
+    val commonPackages = listOf("com.google.inject", "jakarta.inject", "javax.inject")
+    commonPackages.forEach {
+      pretty = pretty.replace("$it.", "")
+    }
 
-    return if (annotation != null) {
-      "$pretty, annotation=$annotation"
-    } else {
-      pretty
+    return pretty
+  }
+
+  private data class BindingMetadata(
+    val type: String,
+    val source: String,
+    val scope: String?,
+    val provider: String?
+  ) {
+    override fun toString(): String {
+      return "$type(source=$source, scope=$scope, provider=$provider)"
     }
   }
 
-  fun Binding<*>.prettyPrint() = toString()
+  fun Binding<*>.prettyPrint(): String {
+    val bindingString = this.toString()
+
+    val source = source.toString().removePrefix("class ")
+
+    val scope = if (bindingString.contains("scope=")) {
+      bindingString.split("scope=").last().split("}").first().split(",").first()
+    } else {
+      null
+    }
+
+    val provider = if (bindingString.contains("provider=")) {
+      bindingString.split("provider=").last().split("}").first().split(",").first()
+    } else {
+      null
+    }
+
+    val type = when (this) {
+      is ConstructorBinding<*> -> "ConstructorBinding"
+      is InstanceBinding<*> -> "InstanceBinding"
+      is LinkedKeyBinding<*> -> "LinkedKeyBinding"
+      is ProviderInstanceBinding<*> -> "ProviderInstanceBinding"
+      is ProviderKeyBinding<*> -> "ProviderKeyBinding"
+      else -> "${this::class.simpleName}"
+    }
+
+    return BindingMetadata(type, source, scope, provider).toString()
+  }
 }

--- a/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
@@ -3,11 +3,6 @@ package misk.web.metadata.guice
 import com.google.inject.Binding
 import com.google.inject.Injector
 import com.google.inject.Key
-import com.google.inject.spi.ConstructorBinding
-import com.google.inject.spi.InstanceBinding
-import com.google.inject.spi.LinkedKeyBinding
-import com.google.inject.spi.ProviderInstanceBinding
-import com.google.inject.spi.ProviderKeyBinding
 import jakarta.inject.Inject
 import misk.web.metadata.Metadata
 import misk.web.metadata.MetadataProvider
@@ -161,14 +156,7 @@ internal class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
       null
     }
 
-    val type = when (this) {
-      is ConstructorBinding<*> -> "ConstructorBinding"
-      is InstanceBinding<*> -> "InstanceBinding"
-      is LinkedKeyBinding<*> -> "LinkedKeyBinding"
-      is ProviderInstanceBinding<*> -> "ProviderInstanceBinding"
-      is ProviderKeyBinding<*> -> "ProviderKeyBinding"
-      else -> "${this::class.simpleName}"
-    }
+    val type = this::class.simpleName ?: "Binding"
 
     return BindingMetadata(type, source, scope, provider).toString()
   }

--- a/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
+++ b/misk/src/main/kotlin/misk/web/metadata/guice/GuiceMetadata.kt
@@ -1,0 +1,88 @@
+package misk.web.metadata.guice
+
+import com.google.inject.Binding
+import com.google.inject.Injector
+import com.google.inject.Key
+import jakarta.inject.Inject
+import misk.web.metadata.Metadata
+import misk.web.metadata.MetadataProvider
+import misk.web.metadata.toFormattedJson
+import wisp.moshi.adapter
+import wisp.moshi.defaultKotlinMoshi
+
+data class GuiceMetadata(
+  val allBindings: Map<String, String>
+) : Metadata(
+  metadata = allBindings,
+  prettyPrint = defaultKotlinMoshi
+    .adapter<Map<String, String>>()
+    .toFormattedJson(allBindings),
+  descriptionString = "Guice bindings."
+)
+
+class GuiceMetadataProvider : MetadataProvider<GuiceMetadata> {
+  @Inject lateinit var injector: Injector
+
+  override val id = "guice"
+
+  override fun get(): GuiceMetadata {
+    val allBindings = injector.allBindings
+
+    return GuiceMetadata(
+      allBindings = allBindings
+        .map { it.key.prettyPrint(injector.allBindings) to it.value.prettyPrint() }
+        .toMap()
+        .toSortedMap()
+    )
+  }
+
+  fun Key<*>.prettyPrint(allBindings: MutableMap<Key<*>, Binding<*>>): String {
+    val ambiguousNames = allBindings.keys
+      .groupBy { it.typeLiteral.rawType.simpleName }
+      .map { entry ->
+        entry.key to entry.value
+          .map { it.typeLiteral.rawType.packageName }
+          .toSet()
+      }
+      .filter { it.second.size > 1 }
+      .toMap()
+
+    val unambiguousPackages = allBindings.filter { it.key.typeLiteral.rawType.simpleName !in ambiguousNames.keys }
+      .keys
+      .map { it.typeLiteral.rawType.packageName }
+      .toSet()
+
+    var pretty = typeLiteral.toString()
+
+    // Protect ambiguous packages by changing . to - in package names
+    ambiguousNames.forEach {
+      it.value.forEach { pkg ->
+        pretty = pretty.replace("$pkg.${it.key}", "${pkg.replace(".", "-")}.${it.key}")
+      }
+    }
+
+    // Cleanup unambiguous packages
+    unambiguousPackages.forEach {
+      pretty = pretty.replace("$it.", "")
+    }
+
+    // Restore ambiguous packages - with .
+    ambiguousNames.forEach {
+      it.value.forEach { pkg ->
+        pretty = pretty.replace("${pkg.replace(".", "-")}.${it.key}", "$pkg.${it.key}")
+      }
+    }
+
+    pretty = pretty
+      .replace("? extends Map${"$"}Entry", "Entry")
+      .replace("Map${"$"}Entry", "Entry")
+
+    return if (annotation != null) {
+      "$pretty, annotation=$annotation"
+    } else {
+      pretty
+    }
+  }
+
+  fun Binding<*>.prettyPrint() = toString()
+}


### PR DESCRIPTION
First PR will add Guice bindings to Misk's Metadata. This will show up
in the Metadata admin dashboard tab and be exposed in the metadata APIs.

Follow up PRs may add a more specialized UI which turns this metadata
into a browsable tree chart or adds search etc.

<img width="1281" alt="Screenshot 2024-06-26 at 17 58 53" src="https://github.com/cashapp/misk/assets/8827217/505e4ca7-458b-4311-abb6-fa148404a100">

<img width="1285" alt="Screenshot 2024-06-26 at 17 59 10" src="https://github.com/cashapp/misk/assets/8827217/9d7db4cc-d162-4466-81ab-07f32f180f8f">