### PR TITLE
return the result without unnecessary overhead of supplyAsync

### DIFF
--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobEnqueuer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobEnqueuer.kt
@@ -14,7 +14,6 @@ import misk.jobqueue.sqs.parentQueue
 import misk.jobqueue.v2.JobEnqueuer
 import misk.moshi.adapter
 import misk.tokens.TokenGenerator
-import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import java.time.Clock
@@ -71,7 +70,7 @@ class SqsJobEnqueuer @Inject constructor(
           sqsMetrics.sqsSendTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
           span.finish()
           scope.close()
-        }.thenCompose { CompletableFuture.supplyAsync { true } }
+        }.thenApply { true }
       } catch (e: Exception) {
         sqsMetrics.jobEnqueueFailures.labels(queueName.value).inc()
         throw e


### PR DESCRIPTION

## Description

Noticing this while working on this file.
.thenApply { true } does the same as before, but without the overhead of creating a new CompletableFuture<Boolean> by .supplyAsync().

## Testing Strategy

Regression test


## Rollout Strategy and Risk Mitigation
The code does not change the behavior, just a bit more efficient

## Checklist

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.

Thank you for contributing to Misk! 🎉
