### PR TITLE
Redis to support parallel tests by using different DBs per test process

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -685,6 +685,11 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 public abstract interface annotation class misk/redis/testing/ForFakeRedis : java/lang/annotation/Annotation {
 }
 
+public final class misk/redis/testing/RealRedisTestModule : misk/inject/KAbstractModule {
+	public fun <init> (Lmisk/redis/RedisReplicationGroupConfig;Lredis/clients/jedis/ConnectionPoolConfig;Z)V
+	public synthetic fun <init> (Lmisk/redis/RedisReplicationGroupConfig;Lredis/clients/jedis/ConnectionPoolConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class misk/redis/testing/RedisFlushService : com/google/common/util/concurrent/AbstractIdleService, misk/testing/TestFixture {
 	public static final field Companion Lmisk/redis/testing/RedisFlushService$Companion;
 	public fun <init> ()V

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RealRedisTestModule.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RealRedisTestModule.kt
@@ -1,0 +1,52 @@
+package misk.redis.testing
+
+import com.google.inject.Provides
+import com.google.inject.util.Modules
+import jakarta.inject.Singleton
+import misk.inject.KAbstractModule
+import misk.redis.JedisPooledWithMetrics
+import misk.redis.RedisClientMetrics
+import misk.redis.RedisModule
+import misk.redis.RedisReplicationGroupConfig
+import misk.testing.parallelTestIndex
+import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.UnifiedJedis
+import wisp.deployment.Deployment
+
+/**
+ * Installs a real redis for testing with support for parallel tests.
+ */
+class RealRedisTestModule(
+  private val redisReplicationGroupConfig: RedisReplicationGroupConfig,
+  private val connectionPoolConfig: ConnectionPoolConfig,
+  private val useSsl: Boolean = false,
+) : KAbstractModule() {
+  override fun configure() {
+    install(
+      Modules.override(
+        RedisModule(redisReplicationGroupConfig, connectionPoolConfig, useSsl)
+      ).with(TestUnifiedJedisModule(connectionPoolConfig, useSsl))
+    )
+  }
+}
+
+private class TestUnifiedJedisModule(
+  private val connectionPoolConfig: ConnectionPoolConfig,
+  private val useSsl: Boolean = true,
+) : KAbstractModule() {
+  @Provides @Singleton
+  internal fun provideUnifiedJedis(
+    clientMetrics: RedisClientMetrics,
+    redisReplicationGroupConfig: RedisReplicationGroupConfig,
+  ): UnifiedJedis {
+    val database = parallelTestIndex()
+    return JedisPooledWithMetrics(
+      metrics = clientMetrics,
+      poolConfig = connectionPoolConfig,
+      replicationGroupConfig = redisReplicationGroupConfig,
+      ssl = useSsl,
+      requiresPassword = false,
+      database = database
+    )
+  }
+}

--- a/misk-testing/api/misk-testing.api
+++ b/misk-testing/api/misk-testing.api
@@ -291,6 +291,7 @@ public final class misk/testing/MockTracingBackendModule : misk/inject/KAbstract
 }
 
 public final class misk/testing/ParallelTestsKt {
+	public static final fun parallelTestIndex ()Ljava/lang/Integer;
 	public static final fun updateForParallelTests (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 

--- a/misk-testing/src/main/kotlin/misk/testing/ParallelTests.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/ParallelTests.kt
@@ -38,13 +38,14 @@ internal sealed interface PartitionedTest {
  *
  * This assumes that the environment variable `MAX_TEST_PARALLEL_FORKS` is set to the number of `maxParallelForks`.
  */
-fun <T> T.updateForParallelTests(update: (T, Int) -> T): T {
+fun <T> T.updateForParallelTests(update: (T, Int) -> T): T = parallelTestIndex()?.let { update(this, it) } ?: this
+
+fun parallelTestIndex(): Int? {
   return when (val partitionedTest = ParallelTests.isPartitioned()) {
     is PartitionedTest.Partitioned -> {
-      update(this, partitionedTest.partitionId)
+      partitionedTest.partitionId
     }
 
-    is PartitionedTest.NotPartitioned -> this
+    is PartitionedTest.NotPartitioned -> null
   }
 }
-


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

There is the existing support for running misk tests in parallel processes for faster build times, with isolation across processes for MySQL and DynamoDB (the former using separate DB schemas and the latter using namespaced table names). This PR adds support for another external data source used commonly in Misk services, namely Redis. This implementation uses different Redis databases, which Redis (in the non-cluster mode) supports ranging from 0 to 15.    

## Checklist

- [x] I have reviewed this PR with relevant experts and/or impacted teams.

Thank you for contributing to Misk! 🎉
