### PR TITLE
Add deprecated annotation to TaggedLogger

### DIFF
--- a/wisp/wisp-logging/src/main/kotlin/wisp/logging/TaggedLogger.kt
+++ b/wisp/wisp-logging/src/main/kotlin/wisp/logging/TaggedLogger.kt
@@ -76,6 +76,7 @@ import kotlin.reflect.KClass
  */
 
 @ExperimentalMiskApi
+@Deprecated("This is currently being replaced and should not be used")
 abstract class TaggedLogger<L:Any, out R> (
   private val kLogger: KLogger,
   private val tags: Set<Tag>


### PR DESCRIPTION
We are refactoring the TaggedLogger within misk to be less opinionated and complicated to use. Under the new implementation, services will still be able to access the original functionality of this logger to add tags to logs and include them on underlying web exceptions thrown by misk.

This PR is just to mark this implementation as deprecated to hint that it shouldn't be used yet.