### PR TITLE
Rework the Vitess error handler to mostly rely on the actual error codes

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/VitessExceptionHandler.kt
@@ -21,11 +21,35 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
   private val probablyBadState =
     setOf(
       // VT05005: typical of a connection error if we can't find the keyspace. Abort the connection
-      KnownErrors(sqlState = "42S02", errorCode = 1146),
-      KnownErrors(sqlState = "hy000", errorCode = 1105),
+      KnownErrors(sqlState = "42S02", errorCode = 1146), // VT05005: keyspace not found
+      KnownErrors(sqlState = "HY000", errorCode = 1105), // general Vitess internal error
+      KnownErrors(sqlState = "HY000", errorCode = 2013), // Lost connection to server during query
+      KnownErrors(sqlState = "HY000", errorCode = 2006), // MySQL server has gone away
+      KnownErrors(sqlState = "08S01", errorCode = 0), // Communication link failure
+      KnownErrors(sqlState = "08003", errorCode = 0), // Connection does not exist
+      KnownErrors(sqlState = "08006", errorCode = 0), // Connection failure
     )
 
-  private val badErrorString = listOf(Regex("connection"), Regex("vttable"))
+  // States that are definitely NOT connection problems — keep the connection
+  private val probablySafeState =
+    setOf(
+      KnownErrors(sqlState = "23000", errorCode = 1062), // Duplicate entry
+      KnownErrors(sqlState = "23000", errorCode = 1452), // FK constraint fails
+      KnownErrors(sqlState = "42000", errorCode = 1064), // Syntax error
+      KnownErrors(sqlState = "22001", errorCode = 1406), // Data too long
+      KnownErrors(sqlState = "21S01", errorCode = 1136), // Column count mismatch
+    )
+
+  // TODO(young): These are a bit of a band-aid, ideally we catch these with their associated error codes, but I'm
+  // scared of just removing them until we've measured them in the wild, particularly the vtgate one.
+  private val badErrorString =
+    listOf(
+      Regex("vttablet:.*connection.*refused", RegexOption.IGNORE_CASE),
+      Regex("vttablet:.*connection.*reset", RegexOption.IGNORE_CASE),
+      Regex("vttablet:.*broken pipe", RegexOption.IGNORE_CASE),
+      Regex("vttablet:.*connection.*closed", RegexOption.IGNORE_CASE),
+      Regex("vtgate:.*connection error", RegexOption.IGNORE_CASE),
+    )
 
   private data class KnownErrors(val sqlState: String, val errorCode: Int)
 
