### PR TITLE
Permit installing JDBC modules outside JooqModule

### DIFF
--- a/misk-jooq/api/misk-jooq.api
+++ b/misk-jooq/api/misk-jooq.api
@@ -31,8 +31,9 @@ public final class misk/jooq/JooqModule : misk/inject/KAbstractModule {
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;Z)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZ)V
-	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZZ)V
+	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceClusterConfig;Ljava/lang/String;Lmisk/jdbc/DatabasePool;Lkotlin/reflect/KClass;Lmisk/jooq/listeners/JooqTimestampRecordListenerOptions;ZZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class misk/jooq/JooqSession : misk/jdbc/Session {

--- a/misk-jooq/src/main/kotlin/misk/jooq/JooqModule.kt
+++ b/misk-jooq/src/main/kotlin/misk/jooq/JooqModule.kt
@@ -33,21 +33,24 @@ constructor(
     JooqTimestampRecordListenerOptions(install = false),
   private val installHealthChecks: Boolean = true,
   private val installSchemaMigrator: Boolean = true,
+  private val jdbcModuleAlreadySetup: Boolean = false,
   private val jooqConfigExtension: Configuration.() -> Unit = {},
 ) : KAbstractModule() {
 
   override fun configure() {
-    install(
-      JdbcModule(
-        qualifier = qualifier,
-        config = dataSourceClusterConfig.writer,
-        readerQualifier = readerQualifier,
-        readerConfig = dataSourceClusterConfig.reader,
-        databasePool = databasePool,
-        installHealthCheck = installHealthChecks,
-        installSchemaMigrator = installSchemaMigrator,
+    if (!jdbcModuleAlreadySetup) {
+      install(
+        JdbcModule(
+          qualifier = qualifier,
+          config = dataSourceClusterConfig.writer,
+          readerQualifier = readerQualifier,
+          readerConfig = dataSourceClusterConfig.reader,
+          databasePool = databasePool,
+          installHealthCheck = installHealthChecks,
+          installSchemaMigrator = installSchemaMigrator,
+        )
       )
-    )
+    }
 
     bind<ConfigurationFactory>()
       .annotatedWith(qualifier.java)

--- a/misk-jooq/src/test/kotlin/misk/jooq/module/JooqModuleTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/module/JooqModuleTest.kt
@@ -1,0 +1,105 @@
+package misk.jooq.module
+
+import com.google.inject.util.Modules
+import jakarta.inject.Inject
+import misk.jdbc.DataSourceClusterConfig
+import misk.jdbc.DataSourceConfig
+import misk.jdbc.DataSourceType
+import misk.jdbc.JdbcModule
+import misk.jdbc.RealDatabasePool
+import misk.jooq.JooqModule
+import misk.jooq.JooqTransacter
+import misk.jooq.config.ClientJooqTestingModule
+import misk.jooq.config.ClientJooqTestingModule.Companion.JOOQ_CONFIG_EXTENSION
+import misk.jooq.config.JooqDBIdentifier
+import misk.jooq.config.JooqDBReadOnlyIdentifier
+import misk.jooq.listeners.JooqTimestampRecordListenerOptions
+import misk.jooq.model.Genre
+import misk.jooq.testgen.tables.references.MOVIE
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+class JooqModuleTest {
+  @MiskTestModule
+  @Suppress("unused")
+  private val module =
+    Modules.override(ClientJooqTestingModule())
+      .with(
+        JdbcModule(
+          qualifier = JooqDBIdentifier::class,
+          config = dataSourceConfig.writer,
+          readerQualifier = JooqDBReadOnlyIdentifier::class,
+          readerConfig = dataSourceConfig.reader,
+          databasePool = RealDatabasePool,
+          installHealthCheck = true,
+          installSchemaMigrator = true,
+        ),
+        JooqModule(
+          qualifier = JooqDBIdentifier::class,
+          dataSourceClusterConfig = dataSourceConfig,
+          jooqCodeGenSchemaName = "jooq",
+          jooqTimestampRecordListenerOptions =
+            JooqTimestampRecordListenerOptions(
+              install = true,
+              createdAtColumnName = "created_at",
+              updatedAtColumnName = "updated_at",
+            ),
+          readerQualifier = JooqDBReadOnlyIdentifier::class,
+          jooqConfigExtension = JOOQ_CONFIG_EXTENSION,
+          jdbcModuleAlreadySetup = true,
+        ),
+      )
+
+  @Inject @JooqDBIdentifier private lateinit var transacter: JooqTransacter
+  @Inject @JooqDBReadOnlyIdentifier private lateinit var readTransacter: JooqTransacter
+
+  @Test
+  fun `jooq transacter remains functional`() {
+    val record =
+      transacter.transaction { session ->
+        session.ctx
+          .newRecord(MOVIE)
+          .apply {
+            genre = Genre.HORROR.name
+            name = "Carrie"
+          }
+          .also { it.store() }
+      }
+    assertThat(record.name).isEqualTo("Carrie")
+
+    val readOnlyRecords = readTransacter.transaction { session -> session.ctx.selectFrom(MOVIE).fetch() }
+    assertThat(readOnlyRecords).hasSize(1)
+    with(readOnlyRecords.single()) {
+      assertThat(genre).isEqualTo("HORROR")
+      assertThat(name).isEqualTo("Carrie")
+    }
+  }
+
+  companion object {
+    private val dataSourceConfig =
+      DataSourceClusterConfig(
+        writer =
+          DataSourceConfig(
+            type = DataSourceType.MYSQL,
+            username = "root",
+            password = "",
+            database = "misk_jooq_testing_writer",
+            migrations_resource = "classpath:/db-migrations",
+            show_sql = "true",
+          ),
+        reader =
+          DataSourceConfig(
+            type = DataSourceType.MYSQL,
+            username = "root",
+            password = "",
+            // Migrations applied to the writer DB only
+            database = "misk_jooq_testing_writer",
+            migrations_resource = "classpath:/db-migrations",
+            show_sql = "true",
+          ),
+      )
+  }
+}


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

`JooqModule` currently does not permit using any JDBC configuration other than the default `JdbcModule`. This is a particular problem for services which use Vitess, which are forced to copy most of `JdbcModule` into their own code so they can install alternative JDBC modules. 

This PR adds a bool parameter that prevents `JooqModule` from installing `JdbcModule` to support those use cases. The default matches the current behavior, so this change is backwards compatible. 

## Testing Strategy

Added an integration test exercising `jdbcModuleAlreadySetup`

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)
    - Outline guidance for affected teams or external Misk users

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
