### PR TITLE
Allow binding custom StringConverters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib
 dist
 .hash
 hooks.gradle
+.kotlin
 
 **/site/
 docs/0.x/*

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1296,7 +1296,11 @@ public final class misk/web/FeatureBinding$DefaultImpls {
 }
 
 public abstract interface class misk/web/FeatureBinding$Factory {
-	public abstract fun create (Lmisk/Action;Lmisk/web/PathPattern;Lmisk/web/FeatureBinding$Claimer;)Lmisk/web/FeatureBinding;
+	public abstract fun create (Lmisk/Action;Lmisk/web/PathPattern;Lmisk/web/FeatureBinding$Claimer;Ljava/util/List;)Lmisk/web/FeatureBinding;
+}
+
+public final class misk/web/FeatureBinding$Factory$DefaultImpls {
+	public static synthetic fun create$default (Lmisk/web/FeatureBinding$Factory;Lmisk/Action;Lmisk/web/PathPattern;Lmisk/web/FeatureBinding$Claimer;Ljava/util/List;ILjava/lang/Object;)Lmisk/web/FeatureBinding;
 }
 
 public abstract interface class misk/web/FeatureBinding$Subject {
@@ -1857,8 +1861,17 @@ public final class misk/web/extractors/RequestBodyException : java/io/IOExceptio
 	public fun <init> (Ljava/lang/Throwable;)V
 }
 
+public abstract interface class misk/web/extractors/StringConverter {
+	public abstract fun convert (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public abstract interface class misk/web/extractors/StringConverter$Factory {
+	public abstract fun create (Lkotlin/reflect/KType;)Lmisk/web/extractors/StringConverter;
+}
+
 public final class misk/web/extractors/StringConverterKt {
-	public static final fun converterFor (Lkotlin/reflect/KType;)Lkotlin/jvm/functions/Function1;
+	public static final fun converterFor (Lkotlin/reflect/KType;Ljava/util/List;)Lmisk/web/extractors/StringConverter;
+	public static synthetic fun converterFor$default (Lkotlin/reflect/KType;Ljava/util/List;ILjava/lang/Object;)Lmisk/web/extractors/StringConverter;
 }
 
 public final class misk/web/formatter/ClassNameFormatter {

--- a/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
@@ -15,6 +15,7 @@ import misk.web.FeatureBinding.Claimer
 import misk.web.FeatureBinding.Subject
 import misk.web.PathPattern
 import misk.web.WebConfig
+import misk.web.extractors.StringConverter
 import misk.web.mediatype.MediaTypes
 import java.lang.reflect.Type
 import kotlin.coroutines.CoroutineContext
@@ -137,7 +138,8 @@ internal class GrpcFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       if (action.dispatchMechanism != DispatchMechanism.GRPC) return null
 

--- a/misk/src/main/kotlin/misk/web/FeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/FeatureBinding.kt
@@ -2,6 +2,7 @@ package misk.web
 
 import misk.Action
 import misk.web.actions.WebAction
+import misk.web.extractors.StringConverter
 import okio.BufferedSink
 import okio.BufferedSource
 import java.util.regex.Matcher
@@ -64,7 +65,8 @@ interface FeatureBinding {
     fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory> = listOf(),
     ): FeatureBinding?
   }
 

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -58,6 +58,7 @@ import misk.web.extractors.RequestCookiesFeatureBinding
 import misk.web.extractors.RequestHeaderFeatureBinding
 import misk.web.extractors.RequestHeadersFeatureBinding
 import misk.web.extractors.ResponseBodyFeatureBinding
+import misk.web.extractors.StringConverter
 import misk.web.extractors.WebSocketFeatureBinding
 import misk.web.extractors.WebSocketListenerFeatureBinding
 import misk.web.interceptors.BeforeContentEncoding
@@ -167,6 +168,7 @@ class MiskWebModule @JvmOverloads constructor(
 
     // Initialize empty sets for our multibindings.
     newMultibinder<NetworkInterceptor.Factory>()
+    newMultibinder<StringConverter.Factory>()
     newMultibinder<ApplicationInterceptor.Factory>()
     newMultibinder<StaticResourceEntry>()
     newMultibinder<WebProxyEntry>()

--- a/misk/src/main/kotlin/misk/web/WebActionBinding.kt
+++ b/misk/src/main/kotlin/misk/web/WebActionBinding.kt
@@ -6,6 +6,7 @@ import okio.BufferedSink
 import okio.BufferedSource
 import java.util.regex.Matcher
 import jakarta.inject.Inject
+import misk.web.extractors.StringConverter
 import kotlin.reflect.KParameter
 
 /** HTTP binding as specified by [FeatureBinding]. */
