### PR TITLE
feat: introduce `isHeld()` method for `Lease`

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
@@ -37,10 +37,7 @@ internal class AwsSqsQueueAttributeImporter @Inject constructor(
       }
       val queue = queues.getForSending(queueName)
       val lease = leaseManager.requestLease("sqs-queue-attributes-${queue.queueName}")
-      var leaseHeld = lease.checkHeld()
-      if (!leaseHeld) {
-        leaseHeld = lease.acquire()
-      }
+      var leaseHeld = lease.isHeld() || lease.acquire()
       if (!leaseHeld) {
         metrics.sqsApproxNumberOfMessages.clear()
         metrics.sqsApproxNumberOfMessagesNotVisible.clear()

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
@@ -57,9 +57,7 @@ class SqsConsumerAllocator @Inject constructor(
   /** Returns true if the lease was acquired false otherwise. */
   private fun maybeAcquireConsumerLease(queueName: QueueName, candidate: Int): Boolean {
     val lease = leaseManager.requestLease(leaseName(queueName, candidate))
-    if (lease.checkHeld()) return true
-
-    return lease.acquire()
+    return lease.isHeld() || lease.acquire()
   }
 
   private fun receiversPerPodForQueue(queueName: QueueName): Int {

--- a/misk-clustering/api/misk-clustering.api
+++ b/misk-clustering/api/misk-clustering.api
@@ -162,6 +162,7 @@ public final class misk/clustering/fake/lease/FakeLease : wisp/lease/Lease {
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z
 	public fun getName ()Ljava/lang/String;
+	public fun isHeld ()Z
 	public final fun notifyAfterAcquire ()V
 	public final fun notifyBeforeRelease ()V
 	public fun release ()Z
@@ -229,6 +230,7 @@ public final class misk/clustering/lease/ClusterAwareLease : wisp/lease/Lease {
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z
 	public fun getName ()Ljava/lang/String;
+	public fun isHeld ()Z
 	public fun release ()Z
 	public fun release (Z)Z
 	public fun shouldHold ()Z

--- a/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLease.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLease.kt
@@ -10,7 +10,9 @@ class FakeLease(
 
   override fun shouldHold(): Boolean = true
 
-  override fun checkHeld() = manager.isLeaseHeld(name)
+  override fun isHeld() = manager.isLeaseHeld(name)
+
+  override fun checkHeld() = isHeld()
 
   /**
    * @return true if the other process holds the lease.
@@ -21,8 +23,8 @@ class FakeLease(
    * @return true if this process acquires the lease.
    */
   override fun acquire(): Boolean {
-    val result = checkHeld()
-    if (checkHeld()) {
+    val result = isHeld()
+    if (result) {
       notifyAfterAcquire()
     }
     return result
@@ -33,7 +35,7 @@ class FakeLease(
    * if the lease was not held.
    */
   override fun release(): Boolean {
-    if (!checkHeld()) {
+    if (!isHeld()) {
       return false
     }
     notifyBeforeRelease()
@@ -44,7 +46,7 @@ class FakeLease(
 
   override fun addListener(listener: Lease.StateChangeListener) {
     listeners.add(listener)
-    if (checkHeld()) {
+    if (isHeld()) {
       listener.afterAcquire(this)
     }
   }

--- a/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLease.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLease.kt
@@ -5,7 +5,7 @@ import wisp.lease.Lease
 
 /**
  * Provides functions to acquire and check if a lease is held.
- * Returns true for acquire() and checkHeld() if the app is running in the active region.
+ * Returns true for acquire() and isHeld() if the app is running in the active region.
  *
  * This lease serves as a no-op lease, suitable for situations where lease injection is necessary
  * but not functionally important, such as in Misk SQS.
@@ -21,13 +21,13 @@ class ClusterAwareLease(
   override fun addListener(listener: Lease.StateChangeListener) {
   }
 
-  override fun checkHeld(): Boolean {
+  override fun isHeld(): Boolean {
     return (clusterWeightProvider.get() != 0)
   }
 
-  override fun checkHeldElsewhere(): Boolean {
-    return (clusterWeightProvider.get() == 0)
-  }
+  override fun checkHeld(): Boolean = isHeld()
+
+  override fun checkHeldElsewhere(): Boolean = !isHeld()
 
   override fun release(): Boolean {
     return true

--- a/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLeaseManager.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLeaseManager.kt
@@ -8,7 +8,7 @@ import wisp.lease.LoadBalancedLeaseManager
 
 /**
  * Returns a Lease that always returns true for acquire() and
- * checkHeld() if the app is running in the active region.
+ * isHeld() if the app is running in the active region.
  */
 class ClusterAwareLeaseManager @Inject internal constructor(
   private val clusterWeightProvider: ClusterWeightProvider

--- a/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLeaseModule.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLeaseModule.kt
@@ -5,7 +5,7 @@ import wisp.lease.LeaseManager
 
 /**
  * Configures a LeaseManager that has leases that always return true for acquire() and
- * checkHeld() if the app is running in the active region.
+ * isHeld() if the app is running in the active region.
  *
  * This can be used to ignore the lease injection required for Misk SQS Jobs.
  */

--- a/misk-clustering/src/test/kotlin/misk/clustering/fake/lease/FakeLeaseManagerTest.kt
+++ b/misk-clustering/src/test/kotlin/misk/clustering/fake/lease/FakeLeaseManagerTest.kt
@@ -13,16 +13,21 @@ internal class FakeLeaseManagerTest {
     val otherLease = leaseManager.requestLease("my-other-lease")
 
     // leases are held by the current process by default
+    assertThat(lease.isHeld()).isTrue()
     assertThat(lease.checkHeld()).isTrue()
     assertThat(otherLease.checkHeld()).isTrue()
 
     leaseManager.markLeaseHeldElsewhere("my-lease")
+    assertThat(lease.isHeld()).isFalse()
     assertThat(lease.checkHeld()).isFalse()
     assertThat(lease.acquire()).isFalse()
+    assertThat(otherLease.isHeld()).isTrue()
     assertThat(otherLease.checkHeld()).isTrue()
 
     leaseManager.markLeaseHeld("my-lease")
+    assertThat(lease.isHeld()).isTrue()
     assertThat(lease.checkHeld()).isTrue()
+    assertThat(otherLease.isHeld()).isTrue()
     assertThat(otherLease.checkHeld()).isTrue()
   }
 }

--- a/misk-clustering/src/test/kotlin/misk/clustering/lease/ClusterAwareLeaseTest.kt
+++ b/misk-clustering/src/test/kotlin/misk/clustering/lease/ClusterAwareLeaseTest.kt
@@ -36,10 +36,12 @@ internal class ClusterAwareLeaseTest {
 
     // This should work for other lease managers as well.
     assertTrue(lease1.acquire())
+    assertTrue(lease1.isHeld())
     assertTrue(lease1.checkHeld())
 
     // This will be false for any lease managers other than the ClusterAwareLeaseManager
     // because lease hasn't been acquired yet.
+    assertTrue(lease2.isHeld())
     assertTrue(lease2.checkHeld())
     assertTrue(lease2.acquire())
   }
@@ -52,6 +54,7 @@ internal class ClusterAwareLeaseTest {
 
     // Both should be false for ClusterAwareLeaseManager
     assertFalse(lease.acquire())
+    assertFalse(lease.isHeld())
     assertFalse(lease.checkHeld())
   }
 }

--- a/misk-cron/src/main/kotlin/misk/cron/CronCoordinator.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronCoordinator.kt
@@ -12,7 +12,7 @@ class SingleLeaseCronCoordinator @Inject constructor(
 ) : CronCoordinator {
   override fun shouldRunTask(taskName: String): Boolean {
     val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
-    return lease.checkHeld() || lease.acquire()
+    return lease.isHeld() || lease.acquire()
   }
 
   companion object {
@@ -25,6 +25,6 @@ class MultipleLeaseCronCoordinator @Inject constructor(
 ) : CronCoordinator {
   override fun shouldRunTask(taskName: String): Boolean {
     val taskLease = leaseManager.requestLease("misk.cron.task.$taskName")
-    return taskLease.checkHeld() || taskLease.acquire()
+    return taskLease.isHeld() || taskLease.acquire()
   }
 }

--- a/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
+++ b/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
@@ -89,20 +89,22 @@ internal class SqlLeaseManager @Inject constructor(
 
     override fun shouldHold(): Boolean = true
 
-    /**
-     * Returns true if this process holds the lease.
-     */
-    override fun checkHeld(): Boolean {
+    override fun isHeld(): Boolean {
       if (heldVersion == NOT_HELD) return false
-      
+
       // We hold the lease until it expires
       return clock.instant() <= heldUntil
     }
 
     /**
+     * Returns true if this process holds the lease.
+     */
+    override fun checkHeld(): Boolean = isHeld()
+
+    /**
      * Returns true if the lease is held by another process.
      */
-    override fun checkHeldElsewhere(): Boolean = !checkHeld()
+    override fun checkHeldElsewhere(): Boolean = !isHeld()
 
     /**
      * Attempts to acquire the lease.
@@ -110,7 +112,7 @@ internal class SqlLeaseManager @Inject constructor(
      */
     override fun acquire(): Boolean {
       val lease = requestLease(name)
-      if (lease.checkHeld()) {
+      if (lease.isHeld()) {
         notifyAfterAcquire()
         return true
       }

--- a/misk-lease-mysql/src/test/kotlin/misk/lease/mysql/SqlLeaseManagerTest.kt
+++ b/misk-lease-mysql/src/test/kotlin/misk/lease/mysql/SqlLeaseManagerTest.kt
@@ -35,10 +35,12 @@ class SqlLeaseManagerTest {
   fun leaseCannotBeAcquiredWhenItIsHeld() {
     val leaseA = leaseManager.requestLease("a")
     assertThat(leaseA).isNotNull()
+    assertThat(leaseA.isHeld()).isTrue()
     assertThat(leaseA.checkHeld()).isTrue()
 
     val leaseA2 = leaseManager.requestLease("a")
     assertThat(leaseA2).isNotNull()
+    assertThat(leaseA2.isHeld()).isFalse()
     assertThat(leaseA2.checkHeld()).isFalse()
   }
 
@@ -49,11 +51,13 @@ class SqlLeaseManagerTest {
   fun leaseCanBeAcquiredAfterItIsReleased() {
     val leaseA = leaseManager.requestLease("a")
     assertThat(leaseA).isNotNull()
+    assertThat(leaseA.isHeld()).isTrue()
     assertThat(leaseA.checkHeld()).isTrue()
     leaseA!!.release()
 
     val leaseA2 = leaseManager.requestLease("a")
     assertThat(leaseA2).isNotNull()
+    assertThat(leaseA2.isHeld()).isTrue()
     assertThat(leaseA2.checkHeld()).isTrue()
   }
 
@@ -64,10 +68,12 @@ class SqlLeaseManagerTest {
   fun multipleLeasesCanBeAcquiredIndependently() {
     val leaseA = leaseManager.requestLease("a")
     assertThat(leaseA).isNotNull()
+    assertThat(leaseA.isHeld()).isTrue()
     assertThat(leaseA.checkHeld()).isTrue()
 
     val leaseB = leaseManager.requestLease("b")
     assertThat(leaseB).isNotNull()
+    assertThat(leaseB.isHeld()).isTrue()
     assertThat(leaseB.checkHeld()).isTrue()
   }
 
@@ -81,6 +87,7 @@ class SqlLeaseManagerTest {
     // Use explicit 60 second duration for this test
     val leaseA = sqlLeaseManager.requestLease("test-lease", Duration.ofSeconds(LEASE_DURATION_SECONDS))
     assertThat(leaseA).isNotNull()
+    assertThat(leaseA.isHeld()).isTrue()
     assertThat(leaseA.checkHeld()).isTrue()
 
     // Advance clock exactly to the lease duration (60 seconds)
@@ -88,6 +95,7 @@ class SqlLeaseManagerTest {
 
     val leaseA2 = sqlLeaseManager.requestLease("test-lease", Duration.ofSeconds(LEASE_DURATION_SECONDS))
     assertThat(leaseA2).isNotNull()
+    assertThat(leaseA2.isHeld()).isFalse()
     assertThat(leaseA2.checkHeld()).isFalse()
   }
 
@@ -101,6 +109,7 @@ class SqlLeaseManagerTest {
     // Use explicit 60 second duration for this test
     val leaseA = sqlLeaseManager.requestLease("test-lease", Duration.ofSeconds(LEASE_DURATION_SECONDS))
     assertThat(leaseA).isNotNull()
+    assertThat(leaseA.isHeld()).isTrue()
     assertThat(leaseA.checkHeld()).isTrue()
 
     // Advance clock past the lease duration (60 seconds + 1)
@@ -108,6 +117,7 @@ class SqlLeaseManagerTest {
 
     val leaseA2 = sqlLeaseManager.requestLease("test-lease", Duration.ofSeconds(LEASE_DURATION_SECONDS))
     assertThat(leaseA2).isNotNull()
+    assertThat(leaseA2.isHeld()).isTrue()
     assertThat(leaseA2.checkHeld()).isTrue()
   }
 
@@ -121,14 +131,17 @@ class SqlLeaseManagerTest {
 
     // Test default duration (300 seconds)
     val defaultLease = sqlLeaseManager.requestLease("default-lease")
+    assertThat(defaultLease.isHeld()).isTrue()
     assertThat(defaultLease.checkHeld()).isTrue()
 
     // Test explicit short duration (30 seconds)
     val shortLease = sqlLeaseManager.requestLease("short-lease", Duration.ofSeconds(30))
+    assertThat(shortLease.isHeld()).isTrue()
     assertThat(shortLease.checkHeld()).isTrue()
 
     // Test explicit long duration (10 minutes)
     val longLease = sqlLeaseManager.requestLease("long-lease", Duration.ofMinutes(10))
+    assertThat(longLease.isHeld()).isTrue()
     assertThat(longLease.checkHeld()).isTrue()
 
     // Advance clock by 31 seconds - short lease should expire, others should still be held
@@ -136,10 +149,13 @@ class SqlLeaseManagerTest {
 
     // Short lease should be expired and acquirable by someone else
     val shortLease2 = sqlLeaseManager.requestLease("short-lease", Duration.ofSeconds(30))
+    assertThat(shortLease2.isHeld()).isTrue()
     assertThat(shortLease2.checkHeld()).isTrue()
 
     // Default and long leases should still be held
+    assertThat(defaultLease.isHeld()).isTrue()
     assertThat(defaultLease.checkHeld()).isTrue()
+    assertThat(longLease.isHeld()).isTrue()
     assertThat(longLease.checkHeld()).isTrue()
   }
 }

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/actions/LeaseAcquireWebAction.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/actions/LeaseAcquireWebAction.kt
@@ -22,7 +22,7 @@ class LeaseAcquireWebAction @Inject constructor(
   ): LeaseAcquireResponse {
     // Attempt to acquire a lease (will be held for configured duration)
     val lease = leaseManager.requestLease(name)
-    val acquired = lease.checkHeld()
+    val acquired = lease.acquire()
 
     return LeaseAcquireResponse(
       name = name,

--- a/wisp/wisp-lease-testing/README.md
+++ b/wisp/wisp-lease-testing/README.md
@@ -23,14 +23,14 @@ fakeLeaseManager.markLeaseHeld("YourLeaseName")
 
 // to mark the lease held somewhere else
 fakeLeaseManager.markLeaseHeldElsewhere("YourLeaseName")
-assertThat(lease.checkHeld()).isFalse()
+assertThat(lease.isHeld()).isFalse()
 assertThat(lease.acquire()).isFalse()
 
 // add a listener and test if the lease is held...
 val leaseHeld = AtomicBoolean()
 lease.addListener(object : Lease.StateChangeListener {
   override fun afterAcquire(lease: Lease) {
-    if (lease.checkHeld()) {
+    if (lease.isHeld()) {
       leaseHeld.set(true)
     }
   }

--- a/wisp/wisp-lease-testing/api/wisp-lease-testing.api
+++ b/wisp/wisp-lease-testing/api/wisp-lease-testing.api
@@ -5,6 +5,7 @@ public final class wisp/lease/FakeLease : wisp/lease/Lease {
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z
 	public fun getName ()Ljava/lang/String;
+	public fun isHeld ()Z
 	public final fun notifyAfterAcquire ()V
 	public final fun notifyBeforeRelease ()V
 	public fun release ()Z

--- a/wisp/wisp-lease-testing/src/main/kotlin/wisp/lease/FakeLease.kt
+++ b/wisp/wisp-lease-testing/src/main/kotlin/wisp/lease/FakeLease.kt
@@ -8,7 +8,9 @@ class FakeLease(
 
     override fun shouldHold(): Boolean = true
 
-    override fun checkHeld() = manager.isLeaseHeld(name)
+    override fun isHeld(): Boolean  = manager.isLeaseHeld(name)
+
+    override fun checkHeld() = isHeld()
 
     /**
      * @return true if the other process holds the lease.
@@ -19,19 +21,19 @@ class FakeLease(
      * @return true if this process acquires the lease.
      */
     override fun acquire(): Boolean {
-        val result = checkHeld()
-        if (checkHeld()) {
+        val result = isHeld()
+        if (result) {
             notifyAfterAcquire()
         }
         return result
     }
 
     /**
-     * Release the lease.  This will return true if released.  Note that it will return false
+     * Release the lease. This will return true if released. Note that it will return false
      * if the lease was not held.
      */
     override fun release(): Boolean {
-        if (!checkHeld()) {
+        if (!isHeld()) {
             return false
         }
         notifyBeforeRelease()
@@ -42,7 +44,7 @@ class FakeLease(
 
     override fun addListener(listener: Lease.StateChangeListener) {
         listeners.add(listener)
-        if (checkHeld()) {
+        if (isHeld()) {
             listener.afterAcquire(this)
         }
     }

--- a/wisp/wisp-lease-testing/src/test/kotlin/wisp/lease/FakeLeaseManagerTest.kt
+++ b/wisp/wisp-lease-testing/src/test/kotlin/wisp/lease/FakeLeaseManagerTest.kt
@@ -13,16 +13,22 @@ internal class FakeLeaseManagerTest {
         val otherLease = leaseManager.requestLease("my-other-lease")
 
         // leases are held by the current process by default
+        assertThat(lease.isHeld()).isTrue()
         assertThat(lease.checkHeld()).isTrue()
+        assertThat(otherLease.isHeld()).isTrue()
         assertThat(otherLease.checkHeld()).isTrue()
 
         leaseManager.markLeaseHeldElsewhere("my-lease")
+        assertThat(lease.isHeld()).isFalse()
         assertThat(lease.checkHeld()).isFalse()
         assertThat(lease.acquire()).isFalse()
+        assertThat(otherLease.isHeld()).isTrue()
         assertThat(otherLease.checkHeld()).isTrue()
 
         leaseManager.markLeaseHeld("my-lease")
+        assertThat(lease.isHeld()).isTrue()
         assertThat(lease.checkHeld()).isTrue()
+        assertThat(otherLease.isHeld()).isTrue()
         assertThat(otherLease.checkHeld()).isTrue()
     }
 }

--- a/wisp/wisp-lease/README.md
+++ b/wisp/wisp-lease/README.md
@@ -24,7 +24,7 @@ if (lease.acquire()) {
 }
 
 // check if the lease is held (might have timed out, etc)
-if (lease.checkHeld()) {
+if (lease.isHeld()) {
   // lease is held
 }
 
@@ -33,7 +33,7 @@ val leaseHeld = AtomicBoolean()
 lease.addListener(object : Lease.StateChangeListener {
   override fun afterAcquire(lease: Lease) {
     // lease should be held at this point, but it's best to check
-    if (lease.checkHeld()) {
+    if (lease.isHeld()) {
       leaseHeld.set(true)
     }
   }

--- a/wisp/wisp-lease/api/wisp-lease.api
+++ b/wisp/wisp-lease/api/wisp-lease.api
@@ -8,6 +8,7 @@ public final class wisp/lease/AutoCloseableLease : java/lang/AutoCloseable, wisp
 	public fun checkHeldElsewhere ()Z
 	public fun close ()V
 	public fun getName ()Ljava/lang/String;
+	public fun isHeld ()Z
 	public fun release ()Z
 	public fun release (Z)Z
 	public fun shouldHold ()Z
@@ -32,6 +33,7 @@ public abstract interface class wisp/lease/Lease {
 	public abstract fun checkHeld ()Z
 	public abstract fun checkHeldElsewhere ()Z
 	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isHeld ()Z
 	public abstract fun release ()Z
 	public abstract fun release (Z)Z
 	public abstract fun shouldHold ()Z

--- a/wisp/wisp-lease/src/main/kotlin/wisp/lease/Lease.kt
+++ b/wisp/wisp-lease/src/main/kotlin/wisp/lease/Lease.kt
@@ -1,7 +1,7 @@
 package wisp.lease
 
 /**
- * A [Lease] is a cluster-wide time-based lock on a given resource. Leases are retrieved via
+ * A [Lease] is a cluster-wide, time-based lock on a given resource. Leases are retrieved via
  * [LeaseManager.requestLease].
  *
  * It should be assumed that calls to [checkHeld], [acquire] and [release] could invoke remote
@@ -12,18 +12,39 @@ interface Lease {
     val name: String
 
     /**
+     * Check if this process should own the lease. For example, if a lease is first-come
+     * first-serve, then this process should try to own the lease, whereas a lease that uses
+     * consistent hashing should try to own if and only if it is assigned the lease.
+     *
+     * Note that it is possible for a lease to be held by a process that is not supposed to own it,
+     * e.g. a process is holding the lease but a new process starts and is assigned the lease via
+     * consistent hashing.
+     *
+     * This method should not attempt to acquire the lease, make network calls, or block.
+     *
      * @return true if this process instance should own the lease.
      */
     fun shouldHold(): Boolean
 
     /**
+     * Check if this process owns the lease.
+     *
+     * This method should not attempt to acquire the lease, make network calls, or block.
+     *
+     * @return whether the lease is owned by this process instance.
+     */
+    fun isHeld(): Boolean
+
+    /**
      * @return true if the lease is owned by this process instance.
      */
+    @Deprecated("prefer calling isHeld() to avoid network calls", ReplaceWith("isHeld()"))
     fun checkHeld(): Boolean
 
     /**
      * @return true if the lease is owned by another process instance.
      */
+    @Deprecated("lease is not guaranteed to be held elsewhere, do not depend on this")
     fun checkHeldElsewhere(): Boolean
 
     /**
@@ -44,6 +65,8 @@ interface Lease {
      * Release the lock on the lease, with the option of doing it lazily if possible. This should
      * return false if the lease was not held or if the release is lazy. Listeners should be
      * notified before the lock is released.
+     *
+     * @param lazy whether to attempt to release the lease lazily
      */
     fun release(lazy: Boolean): Boolean
 


### PR DESCRIPTION
## Description
This method works similarly to `checkHeld()` save that it should never make a network call.

Additionally, deprecate:
* `checkHeld()`, since it is the same as `acquire()`
* `checkHeldElsewhere()`, since there is no guarantee that the lease is actually held somewhere else
