### PR TITLE
Deprecated AsyncKAbstractModule implements AsyncModule

### DIFF
--- a/misk-inject/api/misk-inject.api
+++ b/misk-inject/api/misk-inject.api
@@ -1,4 +1,4 @@
-public class misk/inject/AsyncKAbstractModule : misk/inject/KAbstractModule {
+public class misk/inject/AsyncKAbstractModule : misk/inject/KAbstractModule, misk/inject/AsyncModule {
 	public fun <init> ()V
 	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
 }

--- a/misk-inject/src/main/kotlin/misk/inject/AsyncKAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/AsyncKAbstractModule.kt
@@ -12,14 +12,14 @@ import misk.annotation.ExperimentalMiskApi
 @Deprecated(
   message = "Extend both AsyncModule interface and KAbstractModule() or KInstallOnceModule() directly.",
 )
-open class AsyncKAbstractModule : KAbstractModule() {
+open class AsyncKAbstractModule : AsyncModule, KAbstractModule() {
   /**
    * Returns a module that would be installed when async tasks are disabled.
    * By default, this is a module that calls [configureWhenAsyncDisabled].
    * Subclasses can override this method to provide a different module if needed.
    */
   @ExperimentalMiskApi
-  open fun moduleWhenAsyncDisabled(): KAbstractModule? = null
+  override fun moduleWhenAsyncDisabled(): KAbstractModule? = null
 }
 
 /**


### PR DESCRIPTION
Now downstream filtering callsites can be updated to only handle AsyncModule interface matches allowing easier deprecation.