### PR TITLE
Bump Vitess image to v23

### DIFF
--- a/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
@@ -75,16 +75,12 @@ class VitessTransactionModeIntegrationTest {
   }
 
   @Test
-  fun `cross-shard read fails with SINGLE transaction mode`() {
-    // A scatter query reads from all shards in one transaction, which SINGLE mode blocks.
-    val exception = assertThrows<Exception> {
-      transacter.transaction { session ->
-        queryFactory.newQuery<MovieQuery>().allowScatter().list(session)
-      }
+  fun `cross-shard read succeeds in SINGLE transaction mode`() {
+    // Vitess v23+ allows read-only multi-shard transactions in SINGLE mode (vitessio/vitess#18173).
+    val movies = transacter.transaction { session ->
+      queryFactory.newQuery<MovieQuery>().allowScatter().list(session)
     }
-
-    assertThat(generateSequence(exception as Throwable) { it.cause }.any { it is CrossShardTransactionException })
-      .isTrue()
+    assertThat(movies).isNotEmpty()
   }
 
   @Test
@@ -104,13 +100,14 @@ class VitessTransactionModeIntegrationTest {
   }
 
   @Test
-  fun `cross-shard read and write in same transaction fails with SINGLE transaction mode`() {
+  fun `multi-shard write fails with SINGLE transaction mode`() {
+    // Writing to multiple shards in the same transaction is rejected by SINGLE mode.
     val exception = assertThrows<Exception> {
       transacter.transaction { session ->
-        // Read from one shard, write to another.
         val movieA = session.load<DbMovie>(crossShardIdA)
         val movieB = session.load<DbMovie>(crossShardIdB)
-        movieB.name = "Updated from ${movieA.name}"
+        movieA.name = "Updated A"
+        movieB.name = "Updated B"
       }
     }
 

--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
@@ -55,8 +55,8 @@ class CustomArgsTest {
           transactionIsolationLevel = DB1_TXN_ISO_LEVEL,
           transactionMode = DB1_TXN_MODE,
           transactionTimeoutSeconds = Duration.ofSeconds(5),
-          vitessImage = "vitess/vttestserver:v22.0.2-mysql80",
-          vitessVersion = 22,
+          vitessImage = "vitess/vttestserver:v23.0.3-mysql84",
+          vitessVersion = 23,
         )
 
       testDb2 =

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
@@ -28,9 +28,9 @@ object DefaultSettings {
   @JvmField var TRANSACTION_TIMEOUT_SECONDS: Duration = Duration.ofSeconds(30)
   const val VITESS_DOCKER_NETWORK_NAME = "vitess-network"
   const val VITESS_DOCKER_NETWORK_TYPE = "bridge"
-  const val VITESS_IMAGE = "vitess/vttestserver:v22.0.4-mysql84"
-  const val VITESS_VERSION = 22
-  const val VTCTLD_CLIENT_IMAGE = "vitess/vtctldclient:v22.0.4"
+  const val VITESS_IMAGE = "vitess/vttestserver:v23.0.3-mysql84"
+  const val VITESS_VERSION = 23
+  const val VTCTLD_CLIENT_IMAGE = "vitess/vtctldclient:v23.0.3"
   const val VTGATE_USER = "root"
   const val VTGATE_USER_PASSWORD = ""
 }

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
@@ -584,7 +584,16 @@ internal class VitessDockerContainer(
     val images: List<Image> = dockerClient.listImagesCmd().withReferenceFilter(vitessImage).exec()
     if (images.isEmpty()) {
       println("Vitess image `$vitessImage` does not exist, proceeding to pull.")
-      dockerClient.pullImageCmd(vitessImage).start().awaitCompletion()
+      try {
+        dockerClient.pullImageCmd(vitessImage).start().awaitCompletion()
+      } catch (e: NotFoundException) {
+        if ("no matching manifest" !in (e.message ?: "")) throw e
+        // Vitess may not publish images for all architectures. Fall back to amd64 and let
+        // Docker Desktop emulate via Rosetta. This will be unnecessary once Vitess publishes
+        // native ARM images.
+        println("Native pull failed (no matching manifest), retrying with --platform linux/amd64")
+        dockerClient.pullImageCmd(vitessImage).withPlatform("linux/amd64").start().awaitCompletion()
+      }
     }
 
     val networkId = getOrCreateVitessNetwork()

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
@@ -588,9 +588,7 @@ internal class VitessDockerContainer(
         dockerClient.pullImageCmd(vitessImage).start().awaitCompletion()
       } catch (e: NotFoundException) {
         if ("no matching manifest" !in (e.message ?: "")) throw e
-        // Vitess may not publish images for all architectures. Fall back to amd64 and let
-        // Docker Desktop emulate via Rosetta. This will be unnecessary once Vitess publishes
-        // native ARM images.
+        // No native image for this architecture; pull amd64 and let Docker emulate.
         println("Native pull failed (no matching manifest), retrying with --platform linux/amd64")
         dockerClient.pullImageCmd(vitessImage).withPlatform("linux/amd64").start().awaitCompletion()
       }

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessQueryExecutor.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessQueryExecutor.kt
@@ -78,9 +78,12 @@ internal class VitessQueryExecutor(
   fun executeTransaction(query: String, target: String = "@primary"): Boolean {
     val connection = getVtgateConnection()
     return connection.use { conn ->
-      conn.autoCommit = false
+      // Use explicit BEGIN instead of SET autocommit=0. Since vitessio/vitess#19277 (v22.0.4+),
+      // vtgate defers implicit transaction start for autocommit=0, so vttablet doesn't apply
+      // --queryserver-config-transaction-timeout to those queries.
+      execute(conn, "BEGIN;", target)
       val result = execute(conn, query, target)
-      conn.commit()
+      execute(conn, "COMMIT;", target)
       result
     }
   }


### PR DESCRIPTION
## Why

Vitess v23 includes [vitessio/vitess#18173](https://github.com/vitessio/vitess/pull/18173) which changes `transaction_mode=SINGLE` semantics:

- **v22**: All multi-shard transactions rejected (reads and writes)
- **v23**: Only multi-shard **writes** rejected; multi-shard reads allowed

This is needed for services adopting `TransactionMode.SINGLE` for cross-shard write detection. Without v23, read-only transactions that touch multiple shards produce false positives.

## What

- Bump `VITESS_IMAGE` from `v22.0.4-mysql84` to `v23.0.3-mysql84`
- Bump `VTCTLD_CLIENT_IMAGE` from `v22.0.4` to `v23.0.3`
- Add platform fallback for Docker pull: try native first, fall back to `linux/amd64` if no matching manifest (Vitess doesn't publish ARM images; enables Rosetta emulation on Apple Silicon)
- Update `VitessTransactionModeIntegrationTest` for v23 semantics

Generated with [Claude Code](https://claude.ai/code)