### PR TITLE
Use replicaRead to run SHOW VITESS SHARDS

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/RealTransacter.kt
@@ -114,7 +114,7 @@ internal class RealTransacter private constructor(
             // Needs to be fetched on a separate thread to avoid nested transactions
             executorService.submit(
               Callable<Set<Shard>> {
-                transacter.transaction { session ->
+                transacter.replicaRead { session ->
                   session.useConnection { connection ->
                     connection.createStatement().use { s ->
                       val shards = s.executeQuery("SHOW VITESS_SHARDS")


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

<!-- Why is your change necessary? What does it solve? -->
We should explicitly target the Vitess replica shard to run `SHOW VITESS SHARDS` command, since it is read only and in some cases we might be using Vitess for replicas and another DB type for primary, in which case this command fails.

## Testing Strategy

<!-- How did you test your solution? -->
Ran other unit tests; open to testing suggestions.

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
