### PR TITLE
Ensure the CachedConfigurationFactory sets a connection provider

### DIFF
--- a/misk-jooq/src/main/kotlin/misk/jooq/config/ConfigurationFactory.kt
+++ b/misk-jooq/src/main/kotlin/misk/jooq/config/ConfigurationFactory.kt
@@ -46,6 +46,7 @@ internal abstract class ConfigurationFactory {
     return DefaultConfiguration().apply {
       set(settings)
       set(dataSourceConfig.type.toSqlDialect())
+      set(connectionProvider)
       set(DefaultTransactionProvider(connectionProvider, false))
       val executeListeners = buildList {
         add(DefaultExecuteListenerProvider(AvoidUsingSelectStarListener()))

--- a/misk-jooq/src/test/kotlin/misk/jooq/config/CachedConfigurationFactoryTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/config/CachedConfigurationFactoryTest.kt
@@ -17,6 +17,7 @@ import misk.jooq.listeners.JooqTimestampRecordListenerOptions
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.jooq.Configuration
 import org.jooq.SQLDialect
 import org.jooq.conf.MappedSchema
@@ -109,8 +110,8 @@ class CachedConfigurationFactoryTest {
         options,
         JOOQ_CONFIG_EXTENSION,
       )
-    assertThat(writerConfig).usingRecursiveComparison().isEqualTo(legacyWriterConfig)
-    assertThat(readerConfig).usingRecursiveComparison().isEqualTo(legacyReaderConfig)
+    assertConfigurationsEqual(writerConfig, legacyWriterConfig)
+    assertConfigurationsEqual(readerConfig, legacyReaderConfig)
   }
 
   private fun buildOldConfiguration(
@@ -161,5 +162,22 @@ class CachedConfigurationFactoryTest {
           .apply(jooqConfigExtension)
       }
       .configuration()
+  }
+
+  private fun assertConfigurationsEqual(lhs: Configuration, rhs: Configuration) {
+    SoftAssertions.assertSoftly { softAssertions ->
+      with(lhs) {
+        softAssertions.assertThat(dialect()).isEqualTo(rhs.dialect())
+        softAssertions.assertThat(settings()).isEqualTo(rhs.settings())
+        softAssertions.assertThat(clock()).isEqualTo(rhs.clock())
+        softAssertions.assertThat(connectionProvider()).isInstanceOf(rhs.connectionProvider()::class.java)
+        softAssertions.assertThat(transactionProvider()).isInstanceOf(rhs.transactionProvider()::class.java)
+        softAssertions.assertThat(recordListenerProviders()).hasSize(rhs.recordListenerProviders().size)
+        softAssertions.assertThat(executeListenerProviders()).hasSize(rhs.executeListenerProviders().size)
+        softAssertions.assertThat(visitListenerProviders()).hasSize(rhs.visitListenerProviders().size)
+        softAssertions.assertThat(transactionListenerProviders()).hasSize(rhs.transactionListenerProviders().size)
+        softAssertions.assertThat(diagnosticsListenerProviders()).hasSize(rhs.diagnosticsListenerProviders().size)
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

This fixes a bug with the `CachedConfigurationFactory`: it was not configuring a `ConnectionProvider` on the vended `Configuration`. This was missed because all usage in tests is transactional, and since the `TransactionProvider` _was_ set and contains its own `ConnectionProvider`, those usages/tests passed. 

## Testing Strategy

Updated integration tests to exercise non-transactional usage (e.g. `refresh()`).

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
