### PR TITLE
Add metadata for job queues

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataModule.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/AllMetadataModule.kt
@@ -26,6 +26,7 @@ import misk.web.metadata.webaction.WebActionsMetadataProvider
  */
 class AllMetadataModule : KAbstractModule() {
   override fun configure() {
+    // Expose metadata as an API
     install(WebActionModule.create<AllMetadataAction>())
 
     // Built in metadata
@@ -34,7 +35,7 @@ class AllMetadataModule : KAbstractModule() {
     install(MetadataModule(JvmMetadataProvider()))
     install(MetadataModule(WebActionsMetadataProvider()))
 
-    // Install dashbaord tab
+    // Install dashboard tab
     install(WebActionModule.create<MetadataTabIndexAction>())
     install(DashboardModule.createHotwireTab<AdminDashboard, AdminDashboardAccess>(
       slug = "metadata",

--- a/misk-aws/build.gradle.kts
+++ b/misk-aws/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
   testImplementation(project(":wisp:wisp-time-testing"))
   testImplementation(project(":wisp:wisp-logging-testing"))
   testImplementation(project(":misk-clustering"))
-  testImplementation(project(":misk-feature-testing"))
+  testImplementation(testFixtures(project(":misk-feature")))
   testImplementation(project(":misk-testing"))
 }
 

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -11,6 +11,8 @@ import misk.jobqueue.JobHandler
 import misk.jobqueue.QueueName
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.jobqueue.JobqueueMetadataProvider
+import misk.web.metadata.MetadataModule
 import kotlin.reflect.KClass
 
 /**
@@ -36,6 +38,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
         dependsOn = dependsOn
       ).dependsOn<ReadyService>()
     )
+    install(MetadataModule(JobqueueMetadataProvider()))
   }
 
   companion object {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -10,6 +10,7 @@ import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient
 import com.amazonaws.services.sqs.buffered.QueueBufferConfig
 import com.google.inject.Provider
 import com.google.inject.Provides
+import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import misk.ReadyService
 import misk.ServiceModule
@@ -27,7 +28,6 @@ import misk.tasks.RepeatedTaskQueue
 import misk.tasks.RepeatedTaskQueueConfig
 import misk.tasks.RepeatedTaskQueueFactory
 import wisp.lease.LeaseManager
-import jakarta.inject.Inject
 
 /** [AwsSqsJobQueueModule] installs job queue support provided by SQS. */
 open class AwsSqsJobQueueModule(

--- a/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
+++ b/misk-aws/src/test/kotlin/misk/jobqueue/sqs/SqsJobQueueTestModule.kt
@@ -36,8 +36,7 @@ class SqsJobQueueTestModule(
             queue_attribute_importer_frequency_ms = 0
           )
         )
-      )
-        .with(SqsTestModule(credentials, client))
+      ).with(SqsTestModule(credentials, client))
     )
   }
 }

--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -1,6 +1,44 @@
+public final class misk/jobqueue/ColorException : java/lang/Exception {
+	public fun <init> ()V
+}
+
 public final class misk/jobqueue/DevelopmentJobProcessorModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
 	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;)Lmisk/tasks/RepeatedTaskQueue;
