### PR TITLE
feat: add UrlMatcher to inspect if the Misk Application has a handler for a given URL

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1532,6 +1532,10 @@ public final class misk/web/SocketAddress$Unix : misk/web/SocketAddress {
 	public final fun getPath ()Ljava/lang/String;
 }
 
+public abstract interface class misk/web/UrlMatcher {
+	public abstract fun hasBoundAction (Ljava/lang/String;)Z
+}
+
 public abstract interface class misk/web/WebActionSeedDataTransformerFactory {
 	public abstract fun create (Lmisk/web/PathPattern;Lmisk/Action;)Lmisk/scope/SeedDataTransformer;
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -159,6 +159,8 @@ class MiskWebModule @JvmOverloads constructor(
       .annotatedWith<MiskServlet>()
       .to<WebActionsServlet>()
 
+    bind<UrlMatcher>().to<RealUrlMatcher>()
+
     install(ServiceModule<RepeatedTaskQueue>(ReadinessRefreshQueue::class))
 
     // Install support for accessing the current request and caller as ActionScoped types

--- a/misk/src/main/kotlin/misk/web/UrlMatcher.kt
+++ b/misk/src/main/kotlin/misk/web/UrlMatcher.kt
@@ -1,0 +1,38 @@
+package misk.web
+
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.web.actions.NotFoundAction
+import misk.web.jetty.WebActionsServlet
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+/**
+ * Provides a way to check if a URL has a bound action in the application.
+ */
+interface UrlMatcher {
+  /**
+   * Returns true if there is at least one bound action that can handle the given URL.
+   *
+   * @param url The URL to check (e.g., "http://example.com/api/users" or "https://example.com/api/users/123")
+   * @return true if a bound action exists for this URL's path, false otherwise
+   */
+  fun hasBoundAction(url: String): Boolean
+}
+
+@Singleton
+internal class RealUrlMatcher @Inject constructor(
+  private val webActionsServlet: WebActionsServlet
+) : UrlMatcher {
+
+  override fun hasBoundAction(url: String): Boolean {
+    val httpUrl = url.toHttpUrl()
+
+    return webActionsServlet.boundActions.any { boundAction ->
+      val match = boundAction.matchByUrl(httpUrl)
+      val actionClass = boundAction.action.functionAsJavaMethod?.declaringClass
+      val isNotFoundAction = actionClass == NotFoundAction::class.java
+
+      match != null && !isNotFoundAction
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/UrlMatcherTest.kt
+++ b/misk/src/test/kotlin/misk/web/UrlMatcherTest.kt
@@ -1,0 +1,78 @@
+package misk.web
+
+import jakarta.inject.Inject
+import misk.MiskTestingServiceModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import misk.inject.KAbstractModule
+import misk.web.mediatype.MediaTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+internal class UrlMatcherTest {
+  @MiskTestModule
+  val module = TestModule()
+
+  @Inject
+  lateinit var urlMatcher: UrlMatcher
+
+  @Test
+  fun matchesExistingStaticPath() {
+    assertThat(urlMatcher.hasBoundAction("http://example.com/hello")).isTrue()
+  }
+
+  @Test
+  fun matchesExistingPathWithParameter() {
+    assertThat(urlMatcher.hasBoundAction("http://example.com/user/123")).isTrue()
+    assertThat(urlMatcher.hasBoundAction("http://example.com/user/abc")).isTrue()
+  }
+
+  @Test
+  fun doesNotMatchNonExistentPath() {
+    assertThat(urlMatcher.hasBoundAction("http://example.com/does/not/exist")).isFalse()
+  }
+
+  @Test
+  fun doesNotMatchPartialPath() {
+    assertThat(urlMatcher.hasBoundAction("http://example.com/use")).isFalse()
+  }
+
+  @Test
+  fun handlesPathsWithQueryParameters() {
+    // Query parameters should be ignored, only path matters
+    assertThat(urlMatcher.hasBoundAction("http://example.com/hello?foo=bar")).isTrue()
+  }
+
+  @Test
+  fun handlesHttpsUrls() {
+    assertThat(urlMatcher.hasBoundAction("https://example.com/hello")).isTrue()
+  }
+
+  @Test
+  fun handlesDifferentHosts() {
+    assertThat(urlMatcher.hasBoundAction("http://different-host.com/hello")).isTrue()
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<HelloAction>())
+      install(WebActionModule.create<UserAction>())
+    }
+  }
+
+  class HelloAction @Inject constructor() : WebAction {
+    @Get("/hello")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun hello() = "hello"
+  }
+
+  class UserAction @Inject constructor() : WebAction {
+    @Get("/user/{id}")
+    @ResponseContentType(MediaTypes.APPLICATION_JSON)
+    fun getUser(@PathParam("id") id: String) = "user $id"
+  }
+}


### PR DESCRIPTION

This will be useful if embedding Misk to external servlets with fallbacks, as we can determine if the given request would be handled by Misk before actually executing it

<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

<!-- Why is your change necessary? What does it solve? -->

## Testing Strategy

<!-- How did you test your solution? -->

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have added tests to have confidence my changes work as expected.
- [ ] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
