### PR TITLE
Fixes backward incompatible change for newMapBinding

### DIFF
--- a/misk-inject/api/misk-inject.api
+++ b/misk-inject/api/misk-inject.api
@@ -73,11 +73,14 @@ public final class misk/inject/GuiceKt {
 public abstract class misk/inject/KAbstractModule : com/google/inject/AbstractModule {
 	public fun <init> ()V
 	protected fun binder ()Lcom/google/inject/Binder;
+	protected final fun newMapBinder (Lcom/google/inject/TypeLiteral;Lcom/google/inject/TypeLiteral;Ljava/lang/annotation/Annotation;)Lcom/google/inject/multibindings/MapBinder;
+	protected final fun newMapBinder (Lcom/google/inject/TypeLiteral;Lcom/google/inject/TypeLiteral;Lkotlin/reflect/KClass;)Lcom/google/inject/multibindings/MapBinder;
 	protected final fun newMapBinder (Lcom/google/inject/TypeLiteral;Lcom/google/inject/TypeLiteral;Lmisk/inject/BindingQualifier;)Lcom/google/inject/multibindings/MapBinder;
 	protected final fun newMapBinder (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/annotation/Annotation;)Lcom/google/inject/multibindings/MapBinder;
 	protected final fun newMapBinder (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lcom/google/inject/multibindings/MapBinder;
+	protected final fun newMapBinder (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lmisk/inject/BindingQualifier;)Lcom/google/inject/multibindings/MapBinder;
 	public static synthetic fun newMapBinder$default (Lmisk/inject/KAbstractModule;Lcom/google/inject/TypeLiteral;Lcom/google/inject/TypeLiteral;Lmisk/inject/BindingQualifier;ILjava/lang/Object;)Lcom/google/inject/multibindings/MapBinder;
-	public static synthetic fun newMapBinder$default (Lmisk/inject/KAbstractModule;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lcom/google/inject/multibindings/MapBinder;
+	public static synthetic fun newMapBinder$default (Lmisk/inject/KAbstractModule;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lmisk/inject/BindingQualifier;ILjava/lang/Object;)Lcom/google/inject/multibindings/MapBinder;
 	protected final fun newMultibinder (Lcom/google/inject/TypeLiteral;Lmisk/inject/BindingQualifier;)Lcom/google/inject/multibindings/Multibinder;
 	protected final fun newMultibinder (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lcom/google/inject/multibindings/Multibinder;
 	protected final fun newMultibinder (Lkotlin/reflect/KClass;Lmisk/inject/BindingQualifier;)Lcom/google/inject/multibindings/Multibinder;

--- a/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
+++ b/misk-inject/src/main/kotlin/misk/inject/KAbstractModule.kt
@@ -119,7 +119,7 @@ abstract class KAbstractModule : AbstractModule() {
   protected fun <K : Any, V : Any> newMapBinder(
     keyType: KClass<K>,
     valueType: KClass<V>,
-    annotation: KClass<out Annotation>? = null
+    annotation: KClass<out Annotation>?
   ): MapBinder<K, V> = newMapBinder(keyType.typeLiteral(), valueType.typeLiteral(), annotation?.qualifier)
 
   protected inline fun <reified K : Any, reified V : Any> newMapBinder(
@@ -131,6 +131,24 @@ abstract class KAbstractModule : AbstractModule() {
     valueType: KClass<V>,
     annotation: Annotation?
   ): MapBinder<K, V> = newMapBinder(keyType.typeLiteral(), valueType.typeLiteral(), annotation?.qualifier)
+
+  protected fun <K : Any, V : Any> newMapBinder(
+    keyType: KClass<K>,
+    valueType: KClass<V>,
+    qualifier: BindingQualifier? = null
+  ): MapBinder<K, V> = newMapBinder(keyType.typeLiteral(), valueType.typeLiteral(), qualifier)
+
+  protected fun <K : Any, V : Any> newMapBinder(
+    keyType: TypeLiteral<K>,
+    valueType: TypeLiteral<V>,
+    annotation: KClass<out Annotation>?
+  ): MapBinder<K, V>  = newMapBinder(keyType, valueType, annotation?.qualifier)
+
+  protected fun <K : Any, V : Any> newMapBinder(
+    keyType: TypeLiteral<K>,
+    valueType: TypeLiteral<V>,
+    annotation: Annotation?
+  ): MapBinder<K, V>  = newMapBinder(keyType, valueType, annotation?.qualifier)
 
   protected fun <K : Any, V : Any> newMapBinder(
     keyType: TypeLiteral<K>,

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -367,6 +367,7 @@ public final class misk/mcp/testing/resources/WebSearchResource : misk/mcp/McpRe
 public abstract class misk/mcp/testing/tools/AbstractEchoTool : misk/mcp/StructuredMcpTool {
 	public fun <init> ()V
 	public fun buildGreeting (Ljava/lang/String;)Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
 	public synthetic fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handle (Lmisk/mcp/testing/tools/EchoToolInput;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -459,7 +460,6 @@ public final class misk/mcp/testing/tools/CalculatorToolOutput$Companion {
 public final class misk/mcp/testing/tools/EchoTool : misk/mcp/testing/tools/AbstractEchoTool {
 	public fun <init> ()V
 	public fun getDescription ()Ljava/lang/String;
-	public fun getName ()Ljava/lang/String;
 }
 
 public final class misk/mcp/testing/tools/EchoToolInput {
@@ -518,7 +518,6 @@ public final class misk/mcp/testing/tools/EchoToolV2 : misk/mcp/testing/tools/Ab
 	public fun <init> ()V
 	public fun buildGreeting (Ljava/lang/String;)Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
-	public fun getName ()Ljava/lang/String;
 }
 
 public final class misk/mcp/testing/tools/GetNicknameRequest {

--- a/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/tools/EchoTool.kt
+++ b/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/tools/EchoTool.kt
@@ -25,16 +25,15 @@ abstract class AbstractEchoTool : StructuredMcpTool<EchoToolInput, EchoToolOutpu
     return ToolResult(result = EchoToolOutput(buildGreeting(input.name)))
   }
 
+  override val name = "EchoTool"
   open fun buildGreeting(name: String) = "Hello, $name!"
 }
 
 class EchoTool @Inject constructor() : AbstractEchoTool() {
-  override val name = "EchoTool"
   override val description = "This tool will return Hello, <name>!"
 }
 
 class EchoToolV2 @Inject constructor() : AbstractEchoTool() {
-  override val name = "EchoTool"
   override val description = "This tool will return Hello again, <name>!"
 
   override fun buildGreeting(name: String) = "Hello again, $name!"


### PR DESCRIPTION
## Description

Fixes backward incompatible change for newMapBinding. When add the generic binding qualifiers, there is a ambiguous definition for newMapBinding. There was no typeLiteral variation that had a nullable KClass for Annotation parameter

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
