### PR TITLE
chore: set env var when running continous compilation

### DIFF
--- a/misk/src/main/kotlin/misk/dev/Gradle.kt
+++ b/misk/src/main/kotlin/misk/dev/Gradle.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 fun runGradleAsyncCompile(projectDir : String, compilationComplete: () -> Unit, additionalGradleArgs: List<String>) {
   val t = Thread {
     val pb = ProcessBuilder(listOf("gradle", "classes", "--continuous") + additionalGradleArgs)
+    pb.environment().put("MISK_HOT_RELOAD", "true")
     pb.directory(File(projectDir))
 
     val first = AtomicBoolean(false)


### PR DESCRIPTION
This will allow for things like disabling automatic formatting when running continuously, as this is very annoying.
