### PR TITLE
feat(vitess): skip schemabot.yaml in schema directory validation

### DIFF
--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VschemaParserTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VschemaParserTest.kt
@@ -163,6 +163,26 @@ class VitessSchemaParserTest {
   }
 
   @Test
+  fun `test schemabot yaml in schema directory is skipped`() {
+    val schemaDirPath = Files.createTempDirectory("schema_dir")
+    val keyspaceDir = File(schemaDirPath.toFile(), "keyspace1")
+    keyspaceDir.mkdir()
+    val sqlFile = File(keyspaceDir, "v0001__add_table.sql")
+    sqlFile.writeText("CREATE TABLE `test_table` (id int primary key);")
+    val vschemaFile = File(keyspaceDir, "vschema.json")
+    vschemaFile.writeText("{\"tables\": {\"test_table\": {}}}")
+
+    // Add schemabot.yaml alongside keyspace directories
+    val schemabotYaml = File(schemaDirPath.toFile(), "schemabot.yaml")
+    schemabotYaml.writeText("database: testdb\ntype: vitess\n")
+
+    val parser = VitessSchemaParser(false, schemaName, schemaDirPath)
+    val keyspaces = parser.validateAndParse()
+    assertTrue(keyspaces.isNotEmpty())
+    assertEquals("keyspace1", keyspaces[0].name)
+  }
+
+  @Test
   fun `test multiple keyspace directories with one invalid directory`() {
     val schemaDirPath = Files.createTempDirectory("schema_dir")
 

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaParser.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaParser.kt
@@ -54,6 +54,11 @@ internal class VitessSchemaParser(
         return@forEach
       }
 
+      // Skip SchemaBot config file (https://github.com/block/schemabot)
+      if (schemaDirectoryFile.name == "schemabot.yaml") {
+        return@forEach
+      }
+
       if (!schemaDirectoryFile.isDirectory) {
         exceptions.add("`$schemaDirectoryFile` must be a keyspace directory.")
         return@forEach


### PR DESCRIPTION
## Why
The VitessSchemaParser rejects any non-directory file in the schema directory. This prevents repos from adding a `schemabot.yaml` config file alongside keyspace directories, which is required by [SchemaBot](https://github.com/block/schemabot) for declarative schema management.

## What
- Skip `schemabot.yaml` files during schema directory validation, alongside existing dot-file exclusion


Generated with [Claude Code](https://claude.ai/code)