### PR TITLE
refactor: use intersect to evaluate MiskCaller#hasCapability and SquareCaller#isAllowed

### DIFF
--- a/misk-actions/src/main/kotlin/misk/MiskCaller.kt
+++ b/misk-actions/src/main/kotlin/misk/MiskCaller.kt
@@ -29,10 +29,10 @@ data class MiskCaller @JvmOverloads constructor(
   }
 
   /**
-   * Check whether the caller has one of allowedCapabilities.
+   * Check whether this caller has one or more of the [allowedCapabilities].
    */
-  fun hasCapability(allowedCapabilities: Set<String>) =
-    capabilities.any { allowedCapabilities.contains(it) }
+  fun hasCapability(allowedCapabilities: Set<String>): Boolean =
+    capabilities.intersect(allowedCapabilities).isNotEmpty()
 
   /**
    * Check whether this is a service-to-service call from one of allowedServices.
@@ -50,6 +50,6 @@ data class MiskCaller @JvmOverloads constructor(
     if (service != null && allowedServices.contains(service)) return true
 
     // Allow if the caller has provided an allowed capability
-    return capabilities.any { allowedCapabilities.contains(it) }
+    return hasCapability(allowedCapabilities)
   }
 }

--- a/misk/src/test/kotlin/misk/MiskCallerTest.kt
+++ b/misk/src/test/kotlin/misk/MiskCallerTest.kt
@@ -20,6 +20,16 @@ internal class MiskCallerTest {
   @Test fun serviceNameIsNotRedactedFromToString() {
     assertThat("$testService").contains("${testService.service}")
   }
+
+  @Test fun `hasCapability should be true when capabilities contains an allowedCapability`() {
+    val hasCapability = testUser.hasCapability(setOf("not_testing", "testing", "other_capability"))
+    assertThat(hasCapability).isTrue()
+  }
+
+  @Test fun `hasCapability should be false when capabilities does not contain an allowedCapability`() {
+    val hasCapability = testUser.hasCapability(setOf("not_testing", "other_capability"))
+    assertThat(hasCapability).isFalse()
+  }
 }
 
 internal class MiskCallerTestModule : KAbstractModule() {


### PR DESCRIPTION
## Description

This uses the Kotlin built-in `Collections#intersect` to replace `capabilities.any { allowedCapabilities.contains(it) }` with `capabilities.intersect(allowedCapabilities).isNotEmpty()`. To my eyes, this form is easier to grok. I wouldn't be surprised if the `intersect` implementation is more performant, but the size of `capabilities` and `allowedCapabilities` is typically < 1000, so its not that important.

This is a backwards compatible, internal change.

## Testing Strategy

New unit tests are introduced.

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
