### PR TITLE
Move to interface for AsyncModule instead

### DIFF
--- a/misk-inject/api/misk-inject.api
+++ b/misk-inject/api/misk-inject.api
@@ -3,6 +3,14 @@ public class misk/inject/AsyncKAbstractModule : misk/inject/KAbstractModule {
 	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
 }
 
+public abstract interface class misk/inject/AsyncModule {
+	public abstract fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
+}
+
+public final class misk/inject/AsyncModule$DefaultImpls {
+	public static fun moduleWhenAsyncDisabled (Lmisk/inject/AsyncModule;)Lmisk/inject/KAbstractModule;
+}
+
 public final class misk/inject/GuiceKt {
 	public static final fun asSingleton (Lcom/google/inject/binder/ScopedBindingBuilder;)V
 	public static final fun getSetOf (Lcom/google/inject/Injector;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Ljava/util/Set;

--- a/misk-inject/src/main/kotlin/misk/inject/AsyncKAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/AsyncKAbstractModule.kt
@@ -9,6 +9,9 @@ import misk.annotation.ExperimentalMiskApi
  * At service build time, these modules can be optionally filtered out before the Guice injector is created,
  * in cases where async processing is not desired, such as in separated main and jobs deployments.
  */
+@Deprecated(
+  message = "Extend both AsyncModule interface and KAbstractModule() or KInstallOnceModule() directly.",
+)
 open class AsyncKAbstractModule : KAbstractModule() {
   /**
    * Returns a module that would be installed when async tasks are disabled.
@@ -17,4 +20,16 @@ open class AsyncKAbstractModule : KAbstractModule() {
    */
   @ExperimentalMiskApi
   open fun moduleWhenAsyncDisabled(): KAbstractModule? = null
+}
+
+/**
+ * This class should be extended by modules that want to contribute tasks to which involve async processing.
+ * For example, background jobs, job queues, eventing, message pub/sub.
+ *
+ * At service build time, these modules can be optionally filtered out before the Guice injector is created,
+ * in cases where async processing is not desired, such as in separated main and jobs deployments.
+ */
+interface AsyncModule {
+  @ExperimentalMiskApi
+  fun moduleWhenAsyncDisabled(): KAbstractModule? = null
 }


### PR DESCRIPTION
This allows it to be added to either KAbstractModule or KInstallOnceModule like so:

```kotlin
class MyModule: AsyncModule, KAbstractModule() {
  override fun configure() { ... }
  override fun moduleWhenAsyncDisabled() { ... }
}
```

