### PR TITLE
Migrate AsyncModule to AsyncSwitch

### DIFF
--- a/misk-aws/api/misk-aws.api
+++ b/misk-aws/api/misk-aws.api
@@ -64,13 +64,12 @@ public final class misk/jobqueue/sqs/AwsSqsBatchJobHandlerModule$Companion {
 	public static synthetic fun create$default (Lmisk/jobqueue/sqs/AwsSqsBatchJobHandlerModule$Companion;Lmisk/jobqueue/QueueName;Lkotlin/reflect/KClass;ZLjava/util/List;ILjava/lang/Object;)Lmisk/jobqueue/sqs/AwsSqsBatchJobHandlerModule;
 }
 
-public final class misk/jobqueue/sqs/AwsSqsJobHandlerModule : misk/inject/KAbstractModule, misk/inject/AsyncModule {
+public final class misk/jobqueue/sqs/AwsSqsJobHandlerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/jobqueue/sqs/AwsSqsJobHandlerModule$Companion;
 	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Lkotlin/reflect/KClass;ZLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Lmisk/jobqueue/QueueName;Ljava/lang/Class;)Lmisk/jobqueue/sqs/AwsSqsJobHandlerModule;
 	public static final fun create (Lmisk/jobqueue/QueueName;Ljava/lang/Class;Z)Lmisk/jobqueue/sqs/AwsSqsJobHandlerModule;
 	public static final fun create (Lmisk/jobqueue/QueueName;Ljava/lang/Class;ZLjava/util/List;)Lmisk/jobqueue/sqs/AwsSqsJobHandlerModule;
