### PR TITLE
feat: add support for binding multiple DynamoDB modules via qualifiers

### DIFF
--- a/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
+++ b/misk-aws2-dynamodb/api/misk-aws2-dynamodb.api
@@ -3,6 +3,11 @@ public abstract interface class misk/aws2/dynamodb/DynamoDbService : com/google/
 
 public class misk/aws2/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;)V
 	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;)V
 	public fun <init> (Lsoftware/amazon/awssdk/core/client/config/ClientOverrideConfiguration;Ljava/util/List;Ljava/net/URI;)V
@@ -10,12 +15,11 @@ public class misk/aws2/dynamodb/RealDynamoDbModule : misk/inject/KAbstractModule
 	protected fun configure ()V
 	public fun configureClient (Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClientBuilder;)V
 	public fun configureClient (Lsoftware/amazon/awssdk/services/dynamodb/streams/DynamoDbStreamsClientBuilder;)V
-	public final fun provideRequiredTables ()Ljava/util/List;
-	public final fun providesDynamoDbClient (Lmisk/cloud/aws/AwsRegion;Lsoftware/amazon/awssdk/auth/credentials/AwsCredentialsProvider;)Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClient;
-	public final fun providesDynamoDbStreamsClient (Lmisk/cloud/aws/AwsRegion;Lsoftware/amazon/awssdk/auth/credentials/AwsCredentialsProvider;)Lsoftware/amazon/awssdk/services/dynamodb/streams/DynamoDbStreamsClient;
 }
 
 public final class misk/aws2/dynamodb/RealDynamoDbService : com/google/common/util/concurrent/AbstractIdleService, misk/aws2/dynamodb/DynamoDbService {
+	public fun <init> (Lcom/google/inject/Injector;Ljava/util/List;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Lcom/google/inject/Injector;Ljava/util/List;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClient;Ljava/util/List;)V
 }
 
