### PR TITLE
Add support for HKEYS command.

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -74,6 +74,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
+	public fun hkeys (Ljava/lang/String;)Ljava/util/List;
 	public fun hlen (Ljava/lang/String;)J
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
@@ -141,6 +142,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
+	public fun hkeys (Ljava/lang/String;)Ljava/util/List;
 	public fun hlen (Ljava/lang/String;)J
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;
@@ -205,6 +207,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public abstract fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
+	public abstract fun hkeys (Ljava/lang/String;)Ljava/util/List;
 	public abstract fun hlen (Ljava/lang/String;)J
 	public abstract fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public abstract fun hrandField (Ljava/lang/String;J)Ljava/util/List;
@@ -556,6 +559,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis, misk/testing
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Lokio/ByteString;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/Map;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)J
+	public fun hkeys (Ljava/lang/String;)Ljava/util/List;
 	public fun hlen (Ljava/lang/String;)J
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/List;

--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -12,6 +12,7 @@ public abstract interface class misk/redis/DeferredRedis {
 	public abstract fun hget (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun hgetAll (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public abstract fun hkeys (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun hlen (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun hrandField (Ljava/lang/String;J)Ljava/util/function/Supplier;
@@ -621,6 +622,7 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 	public fun hget (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun hgetAll (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun hincrBy (Ljava/lang/String;Ljava/lang/String;J)Ljava/util/function/Supplier;
+	public fun hkeys (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun hlen (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun hmget (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun hrandField (Ljava/lang/String;J)Ljava/util/function/Supplier;

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -31,6 +31,8 @@ interface DeferredRedis {
 
   fun hlen(key: String): Supplier<Long>
 
+  fun hkeys(key: String): Supplier<List<ByteString>?>
+
   fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>>
 
   fun hincrBy(key: String, field: String, increment: Long): Supplier<Long>

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -31,7 +31,7 @@ interface DeferredRedis {
 
   fun hlen(key: String): Supplier<Long>
 
-  fun hkeys(key: String): Supplier<List<ByteString>?>
+  fun hkeys(key: String): Supplier<List<ByteString>>
 
   fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>>
 

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -132,6 +132,19 @@ class FakeRedis : Redis {
   override fun hlen(key: String): Long = hKeyValueStore[key]?.data?.size?.toLong() ?: 0L
 
   @Synchronized
+  override fun hkeys(key: String): List<ByteString>? {
+    val value = hKeyValueStore[key] ?: return null
+
+    // Check if the key has expired
+    if (clock.instant() >= value.expiryInstant) {
+      hKeyValueStore.remove(key)
+      return null
+    }
+
+    return value.data.keys().toList().map { it.encode(Charsets.UTF_8) }
+  }
+
+  @Synchronized
   override fun hmget(key: String, vararg fields: String): List<ByteString?> {
     return hgetAll(key)?.filter { fields.contains(it.key) }?.values?.toList() ?: emptyList()
   }

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -132,13 +132,13 @@ class FakeRedis : Redis {
   override fun hlen(key: String): Long = hKeyValueStore[key]?.data?.size?.toLong() ?: 0L
 
   @Synchronized
-  override fun hkeys(key: String): List<ByteString>? {
-    val value = hKeyValueStore[key] ?: return null
+  override fun hkeys(key: String): List<ByteString> {
+    val value = hKeyValueStore[key] ?: return emptyList()
 
     // Check if the key has expired
     if (clock.instant() >= value.expiryInstant) {
       hKeyValueStore.remove(key)
-      return null
+      return emptyList()
     }
 
     return value.data.keys().toList().map { it.encode(Charsets.UTF_8) }

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -142,6 +142,12 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     return Supplier { response.get() }
   }
 
+  override fun hkeys(key: String): Supplier<List<ByteString>?> {
+    val keyBytes = key.toByteArray(charset)
+    val response = pipeline.hkeys(keyBytes)
+    return Supplier { response.get()?.map { it.toByteString() } }
+  }
+
   override fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>> {
     val keyBytes = key.toByteArray(charset)
     val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -142,10 +142,10 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     return Supplier { response.get() }
   }
 
-  override fun hkeys(key: String): Supplier<List<ByteString>?> {
+  override fun hkeys(key: String): Supplier<List<ByteString>> {
     val keyBytes = key.toByteArray(charset)
     val response = pipeline.hkeys(keyBytes)
-    return Supplier { response.get()?.map { it.toByteString() } }
+    return Supplier { response.get().map { it.toByteString() } }
   }
 
   override fun hmget(key: String, vararg fields: String): Supplier<List<ByteString?>> {

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -137,10 +137,10 @@ class RealRedis(
     return jedis { hlen(keyBytes) }
   }
 
-  override fun hkeys(key: String): List<ByteString>? {
+  override fun hkeys(key: String): List<ByteString> {
     val keyBytes = key.toByteArray(charset)
     return jedis { hkeys(keyBytes) }
-      ?.map { it.toByteString() }
+      .map { it.toByteString() }
   }
 
   override fun hmget(key: String, vararg fields: String): List<ByteString?> {

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -137,6 +137,12 @@ class RealRedis(
     return jedis { hlen(keyBytes) }
   }
 
+  override fun hkeys(key: String): List<ByteString>? {
+    val keyBytes = key.toByteArray(charset)
+    return jedis { hkeys(keyBytes) }
+      ?.map { it.toByteString() }
+  }
+
   override fun hmget(key: String, vararg fields: String): List<ByteString?> {
     val fieldsAsByteArrays = fields.map { it.toByteArray(charset) }.toTypedArray()
     val keyBytes = key.toByteArray(charset)

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -111,6 +111,14 @@ interface Redis {
   fun hlen(key: String): Long
 
   /**
+   * Returns all field names in the hash stored for the given key.
+   *
+   * @param key the key
+   * @return a List<ByteString> of the field names stored for the given key
+   */
+  fun hkeys(key: String): List<ByteString>?
+
+  /**
    * Retrieve the values associated to the specified fields.
    *
    * If some specified fields do not exist, nil values are returned. Non-existing keys are

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -116,7 +116,7 @@ interface Redis {
    * @param key the key
    * @return a List<ByteString> of the field names stored for the given key
    */
-  fun hkeys(key: String): List<ByteString>?
+  fun hkeys(key: String): List<ByteString>
 
   /**
    * Retrieve the values associated to the specified fields.

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -8,6 +8,7 @@ import misk.inject.KAbstractModule
 import misk.redis.testing.DockerRedis
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
+import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -137,6 +138,29 @@ class RealRedisTest : AbstractRedisTest() {
     redis.ltrim(listKey, -3, -1)
 
     assertThat(redis.lrange(listKey, 0, -1).map { it?.utf8() }).containsExactly("two", "three", "four")
+  }
+
+  @Test
+  fun `hkeys returns all map keys within a given key`() {
+    val hashKey = "myhash"
+
+    val map = mapOf(
+      "field1" to "value1".encodeUtf8(),
+      "field2" to "value2".encodeUtf8(),
+      "field3" to "value3".encodeUtf8()
+    )
+
+    redis.hset(hashKey, map)
+
+    assertThat(redis.hkeys(hashKey).map { it.utf8() })
+      .containsExactly("field1", "field2", "field3")
+  }
+
+  @Test
+  fun `hkeys returns empty list if given key is not set`() {
+    val hashKey = "myhash"
+
+    assertThat(redis.hkeys(hashKey)).isEmpty()
   }
 
   private fun scanAll(

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -43,6 +43,8 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(
 
   override fun hlen(key: String): Long = runPipeline { hlen(key) }
 
+  override fun hkeys(key: String): List<ByteString>? = runPipeline { hkeys(key) }
+
   override fun hmget(key: String, vararg fields: String): List<ByteString?> =
     runPipeline { hmget(key, *fields) }
 

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -43,7 +43,7 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(
 
   override fun hlen(key: String): Long = runPipeline { hlen(key) }
 
-  override fun hkeys(key: String): List<ByteString>? = runPipeline { hkeys(key) }
+  override fun hkeys(key: String): List<ByteString> = runPipeline { hkeys(key) }
 
   override fun hmget(key: String, vararg fields: String): List<ByteString?> =
     runPipeline { hmget(key, *fields) }

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -166,13 +166,13 @@ class FakeRedis @Inject constructor(
   override fun hlen(key: String): Long = hKeyValueStore[key]?.data?.size?.toLong() ?: 0L
 
   @Synchronized
-  override fun hkeys(key: String): List<ByteString>? {
-    val value = hKeyValueStore[key] ?: return null
+  override fun hkeys(key: String): List<ByteString> {
+    val value = hKeyValueStore[key] ?: return emptyList()
 
     // Check if the key has expired
     if (clock.instant() >= value.expiryInstant) {
       hKeyValueStore.remove(key)
-      return null
+      return emptyList()
     }
 
     return value.data.keys().toList().map { it.encode(Charsets.UTF_8) }
@@ -525,7 +525,7 @@ class FakeRedis @Inject constructor(
       this@FakeRedis.hlen(key)
     }
 
-    override fun hkeys(key: String): Supplier<List<ByteString>?> = Supplier {
+    override fun hkeys(key: String): Supplier<List<ByteString>> = Supplier {
       this@FakeRedis.hkeys(key)
     }
 

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -166,6 +166,19 @@ class FakeRedis @Inject constructor(
   override fun hlen(key: String): Long = hKeyValueStore[key]?.data?.size?.toLong() ?: 0L
 
   @Synchronized
+  override fun hkeys(key: String): List<ByteString>? {
+    val value = hKeyValueStore[key] ?: return null
+
+    // Check if the key has expired
+    if (clock.instant() >= value.expiryInstant) {
+      hKeyValueStore.remove(key)
+      return null
+    }
+
+    return value.data.keys().toList().map { it.encode(Charsets.UTF_8) }
+  }
+
+  @Synchronized
   override fun hmget(key: String, vararg fields: String): List<ByteString?> {
     val hash: Map<String, ByteString> = hKeyValueStore[key]?.data ?: emptyMap()
     return buildList {

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -525,6 +525,10 @@ class FakeRedis @Inject constructor(
       this@FakeRedis.hlen(key)
     }
 
+    override fun hkeys(key: String): Supplier<List<ByteString>?> = Supplier {
+      this@FakeRedis.hkeys(key)
+    }
+
     override fun hmget(
       key: String,
       vararg fields: String


### PR DESCRIPTION
## Description

This PR adds support for Redis' `HKEYS` command which has been supported since Redis 2.0.0. 

## Testing Strategy

* Added tests for `HKEYS` functionality to misk-redis tests.

## Checklist

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.

