### PR TITLE
Tests should fail if the services throw while starting

### DIFF
--- a/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorLifecycleTest.kt
+++ b/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorLifecycleTest.kt
@@ -31,7 +31,7 @@ class GoogleSpannerEmulatorLifecycleTest {
       instance_id = "test-instance",
       database = "test-database",
       emulator =
-        SpannerEmulatorConfig(enabled = true, hostname = ContainerUtil.dockerTargetOrLocalHost(), version = "1.4.9"),
+        SpannerEmulatorConfig(enabled = true, hostname = ContainerUtil.dockerTargetOrLocalHost()),
     )
 
   @MiskTestModule val module = Modules.combine(DeploymentModule(TESTING), GoogleSpannerModule(spannerConfig))
@@ -116,7 +116,7 @@ class GoogleSpannerEmulatorLifecycleTest {
     fun `pulls a Docker image of the emulator with specified version`() {
       var imageId: String? = null
 
-      emulator.pullImage("1.4.9")
+      emulator.pullImage("1.5.51")
 
       // Throws a NotFoundError if the image isn't present locally.
       assertDoesNotThrow { imageId = dockerClient.inspectImageCmd(GoogleSpannerEmulator.IMAGE_NAME).exec().id }

--- a/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorTest.kt
+++ b/misk-gcp/src/test/kotlin/misk/cloud/gcp/spanner/GoogleSpannerEmulatorTest.kt
@@ -24,7 +24,7 @@ class GoogleSpannerEmulatorTest {
       instance_id = "test-instance",
       database = "test-database",
       emulator =
-        SpannerEmulatorConfig(enabled = true, hostname = ContainerUtil.dockerTargetOrLocalHost(), version = "1.4.9"),
+        SpannerEmulatorConfig(enabled = true, hostname = ContainerUtil.dockerTargetOrLocalHost()),
     )
 
   @MiskTestModule val module = GoogleSpannerTestModule(spannerConfig)

--- a/misk-testing/build.gradle.kts
+++ b/misk-testing/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
   testImplementation(libs.kotlinTest)
   testImplementation(libs.mockitoKotlin)
+  testImplementation(libs.junitLauncher)
 }
 
 mavenPublishing {

--- a/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
+++ b/misk-testing/src/main/kotlin/misk/testing/MiskTestExtension.kt
@@ -147,8 +147,9 @@ internal class MiskTestExtension : BeforeEachCallback, AfterEachCallback {
                 e.addSuppressed(stopError)
               }
               injectedModules.invalidate(context.getSortedActionTestModules())
-              throw e
             }
+            // rethrow the exception so we fail tests instead of continuing to try starting
+            throw e
           }
           runningServices.add(context.getSortedActionTestModules())
           if (context.reuseInjector()) {

--- a/misk-testing/src/test/kotlin/misk/testing/ServiceStartupThrowsTest.kt
+++ b/misk-testing/src/test/kotlin/misk/testing/ServiceStartupThrowsTest.kt
@@ -1,0 +1,71 @@
+package misk.testing
+
+import com.google.common.util.concurrent.AbstractService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.MiskTestingServiceModule
+import misk.ServiceModule
+import misk.inject.KAbstractModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.platform.engine.discovery.DiscoverySelectors
+import org.junit.platform.launcher.LauncherDiscoveryRequest
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request
+import org.junit.platform.launcher.core.LauncherFactory.create
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import org.junit.platform.launcher.listeners.TestExecutionSummary
+
+
+/**
+ * Borrows from https://stackoverflow.com/questions/47237611/check-that-junit-extension-throws-specific-exception
+ */
+class ServiceStartupThrowsTest {
+
+  @Test
+  fun `tests should fail if a service fails to start`() {
+    val listener = SummaryGeneratingListener()
+    val request: LauncherDiscoveryRequest? = request().selectors(
+      DiscoverySelectors.selectMethod(
+        FailingServiceStartupTest::class.java,
+        "service should have failed to start"
+      )
+    ).build()
+    create().execute(request, listener)
+    val summary: TestExecutionSummary = listener.getSummary()
+
+    assertThat(summary.getTestsFailedCount()).isEqualTo(1)
+    assertThat(summary.getFailures().get(0).getException())
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("Just five more minutes Mom!")
+  }
+
+  // This should not run as it's not marked as @Internal
+  @MiskTest(startService = true)
+  internal class FailingServiceStartupTest {
+    @MiskTestModule
+    val module =
+      object : KAbstractModule() {
+        override fun configure() {
+          install(MiskTestingServiceModule())
+          install(ServiceModule<FailingService>())
+        }
+      }
+    @Test
+    fun `service should have failed to start`(){
+      fail("service should have thrown and failed the test")
+    }
+  }
+
+  @Singleton
+  class FailingService @Inject constructor(): AbstractService(){
+    override fun doStart() {
+      throw RuntimeException("Just five more minutes Mom!")
+    }
+
+    override fun doStop() {
+      fail("should not be called")
+    }
+
+  }
+}


### PR DESCRIPTION
<!-- 
Template sections are optional. Consider including relevant sections to better communicate with reviewers and the Misk community the impact of your change.
-->

## Description

<!-- Why is your change necessary? What does it solve? -->
When service startup fails and throws an exception, that exception is suppressed because of the change made in (https://github.com/cashapp/misk/commit/587318e84bb9e13c2d19b18d5471aeea89233efc).

By moving the rethrow down one line, the original behaviour is restored.

## Testing Strategy

Added a new test leveraging the Junit platform infra specifically for testing extensions.
<!-- How did you test your solution? -->

<!-- Additional: Consider including relevant sections below as relevant.

## Related Work
    - Link any relevant PRs, tickets, or documentation for additional context

## Screenshots
    - For visual changes, please include a before and after screenshot image

## Communication Plan
    - Provide details on how and where you’ll communicate updates (e.g. `#misk-external` Slack n
channel)

I cannot get into the misk-external channel, admins won't approve it and it's not publicly available.

    - Outline guidance for affected teams or external Misk users

Unfortunately, they'll need to fix their service startup failures if they have them.

## Definition of Done
    - Define success criteria, such as verification steps beyond merging the code (e.g.,
confirming the change works across all services)

## Rollout Strategy and Risk Mitigation
    - Describe how you plan to release the change (e.g., feature flags, gradual rollout, canary 
testing)
    - Any risks or monitoring steps to detect any issues during the rollout?
-->

## Checklist

<!-- 
Complete checklists to ensure continued high standards for Misk. Delete items that are not 
relevant. 
-->

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
