### PR TITLE
feat: Support HEAD requests

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -274,7 +274,7 @@ internal fun HttpServletRequest.httpUrl(): HttpUrl {
 /** @throws ProtocolException on unexpected methods. */
 internal fun HttpServletRequest.dispatchMechanism(): DispatchMechanism? {
   return when (method) {
-    HttpMethod.GET.name -> DispatchMechanism.GET
+    HttpMethod.GET.name, HttpMethod.HEAD.name -> DispatchMechanism.GET
     HttpMethod.POST.name ->
       when (contentType()) {
         MediaTypes.APPLICATION_GRPC_MEDIA_TYPE,

--- a/misk/src/test/kotlin/misk/web/actions/SupportedHttpMethodsTest.kt
+++ b/misk/src/test/kotlin/misk/web/actions/SupportedHttpMethodsTest.kt
@@ -91,6 +91,16 @@ class SupportedHttpMethodsTest {
   }
 
   @Test
+  fun head() {
+    val request =
+      Request.Builder().head().url(jettyService.httpServerUrl.newBuilder().encodedPath("/resources/id").build()).build()
+
+    val response = httpClient.newCall(request).execute()
+    assertThat(response.isSuccessful).isTrue()
+    assertThat(response.body?.string()).isEmpty()
+  }
+
+  @Test
   fun deleteWithRequestBody() {
     val request =
       Request.Builder()


### PR DESCRIPTION
## Description

HTTP HEAD requests are rejected by Misk (404) because `dispatchMechanism()` doesn't recognize the HEAD method. This change maps HEAD requests to `DispatchMechanism.GET`, allowing them to be routed to the matching GET action. Jetty already handles [stripping](https://github.com/jetty/jetty.project/blob/8fc0958d5aff34151dd10e71eba3e3d7dbbf1862/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java#L911) the response body for HEAD requests, so no additional logic is needed beyond the routing change.

## Testing Strategy

Added a test in SupportedHttpMethodsTest that sends a HEAD request to a GET endpoint and verifies it returns a successful response with an empty body.
Built and test with my project (it receives and handles HEAD requests vs returning a 404 previously)