### PR TITLE
Add ROLLBACK to allowCrossShardTransactions to clear vtgate reserved connection state

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/Session.kt
@@ -71,15 +71,29 @@ fun Session.allowCrossShardTransactions() {
     connection.createStatement().execute("SET transaction_mode = 'multi'")
   }
 
-  // Reset to UNSPECIFIED after the transaction completes (commit or rollback) so it doesn't leak
-  // to subsequent transactions via connection pool reuse. UNSPECIFIED falls back to whatever the
-  // vtgate-level default is, so this is safe regardless of the vtgate's configured transaction mode.
+  // Clean up after the transaction completes (commit or rollback). Two things need to happen:
+  //
+  // 1. SET transaction_mode = 'unspecified' — resets to the vtgate-level default so MULTI doesn't
+  //    leak to subsequent transactions via the connection pool.
+  //
+  // 2. ROLLBACK — clears vtgate's reserved connection state. `SET transaction_mode` triggers
+  //    vtgate's NeedsReservedConn(), which retains stale shard sessions across COMMIT
+  //    (vitessio/vitess#11616). Without ROLLBACK, subsequent queries on this pooled connection
+  //    fail with "multi-db transaction attempted" even for single-shard operations.
+  //
+  // Order matters: SET first (resets the session variable), then ROLLBACK (clears the reserved
+  // connection state created by both the original SET MULTI and the cleanup SET UNSPECIFIED).
+  //
+  // Both are safe in afterCompletion: the Hibernate transaction is already committed (or rolled
+  // back), so ROLLBACK is a data no-op — it only affects vtgate session state. In production where
+  // vtgate defaults to MULTI, SET UNSPECIFIED simply returns to that default.
   hibernateSession.transaction.registerSynchronization(object : Synchronization {
     override fun beforeCompletion() {}
     override fun afterCompletion(status: Int) {
       try {
         hibernateSession.doWork { connection ->
           connection.createStatement().execute("SET transaction_mode = 'unspecified'")
+          connection.createStatement().execute("ROLLBACK")
         }
       } catch (e: Exception) {
         logger.error(e) { "Failed to reset transaction_mode after transaction completion" }

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/vitess/VitessTransactionModeIntegrationTest.kt
@@ -21,6 +21,7 @@ import misk.vitess.Keyspace
 import misk.vitess.Shard
 import misk.vitess.testing.TransactionMode
 import misk.vitess.testing.utilities.DockerVitess
+import kotlin.reflect.KClass
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -95,8 +96,7 @@ class VitessTransactionModeIntegrationTest {
         }
       }
 
-    assertThat(generateSequence(exception as Throwable) { it.cause }.any { it is CrossShardTransactionException })
-      .isTrue()
+    assertThat(exception.hasCause(CrossShardTransactionException::class)).isTrue()
   }
 
   @Test
@@ -111,8 +111,7 @@ class VitessTransactionModeIntegrationTest {
       }
     }
 
-    assertThat(generateSequence(exception as Throwable) { it.cause }.any { it is CrossShardTransactionException })
-      .isTrue()
+    assertThat(exception.hasCause(CrossShardTransactionException::class)).isTrue()
   }
 
   @Test
@@ -151,7 +150,9 @@ class VitessTransactionModeIntegrationTest {
       }
     }
 
-    assertThat(generateSequence(exception as Throwable) { it.cause }.any { it is CrossShardTransactionException })
-      .isTrue()
+    assertThat(exception.hasCause(CrossShardTransactionException::class)).isTrue()
   }
+
+  private fun Throwable.hasCause(type: KClass<*>): Boolean =
+    generateSequence(this) { it.cause }.any { type.isInstance(it) }
 }


### PR DESCRIPTION
## Summary
- After `allowCrossShardTransactions()` commits, send `SET transaction_mode = 'unspecified'` then `ROLLBACK` in `afterCompletion` to clean up vtgate session state
- `SET UNSPECIFIED` resets the session variable so MULTI doesn't leak to the pool
- `ROLLBACK` clears vtgate's reserved connection stale shard sessions (vitessio/vitess#11616) so subsequent queries don't fail with "multi-db transaction attempted"
- Both are safe post-commit — ROLLBACK is a data no-op that only affects vtgate session state
- Updates cross-shard tests to use `hasCause` helper for cleaner exception assertions

## Context
`SET transaction_mode` triggers vtgate's `NeedsReservedConn()`, which retains shard sessions across COMMIT. Without ROLLBACK, pooled connections carry stale shard sessions that cause spurious "multi-db transaction attempted" errors on subsequent single-shard operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)