### PR TITLE
Split Misk and Wisp publishing

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -112,7 +112,8 @@ jobs:
       - name: Publish the artifacts
         run: |
           # disable caching since it breaks publishing to Maven Central
-          gradle clean publish --stacktrace --no-build-cache --no-configuration-cache --no-configure-on-demand
+          gradle clean publishMiskToMavenCentral --stacktrace --no-build-cache --no-configuration-cache --no-configure-on-demand
+          gradle clean publishWispToMavenCentral --stacktrace --no-build-cache --no-configuration-cache --no-configure-on-demand
 
       - name: Tag Misk repo
         uses: mathieudutour/github-tag-action@v6.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,6 +181,24 @@ val doNotDetekt = listOf(
   "misk-bom",
 )
 
+val publishMiskToMavenCentral = tasks.register("publishMiskToMavenCentral")
+val publishWispToMavenCentral = tasks.register("publishWispToMavenCentral")
+
+val publishUrl = System.getProperty("publish_url")
+val hasPublishUrl = !publishUrl.isNullOrBlank()
+if (!hasPublishUrl) {
+  publishMiskToMavenCentral.configure {
+    doFirst {
+      error("Cannot publish Misk to Maven Central with a publish_url specified")
+    }
+  }
+  publishWispToMavenCentral.configure {
+    doFirst {
+      error("Cannot publish Wisp to Maven Central with a publish_url specified")
+    }
+  }
+}
+
 subprojects {
   apply(plugin = "org.jetbrains.dokka")
   apply(plugin = "io.gitlab.arturbosch.detekt")
@@ -345,12 +363,9 @@ subprojects {
       select("com.google.guava:guava:0")
     }
   }
-}
 
-subprojects {
   plugins.withId("com.vanniktech.maven.publish.base") {
-    val publishUrl = System.getProperty("publish_url")
-    if (!publishUrl.isNullOrBlank()) {
+    if (hasPublishUrl) {
       configure<PublishingExtension> {
         repositories {
           maven {
@@ -366,6 +381,13 @@ subprojects {
       configure<MavenPublishBaseExtension> {
         publishToMavenCentral(automaticRelease = true)
         signAllPublications()
+      }
+      when (group) {
+        "app.cash.wisp" -> publishWispToMavenCentral
+        "com.squareup.misk" -> publishMiskToMavenCentral
+        else -> error("Unknown group $group in project $path")
+      }.configure {
+        dependsOn(tasks.named("publishToMavenCentral"))
       }
     }
     configure<MavenPublishBaseExtension> {


### PR DESCRIPTION
The new Central Portal cannot handle publishing across two namespaces at once (yet?).
