### PR TITLE
feat: reattempt in introducing configurable http/2 control frame limiter with observability

### DIFF
--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
   testImplementation(libs.okHttpMockWebServer)
   testImplementation(libs.okHttpSse)
   testImplementation(libs.openTracingMock)
+  testImplementation(libs.mockitoCore)
   testImplementation(project(":misk"))
   testImplementation(project(":misk-testing"))
   testImplementation(project(":wisp:wisp-logging-testing"))

--- a/misk/src/main/kotlin/misk/web/jetty/MeasuredWindowRateControl.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/MeasuredWindowRateControl.kt
@@ -12,7 +12,9 @@
 //
 package misk.web.jetty
 
+import io.prometheus.client.Counter
 import misk.metrics.v2.Metrics
+import misk.metrics.v2.PeakGauge
 import org.eclipse.jetty.http2.parser.RateControl
 import org.eclipse.jetty.io.EndPoint
 import org.eclipse.jetty.util.NanoTime
@@ -24,19 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger
  * Misk's RateControl implementation with observability for monitoring HTTP/2 frame rate limiting.
  * Almost the same implementation as [org.eclipse.jetty.http2.parser.WindowRateControl].
  */
-internal class MeasuredWindowRateControl internal constructor(
-  private val metrics: Metrics,
+class MeasuredWindowRateControl private constructor(
   private val maxEvents: Int,
+  private val rateEventsPeakGauge: PeakGauge,
+  private val rateLimitedEventCounter: Counter,
 ) : RateControl {
 
-  private val rateEventsPeakGauge = metrics.peakGauge(
-    "jetty_http2_rate_control_events_peak",
-    "Peak gauge of observed events per second"
-  )
-  private val rateLimitedEventCounter = metrics.counter(
-    "jetty_http2_rate_control_events_limited",
-    "Count of rate limited events"
-  )
 
   private val events = ConcurrentLinkedQueue<Long>()
   private val size = AtomicInteger()
@@ -55,7 +50,6 @@ internal class MeasuredWindowRateControl internal constructor(
 
     val count = size.incrementAndGet()
     rateEventsPeakGauge.record(count.toDouble())
-
     if (maxEvents == -1) return true
 
     val allowed = count <= maxEvents
@@ -63,12 +57,28 @@ internal class MeasuredWindowRateControl internal constructor(
     return allowed
   }
 
-  class Factory constructor(
-    private val metrics: Metrics,
+  class Factory(
+    metrics: Metrics,
     private val maxEventRate: Int
   ) : RateControl.Factory {
+
+    // Metrics are instantiated in the factory and passed to the class because
+    // there overhead in recreating them for every http/2 connection
+    // (can result in java.io.IOException: FRAME_SIZE_ERROR: 4740180 on the client)
+    private val rateEventsPeakGauge = metrics.peakGauge(
+      "jetty_http2_rate_control_events_peak",
+      "Peak gauge of observed events per second"
+    )
+    private val rateLimitedEventCounter = metrics.counter(
+      "jetty_http2_rate_control_events_limited",
+      "Count of rate limited events"
+    )
+
     override fun newRateControl(endPoint: EndPoint): RateControl {
-      return MeasuredWindowRateControl(metrics, maxEventRate)
+      return MeasuredWindowRateControl(
+        maxEventRate,
+        rateEventsPeakGauge,
+        rateLimitedEventCounter)
     }
   }
 }

--- a/misk/src/test/kotlin/misk/web/jetty/MeasuredWindowRateControlTest.kt
+++ b/misk/src/test/kotlin/misk/web/jetty/MeasuredWindowRateControlTest.kt
@@ -5,7 +5,9 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.jetty.MeasuredWindowRateControl
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jetty.io.EndPoint
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
 
 @MiskTest(startService = false)
 class MeasuredWindowRateControlTest {
@@ -13,9 +15,13 @@ class MeasuredWindowRateControlTest {
   @MiskTestModule val module = FakeMetricsModule()
   @Inject lateinit var metrics: FakeMetrics
 
+
   @Test
   fun `allows events when under maxEvents limit`() {
-    val rateControl = MeasuredWindowRateControl(metrics, maxEvents = 5)
+    val rateControl = MeasuredWindowRateControl.Factory(
+      metrics,
+      maxEventRate = 5
+    ).newRateControl(mock(EndPoint::class.java))
 
     repeat(5) {
       assertThat(rateControl.onEvent("test")).isTrue()
@@ -24,7 +30,10 @@ class MeasuredWindowRateControlTest {
 
   @Test
   fun `blocks events when over maxEvents limit`() {
-    val rateControl = MeasuredWindowRateControl(metrics, maxEvents = 2)
+    val rateControl = MeasuredWindowRateControl.Factory(
+      metrics,
+      maxEventRate = 2
+    ).newRateControl(mock(EndPoint::class.java))
 
     assertThat(rateControl.onEvent("test1")).isTrue()
     assertThat(rateControl.onEvent("test2")).isTrue()
@@ -34,7 +43,10 @@ class MeasuredWindowRateControlTest {
 
   @Test
   fun `allows unlimited events when maxEvents is -1`() {
-    val rateControl = MeasuredWindowRateControl(metrics, maxEvents = -1)
+    val rateControl = MeasuredWindowRateControl.Factory(
+      metrics,
+      maxEventRate = -1
+    ).newRateControl(mock(EndPoint::class.java))
 
     repeat(100) {
       assertThat(rateControl.onEvent("test")).isTrue()
@@ -43,7 +55,10 @@ class MeasuredWindowRateControlTest {
 
   @Test
   fun `window sliding allows events after time passes`() {
-    val rateControl = MeasuredWindowRateControl(metrics, maxEvents = 2)
+    val rateControl = MeasuredWindowRateControl.Factory(
+      metrics,
+      maxEventRate = 2
+    ).newRateControl(mock(EndPoint::class.java))
 
     assertThat(rateControl.onEvent("test1")).isTrue()
     assertThat(rateControl.onEvent("test2")).isTrue()


### PR DESCRIPTION
Previous attempts (https://github.com/cashapp/misk/pull/3408, https://github.com/cashapp/misk/pull/3420) had to be reverted in [here](https://github.com/cashapp/misk/pull/3421) due to failing integration tests and in-memory misk servers. It was found the metrics object instantiation for every http/2 connection added overhead resulting in client errors. Fixed by instantiating metrics in the factory once.