### PR TITLE
Truncate JSON output in Metadata admin dashboard tab

### DIFF
--- a/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
+++ b/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
@@ -26,4 +26,18 @@ open class Metadata @JvmOverloads constructor(
   }
 }
 
-fun <T> JsonAdapter<T>.toFormattedJson(value: T): String = serializeNulls().indent("  ").toJson(value)
+private const val JSON_TRUNCATION_LIMIT = 100_000
+fun <T> JsonAdapter<T>.toFormattedJson(value: T): String {
+  val json = serializeNulls()
+    .indent("  ")
+    .toJson(value)
+  return if (json.length < JSON_TRUNCATION_LIMIT) {
+    json
+  } else {
+    json
+      // Truncate JSON view to prevent tab from crashing for larger production service metadata.
+      // Truncation is only in admin dashboard which uses this method in prettyPrint parameter.
+      // Access via the API is still untruncated.
+      .take(JSON_TRUNCATION_LIMIT) + "...\n\nWARN: Output has been truncated. Use the API directly to get full data."
+  }
+}


### PR DESCRIPTION
Large production services with complex proto endpoints can crash the Web
Actions output for the Metadata admin dashboard tab. Truncation should
fix this. APIs will still be raw and not truncated.

![Screenshot 2024-07-02 at 16 03 28](https://github.com/cashapp/misk/assets/8827217/f9e319c9-9881-4e90-a3a9-cbde8b8f9885)


