### PR TITLE
Fixes transitive ktor dependencies from kotlin-sdk

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -172,7 +172,6 @@ kotlinxCoroutinesSlf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-sl
 kotlinxCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.10.2" }
 kotlinxSerializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.9.0" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.9.0" }
-ktorBom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
 ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktorClientOkhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktorClientContentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/misk-mcp/build.gradle.kts
+++ b/misk-mcp/build.gradle.kts
@@ -13,14 +13,17 @@ dependencies {
   api(libs.jakartaInject)
   api(libs.kotlinxSerializationJson)
   api(libs.mcpKotlinSdkCore)
-  api(libs.mcpKotlinSdkServer)
+  api(libs.mcpKotlinSdkServer){
+    exclude(group = "io.ktor", module = "ktor-server-core")
+    exclude(group = "io.ktor", module = "ktor-server-sse")
+  }
+
   api(project(":misk-actions"))
   api(project(":misk-api"))
   api(project(":misk-inject"))
   api(project(":misk"))
   api(project(":misk-config"))
 
-  implementation(platform(libs.ktorBom))
   implementation(libs.kotlinReflect)
   implementation(libs.kotlinxCoroutinesCore)
   implementation(libs.kotlinxSerializationCore)
@@ -43,12 +46,13 @@ dependencies {
 
   testFixturesApi(libs.mcpKotlinSdkClient)
   testFixturesImplementation(libs.kotlinxSerializationJson)
-  testFixturesImplementation(platform(libs.ktorBom))
-  testFixturesImplementation(libs.ktorClientContentNegotiation)
-  testFixturesImplementation(libs.ktorClientCore)
-  testFixturesImplementation(libs.ktorClientEncoding)
-  testFixturesImplementation(libs.ktorClientLogging)
-  testFixturesImplementation(libs.ktorClientOkhttp)
+  testFixturesApi(libs.ktorClientContentNegotiation)
+  testFixturesApi(libs.ktorClientCore)
+  testFixturesApi(libs.ktorClientEncoding)
+  testFixturesApi(libs.ktorClientLogging)
+  testFixturesApi(libs.ktorClientOkhttp)
+  testFixturesApi(libs.ktorSerializationKotlinxJson)
+
   testFixturesImplementation(libs.ktorSerializationKotlinxJson)
 }
 


### PR DESCRIPTION
## Description

The latest kotlin-sdk switched to using the ktor-bom for version constraints on the ktor dependencies. These are not propagated when used as in an included build causing missing versions. Since misk-mcp doesn't use these, it doesn't declare them as a dependency.  This excludes the server dependencies and makes the client dependencies explicit and API

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
