### PR TITLE
misk-vitess: switch to GHCR multi-arch images

### DIFF
--- a/misk-vitess/README.md
+++ b/misk-vitess/README.md
@@ -66,7 +66,7 @@ Other configurable parameters include:
 - `sqlMode` (defaults to the [MySQL 8.4 defaults](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html)): The server side `sql_mode` setting.
 - `transactionIsolationLevel` (default `REPEATABLE_READ`): The transaction isolation level.
 - `transactionTimeoutSeconds` (default `30s`): the duration in seconds before Vitess times out a transaction. Setting a higher value may be useful for debugging.
-- `vitessImage` (default: `ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84`): The Docker image to use for the container. Block's multi-arch images are at `ghcr.io/block/vitess/vttestserver`. Upstream DockerHub images (amd64 only) are at https://hub.docker.com/r/vitess/vttestserver/tags.
+- `vitessImage` (default: `ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84`): The Docker image to use for the container. Block's multi-arch images are at `ghcr.io/block/vitess/vttestserver`. Upstream DockerHub images (amd64 only) are at https://hub.docker.com/r/vitess/vttestserver/tags.
 - `vitessVersion` (default: `23`): The version of Vitess to use, which must match the version of `vitessImage`.
 
 ### Connecting to the test database

--- a/misk-vitess/README.md
+++ b/misk-vitess/README.md
@@ -66,8 +66,8 @@ Other configurable parameters include:
 - `sqlMode` (defaults to the [MySQL 8.4 defaults](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html)): The server side `sql_mode` setting.
 - `transactionIsolationLevel` (default `REPEATABLE_READ`): The transaction isolation level.
 - `transactionTimeoutSeconds` (default `30s`): the duration in seconds before Vitess times out a transaction. Setting a higher value may be useful for debugging.
-- `vitessImage` (default: `vitess/vttestserver:v22.0.4-mysql84`): The Docker image to use for the container. DockerHub Images can be  found at https://hub.docker.com/r/vitess/vttestserver/tags. Custom ECR images can also be passed in.
-- `vitessVersion` (default: `22`): The version of Vitess to use, which must match the version of `vitessImage`.
+- `vitessImage` (default: `ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84`): The Docker image to use for the container. Block's multi-arch images are at `ghcr.io/block/vitess/vttestserver`. Upstream DockerHub images (amd64 only) are at https://hub.docker.com/r/vitess/vttestserver/tags.
+- `vitessVersion` (default: `23`): The version of Vitess to use, which must match the version of `vitessImage`.
 
 ### Connecting to the test database
 After you start the test database, you can connect to it via a standard connection or through the MySQL CLI.

--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
@@ -55,7 +55,7 @@ class CustomArgsTest {
           transactionIsolationLevel = DB1_TXN_ISO_LEVEL,
           transactionMode = DB1_TXN_MODE,
           transactionTimeoutSeconds = Duration.ofSeconds(5),
-          vitessImage = "vitess/vttestserver:v23.0.3-mysql84",
+          vitessImage = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84",
           vitessVersion = 23,
         )
 
@@ -281,7 +281,7 @@ class CustomArgsTest {
       containerName = "unsupported_scatter_vitess_db",
       enableScatters = false,
       port = DefaultSettings.DYNAMIC_PORT,
-      vitessImage = "vitess/vttestserver:v19.0.9-mysql80",
+      vitessImage = "ghcr.io/block/vitess/vttestserver:mysql84",
       vitessVersion = 19,
     )
   }

--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
@@ -281,7 +281,7 @@ class CustomArgsTest {
       containerName = "unsupported_scatter_vitess_db",
       enableScatters = false,
       port = DefaultSettings.DYNAMIC_PORT,
-      vitessImage = "ghcr.io/block/vitess/vttestserver:mysql84",
+      vitessImage = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84",
       vitessVersion = 19,
     )
   }

