### PR TITLE
Make JobqueueMetadata install once

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -3,16 +3,15 @@ package misk.jobqueue.sqs
 import com.google.common.util.concurrent.AbstractIdleService
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.inject.toKey
 import misk.jobqueue.JobHandler
+import misk.jobqueue.JobqueueMetadataModule
 import misk.jobqueue.QueueName
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
-import misk.jobqueue.JobqueueMetadataProvider
-import misk.web.metadata.MetadataModule
 import kotlin.reflect.KClass
 
 /**
@@ -38,7 +37,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
         dependsOn = dependsOn
       ).dependsOn<ReadyService>()
     )
-    install(MetadataModule(JobqueueMetadataProvider()))
+    install(JobqueueMetadataModule())
   }
 
   companion object {

--- a/misk-jobqueue/api/misk-jobqueue.api
+++ b/misk-jobqueue/api/misk-jobqueue.api
@@ -144,19 +144,6 @@ public abstract interface class misk/jobqueue/JobHandler {
 	public abstract fun handleJob (Lmisk/jobqueue/Job;)V
 }
 
-public final class misk/jobqueue/JobHandlerMetadata {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lmisk/jobqueue/JobHandlerMetadata;
-	public static synthetic fun copy$default (Lmisk/jobqueue/JobHandlerMetadata;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lmisk/jobqueue/JobHandlerMetadata;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHandlerClass ()Ljava/lang/String;
-	public final fun getSupertypes ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class misk/jobqueue/JobQueue {
 	public static final field Companion Lmisk/jobqueue/JobQueue$Companion;
 	public static final field SQS_MAX_BATCH_ENQUEUE_JOB_SIZE I
@@ -228,25 +215,8 @@ public final class misk/jobqueue/JobQueue$JobRequest {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class misk/jobqueue/JobqueueMetadata : misk/web/metadata/Metadata {
-	public fun <init> (Ljava/util/Map;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lmisk/jobqueue/JobqueueMetadata;
-	public static synthetic fun copy$default (Lmisk/jobqueue/JobqueueMetadata;Ljava/util/Map;ILjava/lang/Object;)Lmisk/jobqueue/JobqueueMetadata;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getQueues ()Ljava/util/Map;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class misk/jobqueue/JobqueueMetadataProvider : misk/web/metadata/MetadataProvider {
-	public field queues Ljava/util/Map;
+public final class misk/jobqueue/JobqueueMetadataModule : misk/inject/KInstallOnceModule {
 	public fun <init> ()V
-	public synthetic fun get ()Ljava/lang/Object;
-	public fun get ()Lmisk/jobqueue/JobqueueMetadata;
-	public fun getId ()Ljava/lang/String;
-	public final fun getQueues ()Ljava/util/Map;
-	public final fun setQueues (Ljava/util/Map;)V
 }
 
 public final class misk/jobqueue/QueueName {

--- a/misk-jobqueue/build.gradle.kts
+++ b/misk-jobqueue/build.gradle.kts
@@ -8,9 +8,11 @@ plugins {
 }
 
 dependencies {
-  api(libs.jakartaInject)
-  api(project(":misk-config"))
+  api(project(":misk-inject"))
+  implementation(libs.guice)
+  implementation(libs.jakartaInject)
   implementation(libs.moshiCore)
+  implementation(project(":misk-config"))
   implementation(project(":wisp:wisp-moshi"))
 
   testFixturesApi(libs.guice)

--- a/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueueModule.kt
+++ b/misk-jobqueue/src/testFixtures/kotlin/misk/jobqueue/FakeJobQueueModule.kt
@@ -8,6 +8,6 @@ class FakeJobQueueModule : KAbstractModule() {
     bind<JobQueue>().to<FakeJobQueue>()
     bind<TransactionalJobQueue>().to<FakeJobQueue>()
 
-    install(MetadataModule(JobqueueMetadataProvider()))
+    install(JobqueueMetadataModule())
   }
 }


### PR DESCRIPTION
The new dedicated module ensures install once semantics since it is installed as part of the AwsSqsJobHandlerModule module which is installed multiple times.