### PR TITLE
fix(vitess): stop exposing testFixtures as API from gradle plugin

### DIFF
--- a/misk-vitess-database-gradle-plugin/build.gradle.kts
+++ b/misk-vitess-database-gradle-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ gradlePlugin {
 }
 
 dependencies {
-  api(testFixtures(project(":misk-vitess")))
+  implementation(testFixtures(project(":misk-vitess")))
 
   testImplementation(gradleTestKit())
   testImplementation(libs.assertj)

--- a/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/StartVitessDatabaseTask.kt
+++ b/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/StartVitessDatabaseTask.kt
@@ -39,9 +39,9 @@ abstract class StartVitessDatabaseTask : DefaultTask() {
 
   @get:Input abstract val sqlMode: Property<String>
 
-  @get:Input abstract val transactionIsolationLevel: Property<TransactionIsolationLevel>
+  @get:Input abstract val transactionIsolationLevel: Property<String>
 
-  @get:Input abstract val transactionMode: Property<TransactionMode>
+  @get:Input abstract val transactionMode: Property<String>
 
   @get:Input abstract val transactionTimeoutSeconds: Property<Duration>
 
@@ -66,8 +66,8 @@ abstract class StartVitessDatabaseTask : DefaultTask() {
         port = port.get(),
         schemaDir = schemaDir.get(),
         sqlMode = sqlMode.get(),
-        transactionIsolationLevel = transactionIsolationLevel.get(),
-        transactionMode = transactionMode.get(),
+        transactionIsolationLevel = TransactionIsolationLevel.valueOf(transactionIsolationLevel.get()),
+        transactionMode = TransactionMode.valueOf(transactionMode.get()),
         transactionTimeoutSeconds = transactionTimeoutSeconds.get(),
         vitessImage = vitessImage.get(),
         vitessVersion = vitessVersion.get(),

--- a/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/VitessDatabasePlugin.kt
+++ b/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/VitessDatabasePlugin.kt
@@ -25,8 +25,8 @@ class VitessDatabasePlugin : Plugin<Project> {
         "filesystem:${project.layout.projectDirectory.dir("src/main/resources/vitess/schema").asFile.absolutePath}"
       )
       it.sqlMode.convention(DefaultSettings.SQL_MODE)
-      it.transactionIsolationLevel.convention(DefaultSettings.TRANSACTION_ISOLATION_LEVEL)
-      it.transactionMode.convention(DefaultSettings.TRANSACTION_MODE)
+      it.transactionIsolationLevel.convention(DefaultSettings.TRANSACTION_ISOLATION_LEVEL.name)
+      it.transactionMode.convention(DefaultSettings.TRANSACTION_MODE.name)
       it.transactionTimeoutSeconds.convention(DefaultSettings.TRANSACTION_TIMEOUT_SECONDS)
       it.vitessImage.convention(DefaultSettings.VITESS_IMAGE)
       it.vitessVersion.convention(DefaultSettings.VITESS_VERSION)

--- a/misk-vitess-database-gradle-plugin/src/test/resources/vitess-database-plugin-test/build.gradle.kts
+++ b/misk-vitess-database-gradle-plugin/src/test/resources/vitess-database-plugin-test/build.gradle.kts
@@ -1,5 +1,4 @@
 import misk.vitess.gradle.StartVitessDatabaseTask
-import misk.vitess.testing.TransactionIsolationLevel
 
 plugins {
   id("com.squareup.misk.vitess.vitess-database")
@@ -10,5 +9,5 @@ val startVitessDatabase = tasks.named("startVitessDatabase", StartVitessDatabase
   lintSchema.set(true)
   port.set(31503)
   schemaDir.set("filesystem:${layout.projectDirectory.dir("src/main/resources/vitess/schema")}")
-  transactionIsolationLevel.set(TransactionIsolationLevel.READ_COMMITTED)
+  transactionIsolationLevel.set("READ_COMMITTED")
 }


### PR DESCRIPTION
## Summary
- Changes the `misk-vitess-database-gradle-plugin` dependency on `testFixtures(misk-vitess)` from `api` to `implementation`
- `transactionMode` and `transactionIsolationLevel` task properties are now `Property<String>` instead of enum types
- Consumers that configure these properties use string values (`"SINGLE"`, `"MULTI"`, `"READ_COMMITTED"`, etc.) instead of enum constants

## Breaking change for consumers

If you configure `transactionMode` or `transactionIsolationLevel` on the `startVitessDatabase` task, update from:
```kotlin
transactionMode.set(TransactionMode.SINGLE)
transactionIsolationLevel.set(TransactionIsolationLevel.READ_COMMITTED)
```
to:
```kotlin
transactionMode.set("SINGLE")
transactionIsolationLevel.set("READ_COMMITTED")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)