### PR TITLE
fix: Use TCCL to load classes

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Hibernate.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Hibernate.kt
@@ -38,11 +38,11 @@ internal val Metadata.allProperties: Multimap<Class<*>, Property>
         if (value is Component) {
           for (subProperty in value.propertyIterator) {
             if (subProperty is Property) {
-              result.put(Class.forName(value.componentClass.name), subProperty)
+              result.put(Class.forName(value.componentClass.name, false, Thread.currentThread().contextClassLoader), subProperty)
             }
           }
         } else {
-          result.put(Class.forName(entityBinding.className), property)
+          result.put(Class.forName(entityBinding.className, false, Thread.currentThread().contextClassLoader), property)
         }
       }
     }
@@ -70,7 +70,7 @@ internal fun Properties.getField(name: String): Field? {
   val declaringClassName = getProperty("${name}DeclaringClass") ?: return null
   val fieldName = getProperty("${name}Name") ?: return null
 
-  val entityClass = Class.forName(declaringClassName)
+  val entityClass = Class.forName(declaringClassName, false, Thread.currentThread().contextClassLoader)
   return entityClass.getDeclaredField(fieldName)
 }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SessionFactoryService.kt
@@ -256,7 +256,7 @@ internal class SessionFactoryService(
       "float" -> Float::class
       "double" -> Double::class
       "materialized_clob" -> String::class
-      else -> Class.forName(name).kotlin
+      else -> Class.forName(name, false, Thread.currentThread().contextClassLoader).kotlin
     }
   }
 


### PR DESCRIPTION
Using the declaring classes CL breaks hot reload as hibernates loads the wrong version of the class.