--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/CustomArgsTest.kt
@@ -281,7 +281,7 @@ class CustomArgsTest {
       containerName = "unsupported_scatter_vitess_db",
       enableScatters = false,
       port = DefaultSettings.DYNAMIC_PORT,
-      vitessImage = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84",
+      vitessImage = "vitess/vttestserver:v19.0.9-mysql80",
       vitessVersion = 19,
     )
   }

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
@@ -46,7 +46,7 @@ import misk.vitess.testing.internal.VitessQueryExecutor
  *   `TWOPC` enables atomic distributed transactions via two-phase commit.
  * @property transactionTimeoutSeconds The transaction timeout in seconds. Default is `null`.
  * @property vitessImage The Vitess image to be used. Block's arm64-compatible images are at
- *   `ghcr.io/block/vitess/vttestserver`. Default is `ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84`.
+ *   `ghcr.io/block/vitess/vttestserver`. Default is `ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84`.
  * @property vitessVersion The Vitess major version to be used, which must match the version in `vitessImage`. Default
  *   is `22`.
  */

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
@@ -45,8 +45,8 @@ import misk.vitess.testing.internal.VitessQueryExecutor
  *   commit. `SINGLE` rejects cross-shard writes unless the session opts in via `SET transaction_mode = 'multi'`.
  *   `TWOPC` enables atomic distributed transactions via two-phase commit.
  * @property transactionTimeoutSeconds The transaction timeout in seconds. Default is `null`.
- * @property vitessImage The Vitess image to be used. Open-source Vitess images can be found at
- *   [Docker Hub](https://hub.docker.com/r/vitess/vttestserver/tags). Default is `vitess/vttestserver:v22.0.2-mysql80`.
+ * @property vitessImage The Vitess image to be used. Block's arm64-compatible images are at
+ *   `ghcr.io/block/vitess/vttestserver`. Default is `ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84`.
  * @property vitessVersion The Vitess major version to be used, which must match the version in `vitessImage`. Default
  *   is `22`.
  */

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
@@ -28,7 +28,7 @@ object DefaultSettings {
   @JvmField var TRANSACTION_TIMEOUT_SECONDS: Duration = Duration.ofSeconds(30)
   const val VITESS_DOCKER_NETWORK_NAME = "vitess-network"
   const val VITESS_DOCKER_NETWORK_TYPE = "bridge"
-  const val VITESS_IMAGE = "vitess/vttestserver:v23.0.3-mysql84"
+  const val VITESS_IMAGE = "ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84"
   const val VITESS_VERSION = 23
   const val VTCTLD_CLIENT_IMAGE = "vitess/vtctldclient:v23.0.3"
   const val VTGATE_USER = "root"

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
@@ -28,7 +28,7 @@ object DefaultSettings {
   @JvmField var TRANSACTION_TIMEOUT_SECONDS: Duration = Duration.ofSeconds(30)
   const val VITESS_DOCKER_NETWORK_NAME = "vitess-network"
   const val VITESS_DOCKER_NETWORK_TYPE = "bridge"
-  const val VITESS_IMAGE = "ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84"
+  const val VITESS_IMAGE = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84"
   const val VITESS_VERSION = 23
   const val VTCTLD_CLIENT_IMAGE = "vitess/vtctldclient:v23.0.3"
   const val VTGATE_USER = "root"

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
@@ -30,7 +30,7 @@ object DefaultSettings {
   const val VITESS_DOCKER_NETWORK_TYPE = "bridge"
   const val VITESS_IMAGE = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84"
   const val VITESS_VERSION = 23
-  const val VTCTLD_CLIENT_IMAGE = "vitess/vtctldclient:v23.0.3"
+  const val VTCTLD_CLIENT_IMAGE = "ghcr.io/block/vitess/vtctldclient:23.0.3-block.1"
   const val VTGATE_USER = "root"
   const val VTGATE_USER_PASSWORD = ""
 }


### PR DESCRIPTION
## Summary

Switches the default `vttestserver` Docker image from upstream Docker Hub (`vitess/vttestserver:v23.0.3-mysql84`) to Block's GHCR multi-arch build (`ghcr.io/block/vitess/vttestserver:v23.0.3-block.1-mysql84`), as well as switches `vtctldclient` to `ghcr.io/block/vitess/vtctldclient:23.0.3-block.1`

## Motivation

ARM images will lead to faster build times

See [block/vitess#4](https://github.com/block/vitess/pull/4) for the image publishing setup.

## Changes

- `VitessTestDbSettings.kt` —images updated
- `VitessTestDb.kt` — doc comment updated
- `README.md` — docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)