+}
+
+public final class misk/jobqueue/ExampleJobEnqueuer {
+	public final fun batchEnqueueRed (Ljava/util/List;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;)V
+	public static synthetic fun batchEnqueueRed$default (Lmisk/jobqueue/ExampleJobEnqueuer;Ljava/util/List;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;ILjava/lang/Object;)V
+	public final fun enqueueEnqueuer ()V
+	public final fun enqueueGreen (Ljava/lang/String;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;)V
+	public static synthetic fun enqueueGreen$default (Lmisk/jobqueue/ExampleJobEnqueuer;Ljava/lang/String;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;ILjava/lang/Object;)V
+	public final fun enqueueRed (Ljava/lang/String;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;)V
+	public static synthetic fun enqueueRed$default (Lmisk/jobqueue/ExampleJobEnqueuer;Ljava/lang/String;Ljava/time/Duration;Lmisk/jobqueue/ExampleJobHint;ILjava/lang/Object;)V
+}
+
+public final class misk/jobqueue/ExampleJobHandler : misk/jobqueue/JobHandler {
+	public static final field Companion Lmisk/jobqueue/ExampleJobHandler$Companion;
+	public fun handleJob (Lmisk/jobqueue/Job;)V
+}
+
+public final class misk/jobqueue/ExampleJobHandler$Companion {
+}
+
+public final class misk/jobqueue/ExampleJobHint : java/lang/Enum {
+	public static final field DEAD_LETTER Lmisk/jobqueue/ExampleJobHint;
+	public static final field DEAD_LETTER_ONCE Lmisk/jobqueue/ExampleJobHint;
+	public static final field DELAY_ONCE Lmisk/jobqueue/ExampleJobHint;
+	public static final field DONT_ACK Lmisk/jobqueue/ExampleJobHint;
+	public static final field THROW Lmisk/jobqueue/ExampleJobHint;
+	public static final field THROW_ONCE Lmisk/jobqueue/ExampleJobHint;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/jobqueue/ExampleJobHint;
+	public static fun values ()[Lmisk/jobqueue/ExampleJobHint;
+}
+
+public final class misk/jobqueue/ExampleJobQueuesTestingModule : misk/inject/KAbstractModule {
+	public fun <init> ()V
 }
 
 public final class misk/jobqueue/FakeJob : java/lang/Comparable, misk/jobqueue/Job {
@@ -106,6 +144,19 @@ public abstract interface class misk/jobqueue/JobHandler {
 	public abstract fun handleJob (Lmisk/jobqueue/Job;)V
 }
 
+public final class misk/jobqueue/JobHandlerMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lmisk/jobqueue/JobHandlerMetadata;
+	public static synthetic fun copy$default (Lmisk/jobqueue/JobHandlerMetadata;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lmisk/jobqueue/JobHandlerMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHandlerClass ()Ljava/lang/String;
+	public final fun getSupertypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class misk/jobqueue/JobQueue {
 	public static final field Companion Lmisk/jobqueue/JobQueue$Companion;
 	public static final field SQS_MAX_BATCH_ENQUEUE_JOB_SIZE I
@@ -177,6 +228,27 @@ public final class misk/jobqueue/JobQueue$JobRequest {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class misk/jobqueue/JobqueueMetadata : misk/web/metadata/Metadata {
+	public fun <init> (Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lmisk/jobqueue/JobqueueMetadata;
+	public static synthetic fun copy$default (Lmisk/jobqueue/JobqueueMetadata;Ljava/util/Map;ILjava/lang/Object;)Lmisk/jobqueue/JobqueueMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQueues ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/jobqueue/JobqueueMetadataProvider : misk/web/metadata/MetadataProvider {
+	public field queues Ljava/util/Map;
+	public fun <init> ()V
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lmisk/jobqueue/JobqueueMetadata;
+	public fun getId ()Ljava/lang/String;
+	public final fun getQueues ()Ljava/util/Map;
+	public final fun setQueues (Ljava/util/Map;)V
+}
+
 public final class misk/jobqueue/QueueName {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -186,5 +258,10 @@ public final class misk/jobqueue/QueueName {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/jobqueue/TestFixturesKt {
+	public static final fun getGREEN_QUEUE ()Lmisk/jobqueue/QueueName;
+	public static final fun getRED_QUEUE ()Lmisk/jobqueue/QueueName;
 }
 

--- a/misk-jobqueue/build.gradle.kts
+++ b/misk-jobqueue/build.gradle.kts
@@ -8,6 +8,11 @@ plugins {
 }
 
 dependencies {
+  api(libs.jakartaInject)
+  api(project(":misk-config"))
+  implementation(libs.moshiCore)
+  implementation(project(":wisp:wisp-moshi"))
+
   testFixturesApi(libs.guice)
   testFixturesApi(libs.jakartaInject)
   testFixturesApi(project(":wisp:wisp-token"))
@@ -18,6 +23,7 @@ dependencies {
   testFixturesApi(project(":misk-transactional-jobqueue"))
   testFixturesImplementation(project(":misk-core"))
   testFixturesImplementation(project(":misk-service"))
+  testFixturesImplementation(project(":wisp:wisp-logging"))
 
   testImplementation(libs.assertj)
   testImplementation(libs.guice)

--- a/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobqueueMetadata.kt
+++ b/misk-jobqueue/src/main/kotlin/misk/jobqueue/JobqueueMetadata.kt
@@ -1,0 +1,42 @@
+package misk.jobqueue
+
+import jakarta.inject.Inject
+import misk.inject.typeLiteral
+import misk.web.metadata.Metadata
+import misk.web.metadata.MetadataProvider
+import misk.web.metadata.toFormattedJson
+import wisp.moshi.adapter
+import wisp.moshi.defaultKotlinMoshi
+
+data class JobHandlerMetadata(
+  val handlerClass: String,
+  val supertypes: List<String>,
+)
+
+data class JobqueueMetadata(
+  val queues: Map<String, JobHandlerMetadata>
+): Metadata(
+  metadata = queues,
+  prettyPrint = defaultKotlinMoshi
+    .adapter<Map<String, JobHandlerMetadata>>()
+    .toFormattedJson(queues),
+  descriptionString = "Job queues and their registered handlers."
+  )
+
+class JobqueueMetadataProvider: MetadataProvider<JobqueueMetadata> {
+  @Inject lateinit var queues: Map<QueueName, JobHandler>
+
+  override val id = "job-queue"
+
+  override fun get(): JobqueueMetadata {
+    return JobqueueMetadata(queues = queues.entries
+      .associate { it.key.value to JobHandlerMetadata(
+        handlerClass = it.value::class.qualifiedName!!,
+        supertypes = it.value::class.supertypes
+          .map { it.toString() }
+          // Every class implements Any so not useful to display that in the metadata
+          .filterNot { it == Any::class.qualifiedName }
+      ) }
+      .toSortedMap())
+  }
+}

--- a/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
+++ b/misk-jobqueue/src/test/kotlin/misk/jobqueue/FakeJobQueueTest.kt
@@ -1,22 +1,17 @@
 package misk.jobqueue
 
-import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.logging.LogCollectorModule
-import misk.moshi.adapter
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import wisp.logging.LogCollector
-import wisp.logging.getLogger
 import wisp.time.FakeClock
 import java.time.Duration
 import java.time.temporal.ChronoUnit
-import java.util.concurrent.ConcurrentHashMap
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 import kotlin.test.assertFailsWith
 
 @MiskTest(startService = true)
@@ -552,129 +547,7 @@ private class TestModule : KAbstractModule() {
   override fun configure() {
     install(MiskTestingServiceModule())
     install(LogCollectorModule())
-    install(FakeJobHandlerModule.create<ExampleJobHandler>(RED_QUEUE))
-    install(FakeJobHandlerModule.create<ExampleJobHandler>(GREEN_QUEUE))
-    install(FakeJobHandlerModule.create<EnqueuerJobHandler>(ENQUEUER_QUEUE))
-    install(FakeJobQueueModule())
+    install(ExampleJobQueuesTestingModule())
   }
 }
 
-internal val RED_QUEUE = QueueName("red_queue")
-internal val GREEN_QUEUE = QueueName("green_queue")
-internal val ENQUEUER_QUEUE = QueueName("first_step_queue")
-
-internal enum class Color {
-  RED,
-  GREEN
-}
-
-internal class ColorException : Exception()
-
-internal data class ExampleJob(
-  val color: Color,
-  val message: String,
-  val hint: ExampleJobHint? = null
-)
-
-internal enum class ExampleJobHint {
-  DONT_ACK,
-  THROW,
-  THROW_ONCE,
-  DEAD_LETTER,
-  DEAD_LETTER_ONCE,
-  DELAY_ONCE,
-}
-
-internal class ExampleJobEnqueuer @Inject private constructor(
-  private val jobQueue: JobQueue,
-  moshi: Moshi
-) {
-  private val jobAdapter = moshi.adapter<ExampleJob>()
-
-  fun enqueueRed(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
-    val job = ExampleJob(Color.RED, message, hint)
-    jobQueue.enqueue(
-      RED_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
-      attributes = mapOf("key" to "value")
-    )
-  }
-
-  fun enqueueGreen(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
-    val job = ExampleJob(Color.GREEN, message, hint)
-    jobQueue.enqueue(
-      GREEN_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
-      attributes = mapOf("key" to "value")
-    )
-  }
-
-  fun batchEnqueueRed(messages: List<String>, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
-    jobQueue.batchEnqueue(RED_QUEUE, messages.map {
-      JobQueue.JobRequest(
-        body = jobAdapter.toJson(ExampleJob(Color.RED, it, hint)),
-        deliveryDelay = deliveryDelay,
-        attributes = mapOf("key" to "value")
-      )
-    })
-  }
-
-  fun enqueueEnqueuer() {
-    jobQueue.enqueue(ENQUEUER_QUEUE, body = "")
-  }
-}
-
-@Singleton
-internal class ExampleJobHandler @Inject private constructor(moshi: Moshi) : JobHandler {
-  private val jobAdapter = moshi.adapter<ExampleJob>()
-  private val jobsExecutedOnce = ConcurrentHashMap<String, Boolean>()
-
-  override fun handleJob(job: Job) {
-    val deserializedJob = jobAdapter.fromJson(job.body)!!
-    log.info { "received ${deserializedJob.color} job with message: ${deserializedJob.message}" }
-
-    assertThat(job.attributes).containsEntry("key", "value")
-
-    val key = "${deserializedJob.color}:${deserializedJob.hint}:${deserializedJob.message}"
-    val jobExecutedBefore = jobsExecutedOnce.putIfAbsent(key, true) == true
-    when (deserializedJob.hint) {
-      ExampleJobHint.DONT_ACK -> return
-      ExampleJobHint.DEAD_LETTER -> {
-        job.deadLetter()
-        return
-      }
-      ExampleJobHint.DEAD_LETTER_ONCE -> if (!jobExecutedBefore) {
-        job.deadLetter()
-        return
-      }
-      ExampleJobHint.THROW -> throw ColorException()
-      ExampleJobHint.THROW_ONCE -> if (!jobExecutedBefore) {
-        throw ColorException()
-      }
-      ExampleJobHint.DELAY_ONCE -> if (!jobExecutedBefore) {
-        job.delayWithBackoff()
-        throw ColorException()
-      }
-      else -> Unit
-    }
-
-    job.acknowledge()
-  }
-
-  companion object {
-    private val log = getLogger<ExampleJobHandler>()
-  }
-}
-
-internal class EnqueuerJobHandler @Inject private constructor(
-  private val jobQueue: JobQueue,
-  moshi: Moshi
-) : JobHandler {
-  private val jobAdapter = moshi.adapter<ExampleJob>()
-
-  override fun handleJob(job: Job) {
-    jobQueue.enqueue(
-      queueName = GREEN_QUEUE,
-      body = jobAdapter.toJson(ExampleJob(color = Color.GREEN, message = "We made it!"))
-    )
-    job.acknowledge()
-  }
-}

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueueModule.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueueModule.kt
@@ -1,10 +1,13 @@
 package misk.jobqueue
 
 import misk.inject.KAbstractModule
+import misk.web.metadata.MetadataModule
 
 class FakeJobQueueModule : KAbstractModule() {
   override fun configure() {
     bind<JobQueue>().to<FakeJobQueue>()
     bind<TransactionalJobQueue>().to<FakeJobQueue>()
+
+    install(MetadataModule(JobqueueMetadataProvider()))
   }
 }

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/testFixtures.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/testFixtures.kt
@@ -1,0 +1,141 @@
+package misk.jobqueue
+
+import com.squareup.moshi.Moshi
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.inject.KAbstractModule
+import misk.moshi.adapter
+import wisp.logging.getLogger
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+class ExampleJobQueuesTestingModule : KAbstractModule() {
+  override fun configure() {
+    install(FakeJobHandlerModule.create<ExampleJobHandler>(RED_QUEUE))
+    install(FakeJobHandlerModule.create<ExampleJobHandler>(GREEN_QUEUE))
+    install(FakeJobHandlerModule.create<EnqueuerJobHandler>(ENQUEUER_QUEUE))
+    install(FakeJobQueueModule())
+  }
+}
+
+val RED_QUEUE = QueueName("red_queue")
+val GREEN_QUEUE = QueueName("green_queue")
+internal val ENQUEUER_QUEUE = QueueName("first_step_queue")
+
+internal enum class Color {
+  RED,
+  GREEN
+}
+
+class ColorException : Exception()
+
+internal data class ExampleJob(
+  val color: Color,
+  val message: String,
+  val hint: ExampleJobHint? = null
+)
+
+enum class ExampleJobHint {
+  DONT_ACK,
+  THROW,
+  THROW_ONCE,
+  DEAD_LETTER,
+  DEAD_LETTER_ONCE,
+  DELAY_ONCE,
+}
+
+class ExampleJobEnqueuer @Inject private constructor(
+  private val jobQueue: JobQueue,
+  moshi: Moshi
+) {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+
+  fun enqueueRed(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    val job = ExampleJob(Color.RED, message, hint)
+    jobQueue.enqueue(
+      RED_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
+      attributes = mapOf("key" to "value")
+    )
+  }
+
+  fun enqueueGreen(message: String, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    val job = ExampleJob(Color.GREEN, message, hint)
+    jobQueue.enqueue(
+      GREEN_QUEUE, body = jobAdapter.toJson(job), deliveryDelay = deliveryDelay,
+      attributes = mapOf("key" to "value")
+    )
+  }
+
+  fun batchEnqueueRed(messages: List<String>, deliveryDelay: Duration? = null, hint: ExampleJobHint? = null) {
+    jobQueue.batchEnqueue(RED_QUEUE, messages.map {
+      JobQueue.JobRequest(
+        body = jobAdapter.toJson(ExampleJob(Color.RED, it, hint)),
+        deliveryDelay = deliveryDelay,
+        attributes = mapOf("key" to "value")
+      )
+    })
+  }
+
+  fun enqueueEnqueuer() {
+    jobQueue.enqueue(ENQUEUER_QUEUE, body = "")
+  }
+}
+
+@Singleton
+class ExampleJobHandler @Inject private constructor(moshi: Moshi) : JobHandler {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+  private val jobsExecutedOnce = ConcurrentHashMap<String, Boolean>()
+
+  override fun handleJob(job: Job) {
+    val deserializedJob = jobAdapter.fromJson(job.body)!!
+    log.info { "received ${deserializedJob.color} job with message: ${deserializedJob.message}" }
+
+    check(job.attributes["key"] == "value") {
+      "Expected attribute key to be 'value' but was ${job.attributes["key"]} instead"
+    }
+
+    val key = "${deserializedJob.color}:${deserializedJob.hint}:${deserializedJob.message}"
+    val jobExecutedBefore = jobsExecutedOnce.putIfAbsent(key, true) == true
+    when (deserializedJob.hint) {
+      ExampleJobHint.DONT_ACK -> return
+      ExampleJobHint.DEAD_LETTER -> {
+        job.deadLetter()
+        return
+      }
+      ExampleJobHint.DEAD_LETTER_ONCE -> if (!jobExecutedBefore) {
+        job.deadLetter()
+        return
+      }
+      ExampleJobHint.THROW -> throw ColorException()
+      ExampleJobHint.THROW_ONCE -> if (!jobExecutedBefore) {
+        throw ColorException()
+      }
+      ExampleJobHint.DELAY_ONCE -> if (!jobExecutedBefore) {
+        job.delayWithBackoff()
+        throw ColorException()
+      }
+      else -> Unit
+    }
+
+    job.acknowledge()
+  }
+
+  companion object {
+    private val log = getLogger<ExampleJobHandler>()
+  }
+}
+
+internal class EnqueuerJobHandler @Inject private constructor(
+  private val jobQueue: JobQueue,
+  moshi: Moshi
+) : JobHandler {
+  private val jobAdapter = moshi.adapter<ExampleJob>()
+
+  override fun handleJob(job: Job) {
+    jobQueue.enqueue(
+      queueName = GREEN_QUEUE,
+      body = jobAdapter.toJson(ExampleJob(color = Color.GREEN, message = "We made it!"))
+    )
+    job.acknowledge()
+  }
+}

--- a/samples/exemplar/build.gradle.kts
+++ b/samples/exemplar/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation(project(":misk-prometheus"))
   implementation(project(":misk-service"))
   implementation(project(":misk-testing"))
+  implementation(testFixtures(project(":misk-jobqueue")))
 
   testImplementation(libs.assertj)
   testImplementation(libs.awsDynamodb)

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarService.kt
@@ -6,6 +6,7 @@ import misk.MiskRealServiceModule
 import misk.config.ConfigModule
 import misk.config.MiskConfig
 import misk.environment.DeploymentModule
+import misk.jobqueue.ExampleJobQueuesTestingModule
 import misk.metrics.backends.prometheus.PrometheusMetricsServiceModule
 import misk.monitoring.MonitoringModule
 import misk.web.MiskWebModule
@@ -23,6 +24,7 @@ fun main(args: Array<String>) {
     ExemplarMetadataModule(),
     ExemplarWebActionsModule(),
     ExemplarCronModule(),
+    ExampleJobQueuesTestingModule(),
     MiskRealServiceModule(),
     MiskWebModule(config.web),
     PrometheusMetricsServiceModule(config.prometheus),


### PR DESCRIPTION
Adds metadata for bound job queues and their job handler classes.

![Screenshot 2024-07-02 at 17 22 20](https://github.com/cashapp/misk/assets/8827217/edaf2efb-699e-456f-b180-7ebb11f5d2f0)
