### PR TITLE
fix: Span isn't a DDSpan and original_trace_id isn't being set in the _jobqueue-metadata

### DIFF
--- a/misk-aws/build.gradle.kts
+++ b/misk-aws/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
   implementation(libs.openTracingDatadog)
   implementation(libs.prometheusClient)
   implementation(libs.slf4jApi)
-  implementation(libs.tracingDatadog)
   implementation(project(":misk-api"))
   implementation(project(":misk-moshi"))
   implementation(project(":misk-testing"))

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsJobQueue.kt
@@ -141,9 +141,8 @@ internal class SqsJobQueue @Inject internal constructor(
     )
 
     // Preserve original trace id, if available.
-    (span as? DDSpan)?.let {
-      val traceId = it.context().traceId.toString()
-      metadata[SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID] = traceId
+    span.context().toTraceId()?.takeIf { it.isNotBlank() }?.let {
+      metadata[SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID] = it
     }
 
     return MessageAttributeValue()

--- a/misk-aws2-sqs/build.gradle.kts
+++ b/misk-aws2-sqs/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
   implementation(libs.aws2Regions)
   implementation(libs.loggingApi)
   implementation(libs.openTracingDatadog)
-  implementation(libs.tracingDatadog)
   implementation(project(":misk-api"))
   implementation(project(":misk-aws"))
   implementation(project(":misk-metrics"))

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobEnqueuer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobEnqueuer.kt
@@ -237,9 +237,8 @@ class SqsJobEnqueuer @Inject constructor(
     )
 
     // Preserve original trace id, if available.
-    (span as? DDSpan)?.let {
-      val traceId = it.context().traceId.toString()
-      metadata[SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID] = traceId
+    span.context().toTraceId()?.takeIf { it.isNotBlank() }?.let {
+      metadata[SqsJob.JOBQUEUE_METADATA_ORIGINAL_TRACE_ID] = it
     }
 
     return MessageAttributeValue.builder()


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

While testing some sqs changes we found that `JOBQUEUE_METADATA_ORIGINAL_TRACE_ID` isn't being set when testing some changes rlated to sqs integration work with playpen. Looks like the Span is never a DDSpan but an OTSpan.

## Testing Strategy

Tested using playpen before and after the change in cash-playpen-testbed app.

### Before
`original_trace_id` not present in the `_jobqueue-metadata` MessageAttribute.
<img width="489" height="802" alt="Screenshot 2025-11-19 at 4 42 12 PM" src="https://github.com/user-attachments/assets/f53abdb9-efcf-481e-89ac-ddb9af0fae7a" />

### After
`original_trace_id` now present in the `_jobqueue-metadata` MessageAttribute.
<img width="1709" height="532" alt="Screenshot 2025-11-19 at 4 04 16 PM" src="https://github.com/user-attachments/assets/a41e4423-5daa-48b0-923c-a49b0399fc3c" />


## Related Work

https://sq-block.slack.com/archives/C096YVAPX7G/p1763502983981289?thread_ts=1763434406.968859&cid=C096YVAPX7G

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [ ] I have manually testing this via playpen in one of the app (`cash-playpen-testbed`) by including local changes from misk.

Thank you for contributing to Misk! 🎉
