### PR TITLE
Make content overrideable

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/all/MetadataTabIndexAction.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/all/MetadataTabIndexAction.kt
@@ -91,9 +91,7 @@ internal class MetadataTabIndexAction @Inject constructor(
               metadata.descriptionBlock(this@build)
             }
 
-            h3("text-xl font-bold my-4") { +"""Metadata""" }
-
-            CodeBlock(metadata.prettyPrint)
+            metadata.contentBlock(this@build)
           }
         }
       }

--- a/misk-config/api/misk-config.api
+++ b/misk-config/api/misk-config.api
@@ -98,6 +98,7 @@ public class misk/web/metadata/Metadata {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentBlock (Lkotlinx/html/TagConsumer;)Lkotlinx/html/TagConsumer;
 	public fun descriptionBlock (Lkotlinx/html/TagConsumer;)Lkotlinx/html/TagConsumer;
 	public final fun getDescriptionString ()Ljava/lang/String;
 	public final fun getMetadata ()Ljava/lang/Object;

--- a/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
+++ b/misk-config/src/main/kotlin/misk/web/metadata/Metadata.kt
@@ -2,7 +2,10 @@ package misk.web.metadata
 
 import com.squareup.moshi.JsonAdapter
 import kotlinx.html.TagConsumer
+import kotlinx.html.div
+import kotlinx.html.h3
 import misk.tailwind.components.AlertInfoHighlight
+import misk.tailwind.components.CodeBlock
 
 open class Metadata @JvmOverloads constructor(
   /** Metadata object, should be a data class for easy built-in serialization to JSON. */
@@ -23,6 +26,12 @@ open class Metadata @JvmOverloads constructor(
   /** HTML block for description. Can be overridden to show more complex UI or documentation. */
   open fun descriptionBlock(tagConsumer: TagConsumer<*>) = tagConsumer.apply {
     AlertInfoHighlight(message = descriptionString)
+  }
+
+  /** HTML block for the content. Can be overridden to show more complex UI than the default prettyPrint console output. */
+  open fun contentBlock(tagConsumer: TagConsumer<*>) = tagConsumer.apply {
+    h3("text-xl font-bold my-4") { +"""Metadata""" }
+    CodeBlock(prettyPrint)
   }
 }
 

--- a/samples/exemplar/build.gradle.kts
+++ b/samples/exemplar/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   implementation(project(":misk-hotwire"))
   implementation(project(":misk-prometheus"))
   implementation(project(":misk-service"))
+  implementation(project(":misk-tailwind"))
   implementation(project(":misk-testing"))
 
   testImplementation(libs.assertj)

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarMetadataModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarMetadataModule.kt
@@ -1,7 +1,13 @@
 package com.squareup.exemplar
 
+import kotlinx.html.TagConsumer
+import kotlinx.html.div
+import kotlinx.html.dl
+import kotlinx.html.dt
+import kotlinx.html.p
 import misk.inject.KAbstractModule
 import misk.security.authz.AccessAnnotationEntry
+import misk.tailwind.components.AlertError
 import misk.web.metadata.Metadata
 import misk.web.metadata.MetadataModule
 import misk.web.metadata.MetadataProvider
@@ -22,10 +28,46 @@ class ExemplarMetadataModule : KAbstractModule() {
   }
 }
 
+data class DinoMetadata(
+  val dinos: List<String>
+): Metadata(
+  metadata = dinos,
+  descriptionString = "Dinos in the world",
+) {
+  override fun contentBlock(tagConsumer: TagConsumer<*>): TagConsumer<*> = tagConsumer.apply {
+    AlertError("Dinos are on the loose!")
+    p { +"The following dinos are in the world:" }
+    p { +dinos.joinToString(", ") }
+
+    dl("mx-auto grid grid-cols-1 gap-px bg-gray-900/5 sm:grid-cols-2 lg:grid-cols-4") {
+      div("flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8") {
+        this@dl.dt("text-sm font-medium leading-6 text-gray-500") { +"""Revenue""" }
+        this@dl.dt("text-xs font-medium text-gray-700") { +"""+4.75%""" }
+        this@dl.dt("w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900") { +"""$405,091.00""" }
+      }
+      div("flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8") {
+        this@dl.dt("text-sm font-medium leading-6 text-gray-500") { +"""Overdue invoices""" }
+        this@dl.dt("text-xs font-medium text-rose-600") { +"""+54.02%""" }
+        this@dl.dt("w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900") { +"""$12,787.00""" }
+      }
+      div("flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8") {
+        this@dl.dt("text-sm font-medium leading-6 text-gray-500") { +"""Outstanding invoices""" }
+        this@dl.dt("text-xs font-medium text-gray-700") { +"""-1.39%""" }
+        this@dl.dt("w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900") { +"""$245,988.00""" }
+      }
+      div("flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8") {
+        this@dl.dt("text-sm font-medium leading-6 text-gray-500") { +"""Expenses""" }
+        this@dl.dt("text-xs font-medium text-rose-600") { +"""+10.18%""" }
+        this@dl.dt("w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900") { +"""$30,156.00""" }
+      }
+    }
+  }
+}
+
 class DinoMetadataProvider : MetadataProvider<Metadata> {
   override val id: String = "dino"
 
-  override fun get() = Metadata(
-    metadata = listOf("t-rex", "stegosaurus", "triceratops")
+  override fun get() = DinoMetadata(
+    dinos = listOf("T-Rex", "Velociraptor", "Stegosaurus")
   )
 }


### PR DESCRIPTION
For cases where Metadata is best displayed in something other than a JSON dump in a code block, the content for the page can now be entirely overriden with whatever custom HTML the metadata provider wants to use.

<img width="1147" alt="Screenshot 2024-07-05 at 15 12 29" src="https://github.com/cashapp/misk/assets/8827217/23a5cd39-c4af-4ff2-9678-3959360fbda1">
