### PR TITLE
Updates misk-mcp Documentation

### DIFF
--- a/misk-mcp/README.md
+++ b/misk-mcp/README.md
@@ -38,8 +38,8 @@ To expose MCP functionality through HTTP endpoints, you need to create web actio
 
 ### Transport Options
 
-#### Server-Sent Events (SSE) Transport
-Uses HTTP POST requests with SSE responses for real-time communication:
+#### StreamableHTTP Transport
+Uses HTTP POST requests with Server-Sent Events (SSE) for streaming responses:
 - **`@McpPost`** (Required): Handles incoming MCP requests from clients
 - **`@McpGet`** (Optional): Enables out-of-band server-to-client notifications
 - **`@McpDelete`** (Optional): Allows clients to explicitly delete an existing stateful session
@@ -48,7 +48,7 @@ Uses HTTP POST requests with SSE responses for real-time communication:
 Uses persistent WebSocket connections for full bidirectional communication:
 - **`@McpWebSocket`** (Required): Handles all MCP communication over WebSocket
 
-### SSE Transport Example
+### StreamableHTTP Transport Example
 
 ```kotlin
 @ExperimentalMiskApi
@@ -105,9 +105,9 @@ class MyMcpWebSocketAction @Inject constructor(
 
 ### Transport Comparison
 
-| Feature | SSE Transport | WebSocket Transport |
-|---------|---------------|-------------------|
-| **Connection Type** | HTTP POST + SSE | Persistent WebSocket |
+| Feature | StreamableHTTP Transport | WebSocket Transport |
+|---------|--------------------------|-------------------|
+| **Connection Type** | HTTP POST + SSE streaming | Persistent WebSocket |
 | **Communication** | Client→Server (POST)<br/>Server→Client (SSE) | Full bidirectional |
 | **Complexity** | Multiple endpoints | Single endpoint |
 | **Session Management** | Optional via headers | Built-in connection state |
@@ -116,7 +116,7 @@ class MyMcpWebSocketAction @Inject constructor(
 
 ### Choosing a Transport
 
-**Use SSE Transport when:**
+**Use StreamableHTTP Transport when:**
 - Building traditional web applications
 - Need maximum client compatibility
 - Implementing request-response patterns

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpSessionHandler.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpSessionHandler.kt
@@ -1,17 +1,17 @@
 package misk.mcp
 
 /**
- * Handles MCP (Model Context Protocol) session lifecycle management for StreamableHttp transport.
+ * Handles MCP (Model Context Protocol) session lifecycle management for StreamableHTTP transport.
  *
- * This interface provides session management capabilities for MCP servers using StreamableHttp
- * transport (SSE-based communication via `@McpPost`, `@McpGet`, and `@McpDelete` endpoints).
+ * This interface provides session management capabilities for MCP servers using StreamableHTTP
+ * transport (StreamableHTTP-based communication via `@McpPost`, `@McpGet`, and `@McpDelete` endpoints).
  * When installed via [McpSessionHandlerModule], the framework automatically integrates with
  * the session lifecycle and returns the session ID in the "Mcp-Session-Id" response header.
  *
  * ## Transport Compatibility
  *
- * **StreamableHttp Transport Only**: This session handler is designed exclusively for
- * StreamableHttp transport using Server-Sent Events. It is not used with WebSocket
+ * **StreamableHTTP Transport Only**: This session handler is designed exclusively for
+ * StreamableHTTP transport using Server-Sent Events. It is not used with WebSocket
  * transport (`@McpWebSocket`), which maintains connection state through the persistent
  * WebSocket connection itself.
  *
@@ -43,9 +43,9 @@ package misk.mcp
  * <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management>
  *
  * @see McpSessionHandlerModule for installation instructions
- * @see misk.mcp.action.McpPost for StreamableHttp request handling
- * @see misk.mcp.action.McpGet for StreamableHttp event streaming
- * @see misk.mcp.action.McpDelete for StreamableHttp session termination
+ * @see misk.mcp.action.McpPost for StreamableHTTP request handling
+ * @see misk.mcp.action.McpGet for StreamableHTTP event streaming
+ * @see misk.mcp.action.McpDelete for StreamableHTTP session termination
  */
 interface McpSessionHandler {
   /**

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpSessionHandlerModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpSessionHandlerModule.kt
@@ -6,15 +6,15 @@ import misk.inject.keyOf
 import kotlin.reflect.KClass
 
 /**
- * Guice module for installing MCP session handlers for StreamableHttp transport.
+ * Guice module for installing MCP session handlers for StreamableHTTP transport.
  *
  * This module registers an [McpSessionHandler] implementation with the dependency injection
- * framework, enabling automatic session management for MCP servers using StreamableHttp
- * transport (SSE-based communication via `@McpPost`, `@McpGet`, and `@McpDelete` endpoints).
+ * framework, enabling automatic session management for MCP servers using StreamableHTTP
+ * transport (StreamableHTTP-based communication via `@McpPost`, `@McpGet`, and `@McpDelete` endpoints).
  *
  * ## Transport Compatibility
  *
- * **StreamableHttp Transport Only**: This module is designed exclusively for StreamableHttp
+ * **StreamableHTTP Transport Only**: This module is designed exclusively for StreamableHTTP
  * transport using Server-Sent Events. Session handlers are not used with WebSocket transport
  * (`@McpWebSocket`), which maintains connection state through the persistent WebSocket
  * connection itself.
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
  * ## Basic Installation
  *
  * ```kotlin
