### PR TITLE
Make DynamicLogLevelService depend on ReadyService

### DIFF
--- a/misk/src/main/kotlin/misk/logging/DynamicLogLevelModule.kt
+++ b/misk/src/main/kotlin/misk/logging/DynamicLogLevelModule.kt
@@ -3,6 +3,7 @@ package misk.logging
 import com.google.inject.BindingAnnotation
 import com.google.inject.Provides
 import jakarta.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
 import misk.tasks.RepeatedTaskQueue
@@ -53,7 +54,10 @@ import misk.tasks.RepeatedTaskQueueFactory
 class DynamicLogLevelModule(val config: DynamicLoggingConfig) : KAbstractModule() {
   override fun configure() {
     install(ServiceModule<RepeatedTaskQueue>(DynamicLogLevel::class))
-    install(ServiceModule<DynamicLogLevelService>().dependsOn<RepeatedTaskQueue>(DynamicLogLevel::class))
+    install(ServiceModule<DynamicLogLevelService>()
+      .dependsOn<RepeatedTaskQueue>(DynamicLogLevel::class)
+      .dependsOn<ReadyService>()
+    )
     bind<DynamicLoggingConfig>().toInstance(config)
   }
 

--- a/misk/src/test/kotlin/misk/logging/DynamicLogLevelIntegrationTest.kt
+++ b/misk/src/test/kotlin/misk/logging/DynamicLogLevelIntegrationTest.kt
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.LoggerContext
 import com.google.inject.Provides
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import misk.ReadyService
 import misk.ServiceModule
 import misk.feature.Feature
 import misk.feature.testing.FakeFeatureFlags
@@ -266,7 +267,10 @@ class DynamicLogLevelIntegrationTest {
       bind<DynamicLoggingConfig>()
         .toInstance(DynamicLoggingConfig(enabled = true, feature_flag_name = "test-dynamic-logging"))
       install(ServiceModule<RepeatedTaskQueue>(DynamicLogLevel::class))
-      install(ServiceModule<DynamicLogLevelService>().dependsOn<RepeatedTaskQueue>(DynamicLogLevel::class))
+      install(ServiceModule<DynamicLogLevelService>()
+        .dependsOn<RepeatedTaskQueue>(DynamicLogLevel::class)
+        .dependsOn<ReadyService>()
+      )
     }
 
     @Provides @DynamicLogLevel fun providesDynamicLogLevel(): Feature = Feature("test-dynamic-logging")


### PR DESCRIPTION
## Description

Sometimes the DynamicLogLevelService starts but the FeatureService is not ready. This makes DynamicLogLevelService depend on the ReadyService to ensure that FeatureService is running before the DynamicLogLevelService.

## Testing Strategy

Unit testing.

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
