### PR TITLE
fix: flaky metrics tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist
 .hash
 hooks.gradle
 .kotlin
+.claude
 
 **/site/
 docs/0.x/*

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
   runtimeOnly(libs.jettyAlpnServerJava)
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
   testImplementation(libs.assertj)
+  testImplementation(libs.awaitility)
+  testImplementation(libs.awaitilityKotlin)
   testImplementation(libs.guavaTestLib)
   testImplementation(libs.junitApi)
   testImplementation(libs.junitParams)

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorNoSummaryTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorNoSummaryTest.kt
@@ -65,7 +65,7 @@ class MetricsInterceptorNoSummaryTest {
     assertThat(metricsInterceptorFactory.requestDurationSummary).isNull()
 
     // Prometheus processes events asynchronously, thus we might have to wait for a bit.
-    await withPollInterval ONE_MILLISECOND atMost ONE_HUNDRED_MILLISECONDS untilAsserted {
+    await.withPollInterval(ONE_MILLISECOND).atMost(ONE_HUNDRED_MILLISECONDS).untilAsserted {
       // Make sure all the right histo metrics were generated
       val histoDuration = metricsInterceptorFactory.requestDurationHistogram
       assertThat(histoDuration.labels(*labels(200)).get().count()).isEqualTo(2)

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorNoSummaryTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorNoSummaryTest.kt
@@ -22,6 +22,12 @@ import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS
+import org.awaitility.Durations.ONE_MILLISECOND
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -58,14 +64,17 @@ class MetricsInterceptorNoSummaryTest {
     // Make sure all the right non-histo metrics were not generated.
     assertThat(metricsInterceptorFactory.requestDurationSummary).isNull()
 
-    // Make sure all the right histo metrics were generated
-    val histoDuration = metricsInterceptorFactory.requestDurationHistogram
-    assertThat(histoDuration.labels(*labels(200)).get().count()).isEqualTo(2)
-    assertThat(histoDuration.labels(*labels(202)).get().count()).isEqualTo(1)
-    assertThat(histoDuration.labels(*labels(404)).get().count()).isEqualTo(1)
-    assertThat(histoDuration.labels(*labels(403)).get().count()).isEqualTo(2)
-    assertThat(histoDuration.labels(*labels(200, "my-peer")).get().count()).isEqualTo(4)
-    assertThat(histoDuration.labels(*labels(200, "<user>")).get().count()).isEqualTo(1)
+    // Prometheus processes events asynchronously, thus we might have to wait for a bit.
+    await withPollInterval ONE_MILLISECOND atMost ONE_HUNDRED_MILLISECONDS untilAsserted {
+      // Make sure all the right histo metrics were generated
+      val histoDuration = metricsInterceptorFactory.requestDurationHistogram
+      assertThat(histoDuration.labels(*labels(200)).get().count()).isEqualTo(2)
+      assertThat(histoDuration.labels(*labels(202)).get().count()).isEqualTo(1)
+      assertThat(histoDuration.labels(*labels(404)).get().count()).isEqualTo(1)
+      assertThat(histoDuration.labels(*labels(403)).get().count()).isEqualTo(2)
+      assertThat(histoDuration.labels(*labels(200, "my-peer")).get().count()).isEqualTo(4)
+      assertThat(histoDuration.labels(*labels(200, "<user>")).get().count()).isEqualTo(1)
+    }
   }
 
   fun invoke(

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -70,7 +70,7 @@ class MetricsInterceptorTest {
     requestDuration.labels(*labels(200, "<user>")).observe(1.0)
 
     // Promteheus processes events asynchronously, thus we might have to wait for a bit.
-    await withPollInterval ONE_MILLISECOND atMost ONE_HUNDRED_MILLISECONDS untilAsserted {
+    await.withPollInterval(ONE_MILLISECOND).atMost(ONE_HUNDRED_MILLISECONDS).untilAsserted {
       // Summary metrics assertions
       assertThat(requestDuration.labels(*labels(200)).get().count.toInt()).isEqualTo(3)
       assertThat(requestDuration.labels(*labels(202)).get().count.toInt()).isEqualTo(2)

--- a/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
+++ b/misk/src/test/kotlin/misk/web/interceptors/MetricsInterceptorTest.kt
@@ -21,6 +21,12 @@ import misk.web.actions.WebAction
 import misk.web.jetty.JettyService
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS
+import org.awaitility.Durations.ONE_MILLISECOND
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -57,28 +63,31 @@ class MetricsInterceptorTest {
     // Make sure all the right non-histo metrics were generated
     val requestDuration = metricsInterceptorFactory.requestDurationSummary!!
     requestDuration.labels(*labels(200)).observe(1.0)
-    assertThat(requestDuration.labels(*labels(200)).get().count.toInt()).isEqualTo(3)
     requestDuration.labels(*labels(202)).observe(1.0)
-    assertThat(requestDuration.labels(*labels(202)).get().count.toInt()).isEqualTo(2)
     requestDuration.labels(*labels(404)).observe(1.0)
-    assertThat(requestDuration.labels(*labels(404)).get().count.toInt()).isEqualTo(2)
     requestDuration.labels(*labels(403)).observe(1.0)
-    assertThat(requestDuration.labels(*labels(403)).get().count.toInt()).isEqualTo(3)
-
     requestDuration.labels(*labels(200, "my-peer")).observe(1.0)
-    assertThat(requestDuration.labels(*labels(200, "my-peer")).get().count.toInt()).isEqualTo(5)
-
     requestDuration.labels(*labels(200, "<user>")).observe(1.0)
-    assertThat(requestDuration.labels(*labels(200, "<user>")).get().count.toInt()).isEqualTo(2)
 
-    // Make sure all the right histo metrics were generated
-    val histoDuration = metricsInterceptorFactory.requestDurationHistogram
-    assertThat(histoDuration.labels(*labels(200)).get().count()).isEqualTo(2)
-    assertThat(histoDuration.labels(*labels(202)).get().count()).isEqualTo(1)
-    assertThat(histoDuration.labels(*labels(404)).get().count()).isEqualTo(1)
-    assertThat(histoDuration.labels(*labels(403)).get().count()).isEqualTo(2)
-    assertThat(histoDuration.labels(*labels(200, "my-peer")).get().count()).isEqualTo(4)
-    assertThat(histoDuration.labels(*labels(200, "<user>")).get().count()).isEqualTo(1)
+    // Promteheus processes events asynchronously, thus we might have to wait for a bit.
+    await withPollInterval ONE_MILLISECOND atMost ONE_HUNDRED_MILLISECONDS untilAsserted {
+      // Summary metrics assertions
+      assertThat(requestDuration.labels(*labels(200)).get().count.toInt()).isEqualTo(3)
+      assertThat(requestDuration.labels(*labels(202)).get().count.toInt()).isEqualTo(2)
+      assertThat(requestDuration.labels(*labels(404)).get().count.toInt()).isEqualTo(2)
+      assertThat(requestDuration.labels(*labels(403)).get().count.toInt()).isEqualTo(3)
+      assertThat(requestDuration.labels(*labels(200, "my-peer")).get().count.toInt()).isEqualTo(5)
+      assertThat(requestDuration.labels(*labels(200, "<user>")).get().count.toInt()).isEqualTo(2)
+
+      // Histogram metrics assertions
+      val histoDuration = metricsInterceptorFactory.requestDurationHistogram
+      assertThat(histoDuration.labels(*labels(200)).get().count()).isEqualTo(2)
+      assertThat(histoDuration.labels(*labels(202)).get().count()).isEqualTo(1)
+      assertThat(histoDuration.labels(*labels(404)).get().count()).isEqualTo(1)
+      assertThat(histoDuration.labels(*labels(403)).get().count()).isEqualTo(2)
+      assertThat(histoDuration.labels(*labels(200, "my-peer")).get().count()).isEqualTo(4)
+      assertThat(histoDuration.labels(*labels(200, "<user>")).get().count()).isEqualTo(1)
+    }
   }
 
   fun invoke(


### PR DESCRIPTION
As prometheus does not upgrade metrics synchronously, we might have to retry some metric assertions to avoid flaky tests

<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

<!-- Why is your change necessary? What does it solve? -->

## Testing Strategy

<!-- How did you test your solution? -->

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