@@ -220,7 +221,8 @@ internal class WebActionBinding @Inject constructor(
 
   /** Creates feature bindings for use before and after a web call. */
   class Factory @Inject constructor(
-    private val featureBindingFactories: List<FeatureBinding.Factory>
+    private val featureBindingFactories: List<FeatureBinding.Factory>,
+    private val stringConverterFactories: List<StringConverter.Factory>,
   ) {
     fun create(
       action: Action,
@@ -228,7 +230,7 @@ internal class WebActionBinding @Inject constructor(
     ): WebActionBinding {
       val claimer = RealClaimer(action)
       for (factory in featureBindingFactories) {
-        val binding = factory.create(action, pathPattern, claimer)
+        val binding = factory.create(action, pathPattern, claimer, stringConverterFactories)
         claimer.commitClaims(factory, binding)
       }
       return claimer.newWebActionBinder()

--- a/misk/src/main/kotlin/misk/web/extractors/FormValueFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/FormValueFeatureBinding.kt
@@ -24,13 +24,14 @@ internal class FormValueFeatureBinding<T : Any>(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       val parameter = action.parameterAnnotatedOrNull<FormValue>() ?: return null
       if (parameter.type.classifier !is KClass<*>) return null
 
       val kClass = parameter.type.classifier as KClass<*>
-      val formAdapter = FormAdapter.create(kClass) ?: return null
+      val formAdapter = FormAdapter.create(kClass, stringConverterFactories) ?: return null
       claimer.claimRequestBody()
       claimer.claimParameter(parameter)
       return FormValueFeatureBinding(parameter, formAdapter)

--- a/misk/src/main/kotlin/misk/web/extractors/RequestBodyFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestBodyFeatureBinding.kt
@@ -53,7 +53,8 @@ internal class RequestBodyFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       val parameter = action.parameterAnnotatedOrNull<RequestBody>() ?: return null
       claimer.claimParameter(parameter)

--- a/misk/src/main/kotlin/misk/web/extractors/RequestCookiesFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestCookiesFeatureBinding.kt
@@ -20,7 +20,8 @@ internal class RequestCookiesFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       val parameter = action.parameterAnnotatedOrNull<RequestCookies>() ?: return null
       claimer.claimParameter(parameter)

--- a/misk/src/main/kotlin/misk/web/extractors/RequestHeadersFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestHeadersFeatureBinding.kt
@@ -20,7 +20,8 @@ internal class RequestHeadersFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       val parameter = action.parameterAnnotatedOrNull<RequestHeaders>() ?: return null
       claimer.claimParameter(parameter)

--- a/misk/src/main/kotlin/misk/web/extractors/ResponseBodyFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/ResponseBodyFeatureBinding.kt
@@ -39,7 +39,8 @@ internal class ResponseBodyFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       if (action.dispatchMechanism == DispatchMechanism.GRPC && action.function.findAnnotation<Grpc>() == null) return null
       if (action.returnType.classifier == Unit::class) return null

--- a/misk/src/main/kotlin/misk/web/extractors/WebSocketFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/WebSocketFeatureBinding.kt
@@ -21,7 +21,8 @@ internal class WebSocketFeatureBinding(
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       val parameter = action.parameters.firstOrNull {
         it.type.classifier == WebSocket::class

--- a/misk/src/main/kotlin/misk/web/extractors/WebSocketListenerFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/WebSocketListenerFeatureBinding.kt
@@ -18,7 +18,8 @@ internal class WebSocketListenerFeatureBinding : FeatureBinding {
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: Claimer
+      claimer: Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       if (action.returnType.classifier == WebSocketListener::class) {
         claimer.claimReturnValue()

--- a/misk/src/test/kotlin/misk/web/WebActionBindingTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebActionBindingTest.kt
@@ -3,6 +3,7 @@ package misk.web
 import misk.Action
 import misk.asAction
 import misk.web.actions.WebAction
+import misk.web.extractors.StringConverter
 import okio.BufferedSink
 import okio.BufferedSource
 import org.assertj.core.api.Assertions.assertThat
@@ -19,13 +20,14 @@ internal class WebActionBindingTest {
     claimParameterValues = mutableMapOf(0 to "zero", 1 to "one")
   )
   private val webActionBindingFactory = WebActionBinding.Factory(
-    listOf(
+    featureBindingFactories = listOf(
       defaultFactory,
       requestBodyFactory,
       responseBodyFactory,
       returnValueFactory,
-      parametersFactory
-    )
+      parametersFactory,
+    ),
+    stringConverterFactories = listOf(),
   )
   private val pathPattern = PathPattern.parse("/")
   private val voidApiCallAction = TestAction::voidApiCall.asAction(DispatchMechanism.POST)
@@ -213,7 +215,8 @@ internal class WebActionBindingTest {
     override fun create(
       action: Action,
       pathPattern: PathPattern,
-      claimer: FeatureBinding.Claimer
+      claimer: FeatureBinding.Claimer,
+      stringConverterFactories: List<StringConverter.Factory>
     ): FeatureBinding? {
       if (claimRequestBody) claimer.claimRequestBody()
       for (index in claimParameterValues.keys) {

--- a/misk/src/test/kotlin/misk/web/extractors/QueryParamFeatureBindingTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/QueryParamFeatureBindingTest.kt
@@ -6,12 +6,25 @@ import misk.web.extractors.QueryParamFeatureBinding.Factory.toQueryBinding
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KParameter
+import kotlin.reflect.KType
 import kotlin.test.assertFailsWith
 
 internal class QueryParamFeatureBindingTest {
+  private val stringConverterFactories = listOf<StringConverter.Factory>(
+    object: StringConverter.Factory {
+      override fun create(kType: KType): StringConverter? {
+        return if (kType.classifier == ValueClass::class) {
+          StringConverter { ValueClass(it) }
+        } else {
+          null
+        }
+      }
+    }
+  )
+
   @Test
   fun simpleString() {
-    val queryStringProcessor = TestMemberStore.stringParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.stringParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("foo"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo("foo")
@@ -19,7 +32,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalStringPresent() {
-    val queryStringProcessor = TestMemberStore.optionalStringParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalStringParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("foo"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo("foo")
@@ -27,14 +40,14 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalStringNotPresent() {
-    val queryStringProcessor = TestMemberStore.optionalStringParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalStringParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
 
   @Test
   fun stringList() {
-    val queryStringProcessor = TestMemberStore.stringListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.stringListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("foo", "bar"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
@@ -42,7 +55,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalStringListPresent() {
-    val queryStringProcessor = TestMemberStore.optionalStringListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalStringListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("foo", "bar"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(listOf("foo", "bar"))
@@ -50,14 +63,14 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalStringListNotPresent() {
-    val queryStringProcessor = TestMemberStore.optionalStringListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalStringListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
 
   @Test
   fun simpleInt() {
-    val queryStringProcessor = TestMemberStore.intParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.intParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("42"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(42)
@@ -65,7 +78,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun invalidInt() {
-    val queryStringProcessor = TestMemberStore.intParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.intParameter().toQueryBinding(stringConverterFactories)!!
     assertFailsWith<BadRequestException> {
       queryStringProcessor.parameterValue(listOf("forty two"))
     }
@@ -73,7 +86,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalIntPresent() {
-    val queryStringProcessor = TestMemberStore.optionalIntParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalIntParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("42"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(42)
@@ -81,14 +94,14 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalIntNotPresent() {
-    val queryStringProcessor = TestMemberStore.optionalIntParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalIntParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
 
   @Test
   fun intList() {
-    val queryStringProcessor = TestMemberStore.intListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.intListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("42", "23"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(listOf(42, 23))
@@ -96,7 +109,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalIntListPresent() {
-    val queryStringProcessor = TestMemberStore.optionalIntListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalIntListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(
       listOf("42", "23")
     )
@@ -106,14 +119,14 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalIntListNotPresent() {
-    val queryStringProcessor = TestMemberStore.optionalIntListParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalIntListParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
 
   @Test
   fun simpleLong() {
-    val queryStringProcessor = TestMemberStore.longParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.longParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("42"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(42L)
@@ -121,7 +134,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun simpleEnum() {
-    val queryStringProcessor = TestMemberStore.enumParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.enumParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("ONE"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(TestEnum.ONE)
@@ -129,7 +142,7 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalEnumPresent() {
-    val queryStringProcessor = TestMemberStore.optionalEnumParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalEnumParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf("ONE"))
     assertThat(extractedResult).isNotNull()
     assertThat(extractedResult).isEqualTo(TestEnum.ONE)
@@ -137,14 +150,14 @@ internal class QueryParamFeatureBindingTest {
 
   @Test
   fun optionalEnumNotPresent() {
-    val queryStringProcessor = TestMemberStore.optionalEnumParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.optionalEnumParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
 
   @Test
   fun defaultEnumPresent() {
-    val queryStringProcessor = TestMemberStore.defaultEnumParameter().toQueryBinding()!!
+    val queryStringProcessor = TestMemberStore.defaultEnumParameter().toQueryBinding(stringConverterFactories)!!
     val extractedResult = queryStringProcessor.parameterValue(listOf())
     assertThat(extractedResult).isNull()
   }
@@ -152,14 +165,25 @@ internal class QueryParamFeatureBindingTest {
   @Test
   fun unsupportedClass() {
     assertFailsWith<IllegalArgumentException> {
-      TestMemberStore.unsupportedParameter().toQueryBinding()
+      TestMemberStore.unsupportedParameter().toQueryBinding(stringConverterFactories)
     }
+  }
+
+  @Test
+  fun customStringConverterCanBeUsed() {
+    val queryStringProcessor = TestMemberStore.valueClassParameter().toQueryBinding(stringConverterFactories)!!
+    val extractedResult = queryStringProcessor.parameterValue(listOf("foo"))
+    assertThat(extractedResult).isNotNull()
+    assertThat(extractedResult).isEqualTo(ValueClass("foo"))
   }
 
   enum class TestEnum {
     ONE,
     TWO
   }
+
+  @JvmInline
+  value class ValueClass(val value: String)
 
   @Suppress("UNUSED_PARAMETER")
   internal class TestMemberStore {
@@ -196,6 +220,11 @@ internal class QueryParamFeatureBindingTest {
     ) {
     }
 
+    fun customStringConverterTest(
+      @QueryParam valueClass: ValueClass,
+    ) {
+    }
+
     companion object {
       fun stringParameter(): KParameter = TestMemberStore::strTest.parameters.get(1)
       fun optionalStringParameter(): KParameter = TestMemberStore::strTest.parameters.get(2)
@@ -210,6 +239,7 @@ internal class QueryParamFeatureBindingTest {
       fun optionalEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(2)
       fun defaultEnumParameter(): KParameter = TestMemberStore::enumTest.parameters.get(3)
       fun unsupportedParameter(): KParameter = TestMemberStore::unsupportedTest.parameters.get(1)
+      fun valueClassParameter(): KParameter = TestMemberStore::customStringConverterTest.parameters.get(1)
     }
   }
 }


### PR DESCRIPTION
## Description

Currently params had to be one of the supported types, or expose a `valueOf` function. However at Faire, we want to offer better type validation for our parameters. For example, we have `Token<T>` where `T` could be something like `Brand` or `Product`. Each of these token types has a unique prefix, so even if we have a `valueOf` function exposed we lack the ability to validate the type is correct. With this change we can inspect the type of the parameter, and validate it's the correct type before converting the `String`.

Note that this is technically a breaking change because I've changed `StringConverter` to an interface, and updated the public constructor of `FeatureBindingFactory`, but they're small enough changes that I don't think people will have any issues upgrading.

## Testing Strategy

I updated `QueryParamFeatureBindingTest` to show that a custom `StringConverter` can be used to properly parse a string to a value class, which otherwise would fail. I didn't update all the other binding tests because the code path is the same, but can update them if people feel strongly.