### PR TITLE
Add server version as a metrics label

### DIFF
--- a/misk-mcp/src/main/kotlin/misk/mcp/McpMetrics.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpMetrics.kt
@@ -21,6 +21,7 @@ import kotlin.time.Duration
  *
  * **Labels:**
  * - `server_name`: The name of the MCP server instance (from [MiskMcpServer.name])
+ * - `server_version`: The version of the MCP server instance (from [MiskMcpServer.version])
  * - `tool_name`: The name of the executed tool (from [McpTool.name])
  * - `tool_outcome`: The execution outcome - one of [ToolCallOutcome] values
  *
@@ -74,7 +75,7 @@ internal class McpMetrics @Inject internal constructor(metrics: Metrics) {
   private val mcpToolHandlerLatency = metrics.histogram(
     "mcp_tool_handler_latency",
     "how long a tool's handler() method took",
-    listOf("server_name", "tool_name", "tool_outcome")
+    listOf("server_name", "server_version", "tool_name", "tool_outcome")
   )
   
   /**
@@ -85,12 +86,19 @@ internal class McpMetrics @Inject internal constructor(metrics: Metrics) {
    *
    * @param duration The time taken to execute the tool handler
    * @param serverName The name of the MCP server instance
+   * @param version The version of the MCP server instance
    * @param toolName The name of the executed tool
    * @param outcome The execution outcome (Success, Error, or Exception)
    */
-  fun mcpToolHandlerLatency(duration: Duration, serverName: String, toolName: String, outcome: ToolCallOutcome) {
+  fun mcpToolHandlerLatency(
+    duration: Duration,
+    serverName: String,
+    version: String,
+    toolName: String,
+    outcome: ToolCallOutcome
+  ) {
     mcpToolHandlerLatency
-      .labels(serverName, toolName, outcome.name)
+      .labels(serverName, version, toolName, outcome.name)
       .observe(duration.inWholeMilliseconds.toDouble())
   }
   

--- a/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
@@ -182,7 +182,7 @@ class MiskMcpServer internal constructor(
         throw ex
       } finally {
         val duration = mark.elapsedNow()
-        mcpMetrics.mcpToolHandlerLatency(duration, name, toolName, outcome)
+        mcpMetrics.mcpToolHandlerLatency(duration, name, version, toolName, outcome)
       }
     }
   }

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
@@ -434,6 +434,7 @@ internal abstract class McpServerActionTest {
       actual = registry.summaryCount(
         "mcp_tool_handler_latency",
         "server_name" to "mcp-server-action-test-server",
+        "server_version" to "1.0.0",
         "tool_name" to "calculator",
         "tool_outcome" to "Success",
       )
@@ -452,6 +453,7 @@ internal abstract class McpServerActionTest {
         registry.summaryCount(
         "mcp_tool_handler_latency",
         "server_name" to "mcp-server-action-test-server",
+        "server_version" to "1.0.0",
         "tool_name" to "calculator",
         "tool_outcome" to "Error",
       )
@@ -468,6 +470,7 @@ internal abstract class McpServerActionTest {
       actual = registry.summaryCount(
         "mcp_tool_handler_latency",
         "server_name" to "mcp-server-action-test-server",
+        "server_version" to "1.0.0",
         "tool_name" to "throwing",
         "tool_outcome" to "Exception",
       )


### PR DESCRIPTION
## Description

This PR adds `server_version` as a label to the `mcp_tool_handler_latency` metric, enabling better tracking and analysis of tool performance across different server versions.

### Changes

#### Metrics Enhancement
- **Updated `McpMetrics.kt`**:
  - Added `server_version` label to the `mcp_tool_handler_latency` histogram
  - Updated the `mcpToolHandlerLatency()` method signature to accept a `version` parameter
  - Enhanced KDoc documentation to reflect the new label

#### Integration
- **Updated `MiskMcpServer.kt`**:
  - Modified the tool execution flow to pass the server version when recording metrics
  - Ensures version information is captured for every tool invocation

#### Test Updates
- **Updated `McpServerActionTest.kt`**:
  - Added `server_version` label assertions to all metric validation tests
  - Ensures tests verify the new label is properly recorded for Success, Error, and Exception outcomes

### Benefits
- **Version-based Analysis**: Enables tracking tool performance differences across server versions
- **Debugging**: Helps identify version-specific performance issues or regressions
- **Monitoring**: Allows for version-specific alerting and dashboards

### Backward Compatibility
This change modifies the metric label structure. Existing dashboards or alerts that query `mcp_tool_handler_latency` will need to be updated to account for the new `server_version` label.

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
