### PR TITLE
Leverage jooq-bom and jooq-kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencyAnalysis {
     project(":misk-jooq") {
       onIncorrectConfiguration {
         exclude("org.jooq:jooq")
+        exclude("org.jooq:jooq-kotlin")
       }
     }
     project(":detektive") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ googleHttp = "2.0.0"
 guava = "33.5.0-jre"
 hoplite = "2.7.5"
 jackson = "2.20.0"
+jooq = "3.19.29"
 junit = "5.14.1"
 kotest = "6.0.3"
 kotlin = "2.1.21"
@@ -146,7 +147,9 @@ jettyUtil = { module = "org.eclipse.jetty:jetty-util" }
 jettyWebsocketApi = { module = "org.eclipse.jetty.websocket:websocket-jetty-api" }
 jettyWebsocketServer = { module = "org.eclipse.jetty.websocket:websocket-jetty-server" }
 jnrUnixsocket = { module = "com.github.jnr:jnr-unixsocket", version = "0.38.23" }
-jooq = { module = "org.jooq:jooq", version = "3.19.17" }
+jooq = { module = "org.jooq:jooq" }
+jooqBom = { module = "org.jooq:jooq-bom", version.ref="jooq" }
+jooqKotlin = { module = "org.jooq:jooq-kotlin" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version = "2.0.0" }
 jsqlparser = { module = "com.github.jsqlparser:jsqlparser", version = "5.3" }
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }

--- a/misk-jooq/build.gradle.kts
+++ b/misk-jooq/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 dependencies {
   api(libs.guava)
   api(libs.guice)
+  api(platform(libs.jooqBom))
+  api(libs.jooqKotlin)
   api(libs.jooq)
   api(libs.loggingApi)
   api(project(":misk-core"))


### PR DESCRIPTION
## Description

BOMifies jOOQ dependencies and uses `jooq-kotlin` to do some minor cleanup in `JooqTransacter`; this also exposes `jooq-kotlin` via an `api` dependency to module consumers so they can leverage the kotlin convenience extensions. 

## Testing Strategy

Existing test suite

