### PR TITLE
CCPOKR-14316 | [Security][High] - Arbitrary file access during archive extraction

### DIFF
--- a/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
+++ b/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
@@ -4,6 +4,7 @@ import okio.BufferedSource
 import okio.buffer
 import okio.source
 import java.io.File
+import java.nio.file.Paths
 import java.util.jar.JarFile
 
 /**
@@ -76,7 +77,7 @@ object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
                 // Verify that the normalized file path still has the correct prefix
                 // This is to fix a security vulnerability where a zip file may contain file entries such as "..\sneaky-file"
                 val childFilePath = File(entry.name).toPath().normalize()
-                if (!childFilePath.startsWith(pathPrefix)) continue
+                if (!childFilePath.startsWith(Paths.get(pathPrefix))) continue
 
                 var endIndex = entry.name.indexOf("/", pathPrefix.length)
                 if (endIndex == -1) endIndex = entry.name.length

--- a/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
+++ b/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
@@ -79,10 +79,11 @@ object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
                 val childFilePath = File(entry.name).toPath().normalize()
                 if (!childFilePath.startsWith(Paths.get(pathPrefix))) continue
 
-                var endIndex = entry.name.indexOf("/", pathPrefix.length)
-                if (endIndex == -1) endIndex = entry.name.length
+                val childFilePathStr = childFilePath.toString()
+                var endIndex = childFilePathStr.indexOf("/", pathPrefix.length)
+                if (endIndex == -1) endIndex = childFilePathStr.length
 
-                result += entry.name.substring(pathPrefix.length, endIndex)
+                result += childFilePathStr.substring(pathPrefix.length, endIndex)
             }
         }
         return result

--- a/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
+++ b/wisp/wisp-resource-loader/src/main/kotlin/wisp/resources/ClasspathResourceLoaderBackend.kt
@@ -77,13 +77,12 @@ object ClasspathResourceLoaderBackend : ResourceLoader.Backend() {
                 // Verify that the normalized file path still has the correct prefix
                 // This is to fix a security vulnerability where a zip file may contain file entries such as "..\sneaky-file"
                 val childFilePath = File(entry.name).toPath().normalize()
-                if (!childFilePath.startsWith(Paths.get(pathPrefix))) continue
+                val prefixFilePath = Paths.get(pathPrefix)
+                if (!childFilePath.startsWith(prefixFilePath)) continue
 
-                val childFilePathStr = childFilePath.toString()
-                var endIndex = childFilePathStr.indexOf("/", pathPrefix.length)
-                if (endIndex == -1) endIndex = childFilePathStr.length
-
-                result += childFilePathStr.substring(pathPrefix.length, endIndex)
+                if (childFilePath.nameCount > prefixFilePath.nameCount) {
+                    result += childFilePath.getName(prefixFilePath.nameCount).toString()
+                }
             }
         }
         return result


### PR DESCRIPTION
Use the normalized path instead of the actual file name from JAR