### PR TITLE
fix: restore calls to checkHeld()

### DIFF
--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsQueueAttributeImporter.kt
@@ -37,7 +37,7 @@ internal class AwsSqsQueueAttributeImporter @Inject constructor(
       }
       val queue = queues.getForSending(queueName)
       val lease = leaseManager.requestLease("sqs-queue-attributes-${queue.queueName}")
-      var leaseHeld = lease.isHeld() || lease.acquire()
+      var leaseHeld = lease.checkHeld() || lease.acquire()
       if (!leaseHeld) {
         metrics.sqsApproxNumberOfMessages.clear()
         metrics.sqsApproxNumberOfMessagesNotVisible.clear()

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConsumerAllocator.kt
@@ -57,7 +57,7 @@ class SqsConsumerAllocator @Inject constructor(
   /** Returns true if the lease was acquired false otherwise. */
   private fun maybeAcquireConsumerLease(queueName: QueueName, candidate: Int): Boolean {
     val lease = leaseManager.requestLease(leaseName(queueName, candidate))
-    return lease.isHeld() || lease.acquire()
+    return lease.checkHeld() || lease.acquire()
   }
 
   private fun receiversPerPodForQueue(queueName: QueueName): Int {

--- a/misk-cron/src/main/kotlin/misk/cron/CronCoordinator.kt
+++ b/misk-cron/src/main/kotlin/misk/cron/CronCoordinator.kt
@@ -12,7 +12,7 @@ class SingleLeaseCronCoordinator @Inject constructor(
 ) : CronCoordinator {
   override fun shouldRunTask(taskName: String): Boolean {
     val lease = leaseManager.requestLease(CRON_CLUSTER_LEASE_NAME)
-    return lease.isHeld() || lease.acquire()
+    return lease.checkHeld() || lease.acquire()
   }
 
   companion object {
@@ -25,6 +25,6 @@ class MultipleLeaseCronCoordinator @Inject constructor(
 ) : CronCoordinator {
   override fun shouldRunTask(taskName: String): Boolean {
     val taskLease = leaseManager.requestLease("misk.cron.task.$taskName")
-    return taskLease.isHeld() || taskLease.acquire()
+    return taskLease.checkHeld() || taskLease.acquire()
   }
 }

--- a/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
+++ b/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
@@ -104,7 +104,7 @@ internal class SqlLeaseManager @Inject constructor(
     /**
      * Returns true if the lease is held by another process.
      */
-    override fun checkHeldElsewhere(): Boolean = !isHeld()
+    override fun checkHeldElsewhere(): Boolean = !checkHeld()
 
     /**
      * Attempts to acquire the lease.


### PR DESCRIPTION
## Description

An internal implementation of `checkHeld()` has a side effect of dropping the lock, which is a dependency for these uses to work with load-balanced leasing. For now, add back the calls to `checkHeld()` to restore the previous behavior.

The long-term fix is to change the API to require a release with every call to acquire (e.g. via try-with-resource or a use block) so that callers are agnostic to how the underlying lease implementation manages its lifetime.
