### PR TITLE
Deprecate misk-aws S3 v1 module in favor of misk-aws2-s3

### DIFF
--- a/misk-aws/README.md
+++ b/misk-aws/README.md
@@ -4,6 +4,9 @@
 This AWS SDK v1 SQS jobqueue module is deprecated. Use the AWS SDK v2 SQS jobqueue in
 `misk-aws2-sqs` (`misk.aws2.sqs.jobqueue`) for new integrations and migrations.
 
+The AWS SDK v1 S3 module (`misk.s3.RealS3Module`) is also deprecated. Use the AWS SDK v2
+S3 module in `misk-aws2-s3` (`misk.aws2.s3.S3Module`) for new integrations and migrations.
+
 ## Metrics
 This module automatically generates metrics related to SQS, including metrics provided by AWS through cloudwatch. These metrics are defined by the `SQSMetrics` class, and are as follows:
 

--- a/misk-aws/src/main/kotlin/misk/s3/RealS3Module.kt
+++ b/misk-aws/src/main/kotlin/misk/s3/RealS3Module.kt
@@ -8,6 +8,10 @@ import jakarta.inject.Singleton
 import misk.cloud.aws.AwsRegion
 import misk.inject.KAbstractModule
 
+@Deprecated(
+  message = "AWS SDK v1 S3 is deprecated. Use the AWS SDK v2 S3 module in " +
+    "misk-aws2-s3 (misk.aws2.s3.S3Module) instead."
+)
 open class RealS3Module : KAbstractModule() {
   override fun configure() {
     requireBinding<AWSCredentialsProvider>()


### PR DESCRIPTION
Annotate `RealS3Module` with `@Deprecated` and update the misk-aws README to direct users to the AWS SDK v2 S3 module (`misk.aws2.s3.S3Module`) in `misk-aws2-s3`.

This mirrors the existing deprecation of the AWS SDK v1 SQS jobqueue in misk-aws.