### PR TITLE
Misk servlet embeddable to an external servlet containers

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1371,6 +1371,9 @@ public final class misk/web/HttpCall$DefaultImpls {
 	public static fun contentType (Lmisk/web/HttpCall;)Lokhttp3/MediaType;
 }
 
+public abstract interface annotation class misk/web/MiskServlet : java/lang/annotation/Annotation {
+}
+
 public final class misk/web/MiskWebFormBuilder {
 	public static final field Companion Lmisk/web/MiskWebFormBuilder$Companion;
 	public fun <init> ()V
@@ -1577,7 +1580,8 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;I)V
-	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IZ)V
+	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()Ljava/lang/Integer;
@@ -1616,13 +1620,14 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun component41 ()Ljava/util/List;
 	public final fun component42 ()Lmisk/web/RequestDeadlinesConfig;
 	public final fun component43 ()I
+	public final fun component44 ()Z
 	public final fun component5 ()Lmisk/web/GracefulShutdownConfig;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lmisk/web/WebSslConfig;
 	public final fun component8 ()Lmisk/web/WebUnixDomainSocketConfig;
 	public final fun component9 ()Z
-	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;I)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IIILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IZ)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;IZIILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
@@ -1631,6 +1636,7 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun getConcurrency_limiter_disabled ()Z
 	public final fun getConcurrency_limiter_log_level ()Lorg/slf4j/event/Level;
 	public final fun getCors ()Ljava/util/Map;
+	public final fun getDisable_jetty ()Z
 	public final fun getEnable_thread_pool_health_check ()Z
 	public final fun getEnable_thread_pool_queue_metrics ()Z
 	public final fun getGraceful_shutdown_config ()Lmisk/web/GracefulShutdownConfig;

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -74,15 +74,16 @@ internal class BoundAction<A : WebAction>(
   }
 
   fun matchByUrl(url: HttpUrl): BoundActionMatch? {
-    val patchMather = pathPattern.matcher(url) ?: return null
+    val pathMatcher = pathPattern.matcher(url) ?: return null
     return BoundActionMatch(
       action = this,
-      pathMatcher = patchMather,
+      pathMatcher = pathMatcher,
       acceptedMediaRange = MediaRange.ALL_MEDIA,
       requestCharsetMatch = false,
       responseContentType = MediaTypes.ALL_MEDIA_TYPE
     )
   }
+
 
   /**
    * Returns true if this [BoundAction] has identical routing annotations as the provided

--- a/misk/src/main/kotlin/misk/web/MiskServlet.kt
+++ b/misk/src/main/kotlin/misk/web/MiskServlet.kt
@@ -1,0 +1,11 @@
+package misk.web
+
+import jakarta.inject.Qualifier
+
+/**
+ * Qualifier annotation for the Misk WebActions servlet that can be embedded in external servlet containers.
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+annotation class MiskServlet

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -129,24 +129,27 @@ class MiskWebModule @JvmOverloads constructor(
     bind<WebConfig>().toInstance(config)
     bind<ActionExceptionLogLevelConfig>().toInstance(config.action_exception_log_level)
 
-    install(
-      ServiceModule(
-        key = JettyService::class.toKey(),
-        dependsOn = jettyDependsOn
-      ).dependsOn<ReadyService>()
-    )
-    install(
-      ServiceModule<JettyThreadPoolMetricsCollector>()
-        .enhancedBy<ReadyService>()
-    )
-    install(
-      ServiceModule<JettyConnectionMetricsCollector>()
-        .enhancedBy<ReadyService>()
-    )
-    install(
-      ServiceModule<ReadinessCheckService>()
-        .enhancedBy<ReadyService>()
-    )
+    // Only install JettyService if not disabled.
+    if (!config.disable_jetty) {
+      install(
+        ServiceModule(
+          key = JettyService::class.toKey(),
+          dependsOn = jettyDependsOn
+        ).dependsOn<ReadyService>()
+      )
+      install(
+        ServiceModule<JettyThreadPoolMetricsCollector>()
+          .enhancedBy<ReadyService>()
+      )
+      install(
+        ServiceModule<JettyConnectionMetricsCollector>()
+          .enhancedBy<ReadyService>()
+      )
+      install(
+        ServiceModule<ReadinessCheckService>()
+          .enhancedBy<ReadyService>()
+      )
+    }
 
     install(ServiceModule<RepeatedTaskQueue>(ReadinessRefreshQueue::class))
 

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -80,6 +80,7 @@ import misk.web.interceptors.hooks.RequestResponseHook
 import misk.web.interceptors.hooks.RequestResponseLoggingHook
 import misk.web.jetty.JettyConnectionMetricsCollector
 import misk.web.jetty.JettyService
+import misk.web.jetty.WebActionsServlet
 import misk.web.jetty.JettyThreadPoolHealthCheck
 import misk.web.jetty.JettyThreadPoolMetricsCollector
 import misk.web.jetty.MeasuredQueuedThreadPool
@@ -94,6 +95,7 @@ import misk.web.marshal.PlainTextMarshaller
 import misk.web.marshal.ProtobufMarshaller
 import misk.web.marshal.ProtobufUnmarshaller
 import misk.web.marshal.Unmarshaller
+import misk.web.MiskServlet
 import misk.web.mdc.LogContextProvider
 import misk.web.mdc.RequestHttpMethodLogContextProvider
 import misk.web.mdc.RequestProtocolLogContextProvider
@@ -105,6 +107,7 @@ import misk.web.shutdown.GracefulShutdownModule
 import misk.web.sse.ServerSentEventMarshaller
 import misk.web.sse.ServerSentEventUnmarshaller
 import org.eclipse.jetty.io.EofException
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet
 import org.eclipse.jetty.server.handler.StatisticsHandler
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
 import org.eclipse.jetty.util.VirtualThreads
@@ -118,6 +121,7 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import kotlin.math.min
 
@@ -129,7 +133,6 @@ class MiskWebModule @JvmOverloads constructor(
     bind<WebConfig>().toInstance(config)
     bind<ActionExceptionLogLevelConfig>().toInstance(config.action_exception_log_level)
 
-    // Only install JettyService if not disabled.
     if (!config.disable_jetty) {
       install(
         ServiceModule(
@@ -150,6 +153,11 @@ class MiskWebModule @JvmOverloads constructor(
           .enhancedBy<ReadyService>()
       )
     }
+
+    // Expose WebActionsServlet for externally managed servlet container
+    bind<HttpServlet>()
+      .annotatedWith<MiskServlet>()
+      .to<WebActionsServlet>()
 
     install(ServiceModule<RepeatedTaskQueue>(ReadinessRefreshQueue::class))
 

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -217,7 +217,7 @@ data class WebConfig @JvmOverloads constructor(
    */
   val jetty_http2_max_events_per_second: Int = 128,
 
