### PR TITLE
Preserve MULTI transaction mode through onSessionClose hooks

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -74,12 +74,23 @@ fun Session.allowCrossShardTransactions() {
   // Reset to UNSPECIFIED after the transaction completes (commit or rollback) so it doesn't leak
   // to subsequent transactions via connection pool reuse. UNSPECIFIED falls back to whatever the
   // vtgate-level default is, so this is safe regardless of the vtgate's configured transaction mode.
+  //
+  // If the Hibernate session is still open (e.g. onSessionClose hooks pending), re-set MULTI so
+  // those hooks can also use cross-shard transactions. This is needed because vtgate's reserved
+  // connection mode (triggered by SET) retains stale shard sessions across COMMIT
+  // (vitessio/vitess#11616), which causes subsequent operations on the same pooled connection
+  // to fail in SINGLE mode with "multi-db transaction attempted".
   hibernateSession.transaction.registerSynchronization(object : Synchronization {
     override fun beforeCompletion() {}
     override fun afterCompletion(status: Int) {
       try {
         hibernateSession.doWork { connection ->
           connection.createStatement().execute("SET transaction_mode = 'unspecified'")
+        }
+        if (hibernateSession.isOpen) {
+          hibernateSession.doWork { connection ->
+            connection.createStatement().execute("SET transaction_mode = 'multi'")
+          }
         }
       } catch (e: Exception) {
         logger.error(e) { "Failed to reset transaction_mode after transaction completion" }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
@@ -157,4 +157,35 @@ class VitessTransactionModeIntegrationTest {
     assertThat(generateSequence(exception as Throwable) { it.cause }.any { it is CrossShardTransactionException })
       .isTrue()
   }
+
+  @Test
+  fun `onSessionClose hooks can use cross-shard transactions after allowCrossShardTransactions`() {
+    // Verifies that after a transaction with allowCrossShardTransactions() commits, onSessionClose
+    // hooks that reuse the thread-local session can still perform cross-shard reads. Without the
+    // afterCompletion re-set to MULTI, the session reverts to SINGLE mode after commit, and the
+    // onSessionClose hook's cross-shard read fails with stale reserved connection shard sessions.
+    var onSessionCloseSucceeded = false
+
+    transacter.transaction { session ->
+      session.allowCrossShardTransactions()
+
+      // Do a cross-shard write.
+      val movieA = session.load<DbMovie>(crossShardIdA)
+      val movieB = session.load<DbMovie>(crossShardIdB)
+      movieA.name = "Hook Test A"
+      movieB.name = "Hook Test B"
+
+      // Register onSessionClose hook that does a cross-shard read.
+      session.onSessionClose {
+        transacter.readOnly().transaction { readSession ->
+          queryFactory.newQuery<MovieQuery>().allowScatter().list(readSession)
+          onSessionCloseSucceeded = true
+        }
+      }
+    }
+
+    assertThat(onSessionCloseSucceeded)
+      .withFailMessage("onSessionClose hook should succeed with cross-shard read after allowCrossShardTransactions")
+      .isTrue()
+  }
 }


### PR DESCRIPTION
## Why

When `allowCrossShardTransactions()` resets `transaction_mode` to UNSPECIFIED in `afterCompletion`, the Hibernate session may still have pending `onSessionClose` hooks that need cross-shard access. These hooks reuse the thread-local Hibernate session, which is now in SINGLE mode.

Additionally, vtgate's reserved connection mode (triggered by `SET transaction_mode`) retains stale shard sessions across COMMIT ([vitessio/vitess#11616](https://github.com/vitessio/vitess/issues/11616)). Without re-setting to MULTI, subsequent WRITE operations on the same pooled connection fail in SINGLE mode with "multi-db transaction attempted".

## What

After resetting to UNSPECIFIED in `afterCompletion`, check if the Hibernate session is still open. If so, re-set to MULTI so close hooks and subsequent pooled connection users operate correctly.

## Test plan

- Added regression test `onSessionClose hooks can use cross-shard transactions after allowCrossShardTransactions` that:
  - Opens a transaction with `allowCrossShardTransactions()`
  - Registers an `onSessionClose` hook that does a cross-shard read
  - Verifies the hook succeeds
  - **Fails without the fix, passes with it** (verified locally)

Generated with [Claude Code](https://claude.ai/code)