### PR TITLE
Flush only the current DB when resetting redis between tests

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -74,6 +74,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun flushAll ()V
+	public fun flushDB ()V
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
 	public final fun getClock ()Ljava/time/Clock;
 	public fun getDel (Ljava/lang/String;)Lokio/ByteString;
@@ -148,6 +149,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun flushAll ()V
+	public fun flushDB ()V
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
 	public fun getDel (Ljava/lang/String;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
@@ -217,6 +219,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun expire (Ljava/lang/String;J)Z
 	public abstract fun expireAt (Ljava/lang/String;J)Z
 	public abstract fun flushAll ()V
+	public abstract fun flushDB ()V
 	public abstract fun get (Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun getDel (Ljava/lang/String;)Lokio/ByteString;
 	public abstract fun hdel (Ljava/lang/String;[Ljava/lang/String;)J
@@ -573,6 +576,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis, misk/testing
 	public fun expire (Ljava/lang/String;J)Z
 	public fun expireAt (Ljava/lang/String;J)Z
 	public fun flushAll ()V
+	public fun flushDB ()V
 	public fun get (Ljava/lang/String;)Lokio/ByteString;
 	public fun getDel (Ljava/lang/String;)Lokio/ByteString;
 	public fun hdel (Ljava/lang/String;[Ljava/lang/String;)J

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -516,6 +516,10 @@ class FakeRedis : Redis {
     lKeyValueStore.clear()
   }
 
+  override fun flushDB() {
+    flushAll()
+  }
+
   override fun zadd(
     key: String,
     score: Double,

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -454,6 +454,10 @@ class RealRedis(
     unifiedJedis.flushAllWithClusterSupport(logger)
   }
 
+  override fun flushDB() {
+    unifiedJedis.flushDB()
+  }
+
   override fun zadd(
     key: String,
     score: Double,

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -568,6 +568,11 @@ interface Redis {
   fun flushAll()
 
   /**
+   * Flushes the current database only.
+   */
+  fun flushDB()
+
+  /**
    * Adds the specified [member] with the specified [score] to the sorted set at the [key].
    * If a specified [member] is already a member of the sorted set, the [score] is updated and the
    * element reinserted at the right position to ensure the correct ordering.

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -195,6 +195,10 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(
     unifiedJedis.flushAllWithClusterSupport(logger)
   }
 
+  override fun flushDB() {
+    unifiedJedis.flushDB()
+  }
+
   override fun zadd(
     key: String,
     score: Double,

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -828,6 +828,10 @@ class FakeRedis @Inject constructor(
     keyValueStore.clear()
   }
 
+  override fun flushDB() {
+    flushAll()
+  }
+
   private fun zaddInternal(
     key: String,
     score: Double,

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RealRedisTestModule.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RealRedisTestModule.kt
@@ -27,6 +27,7 @@ class RealRedisTestModule(
         RedisModule(redisReplicationGroupConfig, connectionPoolConfig, useSsl)
       ).with(TestUnifiedJedisModule(connectionPoolConfig, useSsl))
     )
+    install(RedisTestFlushModule())
   }
 }
 

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RedisFlushService.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/RedisFlushService.kt
@@ -4,9 +4,9 @@ import com.google.common.util.concurrent.AbstractIdleService
 import jakarta.inject.Inject
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
+import misk.logging.getLogger
 import misk.redis.Redis
 import misk.testing.TestFixture
-import misk.logging.getLogger
 
 /**
  * Flushes all Redis databases on startup.
@@ -20,19 +20,18 @@ class RedisFlushService @Inject constructor() : AbstractIdleService(), TestFixtu
   private val redis by lazy { redisProvider.get() }
 
   override fun startUp() {
-    flushAll()
+    flush()
   }
 
   override fun shutDown() {}
 
   override fun reset() {
-    flushAll()
+    flush()
   }
 
-  private fun flushAll() {
+  private fun flush() {
     logger.info("Flushing Redis")
-    redis.flushAll()
-    logger.info("Flushed Redis")
+    redis.flushDB()
   }
 
   companion object {


### PR DESCRIPTION
## Description

[This previous PR](https://github.com/cashapp/misk/pull/3463) which added support for using Redis in parallel tests, caused some flakiness in tests I believe due to the current implementation for resetting Redis in between tests, using `flushAll` which flushes all DBs. Switching to `flushDB` instead in this PR which should address the flakiness by flushing data only from the database the current unified jedis client is conneced to.

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
