### PR TITLE
Always wire ExecutorService for @ForSqsHandling and @ForSqsReceiving

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -39,24 +39,6 @@ open class AwsSqsJobQueueModule(
     install(CommonModule(config, ::configureSyncClient, ::configureAsyncClient))
 
     install(ServiceModule(keyOf<RepeatedTaskQueue>(ForSqsHandling::class)).dependsOn<ReadyService>())
-
-    // We use an unbounded thread pool for the number of consumers, as we want to process
-    // the messages received as fast a possible.
-    install(
-      ExecutorServiceModule.withUnboundThreadPool(
-        ForSqsHandling::class,
-        "sqs-consumer-%d",
-      ),
-    )
-
-    // We use an unbounded thread pool for number of receivers, as this will be controlled dynamically
-    // using a feature flag.
-    install(
-      ExecutorServiceModule.withUnboundThreadPool(
-        ForSqsReceiving::class,
-        "sqs-receiver-%d",
-      ),
-    )
   }
 
   @OptIn(ExperimentalMiskApi::class)
@@ -86,6 +68,24 @@ open class AwsSqsJobQueueModule(
       bind<JobConsumer>().to<SqsJobConsumer>()
       bind<JobQueue>().to<SqsJobQueue>()
       bind<TransactionalJobQueue>().to<SqsTransactionalJobQueue>()
+
+      // We use an unbounded thread pool for the number of consumers, as we want to process
+      // the messages received as fast a possible.
+      install(
+        ExecutorServiceModule.withUnboundThreadPool(
+          ForSqsHandling::class,
+          "sqs-consumer-%d",
+        ),
+      )
+
+      // We use an unbounded thread pool for number of receivers, as this will be controlled dynamically
+      // using a feature flag.
+      install(
+        ExecutorServiceModule.withUnboundThreadPool(
+          ForSqsReceiving::class,
+          "sqs-receiver-%d",
+        ),
+      )
 
       // Bind a map of AmazonSQS clients for each external region that we need to contact
       val regionSpecificClientBinder = newMapBinder<AwsRegion, AmazonSQS>()


### PR DESCRIPTION
The dependencies are needed for other objects that are being installed like SqsJobConsumer

<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

SqsJobConsumer is triggering some initialization issues when installed exercising the AyncMode 


## Related Work
    - https://github.com/cashapp/misk/pull/3479 

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
