### PR TITLE
fix: remove unnecessary dependency override

### DIFF
--- a/misk-aws-dynamodb/build.gradle.kts
+++ b/misk-aws-dynamodb/build.gradle.kts
@@ -36,13 +36,6 @@ dependencies {
   testImplementation(libs.assertj)
   testImplementation(libs.junitApi)
 
-  if (org.apache.tools.ant.taskdefs.condition.Os.isArch("aarch64")) {
-    // Without this, we can't compile on Apple Silicon currently.
-    // This is likely not necessary to have long term,
-    // so we should remove it when things get fixed upstream.
-    testImplementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-  }
-
   testImplementation(libs.kotlinReflect)
   testImplementation(libs.tempestTesting)
   testImplementation(libs.tempestTestingDocker)


### PR DESCRIPTION
## Description

Tempest no longer requires these overrides for running DynamoDBLocal