### PR TITLE
Fix edge-case issue with `RetryingTransacter`

### DIFF
--- a/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt
+++ b/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt
@@ -51,53 +51,51 @@ abstract class RetryingTransacter @JvmOverloads constructor(
       inTransaction.set(true)
     }
 
-    val backoff = ExponentialBackoff(
-      Duration.ofMillis(options.minRetryDelayMillis),
-      Duration.ofMillis(options.maxRetryDelayMillis),
-      Duration.ofMillis(options.retryJitterMillis)
-    )
-    var attempt = 0
-    while (true) {
-      try {
-        attempt++
-        val result = work()
+    try {
+      val backoff = ExponentialBackoff(
+        Duration.ofMillis(options.minRetryDelayMillis),
+        Duration.ofMillis(options.maxRetryDelayMillis),
+        Duration.ofMillis(options.retryJitterMillis)
+      )
+      var attempt = 0
+      while (true) {
+        try {
+          attempt++
+          val result = work()
 
-        if (attempt > 1) {
-          logger.info {
-            "retried transaction succeeded (attempt $attempt)"
+          if (attempt > 1) {
+            logger.info {
+              "retried transaction succeeded (attempt $attempt)"
+            }
           }
-        }
 
-        if (outermostTransaction) {
-          inTransaction.set(false)
-        }
+          return result
+        } catch (e: Exception) {
+          if (!(isRetryable(e) && outermostTransaction)) throw e
 
-        return result
-      } catch (e: Exception) {
-        if (!(isRetryable(e) && outermostTransaction)) throw e
+          if (attempt >= options.maxAttempts) {
+            logger.info {
+              "recoverable transaction exception " +
+                "(attempt $attempt), no more attempts"
+            }
 
-        if (attempt >= options.maxAttempts) {
-          logger.info {
+            throw e
+          }
+
+          val sleepDuration = backoff.nextRetry()
+          logger.info(e) {
             "recoverable transaction exception " +
-              "(attempt $attempt), no more attempts"
+              "(attempt $attempt), will retry after a $sleepDuration delay"
           }
 
-          if (outermostTransaction) {
-            inTransaction.set(false)
+          if (!sleepDuration.isZero) {
+            Thread.sleep(sleepDuration.toMillis())
           }
-
-          throw e
         }
-
-        val sleepDuration = backoff.nextRetry()
-        logger.info(e) {
-          "recoverable transaction exception " +
-            "(attempt $attempt), will retry after a $sleepDuration delay"
-        }
-
-        if (!sleepDuration.isZero) {
-          Thread.sleep(sleepDuration.toMillis())
-        }
+      }
+    } finally {
+      if (outermostTransaction) {
+        inTransaction.set(false)
       }
     }
   }


### PR DESCRIPTION
I was pairing with @frojasg to investigate a rare issue where our application had failed to retry a database query run within a `RetryingTransacter` that threw a `OptimisticLockException`, in a situation where it normally would retry. We determined that the transacter was not retrying due to the `outermostTransaction` flag being false [when checked here](https://github.com/cashapp/misk/blob/master/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt#L77), causing an immediate re-throw of the exception - however, this was the outer-most transaction.

We determined the root cause was that the `inTransaction` thread-local flag had not been reset properly by a previous database call using the `RetryingTransacter` on the same thread. There are a number of exit paths out of the primary `while` loop in the `retryWithWork` function, and the flag is reset correctly both [when a successful result is returned](https://github.com/cashapp/misk/blob/master/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt#L71-L75) and also [when the maximum attempts have been exceeded](https://github.com/cashapp/misk/blob/master/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt#L85-L89) and the final exception re-thrown. However, the flag is not reset correctly if a non-retryable error occurs during the outermost transaction - instead [the exception is immediately thrown](https://github.com/cashapp/misk/blob/master/misk-sqldelight/src/main/kotlin/misk/sqldelight/RetryingTransacter.kt#L77) and the flag is left in the `true` state.

Our hypothesis is that the transaction that resulted in the `OptimisticLockException` was immediately preceded by another transaction that threw a non-retryable exception - resulting in the `inTransaction` flag being set `true` at the beginning of the second transaction, and therefore skipping its retry behavior.

This change hoists the flag cleanup out of the discrete code paths into a `finally` clause, ensuring that it gets run in any event, whether a result is returned or an exception is thrown.

This change is easiest to review with whitespace changes disabled, due to indentation changes:
https://github.com/cashapp/misk/pull/3456/files?w=1