- * // Install a session handler implementation for StreamableHttp transport
+ * // Install a session handler implementation for StreamableHTTP transport
  * install(McpSessionHandlerModule.create<MySessionHandler>())
  * ```
  *
@@ -56,13 +56,13 @@ import kotlin.reflect.KClass
  * }
  * ```
  *
- * Once installed, the framework will automatically handle session lifecycle for StreamableHttp
+ * Once installed, the framework will automatically handle session lifecycle for StreamableHTTP
  * requests and include session IDs in the "Mcp-Session-Id" response header.
  *
  * @see McpSessionHandler for session management interface
- * @see misk.mcp.action.McpPost for StreamableHttp request handling
- * @see misk.mcp.action.McpGet for StreamableHttp event streaming
- * @see misk.mcp.action.McpDelete for StreamableHttp session termination
+ * @see misk.mcp.action.McpPost for StreamableHTTP request handling
+ * @see misk.mcp.action.McpGet for StreamableHTTP event streaming
+ * @see misk.mcp.action.McpDelete for StreamableHTTP session termination
  */
 class McpSessionHandlerModule<T: McpSessionHandler>(
   private val mcpSessionHandlerClass: KClass<T>,

--- a/misk-mcp/src/main/kotlin/misk/mcp/action/McpDelete.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/action/McpDelete.kt
@@ -6,16 +6,16 @@ import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 
 /**
- * Annotation for web action methods that handle MCP session deletion for StreamableHttp transport.
+ * Annotation for web action methods that handle MCP session deletion for StreamableHTTP transport.
  *
  * This annotation configures a web action to handle explicit MCP session termination for
- * StreamableHttp transport (Server-Sent Events) as specified in the MCP specification for
+ * StreamableHTTP transport (Server-Sent Events) as specified in the MCP specification for
  * session management. The client sends a DELETE request with the session ID to cleanly
  * terminate an existing MCP session.
  *
  * ## Transport Compatibility
  *
- * **StreamableHttp Transport Only**: This annotation is designed exclusively for StreamableHttp
+ * **StreamableHTTP Transport Only**: This annotation is designed exclusively for StreamableHTTP
  * transport using Server-Sent Events. WebSocket transport (`@McpWebSocket`) does not use
  * explicit session deletion endpoints, as session termination is handled automatically when
  * the WebSocket connection is closed.
@@ -64,7 +64,7 @@ import misk.web.mediatype.MediaTypes
  * ## Session Cleanup
  *
  * When implementing session deletion:
- * - Close any open SSE connections for the session
+ * - Close any open Server-Sent Events (SSE) connections for the session
  * - Release server resources associated with the session
  * - Clean up session-specific data and state
  * - Return confirmation of successful termination

--- a/misk-mcp/src/main/kotlin/misk/mcp/action/McpGet.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/action/McpGet.kt
@@ -6,27 +6,27 @@ import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 
 /**
- * Marks a web action method as an MCP (Model Context Protocol) HTTP GET endpoint for StreamableHttp transport.
+ * Marks a web action method as an MCP (Model Context Protocol) HTTP GET endpoint for StreamableHTTP transport.
  *
  * This annotation creates endpoints that allow clients to listen for messages sent from the MCP server
- * using StreamableHttp transport (Server-Sent Events). The endpoint establishes an SSE connection
+ * using StreamableHTTP transport (Server-Sent Events). The endpoint establishes a Server-Sent Events (SSE) connection
  * for real-time server-to-client communication.
  *
  * ## Transport Compatibility
  *
- * **StreamableHttp Transport Only**: This annotation is designed exclusively for StreamableHttp
+ * **StreamableHTTP Transport Only**: This annotation is designed exclusively for StreamableHTTP
  * transport using Server-Sent Events. For WebSocket-based MCP communication, use `@McpWebSocket`
  * instead, which handles all communication over a persistent WebSocket connection.
  *
  * ## Purpose
  * Implements the MCP specification requirement for "listening for messages from the server"
- * by providing an SSE endpoint where clients can receive server-initiated events and notifications.
+ * by providing a Server-Sent Events (SSE) endpoint where clients can receive server-initiated events and notifications.
  *
  * ## Configuration
  *
  * The annotation automatically configures:
  * - **Endpoint**: `GET /mcp`
- * - **Response Content-Type**: `text/event-stream` (for SSE responses)
+ * - **Response Content-Type**: `text/event-stream` (for Server-Sent Events (SSE) responses)
  * - **No Request Body**: GET requests don't accept request bodies
  *
  * ## Session Support
@@ -47,7 +47,7 @@ import misk.web.mediatype.MediaTypes
  * ## Method Signature Requirements
  *
  * Methods annotated with `@McpGet` should typically have:
- * - `sendChannel: SendChannel<ServerSentEvent>` - For SSE responses
+ * - `sendChannel: SendChannel<ServerSentEvent>` - For Server-Sent Events (SSE) responses
  * - `suspend` modifier for coroutine support
  * - Optional `@RequestHeaders headers: Headers` for session ID extraction
  *

--- a/misk-mcp/src/main/kotlin/misk/mcp/action/McpPost.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/action/McpPost.kt
@@ -7,21 +7,21 @@ import misk.web.ResponseContentType
 import misk.web.mediatype.MediaTypes
 
 /**
- * Marks a web action method as an MCP (Model Context Protocol) HTTP POST endpoint for StreamableHttp transport.
+ * Marks a web action method as an MCP (Model Context Protocol) HTTP POST endpoint for StreamableHTTP transport.
  *
  * This annotation creates endpoints that handle client-to-server JSON-RPC 2.0 messages using
- * StreamableHttp transport (Server-Sent Events). The endpoint accepts JSON-RPC requests from
- * MCP clients and responds with SSE for real-time bidirectional communication.
+ * StreamableHTTP transport (Server-Sent Events). The endpoint accepts JSON-RPC requests from
+ * MCP clients and responds with Server-Sent Events (SSE) for real-time bidirectional communication.
  *
  * ## Transport Compatibility
  *
- * **StreamableHttp Transport Only**: This annotation is designed exclusively for StreamableHttp
+ * **StreamableHTTP Transport Only**: This annotation is designed exclusively for StreamableHTTP
  * transport using Server-Sent Events. For WebSocket-based MCP communication, use `@McpWebSocket`
  * instead, which handles all communication over a persistent WebSocket connection.
  *
  * ## Purpose
  * Implements the MCP specification requirement for "sending messages to the server" by providing
- * an HTTP POST endpoint that processes client JSON-RPC 2.0 messages and maintains SSE connections
+ * an HTTP POST endpoint that processes client JSON-RPC 2.0 messages and maintains Server-Sent Events (SSE) connections
  * for server responses.
  *
  * ## Configuration
@@ -29,7 +29,7 @@ import misk.web.mediatype.MediaTypes
  * The annotation automatically configures:
  * - **Endpoint**: `POST /mcp`
  * - **Request Content-Type**: `application/json` (for JSON-RPC messages)
- * - **Response Content-Type**: `text/event-stream` (for SSE responses)
+ * - **Response Content-Type**: `text/event-stream` (for Server-Sent Events (SSE) responses)
  *
  * ## Session Support
  * The endpoint accepts an optional `Mcp-Session-Id` header (referenced by [SESSION_ID_HEADER])
@@ -52,7 +52,7 @@ import misk.web.mediatype.MediaTypes
  *
  * Methods annotated with `@McpPost` should typically have:
  * - `@RequestBody message: JSONRPCMessage` - For JSON-RPC 2.0 message processing
- * - `sendChannel: SendChannel<ServerSentEvent>` - For SSE responses
+ * - `sendChannel: SendChannel<ServerSentEvent>` - For Server-Sent Events (SSE) responses
  * - `suspend` modifier for coroutine support
  * - Optional `@RequestHeaders headers: Headers` for session ID extraction
  *
@@ -80,7 +80,7 @@ import misk.web.mediatype.MediaTypes
  *     sendChannel: SendChannel<ServerSentEvent>
  *   ) {
  *     mcpStreamManager.withSseChannel(sendChannel) {
- *       // Process client JSON-RPC message and send response via SSE
+ *       // Process client JSON-RPC message and send response via Server-Sent Events (SSE)
  *       handleMessage(message)
  *     }
  *   }

--- a/misk-mcp/src/main/kotlin/misk/mcp/action/McpStreamManager.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/action/McpStreamManager.kt
@@ -25,7 +25,7 @@ import misk.web.sse.ServerSentEvent
 
 
 /**
- * Manages MCP (Model Context Protocol) server connections for both SSE and WebSocket transports.
+ * Manages MCP (Model Context Protocol) server connections for both StreamableHTTP and WebSocket transports.
  *
  * This class provides the bridge between Misk web actions and MCP server instances, handling
  * the lifecycle of client connections and ensuring proper setup and teardown of MCP server
@@ -33,10 +33,10 @@ import misk.web.sse.ServerSentEvent
  *
  * ## Supported Transport Types
  *
- * ### Server-Sent Events (SSE) via HTTP
+ * ### StreamableHTTP Transport
  * - Used with [McpPost] annotated actions
  * - Supports streamable HTTP transport for real-time communication
- * - Client sends JSON-RPC messages via POST, server responds via SSE stream
+ * - Client sends JSON-RPC messages via POST, server responds via Server-Sent Events (SSE) stream
  *
  * ### WebSocket
  * - Used with [McpWebSocket] annotated actions  
@@ -45,15 +45,15 @@ import misk.web.sse.ServerSentEvent
  *
  * ## Connection Lifecycle
  *
- * 1. **Connection Establishment**: Client initiates connection (SSE or WebSocket) to `/mcp` endpoint
+ * 1. **Connection Establishment**: Client initiates connection (StreamableHTTP or WebSocket) to `/mcp` endpoint
  * 2. **Transport Creation**: Appropriate transport ([MiskStreamableHttpServerTransport] or [MiskWebSocketServerTransport]) is created
  * 3. **Server Initialization**: [MiskMcpServer] instance is created and connected to transport
  * 4. **Message Handling**: Client messages are processed through the MCP server
  * 5. **Connection Cleanup**: Transport and server resources are properly closed when connection ends
  *
- * ## SSE Usage in Web Actions
+ * ## StreamableHTTP Usage in Web Actions
  *
- * Use [withSseChannel] in web actions that handle MCP client requests via Server-Sent Events:
+ * Use [withSseChannel] in web actions that handle MCP client requests via StreamableHTTP transport:
  *
  * ```kotlin
  * @Singleton
@@ -92,7 +92,7 @@ import misk.web.sse.ServerSentEvent
  * }
  * ```
  *
- * ## Advanced SSE Usage Examples
+ * ## Advanced StreamableHTTP Usage Examples
  *
  * ### Stateful Stream Handling
  * ```kotlin
@@ -140,7 +140,7 @@ import misk.web.sse.ServerSentEvent
  * Within the [withSseChannel] block, the context provides:
  * - **this**: [MiskMcpServer] instance for handling MCP protocol messages
  * - **transport**: Access to the underlying transport with `streamId`
- * - **sendChannel**: Direct access to SSE response channel (passed as parameter)
+ * - **sendChannel**: Direct access to Server-Sent Events (SSE) response channel (passed as parameter)
  *
  * For WebSocket connections, the [withWebSocket] method returns a [WebSocketListener] that
  * automatically handles message routing to the MCP server instance.
@@ -155,9 +155,9 @@ import misk.web.sse.ServerSentEvent
  * The [withResponseChannel] method is deprecated in favor of [withSseChannel] for clarity.
  *
  * @see MiskMcpServer For the MCP server implementation
- * @see McpPost For SSE-based web action annotation
+ * @see McpPost For StreamableHTTP-based web action annotation
  * @see McpWebSocket For WebSocket-based web action annotation
- * @see MiskStreamableHttpServerTransport For SSE transport implementation
+ * @see MiskStreamableHttpServerTransport For StreamableHTTP transport implementation
  * @see MiskWebSocketServerTransport For WebSocket transport implementation
  */
 @ExperimentalMiskApi
@@ -176,7 +176,7 @@ class McpStreamManager internal constructor(
   ) = withSseChannel(sendChannel,block)
 
   /**
-   * Handles MCP communication over Server-Sent Events transport.
+   * Handles MCP communication over StreamableHTTP transport using Server-Sent Events.
    *
    * Use in [McpPost] annotated web actions to process MCP JSON-RPC messages:
    *
@@ -192,7 +192,7 @@ class McpStreamManager internal constructor(
    * }
    * ```
    *
-   * @param sendChannel SSE channel for sending responses to the client
+   * @param sendChannel Server-Sent Events (SSE) channel for sending responses to the client
    * @param block Function executed with [MiskMcpServer] as receiver context
    */
   suspend fun withSseChannel(
@@ -201,7 +201,7 @@ class McpStreamManager internal constructor(
   ) {
 
     val transport = streamableHttpServerTransportFactory.create(sendChannel).also {
-      logger.debug { "New SSE connection established with streamId: ${it.streamId}" }
+      logger.debug { "New StreamableHTTP connection established with streamId: ${it.streamId}" }
     }
 
 


### PR DESCRIPTION
## Description

This correctly references the StreamableHTTP transport vs the legacy ServerSentEvents transport. This also makes changes to ensure consistency. 

This is just a change to documentation.


## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
