### PR TITLE
Adds support for local.settings.gradle.kts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ docs/changelog.md
 docs/contributing.md
 docs/releasing.md
 docs/wisp/**
+.goose
+local.settings.gradle.kts

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -150,3 +150,10 @@ include(":misk-vitess")
 include(":misk-vitess-database-gradle-plugin")
 include(":samples:exemplar")
 include(":samples:exemplarchat")
+
+val localSettings = file("local.settings.gradle.kts")
+if (localSettings.exists()) {
+  logger.lifecycle("Applying local settings at ${localSettings.absolutePath}")
+  apply(from = localSettings)
+}
+


### PR DESCRIPTION
{public}Adds support for local.settings.gradle.kts{/public}

## Description

Adds support for including a local.settings.gradle.kts file in top level project settings.gradle.kts. This file is ignored by git and primarily used for local settings or for including dependencies as a composite build. 


- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
