### PR TITLE
Create a WebSocketsTest function to repro query argument issues

### DIFF
--- a/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
@@ -67,6 +67,23 @@ internal class WebSocketsTest {
     assertThat(logCollector.takeMessages(RequestLoggingInterceptor::class)).isEmpty()
   }
 
+  @Test
+  fun queryArgumentsAreParsedCorrectly() {
+    val client = OkHttpClient()
+
+    val request = Request.Builder()
+      .url(
+        jettyService.httpServerUrl
+          .resolve("/echo-with-query-args?first=this&second=that&second=those")!!
+      )
+      .build()
+
+    val webSocket = client.newWebSocket(request, listener)
+
+    webSocket.send("hello")
+    assertEquals("ACK hello: this [that, those]", listener.takeMessage())
+  }
+
   class TestModule : KAbstractModule() {
     override fun configure() {
       install(WebServerTestingModule())
@@ -106,4 +123,21 @@ class EchoWebSocket @Inject constructor() : WebAction {
       override fun toString() = "EchoListener"
     }
   }
+
+  @ConnectWebSocket("/echo-with-query-args")
+  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0)
+  fun echoWithQueryArgs(
+    @QueryParam("first") first: String?,
+    @QueryParam("second") second: List<String>,
+    @Suppress("UNUSED_PARAMETER") webSocket: WebSocket
+  ): WebSocketListener {
+    return object : WebSocketListener() {
+      override fun onMessage(webSocket: WebSocket, text: String) {
+        webSocket.send("ACK $text: $first $second")
+      }
+
+      override fun toString() = "EchoListener"
+    }
+  }
+
 }


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

- we're seeing query arguments being added to the url twice right now
- we're currently working around by adding a `&` to the end of the url, which ends up parsing the arguments twice (but at least the parsed values are correct)
- I'm not sure how best to correct this behaviour - was hoping to get some suggestions?

## Testing Strategy

Automated test function included.

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
