### PR TITLE
fix(vitess): disable server-side prepared statements

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -153,7 +153,7 @@ constructor(
     properties["cachePrepStmts"] = "true"
     properties["prepStmtCacheSize"] = "250"
     properties["prepStmtCacheSqlLimit"] = "2048"
-    if (type == DataSourceType.MYSQL || type == DataSourceType.VITESS_MYSQL || type == DataSourceType.TIDB) {
+    if (type == DataSourceType.MYSQL || type == DataSourceType.TIDB) {
       properties["useServerPrepStmts"] = "true"
     }
     if (mysql_use_aws_secret_for_credentials) {
@@ -235,7 +235,6 @@ constructor(
         }
 
         if (type == DataSourceType.VITESS_MYSQL) {
-          queryParams += "&useServerPrepStmts=true"
           // If we leave this as the default (true) the logs get spammed with the following errors:
           // "Ignored inapplicable SET {sql_mode } = strict_trans_tables"
           // Since Vitess always uses strict_trans_tables this makes no difference here except it

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceConfigTest.kt
@@ -18,7 +18,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&sslMode=PREFERRED&" +
+        "jdbcCompliantTruncation=false&sslMode=PREFERRED&" +
         "enabledTLSProtocols=TLSv1.2,TLSv1.3",
       config.buildJdbcUrl(TESTING),
     )
@@ -36,7 +36,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&" +
+        "jdbcCompliantTruncation=false&" +
         "trustCertificateKeyStoreUrl=path/to/truststore&" +
         "trustCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA&" +
         "enabledTLSProtocols=TLSv1.2,TLSv1.3",
@@ -56,7 +56,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&" +
+        "jdbcCompliantTruncation=false&" +
         "clientCertificateKeyStoreUrl=path/to/keystore&clientCertificateKeyStorePassword=" +
         "changeit&sslMode=VERIFY_CA&" +
         "enabledTLSProtocols=TLSv1.2,TLSv1.3",
@@ -78,7 +78,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&" +
+        "jdbcCompliantTruncation=false&" +
         "trustCertificateKeyStoreUrl=path/to/truststore&trustCertificateKeyStorePassword=" +
         "changeit&clientCertificateKeyStoreUrl=path/to/keystore&" +
         "clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA&" +
@@ -101,7 +101,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&" +
+        "jdbcCompliantTruncation=false&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&trustCertificateKeyStorePassword" +
         "=changeit&clientCertificateKeyStoreUrl=file://path/to/keystore&" +
         "clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA&" +
@@ -124,7 +124,7 @@ class DataSourceConfigTest {
     assertEquals(
       "jdbc:tracing:mysql://${ContainerUtil.dockerTargetOrLocalIp()}:$dockerVitessPort/@primary?useLegacyDatetimeCode=false&" +
         "createDatabaseIfNotExist=true&connectTimeout=10000&socketTimeout=60000&" +
-        "useServerPrepStmts=true&jdbcCompliantTruncation=false&" +
+        "jdbcCompliantTruncation=false&" +
         "trustCertificateKeyStoreUrl=file://path/to/truststore&" +
         "trustCertificateKeyStorePassword=changeit&clientCertificateKeyStoreUrl=" +
         "file://path/to/keystore&clientCertificateKeyStorePassword=changeit&sslMode=VERIFY_CA&" +


### PR DESCRIPTION
## Summary

- Disable `useServerPrepStmts` for `VITESS_MYSQL` connections, reverting it to the Connector/J default of `false`
- Server-side prepared statements were enabled in 929a4cda but are not recommended for Vitess:
  - Vitess may reject certain prepared statements, and MySQL Connector/J silently falls back to client-side emulated statements (`emulateUnsupportedPstmts` defaults to `true`), adding a wasted round-trip per failed prepare
  - For multi-table queries, the Vitess query planner cannot determine when two different bind variable placeholders resolve to the same shard key, which can result in cross-shard joins instead of single-shard routing (vitessio/vitess#17497)
  - Server-side prepared statements reduce query observability in Vitess monitoring tools
- `useServerPrepStmts=true` remains enabled for `MYSQL` and `TIDB` connections where it is beneficial

🤖 Generated with [Claude Code](https://claude.com/claude-code)