### PR TITLE
Revert "fix: add missing rate control to uds (#3420)"

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -45,7 +45,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.ThreadPool
 import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer
 import misk.logging.getLogger
-import misk.metrics.v2.Metrics
 import java.io.File
 import java.io.IOException
 import java.lang.Thread.sleep
@@ -69,7 +68,6 @@ class JettyService @Inject internal constructor(
   private val connectionMetricsCollector: JettyConnectionMetricsCollector,
   private val statisticsHandler: StatisticsHandler,
   private val gzipHandler: GzipHandler,
-  private val metrics: Metrics
 ) : AbstractIdleService() {
   private val server = Server(threadPool)
   val healthServerUrl: HttpUrl? get() = server.healthUrl
@@ -130,8 +128,6 @@ class JettyService @Inject internal constructor(
     if (webConfig.http2) {
       val http2 = HTTP2CServerConnectionFactory(httpConfig)
       http2.customize(webConfig)
-      http2.rateControlFactory =
-        MeasuredWindowRateControl.Factory(metrics, webConfig.jetty_http2_max_events_per_second)
       httpConnectionFactories += http2
     }
 
@@ -216,8 +212,6 @@ class JettyService @Inject internal constructor(
       if (webConfig.http2) {
         val http2 = HTTP2ServerConnectionFactory(httpsConfig)
         http2.customize(webConfig)
-        http2.rateControlFactory =
-          MeasuredWindowRateControl.Factory(metrics, webConfig.jetty_http2_max_events_per_second)
         httpsConnectionFactories += http2
       }
 

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -261,10 +261,7 @@ class JettyService @Inject internal constructor(
       val udsConnFactories = mutableListOf<ConnectionFactory>()
       udsConnFactories.add(HttpConnectionFactory(httpConfig))
       if (socketConfig.h2c == true) {
-        val http2 = HTTP2CServerConnectionFactory(httpConfig)
-        http2.rateControlFactory =
-          MeasuredWindowRateControl.Factory(metrics, webConfig.jetty_http2_max_events_per_second)
-        udsConnFactories.add(http2)
+        udsConnFactories.add(HTTP2CServerConnectionFactory(httpConfig))
       }
 
       if (isJEP380Supported(socketConfig.path)) {


### PR DESCRIPTION
This reverts commit 1c293df97d021cf653719e0cf9e62efbba236ee7.

Running into issues:

```
        Caused by:
        java.io.IOException: FRAME_SIZE_ERROR: 4740180
            at okhttp3.internal.http2.Http2Reader.nextFrame(Http2Reader.kt:112)
            at okhttp3.internal.http2.Http2Reader.readConnectionPreface(Http2Reader.kt:75)
            at okhttp3.internal.http2.Http2Connection$ReaderRunnable.invoke(Http2Connection.kt:640)
            at okhttp3.internal.http2.Http2Connection$ReaderRunnable.invoke(Http2Connection.kt:631)
            at okhttp3.internal.concurrent.TaskQueue$execute$1.runOnce(TaskQueue.kt:112)
            at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:81)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
            at java.base/java.lang.Thread.run(Thread.java:1583)
```