@@ -40,22 +64,31 @@ internal class VitessExceptionHandler(registry: CollectorRegistry? = null) : SQL
   private fun adjudicateInternal(sqlException: SQLException): SQLExceptionOverride.Override {
     return when {
       sqlException.toKnownErrors() in probablyBadState -> SQLExceptionOverride.Override.MUST_EVICT
+      sqlException.toKnownErrors() in probablySafeState -> SQLExceptionOverride.Override.DO_NOT_EVICT
       containsKnownBadErrorMessage(sqlException.message) -> SQLExceptionOverride.Override.MUST_EVICT
+      sqlException.sqlState?.uppercase()?.startsWith("HY") == true -> SQLExceptionOverride.Override.MUST_EVICT
+      sqlException.sqlState?.startsWith("21") == true -> SQLExceptionOverride.Override.DO_NOT_EVICT
+      sqlException.sqlState?.startsWith("22") == true -> SQLExceptionOverride.Override.DO_NOT_EVICT
+      sqlException.sqlState?.startsWith("23") == true -> SQLExceptionOverride.Override.DO_NOT_EVICT
+      sqlException.sqlState?.startsWith("42") == true -> SQLExceptionOverride.Override.CONTINUE_EVICT
+      sqlException.sqlState?.startsWith("08") == true -> SQLExceptionOverride.Override.MUST_EVICT
       else -> SQLExceptionOverride.Override.CONTINUE_EVICT
     }
   }
 
   override fun adjudicate(sqlException: SQLException): SQLExceptionOverride.Override {
     return adjudicateInternal(sqlException).also { result ->
-      logger.error(
+      val message =
         "Hikari exception adjudicate: " +
           "errorCode=${sqlException.errorCode}, " +
-          // the logic around sqlState kotlin this is null safe, but the Java shows it being set
-          // as null. Let's be explicit at the behavir.
           "state=${sqlException?.sqlState ?: "null"}, " +
           "message=${sqlException.message}, " +
           "adjudicate=$result"
-      )
+      if (result == SQLExceptionOverride.Override.DO_NOT_EVICT) {
+        logger.warn(message)
+      } else {
+        logger.error(message)
+      }
       errorCounter
         ?.labels(sqlException.errorCode.toString(), sqlException.sqlState, sqlException.message, result.toString())
         ?.inc()

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/VitessExceptionHandlerTest.kt
@@ -13,15 +13,82 @@ class VitessExceptionHandlerTest {
       .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
     assertThat(handler.adjudicate(SQLException("Duplicate entry 'foo_bar'")))
       .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
-    assertThat(handler.adjudicate(SQLException("vtgate connection error")))
+    assertThat(handler.adjudicate(SQLException("vtgate connection error", "HY000", 1105)))
       .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
     assertThat(handler.adjudicate(SQLException("", "42S02", 1146))).isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
     assertThat(handler.adjudicate(SQLException("", "42S02", 1147)))
       .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
 
     assertThat(handler.adjudicate(SQLException("", "hy000", 1105))).isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+  }
 
-    assertThat(handler.adjudicate(SQLException("one of the vttablets: has turned into a pile of slag", "", 0)))
+  @Test
+  fun `does not evict on integrity constraint violations`() {
+    val handler = VitessExceptionHandler()
+    // SQLState 23000 = integrity constraint violation (duplicate key)
+    assertThat(handler.adjudicate(SQLException("Duplicate entry 'foo' for key 'PRIMARY'", "23000", 1062)))
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+    // SQLState 23000 with connection in message — should still NOT evict
+    assertThat(
+        handler.adjudicate(
+          SQLException(
+            "vttablet: rpc error: code = AlreadyExists desc = Duplicate entry connection_id=123",
+            "23000",
+            1062,
+          )
+        )
+      )
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+  }
+
+  @Test
+  fun `does not evict on data exceptions`() {
+    val handler = VitessExceptionHandler()
+    // SQLState 22001 = string data right truncation
+    assertThat(handler.adjudicate(SQLException("Data too long for column", "22001", 1406)))
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+    // SQLState 22012 = division by zero
+    assertThat(handler.adjudicate(SQLException("Division by 0", "22012", 1365)))
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+  }
+
+  @Test
+  fun `does not evict on syntax errors`() {
+    val handler = VitessExceptionHandler()
+    // SQLState 42000 = syntax error
+    assertThat(handler.adjudicate(SQLException("You have an error in your SQL syntax near 'null'", "42000", 1064)))
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+  }
+
+  @Test
+  fun `does not evict on cardinality violations`() {
+    val handler = VitessExceptionHandler()
+    // SQLState 21S01 = column count mismatch
+    assertThat(handler.adjudicate(SQLException("Column count doesn't match value count", "21S01", 1136)))
+      .isEqualTo(SQLExceptionOverride.Override.DO_NOT_EVICT)
+  }
+
+  @Test
+  fun `still evicts on real connection failures`() {
+    val handler = VitessExceptionHandler()
+    // Real connection failures come back as (HY000, 1105) from Vitess
+    assertThat(handler.adjudicate(SQLException("vttablet: rpc error: connection refused", "HY000", 1105)))
       .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+    assertThat(handler.adjudicate(SQLException("vttablet: rpc error: connection reset by peer", "HY000", 1105)))
+      .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+    assertThat(handler.adjudicate(SQLException("vttablet: broken pipe", "HY000", 1105)))
+      .isEqualTo(SQLExceptionOverride.Override.MUST_EVICT)
+  }
+
+  @Test
+  fun `does not evict on generic vttablet errors`() {
+    val handler = VitessExceptionHandler()
+    // Generic vttablet error without connection failure — should NOT evict anymore
+    assertThat(
+        handler.adjudicate(
+          SQLException("vttablet: rpc error: code = FailedPrecondition desc = query not supported", "", 0)
+        )
+      )
+      .isEqualTo(SQLExceptionOverride.Override.CONTINUE_EVICT)
   }
 }


### PR DESCRIPTION
This change is mostly to be smarter about when you force a connection reset, to avoid churning connections for no good reason. Ideally this should be entirely based on the error codes, but I want to be a little conservative with this this change initially.

Co-authored by Claude etc etc

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.

Thank you for contributing to Misk! 🎉