-	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
 }
 
 public final class misk/jobqueue/sqs/AwsSqsJobHandlerModule$Companion {
@@ -109,12 +108,14 @@ public final class misk/jobqueue/sqs/AwsSqsJobQueueConfig : misk/config/Config {
 	public final fun getTask_queue ()Lmisk/tasks/RepeatedTaskQueueConfig;
 }
 
-public class misk/jobqueue/sqs/AwsSqsJobQueueModule : misk/inject/KAbstractModule, misk/inject/AsyncModule {
+public class misk/jobqueue/sqs/AwsSqsJobQueueModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/jobqueue/sqs/AwsSqsJobQueueModule$Companion;
 	public fun <init> (Lmisk/jobqueue/sqs/AwsSqsJobQueueConfig;)V
 	protected fun configure ()V
 	public fun configureClient (Lcom/amazonaws/client/builder/AwsClientBuilder;)V
-	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
+	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;Lmisk/jobqueue/sqs/AwsSqsJobQueueConfig;)Lmisk/tasks/RepeatedTaskQueue;
+	public final fun provideSQSClient (Ljava/lang/String;Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;Lmisk/feature/FeatureFlags;)Lcom/amazonaws/services/sqs/AmazonSQS;
+	public final fun provideSQSClientForReceiving (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/sqs/AmazonSQS;
 }
 
 public final class misk/jobqueue/sqs/AwsSqsJobQueueModule$Companion {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobHandlerModule.kt
@@ -2,58 +2,42 @@ package misk.jobqueue.sqs
 
 import com.google.common.util.concurrent.Service
 import com.google.inject.Key
+import kotlin.reflect.KClass
 import misk.ReadyService
 import misk.ServiceModule
-import misk.annotation.ExperimentalMiskApi
-import misk.inject.AsyncModule
+import misk.inject.AsyncSwitch
+import misk.inject.DefaultAsyncSwitchModule
 import misk.inject.KAbstractModule
-import misk.inject.toKey
 import misk.jobqueue.BatchJobHandler
 import misk.jobqueue.JobHandler
 import misk.jobqueue.QueueName
-import kotlin.reflect.KClass
 
 /**
- * Install this module to register a handler for an SQS queue,
- * and if specified, registers its corresponding retry queue.
+ * Install this module to register a handler for an SQS queue, and if specified, registers its corresponding retry
+ * queue.
  */
-class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
+class AwsSqsJobHandlerModule<T : JobHandler>
+private constructor(
   private val queueName: QueueName,
   private val handler: KClass<T>,
   private val installRetryQueue: Boolean,
   private val dependsOn: List<Key<out Service>>,
-) : AsyncModule, KAbstractModule() {
+) : KAbstractModule() {
   override fun configure() {
-    install(CommonModule(queueName, handler, installRetryQueue))
+    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
+    newMapBinder<QueueName, BatchJobHandler>()
 
-    // TODO remove explicit inline environment variable check once AsyncModule filtering in Guice is working
-    if (!System.getenv("DISABLE_ASYNC_TASKS").toBoolean()) {
-      install(
-        ServiceModule(
-          key = AwsSqsJobHandlerSubscriptionService::class.toKey(),
-          dependsOn = dependsOn
-        ).dependsOn<ReadyService>()
-      )
+    if (installRetryQueue) {
+      newMapBinder<QueueName, JobHandler>().addBinding(queueName.retryQueue).to(handler.java)
     }
-  }
 
-  @OptIn(ExperimentalMiskApi::class)
-  override fun moduleWhenAsyncDisabled(): KAbstractModule = CommonModule(queueName, handler, installRetryQueue)
-
-  private class CommonModule<T : JobHandler>(
-    private val queueName: QueueName,
-    private val handler: KClass<T>,
-    private val installRetryQueue: Boolean,
-  ) : KAbstractModule() {
-    override fun configure() {
-
-      newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
-      newMapBinder<QueueName, BatchJobHandler>()
-
-      if (installRetryQueue) {
-        newMapBinder<QueueName, JobHandler>().addBinding(queueName.retryQueue).to(handler.java)
-      }
-    }
+    install(DefaultAsyncSwitchModule())
+    install(
+      ServiceModule<AwsSqsJobHandlerSubscriptionService>()
+        .conditionalOn<AsyncSwitch>("sqs")
+        .dependsOn(dependsOn)
+        .dependsOn<ReadyService>()
+    )
   }
 
   companion object {
@@ -75,9 +59,7 @@ class AwsSqsJobHandlerModule<T : JobHandler> private constructor(
       return create(queueName, handlerClass.kotlin, installRetryQueue, dependsOn)
     }
 
-    /**
-     * Returns a module that registers a handler for an SQS queue.
-     */
+    /** Returns a module that registers a handler for an SQS queue. */
     @JvmOverloads
     fun <T : JobHandler> create(
       queueName: QueueName,

--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -64,22 +64,22 @@ public final class misk/aws2/sqs/jobqueue/SqsJobEnqueuer : misk/jobqueue/v2/JobE
 public final class misk/aws2/sqs/jobqueue/SqsJobEnqueuer$Companion {
 }
 
-public final class misk/aws2/sqs/jobqueue/SqsJobHandlerModule : misk/inject/KAbstractModule, misk/inject/AsyncModule {
+public final class misk/aws2/sqs/jobqueue/SqsJobHandlerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/aws2/sqs/jobqueue/SqsJobHandlerModule$Companion;
 	public synthetic fun <init> (Lmisk/jobqueue/QueueName;Lkotlin/reflect/KClass;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
 }
 
 public final class misk/aws2/sqs/jobqueue/SqsJobHandlerModule$Companion {
 	public final fun create (Lmisk/jobqueue/QueueName;Lkotlin/reflect/KClass;)Lmisk/aws2/sqs/jobqueue/SqsJobHandlerModule;
 }
 
-public class misk/aws2/sqs/jobqueue/SqsJobQueueModule : misk/inject/KAbstractModule, misk/inject/AsyncModule {
+public class misk/aws2/sqs/jobqueue/SqsJobQueueModule : misk/inject/KAbstractModule {
 	public fun <init> (Lmisk/aws2/sqs/jobqueue/config/SqsConfig;)V
 	public fun <init> (Lmisk/aws2/sqs/jobqueue/config/SqsConfig;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lmisk/aws2/sqs/jobqueue/config/SqsConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun configure ()V
-	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
+	public final fun sqsClientFactory (Lsoftware/amazon/awssdk/auth/credentials/AwsCredentialsProvider;)Lmisk/aws2/sqs/jobqueue/SqsClientFactory;
+	public final fun sqsConfig (Lmisk/cloud/aws/AwsRegion;)Lmisk/aws2/sqs/jobqueue/config/SqsConfig;
 }
 
 public final class misk/aws2/sqs/jobqueue/SqsMetrics {

--- a/misk-aws2-sqs/build.gradle.kts
+++ b/misk-aws2-sqs/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 }
 
 dependencies {
+  api(libs.aws2Auth)
   api(libs.aws2Sqs)
   api(libs.guava)
   api(libs.guice6)
@@ -16,18 +17,16 @@ dependencies {
   api(libs.moshiCore)
   api(libs.openTracing)
   api(libs.prometheusClient)
+  api(project(":misk-aws"))
   api(project(":misk-config"))
   api(project(":misk-inject"))
   api(project(":misk-jobqueue"))
   api(project(":misk-testing-api"))
   api(project(":wisp:wisp-token"))
-  implementation(libs.aws2Auth)
   implementation(libs.aws2Core)
   implementation(libs.aws2Regions)
   implementation(libs.loggingApi)
   implementation(libs.openTracingDatadog)
-  implementation(project(":misk-api"))
-  implementation(project(":misk-aws"))
   implementation(project(":misk-metrics"))
   implementation(project(":misk-moshi"))
   implementation(project(":misk-service"))

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobHandlerModule.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobHandlerModule.kt
@@ -1,40 +1,22 @@
 package misk.aws2.sqs.jobqueue
 
+import kotlin.reflect.KClass
 import misk.ReadyService
 import misk.ServiceModule
-import misk.annotation.ExperimentalMiskApi
-import misk.inject.AsyncModule
+import misk.inject.AsyncSwitch
+import misk.inject.DefaultAsyncSwitchModule
 import misk.inject.KAbstractModule
 import misk.jobqueue.QueueName
 import misk.jobqueue.v2.JobHandler
-import kotlin.reflect.KClass
 
-/**
- * Install this module to register a handler for an SQS queue
- */
-class SqsJobHandlerModule private constructor(
-  private val queueName: QueueName,
-  private val handler: KClass<out JobHandler>,
-) : AsyncModule, KAbstractModule() {
+/** Install this module to register a handler for an SQS queue */
+class SqsJobHandlerModule
+private constructor(private val queueName: QueueName, private val handler: KClass<out JobHandler>) : KAbstractModule() {
   override fun configure() {
-    install(CommonModule(queueName, handler))
+    newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
 
-    // TODO remove explicit inline environment variable check once AsyncModule filtering in Guice is working
-    if (!System.getenv("DISABLE_ASYNC_TASKS").toBoolean()) {
-      install(ServiceModule<SubscriptionService>().dependsOn<ReadyService>())
-    }
-  }
-
-  @OptIn(ExperimentalMiskApi::class)
-  override fun moduleWhenAsyncDisabled(): KAbstractModule = CommonModule(queueName, handler)
-
-  private class CommonModule(
-    private val queueName: QueueName,
-    private val handler: KClass<out JobHandler>,
-  ) : KAbstractModule() {
-    override fun configure() {
-      newMapBinder<QueueName, JobHandler>().addBinding(queueName).to(handler.java)
-    }
+    install(DefaultAsyncSwitchModule())
+    install(ServiceModule<SubscriptionService>().conditionalOn<AsyncSwitch>("sqs").dependsOn<ReadyService>())
   }
 
   companion object {

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobQueueModule.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobQueueModule.kt
@@ -4,10 +4,10 @@ import com.google.inject.Provides
 import jakarta.inject.Singleton
 import misk.ReadyService
 import misk.ServiceModule
-import misk.annotation.ExperimentalMiskApi
 import misk.aws2.sqs.jobqueue.config.SqsConfig
 import misk.cloud.aws.AwsRegion
-import misk.inject.AsyncModule
+import misk.inject.AsyncSwitch
+import misk.inject.DefaultAsyncSwitchModule
 import misk.inject.KAbstractModule
 import misk.jobqueue.v2.JobConsumer
 import misk.jobqueue.v2.JobEnqueuer
@@ -18,47 +18,38 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder
 open class SqsJobQueueModule @JvmOverloads constructor(
   private val config: SqsConfig,
   private val configureClient: SqsAsyncClientBuilder.() -> Unit = {}
-) : AsyncModule, KAbstractModule() {
+) : KAbstractModule() {
   override fun configure() {
-    install(CommonModule(config, configureClient))
+    requireBinding<AwsCredentialsProvider>()
+    requireBinding<AwsRegion>()
+    bind<JobConsumer>().to<SqsJobConsumer>()
+    bind<JobEnqueuer>().to<SqsJobEnqueuer>()
+    multibind<TestFixture>().to<SqsJobConsumer>()
 
-    // TODO remove explicit inline environment variable check once AsyncModule filtering in Guice is working
-    if (!System.getenv("DISABLE_ASYNC_TASKS").toBoolean()) {
-      install(ServiceModule<SqsJobConsumer>().dependsOn<ReadyService>())
+    install(DefaultAsyncSwitchModule())
+    install(
+      ServiceModule<SqsJobConsumer>()
+        .conditionalOn<AsyncSwitch>("sqs")
+        .dependsOn<ReadyService>()
+    )
+  }
+
+  @Provides
+  fun sqsConfig(awsRegion: AwsRegion): SqsConfig {
+    return if (config.all_queues.region != null) {
+      config
+    } else {
+      config.copy(
+        all_queues = config.all_queues.copy(
+          region = awsRegion.name,
+        ),
+      )
     }
   }
 
-  @OptIn(ExperimentalMiskApi::class)
-  override fun moduleWhenAsyncDisabled(): KAbstractModule = CommonModule(config, configureClient)
-
-  private class CommonModule(
-    private val config: SqsConfig,
-    private val configureClient: SqsAsyncClientBuilder.() -> Unit
-  ) : KAbstractModule() {
-    override fun configure() {
-      requireBinding<AwsCredentialsProvider>()
-      requireBinding<AwsRegion>()
-      bind<JobConsumer>().to<SqsJobConsumer>()
-      bind<JobEnqueuer>().to<SqsJobEnqueuer>()
-      multibind<TestFixture>().to<SqsJobConsumer>()
-    }
-
-    @Provides
-    fun sqsConfig(awsRegion: AwsRegion): SqsConfig {
-      return if (config.all_queues.region != null) {
-        config
-      } else {
-        config.copy(
-          all_queues = config.all_queues.copy(
-            region = awsRegion.name,
-          ),
-        )
-      }
-    }
-
-    @Provides @Singleton
-    fun sqsClientFactory(
-      credentialsProvider: AwsCredentialsProvider,
-    ): SqsClientFactory = RealSqsClientFactory(credentialsProvider, configureClient)
-  }
+  @Provides
+  @Singleton
+  fun sqsClientFactory(
+    credentialsProvider: AwsCredentialsProvider,
+  ): SqsClientFactory = RealSqsClientFactory(credentialsProvider, configureClient)
 }

--- a/misk-cron/api/misk-cron.api
+++ b/misk-cron/api/misk-cron.api
@@ -56,14 +56,13 @@ public final class misk/cron/CronManager$RunningCronEntry {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class misk/cron/CronModule : misk/inject/KInstallOnceModule, misk/inject/AsyncModule {
+public final class misk/cron/CronModule : misk/inject/KInstallOnceModule {
 	public fun <init> (Ljava/time/ZoneId;)V
 	public fun <init> (Ljava/time/ZoneId;I)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;Z)V
 	public fun <init> (Ljava/time/ZoneId;ILjava/util/List;ZZ)V
 	public synthetic fun <init> (Ljava/time/ZoneId;ILjava/util/List;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun moduleWhenAsyncDisabled ()Lmisk/inject/KAbstractModule;
 	public final fun provideTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;)Lmisk/tasks/RepeatedTaskQueue;
 }
 

--- a/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronTask.kt
@@ -1,15 +1,15 @@
 package misk.cron
 
 import com.google.common.util.concurrent.AbstractIdleService
-import misk.clustering.weights.ClusterWeightProvider
-import misk.tasks.RepeatedTaskQueue
-import misk.tasks.Status
-import wisp.lease.LeaseManager
-import misk.logging.getLogger
-import java.time.Clock
-import java.time.Duration
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.clustering.weights.ClusterWeightProvider
+import misk.inject.AsyncSwitch
+import misk.logging.getLogger
+import misk.tasks.RepeatedTaskQueue
+import misk.tasks.Status
+import java.time.Clock
+import java.time.Duration
 
 @Singleton
 internal class CronTask @Inject constructor() : AbstractIdleService() {
@@ -17,19 +17,30 @@ internal class CronTask @Inject constructor() : AbstractIdleService() {
   @Inject private lateinit var cronManager: CronManager
   @Inject @ForMiskCron private lateinit var taskQueue: RepeatedTaskQueue
   @Inject private lateinit var clusterWeight: ClusterWeightProvider
+  @Inject private lateinit var asyncSwitch: AsyncSwitch
 
   override fun startUp() {
     logger.info { "Starting CronTask" }
     var lastRun = clock.instant()
     taskQueue.scheduleWithBackoff(INTERVAL) {
-      if (clusterWeight.get() == 0) {
-        logger.info { "CronTask is running on a passive node. Skipping." }
-        return@scheduleWithBackoff Status.OK
+      when {
+        asyncSwitch.isDisabled("cron") -> {
+          logger.info { "Async tasks are disabled on this node. Skipping." }
+          Status.OK
+        }
+
+        clusterWeight.get() == 0 -> {
+          logger.info { "CronTask is running on a passive node. Skipping." }
+          Status.OK
+        }
+
+        else -> {
+          val now = clock.instant()
+          cronManager.runReadyCrons(lastRun)
+          lastRun = now
+          Status.OK
+        }
       }
-      val now = clock.instant()
-      cronManager.runReadyCrons(lastRun)
-      lastRun = now
-      Status.OK
     }
   }
 

--- a/misk-inject/build.gradle.kts
+++ b/misk-inject/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
   testImplementation(libs.assertj)
   testImplementation(libs.junitApi)
   testImplementation(libs.kotlinTest)
-  testImplementation(project(":misk-inject"))
   testImplementation(project(":misk-testing"))
 }
 

--- a/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -76,7 +76,7 @@ abstract class KAbstractModule : AbstractModule() {
     qualifier: BindingQualifier? = null
   ): Multibinder<T> = newMultibinder(T::class, qualifier)
 
-  protected inline fun <reified T : Any, reified A: Annotation> newMultibinder(
+  protected inline fun <reified T : Any, reified A : Annotation> newMultibinder(
   ): Multibinder<T> = newMultibinder(T::class, A::class)
 
   protected fun <T : Any> newMultibinder(
@@ -108,7 +108,7 @@ abstract class KAbstractModule : AbstractModule() {
 
     return when (qualifier) {
       is InstanceQualifier -> Multibinder.newSetBinder(binder(), type, qualifier.annotation)
-      is TypeClassifier ->  Multibinder.newSetBinder(binder(), type, qualifier.type.java)
+      is TypeClassifier -> Multibinder.newSetBinder(binder(), type, qualifier.type.java)
       null -> Multibinder.newSetBinder(binder(), type)
     }
   }
@@ -143,13 +143,13 @@ abstract class KAbstractModule : AbstractModule() {
     keyType: TypeLiteral<K>,
     valueType: TypeLiteral<V>,
     annotation: KClass<out Annotation>?
-  ): MapBinder<K, V>  = newMapBinder(keyType, valueType, annotation?.qualifier)
+  ): MapBinder<K, V> = newMapBinder(keyType, valueType, annotation?.qualifier)
 
   protected fun <K : Any, V : Any> newMapBinder(
     keyType: TypeLiteral<K>,
     valueType: TypeLiteral<V>,
     annotation: Annotation?
-  ): MapBinder<K, V>  = newMapBinder(keyType, valueType, annotation?.qualifier)
+  ): MapBinder<K, V> = newMapBinder(keyType, valueType, annotation?.qualifier)
 
   protected fun <K : Any, V : Any> newMapBinder(
     keyType: TypeLiteral<K>,
@@ -190,7 +190,7 @@ abstract class KAbstractModule : AbstractModule() {
   protected fun <T : Any> bindOptional(baseSwitchType: KClass<T>): OptionalBinder<T> =
     OptionalBinder.newOptionalBinder(binder(), baseSwitchType.java)
 
-  protected inline fun <reified T: Any> bindOptional(): OptionalBinder<T> = bindOptional(T::class)
+  protected inline fun <reified T : Any> bindOptional(): OptionalBinder<T> = bindOptional(T::class)
 
   protected fun <T : Any> bindOptionalDefault(key: Key<T>): LinkedBindingBuilder<T> =
     OptionalBinder.newOptionalBinder(binder(), key)
@@ -200,7 +200,7 @@ abstract class KAbstractModule : AbstractModule() {
     OptionalBinder.newOptionalBinder(binder(), baseSwitchType.java)
       .setDefault()
 
-  protected inline fun <reified T: Any> bindOptionalDefault(): LinkedBindingBuilder<T> = bindOptionalDefault(T::class)
+  protected inline fun <reified T : Any> bindOptionalDefault(): LinkedBindingBuilder<T> = bindOptionalDefault(T::class)
 
   protected fun <T : Any> bindOptionalBinding(key: Key<T>): LinkedBindingBuilder<T> =
     OptionalBinder.newOptionalBinder(binder(), key)
@@ -210,5 +210,5 @@ abstract class KAbstractModule : AbstractModule() {
     OptionalBinder.newOptionalBinder(binder(), baseSwitchType.java)
       .setBinding()
 
-  protected inline fun <reified T: Any> bindOptionalBinding(): LinkedBindingBuilder<T> = bindOptionalBinding(T::class)
+  protected inline fun <reified T : Any> bindOptionalBinding(): LinkedBindingBuilder<T> = bindOptionalBinding(T::class)
 }

--- a/misk-service/src/main/kotlin/misk/ServiceModule.kt
+++ b/misk-service/src/main/kotlin/misk/ServiceModule.kt
@@ -5,7 +5,6 @@ import com.google.common.util.concurrent.Service
 import com.google.inject.Key
 import jakarta.inject.Singleton
 import misk.inject.ConditionalProvider
-import misk.inject.ConditionalTypedProvider
 import misk.inject.KAbstractModule
 import misk.inject.Switch
 import misk.inject.asSingleton
@@ -171,13 +170,17 @@ constructor(
   fun conditionalOn(switchKey: String, switchType: KClass<out Switch>) =
     ServiceModule(key, dependsOn, enhancedBy, switchKey, switchType, disabledKey)
 
-  fun dependsOn(upstream: Key<out Service>) = ServiceModule(key, dependsOn + upstream, enhancedBy, switchKey, switchType, disabledKey)
+  fun dependsOn(upstream: Key<out Service>) =
+    ServiceModule(key, dependsOn + upstream, enhancedBy, switchKey, switchType, disabledKey)
 
-  fun dependsOn(upstream: List<Key<out Service>>) = ServiceModule(key, dependsOn + upstream, enhancedBy, switchKey, switchType, disabledKey)
+  fun dependsOn(upstream: List<Key<out Service>>) =
+    ServiceModule(key, dependsOn + upstream, enhancedBy, switchKey, switchType, disabledKey)
 
-  fun enhancedBy(enhancement: Key<out Service>) = ServiceModule(key, dependsOn, enhancedBy + enhancement, switchKey, switchType, disabledKey)
+  fun enhancedBy(enhancement: Key<out Service>) =
+    ServiceModule(key, dependsOn, enhancedBy + enhancement, switchKey, switchType, disabledKey)
 
-  fun enhancedBy(enhancement: List<Key<out Service>>) = ServiceModule(key, dependsOn, enhancedBy + enhancement, switchKey, switchType, disabledKey)
+  fun enhancedBy(enhancement: List<Key<out Service>>) =
+    ServiceModule(key, dependsOn, enhancedBy + enhancement, switchKey, switchType, disabledKey)
 
   @JvmOverloads
   inline fun <reified T : Switch> conditionalOn(switchKey: String = "default") =
@@ -196,6 +199,7 @@ constructor(
  * Returns a [ServiceModule] and hooks up service dependencies and enhancements.
  *
  * Here's how:
+ *
  * ```
  * Guice.createInjector(object : KAbstractModule() {
  *   override fun configure() {
@@ -207,6 +211,7 @@ constructor(
  * ```
  *
  * Dependencies and services may be optionally annotated:
+ *
  * ```
  * Guice.createInjector(object : KAbstractModule() {
  *   override fun configure() {


### PR DESCRIPTION
Migrate AsyncModule to AsyncSwitch. 

The previous AsyncModule approach in practice had issues with preserving Provides methods on the module and the API for fallback module leading to more complicated refactoring than necessary. In most cases, swapping the real for a no-op Guava service was the only change needed to disable async functionality on a pod so a more narrower abstraction for an `AsyncSwitch` with tight integration with `ServiceModule` is being proposed instead.

Spitting this into two to land more safely, first adding the new APIs, then using them.
- [x] https://github.com/cashapp/misk/pull/3562
- [x] https://github.com/cashapp/misk/pull/3563
- [x] using them PR: this PR
- [x] don't merge until internal version bumped to latest