-  /** If true, disables the embedded Jetty server */
+  /** If true, disables the embedded Jetty server. */
   val disable_jetty: Boolean = false,
 ) : Config
 

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -216,6 +216,9 @@ data class WebConfig @JvmOverloads constructor(
    * See https://jetty.org/docs/jetty/10/operations-guide/modules/standard.html#http2
    */
   val jetty_http2_max_events_per_second: Int = 128,
+
+  /** If true, disables the embedded Jetty server */
+  val disable_jetty: Boolean = false,
 ) : Config
 
 data class WebSslConfig @JvmOverloads constructor(

--- a/misk/src/main/kotlin/misk/web/jetty/GenericServletUpstreamResponse.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/GenericServletUpstreamResponse.kt
@@ -1,0 +1,59 @@
+package misk.web.jetty
+
+import misk.web.ServletHttpCall
+import misk.web.actions.WebSocketListener
+import okhttp3.Headers
+import okhttp3.Headers.Companion.headersOf
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * A generic implementation of ServletHttpCall.UpstreamResponse that works with
+ * standard HttpServletResponse instead of requiring Jetty's specific Response class.
+ */
+internal class GenericServletUpstreamResponse(
+  private val response: HttpServletResponse
+) : ServletHttpCall.UpstreamResponse {
+  private var sendTrailers = false
+  private var trailers = headersOf()
+
+  override var statusCode: Int
+    get() = response.status
+    set(value) {
+      response.status = value
+    }
+
+  override val headers: Headers
+    get() = response.headers()
+
+  override fun setHeader(name: String, value: String) {
+    response.setHeader(name, value)
+  }
+
+  override fun addHeaders(headers: Headers) {
+    for (i in 0 until headers.size) {
+      response.addHeader(headers.name(i), headers.value(i))
+    }
+  }
+
+  override fun requireTrailers() {
+    sendTrailers = true
+
+    response.setTrailerFields({
+      val trailerMap = mutableMapOf<String, String>()
+      for (i in 0 until trailers.size) {
+        trailerMap[trailers.name(i)] = trailers.value(i)
+      }
+      trailerMap
+    })
+  }
+
+  override fun setTrailer(name: String, value: String) {
+    check(sendTrailers)
+    trailers = trailers.newBuilder()
+      .set(name, value)
+      .build()
+  }
+
+  override fun initWebSocketListener(webSocketListener: WebSocketListener) =
+    error("no web socket listeners for generic servlets")
+}


### PR DESCRIPTION
This allows running Misk servlet in a separately managed servlet container. 

The first commit allows us to disable JettyService from running with Misk.

The second commit exposes the Servlet as `MiskServlet` in the Guice injector, makes the underlying infrastructure work with generic servlet API, and supports mounting the servlet to a servlet path.