### PR TITLE
Add annotation for logging interceptor entry/exit

### DIFF
--- a/misk-actions/api/misk-actions.api
+++ b/misk-actions/api/misk-actions.api
@@ -307,6 +307,8 @@ public final class misk/web/dashboard/ValidWebEntry$Companion {
 }
 
 public abstract interface annotation class misk/web/interceptors/LogNetworkInterceptorChain : java/lang/annotation/Annotation {
+	public abstract fun logAfter ()Z
+	public abstract fun logBefore ()Z
 }
 
 public abstract interface annotation class misk/web/interceptors/LogRequestResponse : java/lang/annotation/Annotation {

--- a/misk-actions/src/main/kotlin/misk/web/interceptors/LogNetworkInterceptorChain.kt
+++ b/misk-actions/src/main/kotlin/misk/web/interceptors/LogNetworkInterceptorChain.kt
@@ -1,8 +1,14 @@
 package misk.web.interceptors
 
 /**
- *
+ * Triggers an entry and return log for each Interceptor that proceeds
+ * through traffic inside RealNetworkChain.
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
-annotation class LogNetworkInterceptorChain()
+annotation class LogNetworkInterceptorChain(
+  /** If the log before the interceptor is called should be logged */
+  val logBefore: Boolean = true,
+  /** If the log after the interceptor is called should be logged */
+  val logAfter: Boolean = true,
+)

--- a/misk/src/main/kotlin/misk/web/RealNetworkChain.kt
+++ b/misk/src/main/kotlin/misk/web/RealNetworkChain.kt
@@ -28,14 +28,14 @@ internal class RealNetworkChain(
 
   private fun logCallingInterceptor(interceptor: NetworkInterceptor) {
     val loggingAnnotation = webAction::class.findAnnotation<LogNetworkInterceptorChain>()
-    if (loggingAnnotation != null) {
+    if (loggingAnnotation != null && loggingAnnotation.logBefore) {
       logger.info("Interceptor about to process: {}", interceptor)
     }
   }
 
   private fun logInterceptorReturned(interceptor: NetworkInterceptor) {
     val loggingAnnotation = webAction::class.findAnnotation<LogNetworkInterceptorChain>()
-    if (loggingAnnotation != null) {
+    if (loggingAnnotation != null && loggingAnnotation.logAfter) {
       logger.info("Interceptor finished processing: {}", interceptor)
     }
   }


### PR DESCRIPTION
## Description

Services are reporting issues where the call _seems_ to hit the service but the web action never reports entry. The thought is that there is an interceptor causing an error / failing the request, but there are no logs indicating which of the interceptors it would be.

This adds an annotation that can be placed on WebActions to allow the RealNetworkChain to log when it's about to kick off an interceptor, as well as a log when an interceptor comes back from handling the chain.

---

*WARNING* this causes a decent chunk of logs for every call.

For Example the `An AnnotatedAction with a failing intercept still logs` test has 11 logs:
```
Interceptor about to process: misk.web.interceptors.GunzipRequestBodyInterceptor@6afa6740
Interceptor about to process: misk.web.interceptors.InternalErrorInterceptorFactory$Companion$INTERCEPTOR$1@2bb77efd
Interceptor about to process: misk.web.interceptors.RequestLogContextInterceptor@365d08c5
Interceptor about to process: misk.web.interceptors.MetricsInterceptor@15c993c1
Interceptor about to process: misk.web.exceptions.ExceptionHandlingInterceptor@1bc2e83b

Interceptor about to process: misk.web.interceptors.FailableNetworkInterceptor@4afc1a23

Interceptor finished processing: misk.web.exceptions.ExceptionHandlingInterceptor@1bc2e83b
Interceptor finished processing: misk.web.interceptors.MetricsInterceptor@15c993c1
Interceptor finished processing: misk.web.interceptors.RequestLogContextInterceptor@365d08c5
Interceptor finished processing: misk.web.interceptors.InternalErrorInterceptorFactory$Companion$INTERCEPTOR$1@2bb77efd
Interceptor finished processing: misk.web.interceptors.GunzipRequestBodyInterceptor@6afa6740

```

The Interceptor that returns the 400 doesn't have a `finished processing` log

## Concerns:
- ~~[ ] log level is INFO, allow for configurable level?~~
  - [x] keep default to not bring in new LogLevel dependency
- [x] enter and exit logs both always happen, allow for one or the other to be enabled/disabled.

## Testing Strategy

Unit Test for the annotation

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
