### PR TITLE
Log exception when SQS job handler fails

### DIFF
--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -70,6 +70,7 @@ class Subscriber(
             sqsMetrics.handlerDispatchTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
             result
           } catch (e: Exception) {
+            logger.warn(e) { "Handler failed for job ${job.id} from queue ${job.queueName.value}" }
             sqsMetrics.handlerFailures.labels(queueName.value).inc()
             return@withSpan
           }


### PR DESCRIPTION
## Problem

`Subscriber.run()` catches all handler exceptions, increments a `handler_failures` metric, but silently discards the exception. This makes it impossible to diagnose why handlers are failing — you can see failures in metrics but never the cause.

This caused a real debugging issue where staging handler failures from retry queue messages were invisible — the only signal was a metric counter with no context.

## Fix

Add a `logger.warn` with the job ID, source queue name, and full exception stack trace when a handler throws.

## Context

Slack thread: https://sq-block.slack.com/archives/C09MHHW2DK2/p1776829418623509