### PR TITLE
Make loggers private

### DIFF
--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -47,7 +47,6 @@ public final class misk/aws2/sqs/jobqueue/SqsJobConsumer : com/google/common/uti
 }
 
 public final class misk/aws2/sqs/jobqueue/SqsJobConsumer$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public final class misk/aws2/sqs/jobqueue/SqsJobEnqueuer : misk/jobqueue/v2/JobEnqueuer {
@@ -135,7 +134,6 @@ public final class misk/aws2/sqs/jobqueue/Subscriber {
 }
 
 public final class misk/aws2/sqs/jobqueue/Subscriber$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public final class misk/aws2/sqs/jobqueue/SubscriptionService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
@@ -110,6 +110,6 @@ class SqsJobConsumer @Inject constructor(
   }
 
   companion object {
-    val logger = getLogger<SqsJobConsumer>()
+    private val logger = getLogger<SqsJobConsumer>()
   }
 }

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -213,6 +213,6 @@ class Subscriber(
   }
 
   companion object {
-    val logger = getLogger<Subscriber>()
+    private val logger = getLogger<Subscriber>()
   }
 }

--- a/misk-hibernate/api/misk-hibernate.api
+++ b/misk-hibernate/api/misk-hibernate.api
@@ -582,6 +582,5 @@ public final class misk/hibernate/vitess/VitessShardExceptionParser {
 }
 
 public final class misk/hibernate/vitess/VitessShardExceptionParser$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateHealthCheck.kt
@@ -55,7 +55,7 @@ internal class HibernateHealthCheck(
   }
 
   companion object {
-    val logger = getLogger<HibernateHealthCheck>()
+    private val logger = getLogger<HibernateHealthCheck>()
     val CLOCK_SKEW_WARN_THRESHOLD: Duration = Duration.ofSeconds(10)
     val CLOCK_SKEW_UNHEALTHY_THRESHOLD: Duration = Duration.ofSeconds(30)
   }

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumnType.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/SecretColumnType.kt
@@ -22,7 +22,7 @@ internal class SecretColumnType : UserType, ParameterizedType, TypeConfiguration
   companion object {
     const val FIELD_ENCRYPTION_KEY_NAME: String = "key_name"
     const val FIELD_ENCRYPTION_INDEXABLE: String = "indexable"
-    val logger = getLogger<SecretColumnType>()
+    private val logger = getLogger<SecretColumnType>()
   }
 
   private lateinit var encryptionAdapter: EncryptionAdapter

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/vitess/VitessShardExceptionParser.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/vitess/VitessShardExceptionParser.kt
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting
 import misk.vitess.Shard
 import misk.logging.getLogger
 import java.util.Optional
-import java.util.function.Consumer
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -162,7 +161,7 @@ class VitessShardExceptionParser {
       "operation not allowed in state NOT_SERVING"
     )
 
-    val logger = getLogger<VitessShardExceptionParser>()
+    private val logger = getLogger<VitessShardExceptionParser>()
   }
 }
 

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -32,7 +32,6 @@ public final class misk/database/DockerCockroachCluster : misk/database/Database
 }
 
 public final class misk/database/DockerCockroachCluster$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 	public final fun pullImage ()V
 }
 
@@ -56,7 +55,6 @@ public final class misk/database/DockerPostgresServer : misk/database/DatabaseSe
 }
 
 public final class misk/database/DockerPostgresServer$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 	public final fun pullImage ()V
 }
 
@@ -83,7 +81,6 @@ public final class misk/database/DockerTidbCluster : misk/database/DatabaseServe
 }
 
 public final class misk/database/DockerTidbCluster$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 	public final fun pullImage ()V
 }
 
@@ -118,7 +115,6 @@ public final class misk/database/StartDatabaseService$CacheKey {
 }
 
 public final class misk/database/StartDatabaseService$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 	public final fun getServers ()Lcom/google/common/cache/LoadingCache;
 	public final fun setServers (Lcom/google/common/cache/LoadingCache;)V
 }
