### PR TITLE
adding `followRedirects` and `followSslRedirects` config for HttpClientsConfig

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -476,12 +476,16 @@ public final class misk/client/HttpClientConfig {
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;)V
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/time/Duration;
 	public final fun component10 ()Lmisk/client/HttpClientSSLConfig;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ljava/util/List;
 	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/time/Duration;
 	public final fun component3 ()Ljava/time/Duration;
 	public final fun component4 ()Ljava/time/Duration;
@@ -490,11 +494,13 @@ public final class misk/client/HttpClientConfig {
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)Lmisk/client/HttpClientConfig;
-	public static synthetic fun copy$default (Lmisk/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/client/HttpClientConfig;
+	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lmisk/client/HttpClientConfig;
+	public static synthetic fun copy$default (Lmisk/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lmisk/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/client/HttpClientConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCallTimeout ()Ljava/time/Duration;
 	public final fun getConnectTimeout ()Ljava/time/Duration;
+	public final fun getFollowRedirects ()Ljava/lang/Boolean;
+	public final fun getFollowSslRedirects ()Ljava/lang/Boolean;
 	public final fun getKeepAliveDuration ()Ljava/time/Duration;
 	public final fun getMaxIdleConnections ()Ljava/lang/Integer;
 	public final fun getMaxRequests ()Ljava/lang/Integer;

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -114,7 +114,9 @@ data class HttpClientConfig @JvmOverloads constructor(
   val ssl: HttpClientSSLConfig? = null,
   val unixSocketFile: String? = null,
   val protocols: List<String>? = null,
-  val retryOnConnectionFailure: Boolean? = null
+  val retryOnConnectionFailure: Boolean? = null,
+  val followRedirects: Boolean? = null,
+  val followSslRedirects: Boolean? = null,
 ) {
   fun toWispConfig() = wisp.client.HttpClientConfig(
     connectTimeout,
@@ -129,7 +131,9 @@ data class HttpClientConfig @JvmOverloads constructor(
     ssl?.toWispConfig(),
     unixSocketFile,
     protocols,
-    retryOnConnectionFailure
+    retryOnConnectionFailure,
+    followRedirects,
+    followSslRedirects,
   )
 }
 
@@ -147,7 +151,9 @@ fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
     ssl = this.ssl ?: other.ssl,
     unixSocketFile = this.unixSocketFile ?: other.unixSocketFile,
     protocols = this.protocols ?: other.protocols,
-    retryOnConnectionFailure = this.retryOnConnectionFailure ?: other.retryOnConnectionFailure
+    retryOnConnectionFailure = this.retryOnConnectionFailure ?: other.retryOnConnectionFailure,
+    followRedirects = this.followRedirects ?: other.followRedirects,
+    followSslRedirects = this.followSslRedirects ?: other.followSslRedirects,
   )
 
 data class HttpClientEndpointConfig @JvmOverloads constructor(

--- a/wisp/wisp-client/api/wisp-client.api
+++ b/wisp/wisp-client/api/wisp-client.api
@@ -18,12 +18,16 @@ public final class wisp/client/HttpClientConfig {
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;)V
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/time/Duration;
 	public final fun component10 ()Lwisp/client/HttpClientSSLConfig;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ljava/util/List;
 	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/time/Duration;
 	public final fun component3 ()Ljava/time/Duration;
 	public final fun component4 ()Ljava/time/Duration;
@@ -32,11 +36,13 @@ public final class wisp/client/HttpClientConfig {
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)Lwisp/client/HttpClientConfig;
-	public static synthetic fun copy$default (Lwisp/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lwisp/client/HttpClientConfig;
+	public final fun copy (Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lwisp/client/HttpClientConfig;
+	public static synthetic fun copy$default (Lwisp/client/HttpClientConfig;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/time/Duration;Lwisp/client/HttpClientSSLConfig;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lwisp/client/HttpClientConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCallTimeout ()Ljava/time/Duration;
 	public final fun getConnectTimeout ()Ljava/time/Duration;
+	public final fun getFollowRedirect ()Ljava/lang/Boolean;
+	public final fun getFollowSslRedirects ()Ljava/lang/Boolean;
 	public final fun getKeepAliveDuration ()Ljava/time/Duration;
 	public final fun getMaxIdleConnections ()Ljava/lang/Integer;
 	public final fun getMaxRequests ()Ljava/lang/Integer;
@@ -150,6 +156,8 @@ public final class wisp/client/NoOpDns : okhttp3/Dns {
 
 public final class wisp/client/OkHttpClientCommonConfigurator {
 	public static final field Companion Lwisp/client/OkHttpClientCommonConfigurator$Companion;
+	public static final field followRedirects Z
+	public static final field followSslRedirects Z
 	public static final field maxIdleConnections I
 	public static final field retryOnConnectionFailure Z
 	public fun <init> ()V

--- a/wisp/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
+++ b/wisp/wisp-client/src/main/kotlin/wisp/client/HttpClientsConfig.kt
@@ -102,7 +102,9 @@ data class HttpClientConfig @JvmOverloads constructor(
     val ssl: HttpClientSSLConfig? = null,
     val unixSocketFile: String? = null,
     val protocols: List<String>? = null,
-    val retryOnConnectionFailure: Boolean? = null
+    val retryOnConnectionFailure: Boolean? = null,
+    val followRedirect: Boolean? = null,
+    val followSslRedirects: Boolean? = null,
 )
 
 fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
@@ -119,7 +121,9 @@ fun HttpClientConfig.applyDefaults(other: HttpClientConfig) =
         ssl = this.ssl ?: other.ssl,
         unixSocketFile = this.unixSocketFile ?: other.unixSocketFile,
         protocols = this.protocols ?: other.protocols,
-        retryOnConnectionFailure = this.retryOnConnectionFailure ?: other.retryOnConnectionFailure
+        retryOnConnectionFailure = this.retryOnConnectionFailure ?: other.retryOnConnectionFailure,
+        followRedirect = this.followRedirect ?: other.followRedirect,
+        followSslRedirects = this.followSslRedirects ?: other.followSslRedirects,
     )
 
 data class HttpClientEndpointConfig @JvmOverloads constructor(

--- a/wisp/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
+++ b/wisp/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
@@ -70,7 +70,7 @@ class OkHttpClientCommonConfigurator {
         builder: Builder,
         config: HttpClientEndpointConfig,
     ) {
-        builder.retryOnConnectionFailure(
+        builder.followRedirects(
             config.clientConfig.followRedirect ?: followRedirects
         )
     }
@@ -79,7 +79,7 @@ class OkHttpClientCommonConfigurator {
         builder: Builder,
         config: HttpClientEndpointConfig,
     ) {
-        builder.retryOnConnectionFailure(
+        builder.followSslRedirects(
             config.clientConfig.followSslRedirects ?: followSslRedirects
         )
     }

--- a/wisp/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
+++ b/wisp/wisp-client/src/main/kotlin/wisp/client/OkHttpClientCommonConfigurator.kt
@@ -16,6 +16,8 @@ class OkHttpClientCommonConfigurator {
         configureReadTimeout(builder = builder, config = config)
         configureWriteTimeout(builder = builder, config = config)
         configureRetryOnConnectionFailure(builder = builder, config = config)
+        configureFollowRedirects(builder = builder, config = config)
+        configureFollowSslRedirects(builder = builder, config = config)
         return builder
     }
 
@@ -64,6 +66,24 @@ class OkHttpClientCommonConfigurator {
         )
     }
 
+    private fun configureFollowRedirects(
+        builder: Builder,
+        config: HttpClientEndpointConfig,
+    ) {
+        builder.retryOnConnectionFailure(
+            config.clientConfig.followRedirect ?: followRedirects
+        )
+    }
+
+    private fun configureFollowSslRedirects(
+        builder: Builder,
+        config: HttpClientEndpointConfig,
+    ) {
+        builder.retryOnConnectionFailure(
+            config.clientConfig.followSslRedirects ?: followSslRedirects
+        )
+    }
+
     companion object {
         // Copied from okhttp3.ConnectionPool, as it does not provide "use default" option
         const val maxIdleConnections = 5
@@ -73,5 +93,13 @@ class OkHttpClientCommonConfigurator {
 
         // For backwards-compat with previous behavior of always setting this to false
         const val retryOnConnectionFailure = false
+
+        // Default value is true
+        // https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/-builder/follow-redirects.html
+        const val followRedirects = true
+
+        // Default value is true
+        // https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/-builder/follow-ssl-redirects.html
+        const val followSslRedirects = true
     }
 }


### PR DESCRIPTION
Following the pattern shown in previous PRs for [updating wisp HttpClientConfig](https://github.com/cashapp/wisp/pull/88) as well as [updating misk HttpClientConfig](https://github.com/cashapp/misk/pull/2651) of adding `retryOnConnectionFailure` config so it's exposed via skim yaml config, I wanted to do the same for two additional fields - `followRedirects` and `followSslRedirects`

The end output I would like is to be able to define these in a yaml file like so:

```yaml
skim:
  ...
  http_clients:
    endpoints:
      http-service:
        clientConfig:
          ...
          followRedirects: false
          followSslRedirects: false
      ...
```