### PR TITLE
[Chore] Google Library Updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,12 +51,12 @@ flywayGradlePlugin = { module = "org.flywaydb:flyway-gradle-plugin", version.ref
 gax = { module = "com.google.api:gax", version = "2.5.0" }
 gcpCloudCore = { module = "com.google.cloud:google-cloud-core", version = "1.95.4" }
 gcpCloudStorage = { module = "com.google.cloud:google-cloud-storage", version = "1.117.1" }
-gcpDatastore = { module = "com.google.cloud:google-cloud-datastore", version = "1.107.1" }
+gcpDatastore = { module = "com.google.cloud:google-cloud-datastore", version = "2.2.10" }
 gcpKms = { module = "com.google.apis:google-api-services-cloudkms", version ="v1-rev20210622-1.31.5" }
 gcpLogback = { module = "com.google.cloud:google-cloud-logging-logback", version = "0.130.11-alpha" }
 gcpLogging = { module = "com.google.cloud:google-cloud-logging", version = "2.3.2" }
-gcpSpanner = { module = "com.google.cloud:google-cloud-spanner", version = "6.13.0" }
-googleApiClient = { module = "com.google.api-client:google-api-client", version = "1.32.1" }
+gcpSpanner = { module = "com.google.cloud:google-cloud-spanner", version = "6.23.4" }
+googleApiClient = { module = "com.google.api-client:google-api-client", version = "1.35.0" }
 googleApiServicesStorage = { module = "com.google.apis:google-api-services-storage", version = "v1-rev20210127-1.31.5" }
 googleAuthLibraryCredentials = { module = "com.google.auth:google-auth-library-credentials", version = "1.1.0" }
 googleAuthLibraryOauth2 = { module = "com.google.auth:google-auth-library-oauth2-http", version = "1.1.0" }


### PR DESCRIPTION
## Description
This pull request includes updates to the versions of several dependencies in the `gradle/libs.versions.toml` file. The updated dependencies are `gcpDatastore`, `gcpSpanner`, and `googleApiClient`.

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL54-R59): Updated the `gcpDatastore` module from version `1.107.1` to `2.2.10`, the `gcpSpanner` module from version `6.13.0` to `6.23.4`, and the `googleApiClient` module from version `1.32.1` to `1.35.0`.


These updates are aiming to address CVEs in the downstream libraries.