### PR TITLE
Explicit misk-mcp server scoping

### DIFF
--- a/misk-mcp/src/main/kotlin/misk/mcp/McpPromptModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpPromptModule.kt
@@ -3,7 +3,6 @@ package misk.mcp
 import misk.annotation.ExperimentalMiskApi
 import misk.inject.BindingQualifier
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 import misk.inject.qualifier
 import kotlin.reflect.KClass
 
@@ -87,7 +86,6 @@ class McpPromptModule<P : McpPrompt> private constructor(
     // Bind the MCP prompt to the named server's prompt set
     multibind<McpPrompt>(qualifier)
       .to(promptClass.java)
-      .asSingleton()
   }
 
   companion object {

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpResourceModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpResourceModule.kt
@@ -3,7 +3,6 @@ package misk.mcp
 import misk.annotation.ExperimentalMiskApi
 import misk.inject.BindingQualifier
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 import misk.inject.qualifier
 import kotlin.reflect.KClass
 
@@ -87,7 +86,6 @@ class McpResourceModule<R : McpResource> private constructor(
     // Bind the MCP resource to the named server's resource set
     multibind<McpResource>(qualifier)
       .to(resourceClass.java)
-      .asSingleton()
   }
 
   companion object {

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpServerModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpServerModule.kt
@@ -11,7 +11,6 @@ import misk.annotation.ExperimentalMiskApi
 import misk.inject.BindingQualifier
 import misk.inject.KAbstractModule
 import misk.inject.KInstallOnceModule
-import misk.inject.asSingleton
 import misk.inject.keyOf
 import misk.inject.parameterizedType
 import misk.inject.qualifier
@@ -220,7 +219,7 @@ class McpServerModule private constructor(
         instructionsProvider = instructionsProvider,
         mcpMetrics = mcpMetricsProvider.get(),
       )
-    }.asSingleton()
+    }
     val mcpServerProvider = getProvider(serverKey)
 
     // Create a qualified binding for the McpStreamManager

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpToolModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpToolModule.kt
@@ -3,7 +3,6 @@ package misk.mcp
 import misk.annotation.ExperimentalMiskApi
 import misk.inject.BindingQualifier
 import misk.inject.KAbstractModule
-import misk.inject.asSingleton
 import misk.inject.qualifier
 import kotlin.reflect.KClass
 
@@ -87,7 +86,6 @@ class McpToolModule<T : McpTool<*>> private constructor(
     // Bind the MCP tool to the named server's tool set
     multibind<McpTool<*>>(qualifier)
       .to(toolClass.java)
-      .asSingleton()
   }
 
   companion object {

--- a/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
@@ -57,7 +57,6 @@ import kotlin.time.TimeSource
  * [misk.mcp.action.McpStreamManager]:
  *
  * ```kotlin
- * @Singleton
  * class MyMcpWebAction @Inject constructor(
  *   private val mcpStreamManager: McpStreamManager
  * ) : WebAction {

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
@@ -71,7 +71,6 @@ internal abstract class McpServerActionTest {
   class McpStreamableHttpServerActionTest : McpServerActionTest() {
     @OptIn(ExperimentalMiskApi::class)
     @Suppress("unused")
-    @Singleton
     class McpServerActionTestPostAction @Inject constructor(private val mcpStreamManager: McpStreamManager) :
       WebAction {
       @McpPost
@@ -101,7 +100,6 @@ internal abstract class McpServerActionTest {
   class McpWebSocketServerActionTest : McpServerActionTest() {
     @OptIn(ExperimentalMiskApi::class)
     @Suppress("unused")
-    @Singleton
     class McpWebSocketServerActionTestAction @Inject constructor(
       private val mcpStreamManager: McpStreamManager
     ) : WebAction {

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpStatefulServerActionTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpStatefulServerActionTest.kt
@@ -61,7 +61,6 @@ internal class McpStatefulServerActionTest {
 
   @OptIn(ExperimentalMiskApi::class)
   @Suppress("unused")
-  @Singleton
   class McpStatefulServerActionTestPostAction @Inject constructor(private val mcpStreamManager: McpStreamManager) :
     WebAction {
     @McpPost
@@ -72,7 +71,6 @@ internal class McpStatefulServerActionTest {
 
   @OptIn(ExperimentalMiskApi::class)
   @Suppress("unused")
-  @Singleton
   class McpStatefulServerActionTestDeleteAction @Inject constructor(
     private val mcpSessionHandler: McpSessionHandler
   ) : WebAction {


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

This PR improves the scoping and lifecycle management of MCP servers in misk-mcp, making it easier to create request-scoped servers and clarifying best practices for WebAction implementation.

## Key Changes

### 1. Removed Unnecessary Singleton Scoping

**Removed `@Singleton` annotations from:**
- `McpToolModule` bindings - tools no longer forced to be singletons
- `McpPromptModule` bindings - prompts no longer forced to be singletons
- `McpResourceModule` bindings - resources no longer forced to be singletons
- Test WebActions - demonstrating unscoped pattern

**Why:** These components don't need to be singletons and forcing singleton scope prevented request-specific behavior. By removing the singleton constraint, developers can now create fresh instances per request, enabling dynamic tool metadata based on request context (user permissions, tenant, etc.).

### 2. Comprehensive Documentation on WebAction Scoping

**Added new "WebAction Scoping Best Practices" section to README covering:**

- **Recommended pattern:** Unscoped WebActions with direct `McpStreamManager` injection
  - Creates fresh server instances per request
  - Enables request-specific tool/resource/prompt metadata
  - Simpler mental model

- **Alternative pattern:** Singleton WebActions with `Provider<McpStreamManager>`
  - For expensive WebAction initialization
  - Still supports dynamic behavior via provider

- **Anti-pattern warning:** Singleton WebActions with direct injection
  - Creates singleton server (one instance for all requests)
  - Only appropriate when ALL metadata is completely static

**Includes comparison table and clear guidance on when to use each pattern.**

### 3. Documentation Cleanup

- Removed `@Singleton` from code examples in README and KDoc
- Updated MiskMcpServer documentation to reflect unscoped pattern
- Clarified that WebActions should generally be unscoped

## Migration Guide

**Existing code continues to work** - this is a backward-compatible change. However, you may want to:

1. **Remove unnecessary `@Singleton` annotations** from your MCP WebActions
2. **Consider request-scoped behavior** if your tools/resources vary by user/tenant
3. **Use `Provider<McpStreamManager>`** if you need singleton WebActions

## Testing

- All existing tests pass
- Test WebActions updated to demonstrate unscoped pattern
- No breaking changes to public API

## Benefits

✅ More flexible server lifecycle management
✅ Enables request-specific tool metadata
✅ Better support for multi-tenant scenarios
✅ Clearer documentation and best practices
✅ Backward compatible with existing code

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
