### PR TITLE
Escape table names when truncating in JdbcTestFixture

### DIFF
--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/JdbcTestFixture.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/JdbcTestFixture.kt
@@ -72,9 +72,9 @@ class JdbcTestFixture(
                   if (tableName.equals("dual")) continue
 
                   if (config.type == DataSourceType.COCKROACHDB || config.type == DataSourceType.POSTGRESQL) {
-                    statement.addBatch("TRUNCATE $tableName CASCADE")
+                    statement.addBatch("TRUNCATE \"$tableName\" CASCADE")
                   } else {
-                    statement.addBatch("DELETE FROM $tableName")
+                    statement.addBatch("DELETE FROM `$tableName`")
                   }
                   truncatedTableNames += tableName
                 }


### PR DESCRIPTION
-sometimes, some folks get the urge to use database keywords when naming tables

<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

We have a postgres database with a table called `user`.  This is a keyword so the truncate table operation fails in our tests.

## Testing Strategy

<!-- How did you test your solution? -->

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
