### PR TITLE
Don't log the `UnrecognizedPropertyException` for warnings

### DIFF
--- a/misk-config/src/main/kotlin/misk/config/MiskConfig.kt
+++ b/misk-config/src/main/kotlin/misk/config/MiskConfig.kt
@@ -155,7 +155,7 @@ object MiskConfig {
       }
 
       val path = Joiner.on('.').join(e.path.map { it.fieldName ?: it.index })
-      logger.warn(e) {
+      logger.warn {
         "$configFile: '$path' not found in '${configClass.simpleName}', ignoring " +
           suggestSpelling(e)
       }


### PR DESCRIPTION
It adds a fair bit of noise in tests. The error message itself is clear enough.

E.g.
```
15:33:59.994 [Test worker] WARN misk.config.MiskConfig -- xyz-testing.yaml: 'abc' not found in 'XyzConfig', ignoring 

com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "streams" (class com.squareup.cash.xyz.service.XyzConfig), not marked as ignorable (6 known properties: ...])
 at [Source: (StringReader); line: 1, column: 1674] (through reference chain: 
....
```