### PR TITLE
Add McpResourceTemplate support to misk-mcp

### DIFF
--- a/misk-mcp/README.md
+++ b/misk-mcp/README.md
@@ -6,7 +6,7 @@ This module provides Misk with Model Context Protocol (MCP) server capabilities,
 
 The [Model Context Protocol](https://modelcontextprotocol.io/specification/2025-06-18) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. MCP provides a standardized way for applications to:
 
-- **Share contextual information** with language models through resources
+- **Share contextual information** with language models through resources and resource templates
 - **Expose tools and capabilities** to AI systems for function execution  
 - **Create reusable prompt templates** and workflows for users
 - **Build composable integrations** across the AI ecosystem
@@ -27,6 +27,7 @@ class MyAppModule : KAbstractModule() {
     // Register your MCP components
     install(McpToolModule.create<CalculatorTool>())
     install(McpResourceModule.create<DatabaseSchemaResource>())
+    install(McpResourceTemplateModule.create<UserProfileResource>())
     install(McpPromptModule.create<CodeReviewPrompt>())
   }
 }
@@ -695,6 +696,46 @@ Register the resource:
 
 ```kotlin
 install(McpResourceModule.create<DatabaseSchemaResource>())
+```
+
+### Resource Templates
+
+Resource templates provide parameterized resources using [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates. They allow clients to read dynamic resources by extracting variables from the URI. Implement the `McpResourceTemplate` interface:
+
+```kotlin
+@Singleton
+class UserProfileResource @Inject constructor(
+  private val userService: UserService
+) : McpResourceTemplate {
+  override val uriTemplate = "users://{userId}/profile"
+  override val name = "User Profile"
+  override val description = "Profile information for a specific user"
+  override val mimeType = "application/json"
+
+  override suspend fun handler(
+    request: ReadResourceRequest,
+    variables: Map<String, String>,
+  ): ReadResourceResult {
+    val userId = variables["userId"] ?: error("Missing userId")
+    val user = userService.getUser(userId)
+
+    return ReadResourceResult(
+      contents = listOf(
+        TextResourceContents(
+          text = Json.encodeToString(user),
+          uri = request.uri,
+          mimeType = mimeType,
+        )
+      )
+    )
+  }
+}
+```
+
+Register the resource template:
+
+```kotlin
+install(McpResourceTemplateModule.create<UserProfileResource>())
 ```
 
 ### Prompts

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -62,6 +62,28 @@ public final class misk/mcp/McpResourceModule$Companion {
 	public final fun create (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/mcp/McpResourceModule;
 }
 
+public abstract interface class misk/mcp/McpResourceTemplate {
+	public abstract fun getDescription ()Ljava/lang/String;
+	public fun getMimeType ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getUriTemplate ()Ljava/lang/String;
+	public abstract fun handler (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class misk/mcp/McpResourceTemplate$DefaultImpls {
+	public static fun getMimeType (Lmisk/mcp/McpResourceTemplate;)Ljava/lang/String;
+}
+
+public final class misk/mcp/McpResourceTemplateModule : misk/inject/KAbstractModule {
+	public static final field Companion Lmisk/mcp/McpResourceTemplateModule$Companion;
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/inject/BindingQualifier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class misk/mcp/McpResourceTemplateModule$Companion {
+	public final fun create (Lkotlin/reflect/KClass;Ljava/lang/annotation/Annotation;)Lmisk/mcp/McpResourceTemplateModule;
+	public final fun create (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/mcp/McpResourceTemplateModule;
+}
+
 public final class misk/mcp/McpServerModule : misk/inject/KAbstractModule {
 	public static final field Companion Lmisk/mcp/McpServerModule$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lmisk/mcp/config/McpConfig;Lcom/google/inject/Provider;Lmisk/inject/BindingQualifier;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -399,6 +421,15 @@ public final class misk/mcp/testing/prompts/KotlinDeveloperPrompt : misk/mcp/Mcp
 	public fun getDescription ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun handler (Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class misk/mcp/testing/resources/UserProfileResource : misk/mcp/McpResourceTemplate {
+	public fun <init> ()V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getMimeType ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getUriTemplate ()Ljava/lang/String;
+	public fun handler (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class misk/mcp/testing/resources/WebSearchResource : misk/mcp/McpResource {

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpResourceTemplate.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpResourceTemplate.kt
@@ -1,0 +1,114 @@
+package misk.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult
+import misk.annotation.ExperimentalMiskApi
+
+/**
+ * Abstraction for a resource template in the Model Context Protocol (MCP) specification.
+ *
+ * Resource templates are parameterized resources that use RFC 6570 URI templates
+ * (e.g., `schema://database/{tableName}`) to match multiple URIs dynamically.
+ * When a client reads a URI matching the template, the server extracts the variable
+ * values and passes them to the handler.
+ *
+ * ## Implementation Requirements
+ *
+ * Implementations must:
+ * - Provide a [uriTemplate] using RFC 6570 Level 1 syntax (simple `{variableName}` expressions)
+ * - Include a human-readable [name] for the resource template
+ * - Include a [description] explaining what resources this template serves
+ * - Optionally specify a [mimeType] (defaults to "text/html")
+ * - Implement the [handler] function to return content based on the request and extracted variables
+ *
+ * ## Registration
+ *
+ * Resource templates should be registered with an MCP server using [McpResourceTemplateModule]:
+ * ```kotlin
+ * // In your Guice module configuration
+ * install(McpResourceTemplateModule.create<MyResourceTemplate>())
+ * ```
+ *
+ * ## Example Implementation
+ *
+ * ```kotlin
+ * @Singleton
+ * class TableSchemaResource @Inject constructor(
+ *   private val schemaService: SchemaService
+ * ) : McpResourceTemplate {
+ *   override val uriTemplate = "schema://database/{tableName}"
+ *   override val name = "Database Table Schema"
+ *   override val description = "Schema for any database table"
+ *   override val mimeType = "application/json"
+ *
+ *   override suspend fun handler(
+ *     request: ReadResourceRequest,
+ *     variables: Map<String, String>,
+ *   ): ReadResourceResult {
+ *     val tableName = variables["tableName"]!!
+ *     val schema = schemaService.getTableSchema(tableName)
+ *     return ReadResourceResult(
+ *       contents = listOf(TextResourceContents(schema.toJson(), request.uri))
+ *     )
+ *   }
+ * }
+ * ```
+ *
+ * ## URI Template Syntax
+ *
+ * Only RFC 6570 Level 1 syntax is supported: simple `{variableName}` expressions where each variable matches a single
+ * URI path segment. Operator expressions (`{+var}`, `{#var}`, etc.) are treated as literals.
+ *
+ * Examples:
+ * - `schema://database/{tableName}` - matches `schema://database/users`
+ * - `docs://api/{version}/{endpoint}` - matches `docs://api/v2/users`
+ * - `logs://service/{serviceName}/date/{date}` - matches `logs://service/auth/date/2025-01-01`
+ *
+ * @see McpResourceTemplateModule for registration and dependency injection
+ * @see McpResource for static (non-parameterized) resources
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-06-18">MCP Specification</a>
+ */
+@ExperimentalMiskApi
+interface McpResourceTemplate {
+  /**
+   * RFC 6570 URI template for this resource.
+   *
+   * Uses Level 1 syntax with simple `{variableName}` expressions. Each variable matches a single URI path segment.
+   */
+  val uriTemplate: String
+
+  /**
+   * Human-readable name for this resource template.
+   *
+   * Exposed to clients and AI models to help them understand what resources this template serves.
+   */
+  val name: String
+
+  /**
+   * Human-readable description of this resource template's purpose.
+   *
+   * Should explain what family of resources this template provides access to and what the URI template variables
+   * represent.
+   */
+  val description: String
+
+  /**
+   * MIME type indicating the format of the resource content.
+   *
+   * Defaults to "text/html" but should be overridden to match the actual content type being returned.
+   */
+  val mimeType: String
+    get() = "text/html"
+
+  /**
+   * Handles incoming resource read requests matched by this template.
+   *
+   * @param request The incoming resource read request containing the resolved URI
+   * @param variables Map of extracted URI template variable names to their matched values. For example, template
+   *   `schema://database/{tableName}` matched against `schema://database/users` produces
+   *   `mapOf("tableName" to "users")`.
+   * @return The resource content with appropriate MIME type and encoding
+   * @throws Exception if the resource access fails catastrophically
+   */
+  suspend fun handler(request: ReadResourceRequest, variables: Map<String, String>): ReadResourceResult
+}

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpResourceTemplateModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpResourceTemplateModule.kt
@@ -1,0 +1,135 @@
+package misk.mcp
+
+import kotlin.reflect.KClass
+import misk.annotation.ExperimentalMiskApi
+import misk.inject.BindingQualifier
+import misk.inject.KAbstractModule
+import misk.inject.qualifier
+
+/**
+ * Module for registering [McpResourceTemplate] implementations with an MCP server.
+ *
+ * This module registers MCP resource templates that will be available through the configured MCP server. Resource
+ * templates provide parameterized access to families of resources using URI templates.
+ *
+ * ## Usage
+ *
+ * Register resource templates using the reified generic create method:
+ * ```kotlin
+ * class MyApplicationModule : KAbstractModule() {
+ *   override fun configure() {
+ *     install(McpResourceTemplateModule.create<TableSchemaResource>())
+ *     install(McpResourceTemplateModule.create<LogAccessResource>())
+ *   }
+ * }
+ * ```
+ *
+ * ## Resource Template Grouping with BindingQualifiers
+ *
+ * Resource templates can be organized into groups using [BindingQualifier] annotations. This allows multiple MCP servers
+ * to expose different sets of resource templates:
+ * ```kotlin
+ * install(McpResourceTemplateModule.create<AdminMcp, AdminSchemaResource>())
+ * install(McpResourceTemplateModule.create<PublicMcp, PublicSchemaResource>())
+ * ```
+ *
+ * @param RT The type of [McpResourceTemplate] implementation to register
+ * @param resourceTemplateClass The [KClass] of the resource template implementation
+ * @param qualifier The [BindingQualifier] used to group this resource template with a specific MCP server
+ * @see McpResourceTemplate for resource template implementation details
+ * @see McpServerModule for server configuration
+ * @see McpResourceModule for static (non-parameterized) resources
+ * @see <a href="https://modelcontextprotocol.io">MCP Specification</a>
+ */
+@ExperimentalMiskApi
+class McpResourceTemplateModule<RT : McpResourceTemplate>
+private constructor(
+  private val resourceTemplateClass: KClass<RT>,
+  private val qualifier: BindingQualifier?,
+) : KAbstractModule() {
+
+  override fun configure() {
+    multibind<McpResourceTemplate>(qualifier).to(resourceTemplateClass.java)
+  }
+
+  companion object {
+    /**
+     * Creates an [McpResourceTemplateModule] with an optional group annotation class.
+     *
+     * This is the base factory method that accepts a [KClass] for both the resource template and the group annotation.
+     * Use the reified generic versions for more convenient type-safe creation.
+     *
+     * @param RT The type of [McpResourceTemplate] implementation to register
+     * @param resourceTemplateClass The [KClass] of the resource template implementation
+     * @param groupAnnotationClass Optional annotation class for grouping this resource template with a specific MCP server
+     * @return A configured McpResourceTemplateModule instance
+     */
+    fun <RT : McpResourceTemplate> create(
+      resourceTemplateClass: KClass<RT>,
+      groupAnnotationClass: KClass<out Annotation>?,
+    ) = McpResourceTemplateModule(resourceTemplateClass = resourceTemplateClass, qualifier = groupAnnotationClass?.qualifier)
+
+    /**
+     * Creates an [McpResourceTemplateModule] with reified type parameters for both group annotation and resource
+     * template.
+     *
+     * This is the recommended way to register resource templates with a specific MCP server group.
+     *
+     * Example:
+     * ```kotlin
+     * install(McpResourceTemplateModule.create<AdminMcp, TableSchemaResource>())
+     * ```
+     *
+     * @param GA The annotation type for the resource template's MCP group
+     * @param RT The type of [McpResourceTemplate] implementation to register
+     * @return A configured McpResourceTemplateModule instance
+     */
+    inline fun <reified GA : Annotation, reified RT : McpResourceTemplate> create() =
+      create(resourceTemplateClass = RT::class, groupAnnotationClass = GA::class)
+
+    /**
+     * Creates an [McpResourceTemplateModule] without any group annotation.
+     *
+     * Use this when registering a resource template with the default (ungrouped) MCP server.
+     *
+     * Example:
+     * ```kotlin
+     * install(McpResourceTemplateModule.create<TableSchemaResource>())
+     * ```
+     *
+     * @param RT The type of [McpResourceTemplate] implementation to register
+     * @return A configured McpResourceTemplateModule instance with no group annotation
+     */
+    @JvmName("createWithNoGroup")
+    inline fun <reified RT : McpResourceTemplate> create() =
+      create(resourceTemplateClass = RT::class, groupAnnotationClass = null)
+
+    /**
+     * Creates an [McpResourceTemplateModule] with an annotation instance for dynamic grouping.
+     *
+     * Use this when you need to create group annotations dynamically at runtime rather than using compile-time
+     * annotation classes.
+     *
+     * @param RT The type of [McpResourceTemplate] implementation to register
+     * @param resourceTemplateClass The [KClass] of the resource template implementation
+     * @param groupAnnotation Optional annotation instance for grouping this resource template with a specific MCP server
+     * @return A configured McpResourceTemplateModule instance
+     */
+    fun <RT : McpResourceTemplate> create(
+      resourceTemplateClass: KClass<RT>,
+      groupAnnotation: Annotation?,
+    ) = McpResourceTemplateModule(resourceTemplateClass = resourceTemplateClass, qualifier = groupAnnotation?.qualifier)
+
+    /**
+     * Creates an [McpResourceTemplateModule] with a reified resource template type and annotation instance.
+     *
+     * Convenience method that combines reified resource template type with runtime annotation instance.
+     *
+     * @param RT The type of [McpResourceTemplate] implementation to register
+     * @param groupAnnotation Optional annotation instance for grouping this resource template with a specific MCP server
+     * @return A configured McpResourceTemplateModule instance
+     */
+    inline fun <reified RT : McpResourceTemplate> create(groupAnnotation: Annotation?) =
+      create(resourceTemplateClass = RT::class, groupAnnotation = groupAnnotation)
+  }
+}

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpServerModule.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpServerModule.kt
@@ -139,6 +139,7 @@ private constructor(
     install(CommonModule())
     newMultibinder<McpPrompt>(qualifier)
     newMultibinder<McpResource>(qualifier)
+    newMultibinder<McpResourceTemplate>(qualifier)
     newMultibinder<McpTool<*>>(qualifier)
 
     val serverConfig =
@@ -159,6 +160,7 @@ private constructor(
     // Get the providers for tools, resources, and prompts
     val promptsProvider = binder().getProvider(setOfType<McpPrompt>().toKey(qualifier))
     val resourcesProvider = binder().getProvider(setOfType<McpResource>().toKey(qualifier))
+    val resourceTemplatesProvider = binder().getProvider(setOfType<McpResourceTemplate>().toKey(qualifier))
     val toolsProvider = binder().getProvider(setOfType<McpTool<*>>().toKey(qualifier))
 
     val mcpMetricsProvider = binder().getProvider(McpMetrics::class.java)
@@ -207,6 +209,7 @@ private constructor(
         config = serverConfig,
         tools = toolsProvider.get().toSet(),
         resources = resourcesProvider.get().toSet(),
+        resourceTemplates = resourceTemplatesProvider.get().toSet(),
         prompts = promptsProvider.get().toSet(),
         instructionsProvider = instructionsProvider,
         mcpMetrics = mcpMetricsProvider.get(),

--- a/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
@@ -79,18 +79,20 @@ import misk.mcp.internal.build
  *
  * The server automatically determines capabilities from the [McpServerConfig] and registered components:
  * - The server enables tools capability if any [McpTool] implementations are registered
- * - The server enables resources capability if any [McpResource] implementations are registered
+ * - The server enables resources capability if any [McpResource] or [McpResourceTemplate] implementations are registered
  * - The server enables prompts capability if any [McpPrompt] implementations are registered
  *
  * @param name The unique name identifier for this MCP server instance
  * @param config Configuration settings including version and capability flags
  * @param tools Set of tool implementations to register with the server
  * @param resources Set of resource implementations to register with the server
+ * @param resourceTemplates Set of resource template implementations to register with the server
  * @param prompts Set of prompt implementations to register with the server
  * @param instructionsProvider Optional provider for server instructions text
  * @see misk.mcp.action.McpStreamManager For managing SSE streams and server lifecycle
  * @see McpTool For implementing executable tools
  * @see McpResource For implementing accessible resources
+ * @see McpResourceTemplate For implementing parameterized resource templates
  * @see McpPrompt For implementing prompt templates
  */
 @ExperimentalMiskApi

--- a/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MiskMcpServer.kt
@@ -101,6 +101,7 @@ internal constructor(
   val config: McpServerConfig,
   tools: Set<McpTool<*>>,
   resources: Set<McpResource>,
+  resourceTemplates: Set<McpResourceTemplate>,
   prompts: Set<McpPrompt>,
   instructionsProvider: Provider<String>? = null,
   private val mcpMetrics: McpMetrics,
@@ -114,7 +115,7 @@ internal constructor(
           completions = null,
           logging = null,
           prompts = if (prompts.isNotEmpty()) config.prompts.asPrompts() else null,
-          resources = if (resources.isNotEmpty()) config.resources.asResources() else null,
+          resources = if (resources.isNotEmpty() || resourceTemplates.isNotEmpty()) config.resources.asResources() else null,
           tools = if (tools.isNotEmpty()) config.tools.asTools() else null,
         ),
       enforceStrictCapabilities = config.enforce_strict_capabilities,
@@ -142,6 +143,18 @@ internal constructor(
         mimeType = resource.mimeType,
         readHandler = { request ->
           withContext(McpClientConnection(this)) { resource.handler(request) }
+        },
+      )
+    }
+
+    resourceTemplates.forEach { template ->
+      addResourceTemplate(
+        uriTemplate = template.uriTemplate,
+        name = template.name,
+        description = template.description,
+        mimeType = template.mimeType,
+        readHandler = { request, variables ->
+          withContext(McpClientConnection(this)) { template.handler(request, variables) }
         },
       )
     }

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpServerActionTest.kt
@@ -10,6 +10,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequest
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.ListPromptsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListResourceTemplatesRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceRequest
@@ -37,6 +38,7 @@ import misk.mcp.config.McpServerConfig
 import misk.mcp.testing.asMcpStreamableHttpClient
 import misk.mcp.testing.asMcpWebSocketClient
 import misk.mcp.testing.prompts.KotlinDeveloperPrompt
+import misk.mcp.testing.resources.UserProfileResource
 import misk.mcp.testing.resources.WebSearchResource
 import misk.mcp.testing.tools.CalculatorTool
 import misk.mcp.testing.tools.CalculatorToolInput.Operation
@@ -173,6 +175,7 @@ internal abstract class McpServerActionTest {
         install(McpToolModule.create<ClientConnectionTool>())
         install(McpPromptModule.create<KotlinDeveloperPrompt>())
         install(McpResourceModule.create<WebSearchResource>())
+        install(McpResourceTemplateModule.create<UserProfileResource>())
 
         install(WebServerTestingModule())
         install(MiskTestingServiceModule())
@@ -400,6 +403,67 @@ internal abstract class McpServerActionTest {
       content.text,
       "Placeholder content for https://search.com/",
       message = "Expected the placeholder content to be returned",
+    )
+  }
+
+  @Test
+  fun `test ListResourceTemplates`() = runBlocking {
+    val request = ListResourceTemplatesRequest()
+    val response = mcpClient.listResourceTemplates(request)
+
+    assertEquals(
+      expected = 1,
+      actual = response.resourceTemplates.size,
+      message = "Expecting one resource template to be registered",
+    )
+
+    val userProfileTemplate = response.resourceTemplates.firstOrNull()
+    assertNotNull(userProfileTemplate)
+    assertEquals(
+      expected = "users://{userId}/profile",
+      actual = userProfileTemplate.uriTemplate,
+      message = "Expected the correct URI template",
+    )
+    assertEquals(
+      expected = "User Profile",
+      actual = userProfileTemplate.name,
+      message = "Expected the correct name for the resource template",
+    )
+    assertEquals(
+      expected = "Profile information for a specific user",
+      actual = userProfileTemplate.description,
+      message = "Expected the correct description for the resource template",
+    )
+  }
+
+  @Test
+  fun `test ReadResourceTemplate`() = runBlocking {
+    val request = ReadResourceRequest(ReadResourceRequestParams(uri = "users://alice/profile"))
+    val response = mcpClient.readResource(request)
+
+    assertNotNull(response)
+    assertEquals(
+      expected = 1,
+      actual = response.contents.size,
+      message = "Expected one content item in the resource template response",
+    )
+
+    val content = response.contents.firstOrNull() as? TextResourceContents
+    assertNotNull(content)
+    assertEquals(
+      expected = "users://alice/profile",
+      actual = content.uri,
+      message = "Expected the correct URI in the resource content",
+    )
+    assertEquals(
+      expected = "application/json",
+      actual = content.mimeType,
+      message = "Expected the correct MIME type for the resource content",
+    )
+    assertContains(
+      content.text,
+      "\"userId\": \"alice\"",
+      message = "Expected the userId variable to be extracted from the URI",
     )
   }
 

--- a/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/resources/UserProfileResource.kt
+++ b/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/resources/UserProfileResource.kt
@@ -24,7 +24,7 @@ class UserProfileResource @Inject constructor() : McpResourceTemplate {
         TextResourceContents(
           text = """{"userId": "$userId", "name": "User $userId"}""",
           uri = request.uri,
-          mimeType = "application/json",
+          mimeType = mimeType,
         )
       )
     )

--- a/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/resources/UserProfileResource.kt
+++ b/misk-mcp/src/testFixtures/kotlin/misk/mcp/testing/resources/UserProfileResource.kt
@@ -1,0 +1,32 @@
+package misk.mcp.testing.resources
+
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
+import jakarta.inject.Inject
+import misk.annotation.ExperimentalMiskApi
+import misk.mcp.McpResourceTemplate
+
+@OptIn(ExperimentalMiskApi::class)
+class UserProfileResource @Inject constructor() : McpResourceTemplate {
+  override val uriTemplate = "users://{userId}/profile"
+  override val name = "User Profile"
+  override val description = "Profile information for a specific user"
+  override val mimeType = "application/json"
+
+  override suspend fun handler(
+    request: ReadResourceRequest,
+    variables: Map<String, String>,
+  ): ReadResourceResult {
+    val userId = variables["userId"] ?: "unknown"
+    return ReadResourceResult(
+      contents = listOf(
+        TextResourceContents(
+          text = """{"userId": "$userId", "name": "User $userId"}""",
+          uri = request.uri,
+          mimeType = "application/json",
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Add Resource Template Support to Misk MCP

This PR introduces resource template functionality to the Misk MCP module, enabling parameterized resources using RFC 6570 URI templates.

### Changes

- **New `McpResourceTemplate` interface**: Defines parameterized resources that can match multiple URIs using URI templates (e.g., `users://{userId}/profile`)
- **New `McpResourceTemplateModule`**: Guice module for registering resource template implementations with MCP servers
- **Enhanced `MiskMcpServer`**: Updated to handle both static resources and resource templates, automatically enabling resources capability when either type is present
- **Updated documentation**: Added comprehensive examples and usage instructions for resource templates in the README
- **Test coverage**: Added `UserProfileResource` test fixture and corresponding integration tests

Resource templates allow clients to access dynamic resources by extracting variables from URI patterns, providing a more flexible alternative to static resources for data that varies by parameters.

## Checklist

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