### PR TITLE
feat: remove `linux/amd64` platform hardcoding

### DIFF
--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
@@ -682,7 +682,6 @@ internal class VitessDockerContainer(
         .createContainerCmd(vitessImage)
         .withName(containerName)
         .withHostConfig(hostConfig)
-        .withPlatform("linux/amd64")
         .withHealthcheck(healthCheck)
         .withExposedPorts(*vitessPortConfig.allPortMappings().map { ExposedPort(it.containerPort) }.toTypedArray())
         .withEnv(


### PR DESCRIPTION
## Description

Looking to introduce an arm64 build of `vttestserver` so need to remove the platform config as it prevents the arm image from starting up. Docker by default should look up the platform automatically on the host.

## Testing Strategy

Will follow up with testing internally since this is a test package.
