### PR TITLE
feat: websocket outgoing binary message support

### DIFF
--- a/misk-actions/src/main/kotlin/misk/web/actions/WebSocket.kt
+++ b/misk-actions/src/main/kotlin/misk/web/actions/WebSocket.kt
@@ -39,14 +39,14 @@ interface WebSocket {
    * Returns the size in bytes of all messages enqueued to be transmitted to the server. This
    * doesn't include framing overhead. It also doesn't include any bytes buffered by the operating
    * system or network intermediaries. This method returns 0 if no messages are waiting
-   * in the queue. If may return a nonzero value after the web socket has been canceled; this
+   * in the queue. It may return a nonzero value after the web socket has been canceled; this
    * indicates that enqueued messages were not transmitted.
    */
   fun queueSize(): Long
 
   /**
-   * Attempts to enqueue {@code text} to be UTF-8 encoded and sent as a the data of a text (type
-   * {@code 0x1}) message.
+   * Attempts to enqueue {@code bytes} to be sent as the data of a binary (type {@code 0x2})
+   * message.
    *
    * <p>This method returns true if the message was enqueued. Messages that would overflow the
    * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of
@@ -58,8 +58,8 @@ interface WebSocket {
   fun send(bytes: ByteString): Boolean
 
   /**
-   * Attempts to enqueue {@code bytes} to be sent as a the data of a binary (type {@code 0x2})
-   * message.
+   * Attempts to enqueue {@code text} to be UTF-8 encoded and sent as the data of a text (type
+   * {@code 0x1}) message.
    *
    * <p>This method returns true if the message was enqueued. Messages that would overflow the
    * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of

--- a/misk-testing/src/main/kotlin/misk/web/FakeWebSocketListener.kt
+++ b/misk-testing/src/main/kotlin/misk/web/FakeWebSocketListener.kt
@@ -1,14 +1,22 @@
 package misk.web
 
+import okhttp3.WebSocket
+import okio.ByteString
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 
 class FakeWebSocketListener : okhttp3.WebSocketListener() {
   val messages = LinkedBlockingDeque<String>()
+  val binaryMessages = LinkedBlockingDeque<ByteString>()
 
   override fun onMessage(webSocket: okhttp3.WebSocket, text: String) {
     messages.add(text)
   }
 
+  override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+    binaryMessages.add(bytes)
+  }
+
   fun takeMessage() = messages.pollFirst(2, TimeUnit.SECONDS)
+  fun takeBinaryMessage() = binaryMessages.pollFirst(2, TimeUnit.SECONDS)
 }


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

Adds support for sending binary messages over websockets. Also corrects some typos in comments.

## Testing Strategy

Added new unit tests.

## Definition of Done
- I plan on utilizing this in a side project I'm working on, I'll confirm it works locally

## Rollout Strategy and Risk Mitigation
- Minimal risk since this was a feature previously unsupported - threw `NotImplementedError`

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [X] I have added tests to have confidence my changes work as expected.
- [X] I have a rollout plan that minimizes risks and includes monitoring for potential issues.