### PR TITLE
Add exception handler override to log and emit metrics for MySQL (non-Vitess)

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -98,6 +98,7 @@ class DataSourceService @JvmOverloads constructor(
       when (config.type) {
         DataSourceType.MYSQL -> {
           hikariConfig.connectionInitSql = "SET time_zone = '+00:00'"
+          hikariConfig.exceptionOverride = MySQLExceptionHandler(collectorRegistry)
         }
         DataSourceType.VITESS_MYSQL -> {
           hikariConfig.exceptionOverride  = VitessExceptionHandler(collectorRegistry)

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/MySQLExceptionHandler.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/MySQLExceptionHandler.kt
@@ -1,0 +1,68 @@
+package misk.jdbc
+
+import com.google.common.annotations.VisibleForTesting
+import com.zaxxer.hikari.SQLExceptionOverride
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.Counter
+import misk.logging.getLogger
+import java.sql.SQLException
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * No functional exception handling overrides, but logs an exception and emits error metrics.
+ */
+internal class MySQLExceptionHandler(
+  registry: CollectorRegistry? = null,
+  ): SQLExceptionOverride {
+
+  override fun adjudicate(sqlException: SQLException): SQLExceptionOverride.Override {
+    val result = super.adjudicate(sqlException)
+    logger.error(
+      "Hikari exception adjudicate: " +
+              "errorCode=${sqlException.errorCode}, " +
+              // the logic around sqlState kotlin this is null safe, but the Java shows it being set
+              // as null. Let's be explicit at the behavir.
+              "state=${sqlException?.sqlState ?: "null"}, " +
+              "message=${sqlException.message}, " +
+              "adjudicate=$result"
+    )
+    errorCounter?.labels(
+      sqlException.errorCode.toString(),
+      sqlException.sqlState ?: "",
+      sqlException.message,
+      result.name
+    )?.inc()
+    return result
+  }
+
+  @VisibleForTesting
+  val errorCounter = registry?.let { registry ->
+    Counter
+      .build("hikaricp_misk_mysql_exception", "Misk MySQL Exceptions that were recorded for the hikari pool")
+      .labelNames("errorCode", "sqlState", "message", "decision")
+      .create()
+      .registerOrReplace(registry)
+  }
+
+  companion object {
+    /**
+     * This uses a similar check that Hikari does internally. We can't register the same counter twice.
+     * Instead we use some global memory to find the existing reference and return it instead.
+     */
+    private val registrationStatuses: ConcurrentHashMap<CollectorRegistry, Counter> =
+      ConcurrentHashMap()
+    private fun Counter.registerOrReplace(registry: CollectorRegistry): Counter {
+      val existingCounter = registrationStatuses.putIfAbsent(registry, this)
+      return if (existingCounter == null) {
+        registry.register(this)
+        // make sure we have some baseline labels
+        this.labels("", "", "", "CONTINUE_EVICT")
+        this
+      } else {
+        existingCounter
+      }
+    }
+
+    private val logger = getLogger<MySQLExceptionHandler>()
+  }
+}

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
@@ -3,7 +3,7 @@ package misk.jdbc
 import com.zaxxer.hikari.SQLExceptionOverride
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Counter
-import wisp.logging.getLogger
+import misk.logging.getLogger
 import java.sql.SQLException
 import java.util.concurrent.ConcurrentHashMap
 
@@ -14,7 +14,7 @@ internal class VitessExceptionHandler(
 
   private val errorCounter = registry?.let { registry ->
     Counter
-    .build("hikaricp_misk_vitess_exception", "Misk Vitess Exception that were recorded for the hikari pool")
+    .build("hikaricp_misk_vitess_exception", "Misk Vitess Exceptions that were recorded for the hikari pool")
     .labelNames("errorCode", "sqlState", "message", "decision")
       .create()
     .registerOrReplace(registry)

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/MySQLExceptionHandlerTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/MySQLExceptionHandlerTest.kt
@@ -1,0 +1,49 @@
+package misk.jdbc
+
+import com.zaxxer.hikari.SQLExceptionOverride
+import io.prometheus.client.CollectorRegistry
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.sql.SQLException
+
+@MiskTest(startService = true)
+class MySQLExceptionHandlerTest {
+
+  @Inject
+  lateinit var registry: CollectorRegistry
+
+  @MiskTestModule
+  val testingModule = MiskTestingServiceModule()
+
+  @Test
+  fun `matches exception`() {
+    val handler = MySQLExceptionHandler(registry)
+    val adjudicateResult = SQLExceptionOverride.Override.CONTINUE_EVICT
+
+    val exception1 = SQLException("Key not found")
+    assertThat(handler.adjudicate(exception1)).isEqualTo(adjudicateResult)
+    assertThat(handler.errorCounter!!.labels(
+      exception1.errorCode.toString(),
+      "",
+      exception1.message,
+      adjudicateResult.name
+    ).get()).isEqualTo(1.0)
+
+    val exception2 = SQLException(
+      "",
+      "42S02",
+      1147
+    )
+    assertThat(handler.adjudicate(exception2)).isEqualTo(adjudicateResult)
+    assertThat(handler.errorCounter.labels(
+      exception2.errorCode.toString(),
+      exception2.sqlState,
+      exception2.message,
+      adjudicateResult.name
+    ).get()).isEqualTo(1.0)
+  }
+}


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

<!-- Why is your change necessary? What does it solve? -->
Add a wrapper class similar to VitessExceptionHandler for non-Vitess dialects, so that we can track metrics and logs more easily for MySQL exceptions.

## Testing Strategy

<!-- How did you test your solution? -->
Added unit tests.

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Mostly copy pasta from [VitessExceptionHandler](https://github.com/cashapp/misk/commits/master/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt)

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