@@ -360,7 +356,6 @@ public final class misk/jdbc/DataSourceService : com/google/common/util/concurre
 }
 
 public final class misk/jdbc/DataSourceService$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public final class misk/jdbc/DataSourceType : java/lang/Enum {

--- a/misk-jdbc/src/main/kotlin/misk/database/DockerCockroachCluster.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/DockerCockroachCluster.kt
@@ -86,7 +86,7 @@ class DockerCockroachCluster(
   }
 
   companion object {
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
 
     const val SHA = "67f0547f1a989ebd119e5cbf903c8537556f574da20182454c036da63ea67c7d"
     const val IMAGE = "cockroachdb/cockroach@sha256:$SHA"

--- a/misk-jdbc/src/main/kotlin/misk/database/DockerPostgresServer.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/DockerPostgresServer.kt
@@ -53,7 +53,7 @@ class DockerPostgresServer(
   }
 
   companion object {
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
 
     const val SHA = "7421834e2eae283f829d3face39acba2e8ffbe24be756f7cabdfe778e7bfec57"
     const val IMAGE = "postgres@sha256:$SHA"

--- a/misk-jdbc/src/main/kotlin/misk/database/DockerTidbCluster.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/DockerTidbCluster.kt
@@ -95,7 +95,7 @@ class DockerTidbCluster(
   }
 
   companion object {
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
 
     // TiDB version 4.0.4
     const val SHA = "431e8e71d3a02134297b4370abbb40b0bd2bc5aec0c42f12e4d4e03943b50910"

--- a/misk-jdbc/src/main/kotlin/misk/database/StartDatabaseService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/database/StartDatabaseService.kt
@@ -138,7 +138,7 @@ class StartDatabaseService(
   )
 
   companion object {
-    val logger = KotlinLogging.logger {}
+    internal val logger = KotlinLogging.logger {}
 
     /**
      * Global cache of running database servers.

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -154,7 +154,7 @@ class DataSourceService @JvmOverloads constructor(
   }
 
   companion object {
-    val logger = getLogger<DataSourceService>()
+    private val logger = getLogger<DataSourceService>()
     private val DEFAULT_CONNECTION_IDLE_TIMEOUT_OFFSET = Duration.ofSeconds(10)
   }
 

--- a/misk-slack/api/misk-slack.api
+++ b/misk-slack/api/misk-slack.api
@@ -5,7 +5,6 @@ public final class misk/slack/RealSlackClient : misk/slack/SlackClient {
 }
 
 public final class misk/slack/RealSlackClient$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public class misk/slack/SlackClient {

--- a/misk-slack/src/main/kotlin/misk/slack/RealSlackClient.kt
+++ b/misk-slack/src/main/kotlin/misk/slack/RealSlackClient.kt
@@ -55,6 +55,6 @@ class RealSlackClient @Inject constructor(
   }
 
   companion object {
-    val logger = getLogger<RealSlackClient>()
+    private val logger = getLogger<RealSlackClient>()
   }
 }

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -644,7 +644,6 @@ public final class misk/client/HttpClientsConfig : misk/config/Config {
 
 public final class misk/client/HttpClientsConfig$Companion {
 	public final fun getHttpClientConfigDefaults ()Lmisk/client/HttpClientConfig;
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public final class misk/client/HttpClientsConfigBackwardsCompatibilityKt {
@@ -1059,7 +1058,6 @@ public final class misk/security/authz/AccessInterceptor : misk/ApplicationInter
 }
 
 public final class misk/security/authz/AccessInterceptor$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 
 public abstract interface annotation class misk/security/authz/DevelopmentOnly : java/lang/annotation/Annotation {

--- a/misk/src/main/kotlin/misk/client/ClientLoggingInterceptor.kt
+++ b/misk/src/main/kotlin/misk/client/ClientLoggingInterceptor.kt
@@ -29,7 +29,7 @@ import jakarta.inject.Singleton
       .toMap()
 
   companion object {
-    val logger = getLogger<ClientLoggingInterceptor>()
+    private val logger = getLogger<ClientLoggingInterceptor>()
 
     val LOGGED_HEADERS = listOf(
       "content-type",

--- a/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
+++ b/misk/src/main/kotlin/misk/client/HttpClientsConfig.kt
@@ -79,7 +79,7 @@ data class HttpClientsConfig @JvmOverloads constructor(
     }.values
 
   companion object {
-    val logger = getLogger<HttpClientsConfig>()
+    private val logger = getLogger<HttpClientsConfig>()
     val httpClientConfigDefaults = HttpClientConfig(
       maxRequests = 128,
       maxRequestsPerHost = 32,

--- a/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
+++ b/misk/src/main/kotlin/misk/security/authz/AccessInterceptor.kt
@@ -146,6 +146,6 @@ class AccessInterceptor private constructor(
   }
 
   companion object {
-    val logger = getLogger<AccessInterceptor>()
+    private val logger = getLogger<AccessInterceptor>()
   }
 }

--- a/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/ConcurrencyLimitsInterceptor.kt
@@ -216,8 +216,7 @@ internal class ConcurrencyLimitsInterceptor internal constructor(
   }
 
   private companion object {
-    val logger = getLogger<ConcurrencyLimitsInterceptor>()
-
+    private val logger = getLogger<ConcurrencyLimitsInterceptor>()
   }
 }
 

--- a/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarCronModule.kt
+++ b/samples/exemplar/src/main/kotlin/com/squareup/exemplar/ExemplarCronModule.kt
@@ -40,7 +40,7 @@ class ExemplarCronModule : KAbstractModule() {
     override fun shutDown() {}
 
     companion object {
-      val logger = getLogger<DependentService>()
+      private val logger = getLogger<DependentService>()
     }
   }
 
@@ -57,7 +57,7 @@ class ExemplarCronModule : KAbstractModule() {
     }
 
     companion object {
-      val logger = getLogger<MinuteCron>()
+      private val logger = getLogger<MinuteCron>()
     }
   }
 }

--- a/wisp/wisp-launchdarkly/api/wisp-launchdarkly.api
+++ b/wisp/wisp-launchdarkly/api/wisp-launchdarkly.api
@@ -110,6 +110,5 @@ public final class wisp/launchdarkly/LaunchDarklyFeatureFlags : wisp/feature/Fea
 }
 
 public final class wisp/launchdarkly/LaunchDarklyFeatureFlags$Companion {
-	public final fun getLogger ()Lmu/KLogger;
 }
 

--- a/wisp/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
+++ b/wisp/wisp-launchdarkly/src/main/kotlin/wisp/launchdarkly/LaunchDarklyFeatureFlags.kt
@@ -343,6 +343,6 @@ class LaunchDarklyFeatureFlags @JvmOverloads constructor(
   }
 
   companion object {
-    val logger = KotlinLogging.logger {}
+    private val logger = KotlinLogging.logger {}
   }
 }


### PR DESCRIPTION
## Description

A number of loggers in various objects in `misk` are not private to that object, making it possible to accidentally import those loggers elsewhere in misk or, in the case of `public` objects, in code that consumes the module.

This change prevents this from happening.

## Testing Strategy

Compilation works.