### PR TITLE
[bug fix] Fix  `del` operation in FakeRedis.kt

### DIFF
--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -44,10 +44,11 @@ class FakeRedis : Redis {
 
   @Synchronized
   override fun del(key: String): Boolean {
-    if (!keyValueStore.containsKey(key)) {
-      return false
-    }
-    return keyValueStore.remove(key) != null
+    var deleted = false
+    if (keyValueStore.remove(key) != null) deleted = true
+    if (hKeyValueStore.remove(key) != null) deleted = true
+    if (lKeyValueStore.remove(key) != null) deleted = true
+    return deleted
   }
 
   @Synchronized

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -255,6 +255,108 @@ abstract class AbstractRedisTest {
     listOf(*keysToInsert, key3).forEach { assertNull(redis[it], "Key should have been deleted") }
   }
 
+  @Test fun deleteHashKey() {
+    val key = "hashKey"
+    val field = "field1"
+    val value = "value".encodeUtf8()
+
+    // Set hash field
+    redis.hset(key, field, value)
+    assertEquals(value, redis.hget(key, field), "Hash field should have been set")
+    assertTrue(redis.exists(key), "Hash key should exist")
+
+    // Delete hash key
+    assertTrue(redis.del(key), "Hash key should have been deleted")
+    assertNull(redis.hget(key, field), "Hash field should be gone after key deletion")
+    assertFalse(redis.exists(key), "Hash key should not exist after deletion")
+
+    // Try deleting the same key again
+    assertFalse(redis.del(key), "Should not have deleted anything")
+  }
+
+  @Test fun deleteListKey() {
+    val key = "listKey"
+    val elements = listOf("element1", "element2").map { it.encodeUtf8() }
+
+    // Push elements to list
+    redis.lpush(key, *elements.toTypedArray())
+    assertEquals(2L, redis.llen(key), "List should have 2 elements")
+    assertTrue(redis.exists(key), "List key should exist")
+
+    // Delete list key
+    assertTrue(redis.del(key), "List key should have been deleted")
+    assertEquals(0L, redis.llen(key), "List should be empty after key deletion")
+    assertFalse(redis.exists(key), "List key should not exist after deletion")
+
+    // Try deleting the same key again
+    assertFalse(redis.del(key), "Should not have deleted anything")
+  }
+
+  @Test fun deleteMixedDataTypes() {
+    val stringKey = "stringKey"
+    val hashKey = "hashKey"
+    val listKey = "listKey"
+    val nonExistentKey = "nonExistentKey"
+
+    val stringValue = "stringValue".encodeUtf8()
+    val hashField = "field1"
+    val hashValue = "hashValue".encodeUtf8()
+    val listElements = listOf("element1", "element2").map { it.encodeUtf8() }
+
+    // Set up different data types
+    redis[stringKey] = stringValue
+    redis.hset(hashKey, hashField, hashValue)
+    redis.lpush(listKey, *listElements.toTypedArray())
+
+    // Verify all keys exist
+    assertTrue(redis.exists(stringKey), "String key should exist")
+    assertTrue(redis.exists(hashKey), "Hash key should exist")
+    assertTrue(redis.exists(listKey), "List key should exist")
+    assertFalse(redis.exists(nonExistentKey), "Non-existent key should not exist")
+
+    // Delete all keys at once (including non-existent one)
+    assertEquals(3, redis.del(stringKey, hashKey, listKey, nonExistentKey),
+      "3 keys should have been deleted")
+
+    // Verify all keys are gone
+    assertFalse(redis.exists(stringKey), "String key should not exist after deletion")
+    assertFalse(redis.exists(hashKey), "Hash key should not exist after deletion")
+    assertFalse(redis.exists(listKey), "List key should not exist after deletion")
+    assertNull(redis[stringKey], "String value should be null")
+    assertNull(redis.hget(hashKey, hashField), "Hash field should be null")
+    assertEquals(0L, redis.llen(listKey), "List should be empty")
+  }
+
+  @Test fun deleteKeyFromAllDataStores() {
+    val key = "testKey"
+    val stringValue = "stringValue".encodeUtf8()
+    val hashField = "field1"
+    val hashValue = "hashValue".encodeUtf8()
+    val listElement = "listElement".encodeUtf8()
+
+    // This test verifies that del() only removes the key from the correct data store
+    // and doesn't interfere with other stores
+
+    // Test 1: Delete string key, verify hash and list operations still work on different keys
+    redis[key + "_string"] = stringValue
+    redis.hset(key + "_hash", hashField, hashValue)
+    redis.lpush(key + "_list", listElement)
+
+    assertTrue(redis.del(key + "_string"), "String key should be deleted")
+    assertFalse(redis.exists(key + "_string"), "String key should not exist")
+    assertTrue(redis.exists(key + "_hash"), "Hash key should still exist")
+    assertTrue(redis.exists(key + "_list"), "List key should still exist")
+
+    // Test 2: Delete hash key
+    assertTrue(redis.del(key + "_hash"), "Hash key should be deleted")
+    assertFalse(redis.exists(key + "_hash"), "Hash key should not exist")
+    assertTrue(redis.exists(key + "_list"), "List key should still exist")
+
+    // Test 3: Delete list key
+    assertTrue(redis.del(key + "_list"), "List key should be deleted")
+    assertFalse(redis.exists(key + "_list"), "List key should not exist")
+  }
+
   @Test fun incrOnKeyThatDoesNotExist() {
     // Setup
     val key = "does_not_exist_at_first"

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -327,36 +327,6 @@ abstract class AbstractRedisTest {
     assertEquals(0L, redis.llen(listKey), "List should be empty")
   }
 
-  @Test fun deleteKeyFromAllDataStores() {
-    val key = "testKey"
-    val stringValue = "stringValue".encodeUtf8()
-    val hashField = "field1"
-    val hashValue = "hashValue".encodeUtf8()
-    val listElement = "listElement".encodeUtf8()
-
-    // This test verifies that del() only removes the key from the correct data store
-    // and doesn't interfere with other stores
-
-    // Test 1: Delete string key, verify hash and list operations still work on different keys
-    redis[key + "_string"] = stringValue
-    redis.hset(key + "_hash", hashField, hashValue)
-    redis.lpush(key + "_list", listElement)
-
-    assertTrue(redis.del(key + "_string"), "String key should be deleted")
-    assertFalse(redis.exists(key + "_string"), "String key should not exist")
-    assertTrue(redis.exists(key + "_hash"), "Hash key should still exist")
-    assertTrue(redis.exists(key + "_list"), "List key should still exist")
-
-    // Test 2: Delete hash key
-    assertTrue(redis.del(key + "_hash"), "Hash key should be deleted")
-    assertFalse(redis.exists(key + "_hash"), "Hash key should not exist")
-    assertTrue(redis.exists(key + "_list"), "List key should still exist")
-
-    // Test 3: Delete list key
-    assertTrue(redis.del(key + "_list"), "List key should be deleted")
-    assertFalse(redis.exists(key + "_list"), "List key should not exist")
-  }
-
   @Test fun incrOnKeyThatDoesNotExist() {
     // Setup
     val key = "does_not_exist_at_first"

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -78,10 +78,12 @@ class FakeRedis @Inject constructor(
 
   @Synchronized
   override fun del(key: String): Boolean {
-    if (!keyValueStore.containsKey(key)) {
-      return false
-    }
-    return keyValueStore.remove(key) != null
+    var deleted = false
+    if (keyValueStore.remove(key) != null) deleted = true
+    if (hKeyValueStore.remove(key) != null) deleted = true
+    if (lKeyValueStore.remove(key) != null) deleted = true
+    if (sortedSetKeyValueStore.remove(key) != null) deleted = true
+    return deleted
   }
 
   @Synchronized


### PR DESCRIPTION
## Description

Fixes the bug reported in: https://github.com/cashapp/misk/issues/3411

In summary:

The FakeRedis.del() method has a bug where it only attempts to delete keys from the
keyValueStore (string store) and ignores keys that exist in other stores (lKeyValueStore,
hKeyValueStore, sortedSetKeyValueStore). This behavior does not match real Redis, where the
DEL command removes keys regardless of their data type.

## Testing Strategy

I've added the tests for all types keys in `AbstractRedisTest`.  This should propagate to the FakeRedisTest as well as all other Redis implementations. 


## Related Work
    - https://github.com/cashapp/misk/issues/3411

## Communication Plan
    - No communication needed for this one.

## Definition of Done
    - A passing test suite is sufficient

## Rollout plan
Given that this improves QOL for developers using FakeRedis to test their integrations on MiskRedis, this should just work when they upgrade the misk dependency. The [documentation](https://dev-guides.sqprod.co/cash/docs/develop/storage/elasticache/client#:~:text=install(RedisTestModule())) is already aligned with this change.


## Checklist

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
