### PR TITLE
fix(vitess):  prevent evicting connections on application errors

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
@@ -44,7 +44,7 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
 
   private fun adjudicateInternal(sqlException: SQLException): SQLExceptionOverride.Override {
     if (sqlException.errorCode in applicationErrors) {
-      return SQLExceptionOverride.Override.MUST_NOT_EVICT
+      return SQLExceptionOverride.Override.DO_NOT_EVICT
     }
     return when {
       sqlException.toKnownErrors() in probablyBadState -> SQLExceptionOverride.Override.MUST_EVICT
@@ -60,7 +60,7 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
         "state=${sqlException?.sqlState ?: "null"}, " +
         "message=${sqlException.message}, " +
         "adjudicate=$result"
-      if (result == SQLExceptionOverride.Override.MUST_NOT_EVICT) {
+      if (result == SQLExceptionOverride.Override.DO_NOT_EVICT) {
         logger.warn(logMessage)
       } else {
         logger.error(logMessage)

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
@@ -25,6 +25,11 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
       KnownErrors(sqlState = "hy000", errorCode = 1105),
     )
 
+  private val applicationErrors = setOf(
+    1062, // Duplicate entry
+    1213, // Deadlock found when trying to get lock
+  )
+
   private val badErrorString = listOf(Regex("connection"), Regex("vttable"))
 
   private data class KnownErrors(val sqlState: String, val errorCode: Int)
@@ -38,6 +43,9 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
   }
 
   private fun adjudicateInternal(sqlException: SQLException): SQLExceptionOverride.Override {
+    if (sqlException.errorCode in applicationErrors) {
+      return SQLExceptionOverride.Override.MUST_NOT_EVICT
+    }
     return when {
       sqlException.toKnownErrors() in probablyBadState -> SQLExceptionOverride.Override.MUST_EVICT
       containsKnownBadErrorMessage(sqlException.message) -> SQLExceptionOverride.Override.MUST_EVICT
@@ -47,15 +55,16 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
 
   override fun adjudicate(sqlException: SQLException): SQLExceptionOverride.Override {
     return adjudicateInternal(sqlException).also { result ->
-      logger.error(
-        "Hikari exception adjudicate: " +
-          "errorCode=${sqlException.errorCode}, " +
-          // the logic around sqlState kotlin this is null safe, but the Java shows it being set
-          // as null. Let's be explicit at the behavir.
-          "state=${sqlException?.sqlState ?: "null"}, " +
-          "message=${sqlException.message}, " +
-          "adjudicate=$result"
-      )
+      val logMessage = "Hikari exception adjudicate: " +
+        "errorCode=${sqlException.errorCode}, " +
+        "state=${sqlException?.sqlState ?: "null"}, " +
+        "message=${sqlException.message}, " +
+        "adjudicate=$result"
+      if (result == SQLExceptionOverride.Override.MUST_NOT_EVICT) {
+        logger.warn(logMessage)
+      } else {
+        logger.error(logMessage)
+      }
       errorCounter
         ?.labels(sqlException.errorCode.toString(), sqlException.sqlState, sqlException.message, result.toString())
         ?.inc()

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
@@ -16,7 +16,7 @@ class VitessExceptionHandlerTest {
       "23000",
       1062,
     )
-    assertEquals(SQLExceptionOverride.Override.MUST_NOT_EVICT, handler.adjudicate(exception))
+    assertEquals(SQLExceptionOverride.Override.DO_NOT_EVICT, handler.adjudicate(exception))
   }
 
   @Test
@@ -27,7 +27,7 @@ class VitessExceptionHandlerTest {
       "40001",
       1213,
     )
-    assertEquals(SQLExceptionOverride.Override.MUST_NOT_EVICT, handler.adjudicate(exception))
+    assertEquals(SQLExceptionOverride.Override.DO_NOT_EVICT, handler.adjudicate(exception))
   }
 
   @Test

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
@@ -1,27 +1,63 @@
 package misk.jdbc
 
-import com.zaxxer.hikari.SQLExceptionOverride
 import java.sql.SQLException
-import org.assertj.core.api.Assertions.assertThat
+import com.zaxxer.hikari.SQLExceptionOverride
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class VitessExceptionHandlerTest {
+  private val handler = VitessExceptionHandler()
+
   @Test
-  fun `matches exception`() {
-    val handler = VitessExceptionHandler()
-    assertThat(handler.adjudicate(SQLException("Key not found")))
-      .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
-    assertThat(handler.adjudicate(SQLException("Duplicate entry 'foo_bar'")))
-      .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
-    assertThat(handler.adjudicate(SQLException("vtgate connection error")))
-      .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
-    assertThat(handler.adjudicate(SQLException("", "42S02", 1146))).isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
-    assertThat(handler.adjudicate(SQLException("", "42S02", 1147)))
-      .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
+  fun duplicateKeyErrorDoesNotEvict() {
+    val exception = SQLException(
+      "target: keyspace.shard.primary: vttablet: rpc error: code = AlreadyExists " +
+        "desc = Duplicate entry 'foo' for key 'PRIMARY' (errno 1062) (sqlstate 23000)",
+      "23000",
+      1062,
+    )
+    assertEquals(SQLExceptionOverride.Override.MUST_NOT_EVICT, handler.adjudicate(exception))
+  }
 
-    assertThat(handler.adjudicate(SQLException("", "hy000", 1105))).isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+  @Test
+  fun deadlockErrorDoesNotEvict() {
+    val exception = SQLException(
+      "target: keyspace.shard.primary: vttablet: rpc error: code = Aborted " +
+        "desc = Deadlock found when trying to get lock (errno 1213) (sqlstate 40001)",
+      "40001",
+      1213,
+    )
+    assertEquals(SQLExceptionOverride.Override.MUST_NOT_EVICT, handler.adjudicate(exception))
+  }
 
-    assertThat(handler.adjudicate(SQLException("one of the vttablets: has turned into a pile of slag", "", 0)))
-      .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+  @Test
+  fun connectionErrorEvicts() {
+    val exception = SQLException(
+      "target: keyspace.shard.primary: vttablet: rpc error: code = Unavailable " +
+        "desc = connection refused (errno 2002) (sqlstate HY000)",
+      "HY000",
+      2002,
+    )
+    assertEquals(SQLExceptionOverride.Override.MUST_EVICT, handler.adjudicate(exception))
+  }
+
+  @Test
+  fun knownBadStateEvicts() {
+    val exception = SQLException(
+      "target: keyspace.shard.primary: vttablet: table not found",
+      "42S02",
+      1146,
+    )
+    assertEquals(SQLExceptionOverride.Override.MUST_EVICT, handler.adjudicate(exception))
+  }
+
+  @Test
+  fun unknownErrorWithoutBadPatternContinuesEvict() {
+    val exception = SQLException(
+      "some other error without bad patterns",
+      "HY000",
+      9999,
+    )
+    assertEquals(SQLExceptionOverride.Override.CONTINUE_EVICT, handler.adjudicate(exception))
   }
 }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
@@ -60,4 +60,32 @@ class VitessExceptionHandlerTest {
     )
     assertEquals(SQLExceptionOverride.Override.CONTINUE_EVICT, handler.adjudicate(exception))
   }
+
+  @Test
+  fun vtgateConnectionErrorEvicts() {
+    val exception = SQLException("vtgate connection error")
+    assertEquals(SQLExceptionOverride.Override.MUST_EVICT, handler.adjudicate(exception))
+  }
+
+  @Test
+  fun knownBadStateHy000Evicts() {
+    val exception = SQLException("", "hy000", 1105)
+    assertEquals(SQLExceptionOverride.Override.MUST_EVICT, handler.adjudicate(exception))
+  }
+
+  @Test
+  fun vttabletErrorWithoutApplicationErrorCodeEvicts() {
+    val exception = SQLException(
+      "one of the vttablets: has turned into a pile of slag",
+      "",
+      0,
+    )
+    assertEquals(SQLExceptionOverride.Override.MUST_EVICT, handler.adjudicate(exception))
+  }
+
+  @Test
+  fun similarButNonMatchingKnownBadStateContinuesEvict() {
+    val exception = SQLException("", "42S02", 1147)
+    assertEquals(SQLExceptionOverride.Override.CONTINUE_EVICT, handler.adjudicate(exception))
+  }
 }


### PR DESCRIPTION
## Summary

- Fix `VitessExceptionHandler` incorrectly evicting healthy connections from the HikariCP pool on application-level SQL errors
- Vitess error messages typically include "vttablet" in the text (e.g. `target: keyspace.shard.primary: vttablet: rpc error: ...`), which matches the existing `Regex("vttable")` check. This causes `MUST_EVICT` for all Vitess errors, including benign ones like duplicate key (1062) and deadlock (1213) that don't indicate connection problems
- Add an `applicationErrors` set that short-circuits to `MUST_NOT_EVICT` for known application-level error codes before the regex check runs
- Downgrade log level from `error` to `warn` for application errors to reduce noise
- Add unit tests for the exception handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)