@@ -44,11 +48,8 @@ public final class misk/aws2/dynamodb/TableNameMapperKt {
 
 public final class misk/aws2/dynamodb/testing/DockerDynamoDbModule : misk/inject/KAbstractModule {
 	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Lkotlin/reflect/KClass;Ljava/util/List;)V
 	public fun <init> ([Lmisk/aws2/dynamodb/testing/DynamoDbTable;)V
-	public final fun provideRequiredTables ()Ljava/util/List;
-	public final fun providesAmazonDynamoDB (Lmisk/aws2/dynamodb/testing/TestDynamoDb;)Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClient;
-	public final fun providesAmazonDynamoDBStreams (Lmisk/aws2/dynamodb/testing/TestDynamoDb;)Lsoftware/amazon/awssdk/services/dynamodb/streams/DynamoDbStreamsClient;
-	public final fun providesTestDynamoDb ()Lmisk/aws2/dynamodb/testing/TestDynamoDb;
 }
 
 public final class misk/aws2/dynamodb/testing/DynamoDbTable {
@@ -79,11 +80,8 @@ public final class misk/aws2/dynamodb/testing/ExternalTestDynamoDbClientModule :
 
 public final class misk/aws2/dynamodb/testing/InProcessDynamoDbModule : misk/inject/KAbstractModule {
 	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Lkotlin/reflect/KClass;Ljava/util/List;)V
 	public fun <init> ([Lmisk/aws2/dynamodb/testing/DynamoDbTable;)V
-	public final fun provideRequiredTables ()Ljava/util/List;
-	public final fun providesAmazonDynamoDB (Lmisk/aws2/dynamodb/testing/TestDynamoDb;)Lsoftware/amazon/awssdk/services/dynamodb/DynamoDbClient;
-	public final fun providesAmazonDynamoDBStreams (Lmisk/aws2/dynamodb/testing/TestDynamoDb;)Lsoftware/amazon/awssdk/services/dynamodb/streams/DynamoDbStreamsClient;
-	public final fun providesTestDynamoDb ()Lmisk/aws2/dynamodb/testing/TestDynamoDb;
 }
 
 public final class misk/aws2/dynamodb/testing/ParallelTestsTableNameMapper : misk/aws2/dynamodb/TableNameMapper {

--- a/misk-aws2-dynamodb/build.gradle.kts
+++ b/misk-aws2-dynamodb/build.gradle.kts
@@ -10,15 +10,15 @@ plugins {
 dependencies {
   api(libs.aws2Dynamodb)
   api(libs.aws2DynamodbEnhanced)
-  api(libs.aws2Auth)
   api(libs.awsSdkCore)
   api(libs.guava)
   api(libs.guice6)
   api(libs.jakartaInject)
-  api(project(":misk-aws"))
   api(project(":misk-inject"))
+  implementation(libs.aws2Auth)
   implementation(libs.aws2Core)
   implementation(libs.aws2Regions)
+  implementation(project(":misk-aws"))
   implementation(project(":misk-exceptions-dynamodb"))
   implementation(project(":misk-service"))
 

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -1,12 +1,15 @@
 package misk.aws2.dynamodb
 
-import com.google.inject.Provides
-import jakarta.inject.Singleton
+import com.google.inject.Injector
+import com.google.inject.Provider
+import jakarta.inject.Inject
 import misk.ReadyService
 import misk.ServiceModule
 import misk.cloud.aws.AwsRegion
 import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.inject.keyOf
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.regions.Region
@@ -15,27 +18,78 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClientBuilder
 import java.net.URI
+import kotlin.reflect.KClass
 
 /**
  * Install this module to have access to a DynamoDbClient.
+ *
+ * This module supports multiple installations with different qualifiers:
+ * ```
+ * install(RealDynamoDbModule(
+ *   qualifier = PrimaryDynamoDb::class,
+ *   clientOverrideConfig = primaryConfig
+ * ))
+ * install(RealDynamoDbModule(
+ *   qualifier = SecondaryDynamoDb::class,
+ *   clientOverrideConfig = secondaryConfig
+ * ))
+ *
+ * // Usage:
+ * class MyService @Inject constructor(
+ *   @PrimaryDynamoDb val primaryDb: DynamoDbClient,
+ *   @SecondaryDynamoDb val secondaryDb: DynamoDbClient
+ * )
+ * ```
  */
-open class RealDynamoDbModule @JvmOverloads constructor(
-  private val clientOverrideConfig: ClientOverrideConfiguration =
-    ClientOverrideConfiguration.builder().build(),
+open class RealDynamoDbModule
+@JvmOverloads constructor(
+  private val qualifier: KClass<out Annotation>? = null,
+  private val clientOverrideConfig: ClientOverrideConfiguration = ClientOverrideConfiguration.builder().build(),
   private val requiredTables: List<RequiredDynamoDbTable> = listOf(),
   private val endpointOverride: URI? = null,
 ) : KAbstractModule() {
+  // Backward-compatible constructor (unqualified)
+  @JvmOverloads
+  constructor(
+    clientOverrideConfig: ClientOverrideConfiguration,
+    requiredTables: List<RequiredDynamoDbTable> = listOf(),
+    endpointOverride: URI? = null,
+  ) : this(null, clientOverrideConfig, requiredTables, endpointOverride)
+
   override fun configure() {
     requireBinding<AwsCredentialsProvider>()
     requireBinding<AwsRegion>()
-    bind<DynamoDbService>().to<RealDynamoDbService>()
-    install(ServiceModule<DynamoDbService>().enhancedBy<ReadyService>())
+
+    bind(keyOf<DynamoDbClient>(qualifier)).toProvider(object : Provider<DynamoDbClient> {
+      @Inject lateinit var awsRegion: AwsRegion
+      @Inject lateinit var awsCredentialsProvider: AwsCredentialsProvider
+      override fun get(): DynamoDbClient = createDynamoDbClient(awsRegion, awsCredentialsProvider)
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbStreamsClient>(qualifier)).toProvider(object : Provider<DynamoDbStreamsClient> {
+      @Inject lateinit var awsRegion: AwsRegion
+      @Inject lateinit var awsCredentialsProvider: AwsCredentialsProvider
+      override fun get(): DynamoDbStreamsClient = createDynamoDbStreamsClient(awsRegion, awsCredentialsProvider)
+    }).asSingleton()
+
+    bind(keyOf<List<RequiredDynamoDbTable>>(qualifier)).toInstance(requiredTables)
+
+    bind(keyOf<RealDynamoDbService>(qualifier)).toProvider(object : Provider<RealDynamoDbService> {
+      @Inject lateinit var injector: Injector
+      override fun get(): RealDynamoDbService = RealDynamoDbService(
+        injector = injector,
+        requiredTables = requiredTables,
+        qualifier = qualifier
+      )
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbService>(qualifier)).to(keyOf<RealDynamoDbService>(qualifier))
+    install(ServiceModule<DynamoDbService>(qualifier).enhancedBy<ReadyService>())
+
     install(DynamoDbExceptionMapperModule())
   }
 
-  @Provides
-  @Singleton
-  fun providesDynamoDbClient(
+  private fun createDynamoDbClient(
     awsRegion: AwsRegion,
     awsCredentialsProvider: AwsCredentialsProvider,
   ): DynamoDbClient {
@@ -50,9 +104,7 @@ open class RealDynamoDbModule @JvmOverloads constructor(
     return builder.build()
   }
 
-  @Provides
-  @Singleton
-  fun providesDynamoDbStreamsClient(
+  private fun createDynamoDbStreamsClient(
     awsRegion: AwsRegion,
     awsCredentialsProvider: AwsCredentialsProvider,
   ): DynamoDbStreamsClient {
@@ -69,8 +121,4 @@ open class RealDynamoDbModule @JvmOverloads constructor(
 
   open fun configureClient(builder: DynamoDbClientBuilder) {}
   open fun configureClient(builder: DynamoDbStreamsClientBuilder) {}
-
-  @Provides
-  @Singleton
-  fun provideRequiredTables(): List<RequiredDynamoDbTable> = requiredTables
 }

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbService.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbService.kt
@@ -1,16 +1,38 @@
 package misk.aws2.dynamodb
 
 import com.google.common.util.concurrent.AbstractIdleService
+import com.google.inject.Injector
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.inject.keyOf
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest
+import kotlin.reflect.KClass
 
 @Singleton
-class RealDynamoDbService @Inject constructor(
-  private val dynamoDb: DynamoDbClient,
-  private val requiredTables: List<RequiredDynamoDbTable>,
-) : AbstractIdleService(), DynamoDbService {
+class RealDynamoDbService : AbstractIdleService, DynamoDbService {
+  private val dynamoDb: DynamoDbClient
+  private val requiredTables: List<RequiredDynamoDbTable>
+
+  constructor(
+    injector: Injector,
+    requiredTables: List<RequiredDynamoDbTable>,
+    qualifier: KClass<out Annotation>? = null,
+  ) {
+    this.requiredTables = requiredTables
+    this.dynamoDb = injector.getInstance(keyOf<DynamoDbClient>(qualifier))
+  }
+
+  // Backward-compatible constructor (unqualified)
+  @Inject
+  constructor(
+    dynamoDb: DynamoDbClient,
+    requiredTables: List<RequiredDynamoDbTable>,
+  ) {
+    this.dynamoDb = dynamoDb
+    this.requiredTables = requiredTables
+  }
+
   override fun startUp() {
     for (table in requiredTables) {
       dynamoDb.describeTable(

--- a/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/AbstractQualifiedDynamoDbTest.kt
+++ b/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/AbstractQualifiedDynamoDbTest.kt
@@ -1,0 +1,155 @@
+package misk.aws2.dynamodb.testing
+
+import com.google.common.util.concurrent.ServiceManager
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import java.time.LocalDate
+
+abstract class AbstractQualifiedDynamoDbTest {
+  @Inject lateinit var unqualifiedClient: DynamoDbClient
+  @Inject @PrimaryDb lateinit var primaryClient: DynamoDbClient
+  @Inject @SecondaryDb lateinit var secondaryClient: DynamoDbClient
+  @Inject lateinit var serviceManager: ServiceManager
+
+  @Test
+  fun unqualifiedModule() {
+    val enhancedClient = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(unqualifiedClient)
+      .build()
+    val movieTable = enhancedClient.table("movies", MOVIE_TABLE_SCHEMA)
+
+    val movie = DyMovie()
+    movie.name = "Unqualified Movie"
+    movie.release_date = LocalDate.of(2024, 1, 1)
+    movieTable.putItem(movie)
+
+    val actualMovie = movieTable.getItem(
+      Key.builder()
+        .partitionValue("Unqualified Movie")
+        .sortValue(LocalDate.of(2024, 1, 1).toString())
+        .build()
+    )
+    assertThat(actualMovie.name).isEqualTo(movie.name)
+    assertThat(actualMovie.release_date).isEqualTo(movie.release_date)
+  }
+
+  @Test
+  fun primaryQualifiedModule() {
+    val enhancedClient = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(primaryClient)
+      .build()
+    val characterTable = enhancedClient.table("characters", CHARACTER_TABLE_SCHEMA)
+
+    val character = DyCharacter()
+    character.movie_name = "Primary Movie"
+    character.character_name = "Primary Character"
+    characterTable.putItem(character)
+
+    val actualCharacter = characterTable.getItem(
+      Key.builder()
+        .partitionValue("Primary Movie")
+        .sortValue("Primary Character")
+        .build()
+    )
+    assertThat(actualCharacter.movie_name).isEqualTo(character.movie_name)
+    assertThat(actualCharacter.character_name).isEqualTo(character.character_name)
+  }
+
+  @Test
+  fun secondaryQualifiedModule() {
+    val enhancedClient = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(secondaryClient)
+      .build()
+    val movieTable = enhancedClient.table("movies", MOVIE_TABLE_SCHEMA)
+
+    val movie = DyMovie()
+    movie.name = "Secondary Movie"
+    movie.release_date = LocalDate.of(2025, 1, 1)
+    movieTable.putItem(movie)
+
+    val actualMovie = movieTable.getItem(
+      Key.builder()
+        .partitionValue("Secondary Movie")
+        .sortValue(LocalDate.of(2025, 1, 1).toString())
+        .build()
+    )
+    assertThat(actualMovie.name).isEqualTo(movie.name)
+    assertThat(actualMovie.release_date).isEqualTo(movie.release_date)
+  }
+
+  @Test
+  fun allQualifiedClientsWork() {
+    // Test that unqualified and qualified clients all function concurrently
+    val unqualifiedEnhanced = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(unqualifiedClient)
+      .build()
+    val primaryEnhanced = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(primaryClient)
+      .build()
+    val secondaryEnhanced = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(secondaryClient)
+      .build()
+
+    val unqualifiedMovieTable = unqualifiedEnhanced.table("movies", MOVIE_TABLE_SCHEMA)
+    val primaryCharacterTable = primaryEnhanced.table("characters", CHARACTER_TABLE_SCHEMA)
+    val secondaryMovieTable = secondaryEnhanced.table("movies", MOVIE_TABLE_SCHEMA)
+
+    // Add items via different qualified clients
+    val unqualifiedMovie = DyMovie().apply {
+      name = "Unqualified Shared Test"
+      release_date = LocalDate.of(2024, 2, 1)
+    }
+    unqualifiedMovieTable.putItem(unqualifiedMovie)
+
+    val primaryCharacter = DyCharacter().apply {
+      movie_name = "Primary Shared Test"
+      character_name = "Primary Character"
+    }
+    primaryCharacterTable.putItem(primaryCharacter)
+
+    val secondaryMovie = DyMovie().apply {
+      name = "Secondary Shared Test"
+      release_date = LocalDate.of(2025, 2, 1)
+    }
+    secondaryMovieTable.putItem(secondaryMovie)
+
+    // Verify all clients can access the shared database
+    val retrievedUnqualifiedMovie = unqualifiedMovieTable.getItem(
+      Key.builder()
+        .partitionValue("Unqualified Shared Test")
+        .sortValue(LocalDate.of(2024, 2, 1).toString())
+        .build()
+    )
+    assertThat(retrievedUnqualifiedMovie).isNotNull
+    assertThat(retrievedUnqualifiedMovie.name).isEqualTo("Unqualified Shared Test")
+
+    val retrievedPrimaryCharacter = primaryCharacterTable.getItem(
+      Key.builder()
+        .partitionValue("Primary Shared Test")
+        .sortValue("Primary Character")
+        .build()
+    )
+    assertThat(retrievedPrimaryCharacter).isNotNull
+    assertThat(retrievedPrimaryCharacter.character_name).isEqualTo("Primary Character")
+
+    val retrievedSecondaryMovie = secondaryMovieTable.getItem(
+      Key.builder()
+        .partitionValue("Secondary Shared Test")
+        .sortValue(LocalDate.of(2025, 2, 1).toString())
+        .build()
+    )
+    assertThat(retrievedSecondaryMovie).isNotNull
+    assertThat(retrievedSecondaryMovie.name).isEqualTo("Secondary Shared Test")
+  }
+
+  companion object {
+    val MOVIE_TABLE_SCHEMA: TableSchema<DyMovie> = TableSchema.fromClass(DyMovie::class.java)
+    val CHARACTER_TABLE_SCHEMA: TableSchema<DyCharacter> =
+      TableSchema.fromClass(DyCharacter::class.java)
+  }
+}

--- a/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/PrimaryDb.kt
+++ b/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/PrimaryDb.kt
@@ -1,0 +1,8 @@
+package misk.aws2.dynamodb.testing
+
+import jakarta.inject.Qualifier
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PrimaryDb

--- a/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/QualifiedDockerDynamoDbTest.kt
+++ b/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/QualifiedDockerDynamoDbTest.kt
@@ -1,0 +1,50 @@
+package misk.aws2.dynamodb.testing
+
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType
+
+@MiskTest(startService = true)
+class QualifiedDockerDynamoDbTest : AbstractQualifiedDynamoDbTest() {
+  @MiskTestModule val module = TestModule()
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(MiskTestingServiceModule())
+
+      // All modules share the same underlying database
+      // Install an unqualified module with all tables
+      install(
+        DockerDynamoDbModule(
+          tables = listOf(
+            DynamoDbTable("movies", DyMovie::class) { createTableEnhancedRequest ->
+              createTableEnhancedRequest.globalSecondaryIndices(
+                EnhancedGlobalSecondaryIndex.builder()
+                  .indexName("movies.release_date_index")
+                  .projection { it.projectionType(ProjectionType.ALL) }
+                  .provisionedThroughput { it.readCapacityUnits(40_000L).writeCapacityUnits(40_000L) }
+                  .build()
+              )
+            },
+            DynamoDbTable("characters", DyCharacter::class)
+          )
+        )
+      )
+      install(
+        DockerDynamoDbModule(
+          qualifier = PrimaryDb::class,
+          tables = listOf()
+        )
+      )
+      install(
+        DockerDynamoDbModule(
+          qualifier = SecondaryDb::class,
+          tables = listOf()
+        )
+      )
+    }
+  }
+}

--- a/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/SecondaryDb.kt
+++ b/misk-aws2-dynamodb/src/test/kotlin/misk/aws2/dynamodb/testing/SecondaryDb.kt
@@ -1,0 +1,8 @@
+package misk.aws2.dynamodb.testing
+
+import jakarta.inject.Qualifier
+
+@Qualifier
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SecondaryDb

--- a/misk-aws2-dynamodb/src/testFixtures/kotlin/misk/aws2/dynamodb/testing/DockerDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/testFixtures/kotlin/misk/aws2/dynamodb/testing/DockerDynamoDbModule.kt
@@ -4,13 +4,15 @@ import app.cash.tempest2.testing.DockerDynamoDbServer
 import app.cash.tempest2.testing.TestTable
 import app.cash.tempest2.testing.internal.TestDynamoDbService
 import com.google.common.util.concurrent.AbstractService
-import com.google.inject.Provides
+import com.google.inject.Provider
 import jakarta.inject.Inject
-import jakarta.inject.Singleton
+import kotlin.reflect.KClass
 import misk.ServiceModule
 import misk.aws2.dynamodb.DynamoDbService
 import misk.aws2.dynamodb.RequiredDynamoDbTable
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.inject.keyOf
 import misk.testing.TestFixture
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
@@ -20,59 +22,103 @@ import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
  *
  * Note that this may not be used alongside [LocalDynamoDbModule]. DynamoDB may execute in Docker or
  * in-process, but never both.
+ *
+ * This module supports multiple installations with different qualifiers:
+ * ```
+ * install(DockerDynamoDbModule(
+ *   qualifier = PrimaryDynamoDb::class,
+ *   tables = listOf(primaryTable)
+ * ))
+ * install(DockerDynamoDbModule(
+ *   qualifier = SecondaryDynamoDb::class,
+ *   tables = listOf(secondaryTable)
+ * ))
+ *
+ * // Usage:
+ * class MyTest @Inject constructor(
+ *   @PrimaryDynamoDb val primaryDb: DynamoDbClient,
+ *   @SecondaryDynamoDb val secondaryDb: DynamoDbClient
+ * )
+ * ```
+ *
+ * All installations share the same underlying TestDynamoDbService instance (since it can only
+ * be instantiated once per process), but each creates its own set of tables.
  */
-class DockerDynamoDbModule(
-  private val tables: List<DynamoDbTable>,
-) : KAbstractModule() {
+class DockerDynamoDbModule : KAbstractModule {
+  private val qualifier: KClass<out Annotation>?
+  private val tables: List<DynamoDbTable>
 
-  constructor(vararg tables: DynamoDbTable) : this(tables.toList())
+  constructor(
+    qualifier: KClass<out Annotation>?,
+    tables: List<DynamoDbTable>,
+  ) {
+    this.qualifier = qualifier
+    this.tables = tables
+  }
+
+  // Backward-compatible constructors (unqualified)
+  constructor(tables: List<DynamoDbTable>) : this(null, tables)
+  constructor(vararg tables: DynamoDbTable) : this(null, tables.toList())
 
   override fun configure() {
+    // Register tables for this qualifier
+    val qualifiedTableMultibinder = newMultibinder<DynamoDbTable>(qualifier)
     for (table in tables) {
-      multibind<DynamoDbTable>().toInstance(table)
+      qualifiedTableMultibinder.addBinding().toInstance(table)
     }
-    bind<DynamoDbService>().to<DockerDynamoDbService>()
-    install(ServiceModule<DynamoDbService>().dependsOn<TestDynamoDb>())
-    install(ServiceModule<TestDynamoDb>())
-    multibind<TestFixture>().to<TestDynamoDb>()
-  }
 
-  @Provides
-  @Singleton
-  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
-    tables.map { RequiredDynamoDbTable(it.tableName) }
+    // Also register tables in the unqualified multibinder for the core module
+    val tableMultibinder = newMultibinder<DynamoDbTable>()
+    for (table in tables) {
+      tableMultibinder.addBinding().toInstance(table)
+    }
 
-  @Provides
-  @Singleton
-  fun providesTestDynamoDb(): TestDynamoDb {
-    return TestDynamoDb(
-      TestDynamoDbService.create(
-        serverFactory = DockerDynamoDbServer.Factory,
-        tables = tables.map { table ->
-          TestTable.create(table.tableName, table.tableClass) {
-            table.configureTable(it.toBuilder()).build()
-          }
-        },
-        port = null
-      )
+    bind(keyOf<List<RequiredDynamoDbTable>>(qualifier)).toInstance(
+      tables.map { RequiredDynamoDbTable(it.tableName) }
     )
+
+    // Install shared core module that creates TestDynamoDb from all registered tables
+    install(DockerDynamoDbCoreModule)
+
+    val testDynamoDbProvider = getProvider(keyOf<TestDynamoDb>())
+
+    bind(keyOf<DynamoDbClient>(qualifier)).toProvider(Provider {
+      testDynamoDbProvider.get().service.client.dynamoDb
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbStreamsClient>(qualifier)).toProvider(Provider {
+      testDynamoDbProvider.get().service.client.dynamoDbStreams
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbService>(qualifier)).toProvider(Provider {
+      DockerDynamoDbService()
+    }).asSingleton()
+    install(ServiceModule<DynamoDbService>(qualifier).dependsOn<TestDynamoDb>())
   }
 
-  @Provides
-  @Singleton
-  fun providesAmazonDynamoDB(testDynamoDb: TestDynamoDb): DynamoDbClient {
-    return testDynamoDb.service.client.dynamoDb
-  }
-
-  @Provides
-  @Singleton
-  fun providesAmazonDynamoDBStreams(testDynamoDb: TestDynamoDb): DynamoDbStreamsClient {
-    return testDynamoDb.service.client.dynamoDbStreams
+  private object DockerDynamoDbCoreModule : KAbstractModule() {
+    override fun configure() {
+      bind(keyOf<TestDynamoDb>()).toProvider(object : Provider<TestDynamoDb> {
+        @Inject lateinit var allTables: Set<DynamoDbTable>
+        override fun get(): TestDynamoDb = TestDynamoDb(
+          TestDynamoDbService.create(
+            serverFactory = DockerDynamoDbServer.Factory,
+            tables = allTables.map { table ->
+              TestTable.create(table.tableName, table.tableClass) {
+                table.configureTable(it.toBuilder()).build()
+              }
+            },
+            port = null
+          )
+        )
+      }).asSingleton()
+      install(ServiceModule<TestDynamoDb>())
+      multibind<TestFixture>().to(keyOf<TestDynamoDb>())
+    }
   }
 
   /** This service does nothing; depending on Tempest's [TestDynamoDb] is sufficient. */
-  @Singleton
-  private class DockerDynamoDbService @Inject constructor() : AbstractService(), DynamoDbService {
+  private class DockerDynamoDbService : AbstractService(), DynamoDbService {
     override fun doStart() = notifyStarted()
     override fun doStop() = notifyStopped()
   }

--- a/misk-aws2-dynamodb/src/testFixtures/kotlin/misk/aws2/dynamodb/testing/InProcessDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/testFixtures/kotlin/misk/aws2/dynamodb/testing/InProcessDynamoDbModule.kt
@@ -4,13 +4,15 @@ import app.cash.tempest2.testing.JvmDynamoDbServer
 import app.cash.tempest2.testing.TestTable
 import app.cash.tempest2.testing.internal.TestDynamoDbService
 import com.google.common.util.concurrent.AbstractService
-import com.google.inject.Provides
+import com.google.inject.Provider
 import jakarta.inject.Inject
-import jakarta.inject.Singleton
+import kotlin.reflect.KClass
 import misk.ServiceModule
 import misk.aws2.dynamodb.DynamoDbService
 import misk.aws2.dynamodb.RequiredDynamoDbTable
 import misk.inject.KAbstractModule
+import misk.inject.asSingleton
+import misk.inject.keyOf
 import misk.testing.TestFixture
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
@@ -22,59 +24,103 @@ import software.amazon.awssdk.services.dynamodb.streams.DynamoDbStreamsClient
  * Note that this may not be used alongside [DockerDynamoDbModule] and
  * `@MiskExternalDependency DockerDynamoDb`. DynamoDB may execute in Docker or in-process, but never
  * both.
+ *
+ * This module supports multiple installations with different qualifiers:
+ * ```
+ * install(InProcessDynamoDbModule(
+ *   qualifier = PrimaryDynamoDb::class,
+ *   tables = listOf(primaryTable)
+ * ))
+ * install(InProcessDynamoDbModule(
+ *   qualifier = SecondaryDynamoDb::class,
+ *   tables = listOf(secondaryTable)
+ * ))
+ *
+ * // Usage:
+ * class MyTest @Inject constructor(
+ *   @PrimaryDynamoDb val primaryDb: DynamoDbClient,
+ *   @SecondaryDynamoDb val secondaryDb: DynamoDbClient
+ * )
+ * ```
+ *
+ * All installations share the same underlying TestDynamoDbService instance (since it can only
+ * be instantiated once per process), but each creates its own set of tables.
  */
-class InProcessDynamoDbModule(
-  private val tables: List<DynamoDbTable>,
-) : KAbstractModule() {
-  constructor(vararg tables: DynamoDbTable) : this(tables.toList())
+class InProcessDynamoDbModule : KAbstractModule {
+  private val qualifier: KClass<out Annotation>?
+  private val tables: List<DynamoDbTable>
+
+  constructor(
+    qualifier: KClass<out Annotation>?,
+    tables: List<DynamoDbTable>,
+  ) {
+    this.qualifier = qualifier
+    this.tables = tables
+  }
+
+  // Backward-compatible constructors (unqualified)
+  constructor(tables: List<DynamoDbTable>) : this(null, tables)
+  constructor(vararg tables: DynamoDbTable) : this(null, tables.toList())
 
   override fun configure() {
+    // Register tables for this qualifier
+    val qualifiedTableMultibinder = newMultibinder<DynamoDbTable>(qualifier)
     for (table in tables) {
-      multibind<DynamoDbTable>().toInstance(table)
+      qualifiedTableMultibinder.addBinding().toInstance(table)
     }
-    bind<DynamoDbService>().to<InProcessDynamoDbService>()
-    install(ServiceModule<DynamoDbService>().dependsOn<TestDynamoDb>())
-    install(ServiceModule<TestDynamoDb>())
-    multibind<TestFixture>().to<TestDynamoDb>()
-  }
 
-  @Provides
-  @Singleton
-  fun provideRequiredTables(): List<RequiredDynamoDbTable> =
-    tables.map { RequiredDynamoDbTable(it.tableName) }
+    // Also register tables in the unqualified multibinder for the core module
+    val tableMultibinder = newMultibinder<DynamoDbTable>()
+    for (table in tables) {
+      tableMultibinder.addBinding().toInstance(table)
+    }
 
-  @Provides
-  @Singleton
-  fun providesTestDynamoDb(): TestDynamoDb {
-    return TestDynamoDb(
-      TestDynamoDbService.create(
-        serverFactory = JvmDynamoDbServer.Factory,
-        tables = tables.map { table ->
-          TestTable.create(table.tableName, table.tableClass) {
-            table.configureTable(it.toBuilder()).build()
-          }
-        },
-        port = null
-      )
+    bind(keyOf<List<RequiredDynamoDbTable>>(qualifier)).toInstance(
+      tables.map { RequiredDynamoDbTable(it.tableName) }
     )
+
+    // Install shared core module that creates TestDynamoDb from all registered tables
+    install(InProcessDynamoDbCoreModule)
+
+    val testDynamoDbProvider = getProvider(keyOf<TestDynamoDb>())
+
+    bind(keyOf<DynamoDbClient>(qualifier)).toProvider(Provider {
+      testDynamoDbProvider.get().service.client.dynamoDb
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbStreamsClient>(qualifier)).toProvider(Provider {
+      testDynamoDbProvider.get().service.client.dynamoDbStreams
+    }).asSingleton()
+
+    bind(keyOf<DynamoDbService>(qualifier)).toProvider(Provider {
+      InProcessDynamoDbService()
+    }).asSingleton()
+    install(ServiceModule<DynamoDbService>(qualifier).dependsOn<TestDynamoDb>())
   }
 
-  @Provides
-  @Singleton
-  fun providesAmazonDynamoDB(testDynamoDb: TestDynamoDb): DynamoDbClient {
-    return testDynamoDb.service.client.dynamoDb
-  }
-
-  @Provides
-  @Singleton
-  fun providesAmazonDynamoDBStreams(testDynamoDb: TestDynamoDb): DynamoDbStreamsClient {
-    return testDynamoDb.service.client.dynamoDbStreams
+  private object InProcessDynamoDbCoreModule : KAbstractModule() {
+    override fun configure() {
+      bind(keyOf<TestDynamoDb>()).toProvider(object : Provider<TestDynamoDb> {
+        @Inject lateinit var allTables: Set<DynamoDbTable>
+        override fun get(): TestDynamoDb = TestDynamoDb(
+          TestDynamoDbService.create(
+            serverFactory = JvmDynamoDbServer.Factory,
+            tables = allTables.map { table ->
+              TestTable.create(table.tableName, table.tableClass) {
+                table.configureTable(it.toBuilder()).build()
+              }
+            },
+            port = null
+          )
+        )
+      }).asSingleton()
+      install(ServiceModule<TestDynamoDb>())
+      multibind<TestFixture>().to(keyOf<TestDynamoDb>())
+    }
   }
 
   /** This service does nothing; depending on Tempest's [TestDynamoDb] is sufficient. */
-  @Singleton
-  private class InProcessDynamoDbService @Inject constructor() : AbstractService(),
-    DynamoDbService {
+  private class InProcessDynamoDbService : AbstractService(), DynamoDbService {
     override fun doStart() = notifyStarted()
     override fun doStop() = notifyStopped()
   }

--- a/misk-exceptions-dynamodb/api/misk-exceptions-dynamodb.api
+++ b/misk-exceptions-dynamodb/api/misk-exceptions-dynamodb.api
@@ -10,7 +10,7 @@ public final class misk/exceptions/dynamodb/ClientExecutionTimeoutExceptionMappe
 	public synthetic fun toResponse (Ljava/lang/Throwable;)Lmisk/web/Response;
 }
 
-public final class misk/exceptions/dynamodb/DynamoDbExceptionMapperModule : misk/inject/KAbstractModule {
+public final class misk/exceptions/dynamodb/DynamoDbExceptionMapperModule : misk/inject/KInstallOnceModule {
 	public fun <init> ()V
 }
 

--- a/misk-exceptions-dynamodb/src/main/kotlin/misk/exceptions/dynamodb/DynamoDbExceptionMapperModule.kt
+++ b/misk-exceptions-dynamodb/src/main/kotlin/misk/exceptions/dynamodb/DynamoDbExceptionMapperModule.kt
@@ -2,10 +2,10 @@ package misk.exceptions.dynamodb
 
 import com.amazonaws.http.timers.client.ClientExecutionTimeoutException
 import com.amazonaws.services.dynamodbv2.model.TransactionCanceledException
-import misk.inject.KAbstractModule
+import misk.inject.KInstallOnceModule
 import misk.web.exceptions.ExceptionMapperModule
 
-class DynamoDbExceptionMapperModule : KAbstractModule() {
+class DynamoDbExceptionMapperModule : KInstallOnceModule() {
   override fun configure() {
     install(
       ExceptionMapperModule.create<ClientExecutionTimeoutException,


### PR DESCRIPTION
## Description
This allows us to have separate client configurations for different
sets of tables (e.g. application vs framework cluster leasing)