### PR TITLE
feat(misk-mcp): expose RequestMeta to McpTool.handle

### DIFF
--- a/misk-mcp/README.md
+++ b/misk-mcp/README.md
@@ -580,6 +580,47 @@ class WeatherTool @Inject constructor(
 }
 ```
 
+#### Accessing Request Meta (RequestMeta)
+
+When a tool needs access to the inbound `CallToolRequest._meta` field — for example to read a `progressToken` so it can stream progress notifications back, or to inspect related-task metadata — extend one of the meta-aware bridge classes instead of `McpTool` / `StructuredMcpTool`:
+
+- `MetaAwareMcpTool<I>` — for tools that return `ToolResult` (text/media/error content).
+- `MetaAwareStructuredMcpTool<I, O>` — for tools that return structured `O` typed output.
+
+Authors override the meta-aware `handle(input, meta)` overload; the bridge classes seal the input-only `handle(input)` overload to delegate with `meta = null`. The framework's dispatcher routes to the meta-aware overload automatically — no annotation or registration change is needed beyond picking the right base class.
+
+```kotlin
+@Serializable
+data class LongRunningInput(
+  @Description("How many steps the operation should run for")
+  val steps: Int
+)
+
+@ExperimentalMiskApi
+@Singleton
+class LongRunningTool @Inject constructor(
+  private val notifier: ProgressNotifier,
+) : MetaAwareMcpTool<LongRunningInput>() {
+  override val name = "long_running"
+  override val description = "Performs a long-running operation with progress reporting"
+
+  override suspend fun handle(input: LongRunningInput, meta: RequestMeta?): ToolResult {
+    val token = meta?.progressToken
+    repeat(input.steps) { step ->
+      // ... do work ...
+      if (token != null) {
+        notifier.notify(token, progress = step + 1, total = input.steps)
+      }
+    }
+    return ToolResult(TextContent("Completed ${input.steps} steps"))
+  }
+}
+```
+
+Use `MetaAwareStructuredMcpTool<I, O>` the same way; build the typed result with the inherited `ToolResult(result: O, ...)` factories. The interface-level return type is `McpTool.ToolResult`, not `StructuredToolResult<O>` — the typed `O` is preserved at value construction, not at signature.
+
+Tools that don't need meta should keep extending `McpTool` / `StructuredMcpTool` — meta-awareness is strictly opt-in.
+
 Register tools:
 
 ```kotlin

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -128,7 +128,9 @@ public abstract class misk/mcp/McpTool {
 	public fun getOpenWorldHint ()Z
 	public fun getReadOnlyHint ()Z
 	public fun getTitle ()Ljava/lang/String;
-	public abstract fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun handle-7zgdlzo$default (Lmisk/mcp/McpTool;Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	protected fun toCallToolResult (Lmisk/mcp/McpTool$ToolResult;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 }
 

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -166,13 +166,20 @@ public final class misk/mcp/McpToolModule$Companion {
 	public final fun create (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/mcp/McpToolModule;
 }
 
-public abstract interface class misk/mcp/MetaAwareMcpTool {
-	public fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract class misk/mcp/MetaAwareMcpTool : misk/mcp/McpTool, misk/mcp/MetaAwareTool {
+	public fun <init> ()V
+	public final fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class misk/mcp/MetaAwareMcpTool$DefaultImpls {
-	public static fun handle (Lmisk/mcp/MetaAwareMcpTool;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract class misk/mcp/MetaAwareStructuredMcpTool : misk/mcp/StructuredMcpTool, misk/mcp/MetaAwareTool {
+	public fun <init> ()V
+	public final fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class misk/mcp/MetaAwareTool {
+	public abstract fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class misk/mcp/MiskMcpServer : io/modelcontextprotocol/kotlin/sdk/server/Server {

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -128,8 +128,7 @@ public abstract class misk/mcp/McpTool {
 	public fun getOpenWorldHint ()Z
 	public fun getReadOnlyHint ()Z
 	public fun getTitle ()Ljava/lang/String;
-	public fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun toCallToolResult (Lmisk/mcp/McpTool$ToolResult;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 }
 
@@ -165,6 +164,15 @@ public final class misk/mcp/McpToolModule : misk/inject/KAbstractModule {
 public final class misk/mcp/McpToolModule$Companion {
 	public final fun create (Lkotlin/reflect/KClass;Ljava/lang/annotation/Annotation;)Lmisk/mcp/McpToolModule;
 	public final fun create (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lmisk/mcp/McpToolModule;
+}
+
+public abstract interface class misk/mcp/MetaAwareMcpTool {
+	public fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class misk/mcp/MetaAwareMcpTool$DefaultImpls {
+	public static fun handle (Lmisk/mcp/MetaAwareMcpTool;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class misk/mcp/MiskMcpServer : io/modelcontextprotocol/kotlin/sdk/server/Server {

--- a/misk-mcp/api/misk-mcp.api
+++ b/misk-mcp/api/misk-mcp.api
@@ -130,7 +130,6 @@ public abstract class misk/mcp/McpTool {
 	public fun getTitle ()Ljava/lang/String;
 	public fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handle-7zgdlzo (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun handle-7zgdlzo$default (Lmisk/mcp/McpTool;Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	protected fun toCallToolResult (Lmisk/mcp/McpTool$ToolResult;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 }
 

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -6,6 +6,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlin.reflect.KClass
@@ -231,7 +232,7 @@ abstract class McpTool<I : Any> {
           )
           .toCallToolResult()
       }
-    return handle(parsedInput).toCallToolResult()
+    return handle(parsedInput, request.meta).toCallToolResult()
   }
 
   sealed interface ToolResult {
@@ -276,7 +277,29 @@ abstract class McpTool<I : Any> {
       }
     }
 
-  abstract suspend fun handle(input: I): ToolResult
+  /**
+   * Handles a tool invocation with the typed [input] and the request's optional [meta].
+   *
+   * This is the overload the framework dispatches to. The default implementation forwards to
+   * [handle(input)] for backwards compatibility, so existing subclasses that override only the
+   * input-only overload continue to work unchanged.
+   *
+   * Subclasses that need access to the request's [RequestMeta] (e.g. progress tokens, related task
+   * metadata) should override this overload directly. Subclasses must override either this
+   * overload or [handle(input)]; overriding neither results in a runtime error.
+   */
+  open suspend fun handle(input: I, meta: RequestMeta? = null): ToolResult = handle(input)
+
+  /**
+   * Handles a tool invocation with the typed [input].
+   *
+   * Kept for backwards compatibility. Subclasses may override this overload when they don't need
+   * access to the request's [RequestMeta]; the framework reaches it through the default
+   * implementation of [handle(input, meta)]. The default implementation here errors at runtime so
+   * a subclass that overrides neither overload fails fast with a clear message.
+   */
+  open suspend fun handle(input: I): ToolResult =
+    error("McpTool subclass must override either handle(input) or handle(input, meta)")
 
   private val inputType: KType by lazy {
     @Suppress("UNCHECKED_CAST")

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -288,7 +288,7 @@ abstract class McpTool<I : Any> {
    * metadata) should override this overload directly. Subclasses must override either this
    * overload or [handle(input)]; overriding neither results in a runtime error.
    */
-  open suspend fun handle(input: I, meta: RequestMeta? = null): ToolResult = handle(input)
+  open suspend fun handle(input: I, meta: RequestMeta?): ToolResult = handle(input)
 
   /**
    * Handles a tool invocation with the typed [input].

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -232,6 +232,9 @@ abstract class McpTool<I : Any> {
           )
           .toCallToolResult()
       }
+    // Tools opt into receiving request._meta by mixing in MetaAwareTool (typically via the
+    // MetaAwareMcpTool / MetaAwareStructuredMcpTool bridge classes). Plain subclasses pay no
+    // cost — the unchecked cast is safe because the marker interface is parameterized in I/R.
     val result =
       if (this is MetaAwareTool<*, *>) {
         @Suppress("UNCHECKED_CAST") (this as MetaAwareTool<I, ToolResult>).handle(parsedInput, request.meta)

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -233,8 +233,8 @@ abstract class McpTool<I : Any> {
           .toCallToolResult()
       }
     val result =
-      if (this is MetaAwareMcpTool<*, *>) {
-        @Suppress("UNCHECKED_CAST") (this as MetaAwareMcpTool<I, ToolResult>).handle(parsedInput, request.meta)
+      if (this is MetaAwareTool<*, *>) {
+        @Suppress("UNCHECKED_CAST") (this as MetaAwareTool<I, ToolResult>).handle(parsedInput, request.meta)
       } else {
         handle(parsedInput)
       }
@@ -287,9 +287,10 @@ abstract class McpTool<I : Any> {
    * Handles a tool invocation with the typed [input].
    *
    * Subclasses must override this method to implement tool behavior. Tools that need access to the
-   * request's [RequestMeta] (e.g. progress tokens, related task metadata) should additionally
-   * implement the [MetaAwareMcpTool] marker interface; the framework dispatches through that
-   * interface's two-arg overload when it is present.
+   * request's [RequestMeta] (e.g. progress tokens, related task metadata) should extend the
+   * [MetaAwareMcpTool] (or [MetaAwareStructuredMcpTool] for structured outputs) abstract bridge
+   * class instead — the bridge implements [MetaAwareTool] and the framework dispatches through
+   * the meta-aware overload when present.
    */
   abstract suspend fun handle(input: I): ToolResult
 

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -234,7 +234,7 @@ abstract class McpTool<I : Any> {
       }
     // Tools opt into receiving request._meta by mixing in MetaAwareTool (typically via the
     // MetaAwareMcpTool / MetaAwareStructuredMcpTool bridge classes). Plain subclasses pay no
-    // cost — the unchecked cast is safe because the marker interface is parameterized in I/R.
+    // cost — the unchecked cast is safe because the capability interface is parameterized in I/R.
     val result =
       if (this is MetaAwareTool<*, *>) {
         @Suppress("UNCHECKED_CAST") (this as MetaAwareTool<I, ToolResult>).handle(parsedInput, request.meta)

--- a/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/McpTool.kt
@@ -232,7 +232,13 @@ abstract class McpTool<I : Any> {
           )
           .toCallToolResult()
       }
-    return handle(parsedInput, request.meta).toCallToolResult()
+    val result =
+      if (this is MetaAwareMcpTool<*, *>) {
+        @Suppress("UNCHECKED_CAST") (this as MetaAwareMcpTool<I, ToolResult>).handle(parsedInput, request.meta)
+      } else {
+        handle(parsedInput)
+      }
+    return result.toCallToolResult()
   }
 
   sealed interface ToolResult {
@@ -278,28 +284,14 @@ abstract class McpTool<I : Any> {
     }
 
   /**
-   * Handles a tool invocation with the typed [input] and the request's optional [meta].
-   *
-   * This is the overload the framework dispatches to. The default implementation forwards to
-   * [handle(input)] for backwards compatibility, so existing subclasses that override only the
-   * input-only overload continue to work unchanged.
-   *
-   * Subclasses that need access to the request's [RequestMeta] (e.g. progress tokens, related task
-   * metadata) should override this overload directly. Subclasses must override either this
-   * overload or [handle(input)]; overriding neither results in a runtime error.
-   */
-  open suspend fun handle(input: I, meta: RequestMeta?): ToolResult = handle(input)
-
-  /**
    * Handles a tool invocation with the typed [input].
    *
-   * Kept for backwards compatibility. Subclasses may override this overload when they don't need
-   * access to the request's [RequestMeta]; the framework reaches it through the default
-   * implementation of [handle(input, meta)]. The default implementation here errors at runtime so
-   * a subclass that overrides neither overload fails fast with a clear message.
+   * Subclasses must override this method to implement tool behavior. Tools that need access to the
+   * request's [RequestMeta] (e.g. progress tokens, related task metadata) should additionally
+   * implement the [MetaAwareMcpTool] marker interface; the framework dispatches through that
+   * interface's two-arg overload when it is present.
    */
-  open suspend fun handle(input: I): ToolResult =
-    error("McpTool subclass must override either handle(input) or handle(input, meta)")
+  abstract suspend fun handle(input: I): ToolResult
 
   private val inputType: KType by lazy {
     @Suppress("UNCHECKED_CAST")

--- a/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareMcpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareMcpTool.kt
@@ -1,0 +1,42 @@
+package misk.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import misk.annotation.ExperimentalMiskApi
+
+/**
+ * Marker interface for MCP tools that need access to the request's `_meta` field.
+ *
+ * Mix this in alongside [McpTool] (or any subclass: [StructuredMcpTool], or external bases like
+ * cash-server's `MoneybotTool`) to opt into receiving the inbound request's [RequestMeta].
+ *
+ * The dispatcher branches on `tool is MetaAwareMcpTool<*, *>` at invocation time, so non-meta-aware
+ * tools pay zero cost and don't see this overload.
+ *
+ * The default implementation of [handle] (no-meta overload) delegates to [handle] (meta overload)
+ * with `meta = null`. Because Kotlin requires explicit disambiguation when an abstract class
+ * method shares a signature with an interface default, tools implementing both [McpTool] and
+ * [MetaAwareMcpTool] must add a one-line forwarding override:
+ *
+ * ```kotlin
+ * override suspend fun handle(input: I): ToolResult = super<MetaAwareMcpTool>.handle(input)
+ * ```
+ *
+ * This forwards into the interface default (which calls `handle(input, null)`), so direct callers
+ * of the no-meta overload — including test helpers — continue to work without re-implementing
+ * the body.
+ *
+ * Parameterized in [R] so it composes with bases that return covariant subtypes of `ToolResult`
+ * (e.g. [StructuredMcpTool] returning `StructuredToolResult<O>`, or external bases with their own
+ * result types).
+ *
+ * @param I The tool's input type, matching the input type of the [McpTool] this is mixed into.
+ * @param R The tool's return type, matching the return type of [McpTool.handle].
+ */
+@ExperimentalMiskApi
+interface MetaAwareMcpTool<I, R> {
+  /** Handles a tool invocation with the typed [input] and the request's optional [meta]. */
+  suspend fun handle(input: I, meta: RequestMeta?): R
+
+  /** Default no-meta overload — delegates to the meta-aware overload with `meta = null`. */
+  suspend fun handle(input: I): R = handle(input, null)
+}

--- a/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareMcpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareMcpTool.kt
@@ -4,39 +4,39 @@ import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import misk.annotation.ExperimentalMiskApi
 
 /**
- * Marker interface for MCP tools that need access to the request's `_meta` field.
+ * Bridge base class for plain [McpTool] authors that need access to the request's `_meta`.
  *
- * Mix this in alongside [McpTool] (or any subclass: [StructuredMcpTool], or external bases like
- * cash-server's `MoneybotTool`) to opt into receiving the inbound request's [RequestMeta].
- *
- * The dispatcher branches on `tool is MetaAwareMcpTool<*, *>` at invocation time, so non-meta-aware
- * tools pay zero cost and don't see this overload.
- *
- * The default implementation of [handle] (no-meta overload) delegates to [handle] (meta overload)
- * with `meta = null`. Because Kotlin requires explicit disambiguation when an abstract class
- * method shares a signature with an interface default, tools implementing both [McpTool] and
- * [MetaAwareMcpTool] must add a one-line forwarding override:
- *
- * ```kotlin
- * override suspend fun handle(input: I): ToolResult = super<MetaAwareMcpTool>.handle(input)
- * ```
- *
- * This forwards into the interface default (which calls `handle(input, null)`), so direct callers
- * of the no-meta overload — including test helpers — continue to work without re-implementing
+ * Subclasses implement only the meta-aware [handle] overload — the input-only `handle(input)` is
+ * sealed by this class and delegates to the meta-aware overload with `meta = null`, so direct
+ * callers (test helpers, etc.) of the no-meta overload continue to work without re-implementing
  * the body.
  *
- * Parameterized in [R] so it composes with bases that return covariant subtypes of `ToolResult`
- * (e.g. [StructuredMcpTool] returning `StructuredToolResult<O>`, or external bases with their own
- * result types).
+ * The framework's dispatcher branches on `tool is MetaAwareTool<*, *>` at invocation time, so
+ * mixing this base in is the only opt-in step needed — no explicit annotations or registrations.
  *
- * @param I The tool's input type, matching the input type of the [McpTool] this is mixed into.
- * @param R The tool's return type, matching the return type of [McpTool.handle].
+ * ## Example
+ *
+ * ```kotlin
+ * @Singleton
+ * class ProgressTrackingTool @Inject constructor() : MetaAwareMcpTool<MyInput>() {
+ *   override val name = "progress_tracking"
+ *   override val description = "..."
+ *
+ *   override suspend fun handle(input: MyInput, meta: RequestMeta?): ToolResult {
+ *     val progressToken = meta?.progressToken
+ *     // ...
+ *     return ToolResult(TextContent("done"))
+ *   }
+ * }
+ * ```
+ *
+ * @param I The input type for this tool.
+ * @see MetaAwareTool
+ * @see MetaAwareStructuredMcpTool
  */
 @ExperimentalMiskApi
-interface MetaAwareMcpTool<I, R> {
-  /** Handles a tool invocation with the typed [input] and the request's optional [meta]. */
-  suspend fun handle(input: I, meta: RequestMeta?): R
+abstract class MetaAwareMcpTool<I : Any> : McpTool<I>(), MetaAwareTool<I, McpTool.ToolResult> {
+  abstract override suspend fun handle(input: I, meta: RequestMeta?): ToolResult
 
-  /** Default no-meta overload — delegates to the meta-aware overload with `meta = null`. */
-  suspend fun handle(input: I): R = handle(input, null)
+  final override suspend fun handle(input: I): ToolResult = handle(input, null)
 }

--- a/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareStructuredMcpTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareStructuredMcpTool.kt
@@ -1,0 +1,27 @@
+package misk.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import misk.annotation.ExperimentalMiskApi
+
+/**
+ * Bridge base class for [StructuredMcpTool] authors that need access to the request's `_meta`.
+ *
+ * Subclasses implement only the meta-aware [handle] overload — the input-only `handle(input)` is
+ * sealed by this class and delegates to the meta-aware overload with `meta = null`. Returns
+ * [McpTool.ToolResult] (rather than `StructuredToolResult<O>` directly) because
+ * `StructuredMcpTool.handle` does not narrow the return type — implementations build their typed
+ * result via the inherited `ToolResult(result: O, ...)` factories, which already produce a
+ * `StructuredToolResult<O>` typed as `ToolResult`.
+ *
+ * @param I The input type for this tool.
+ * @param O The output type for this tool.
+ * @see MetaAwareTool
+ * @see MetaAwareMcpTool
+ */
+@ExperimentalMiskApi
+abstract class MetaAwareStructuredMcpTool<I : Any, O : Any> :
+  StructuredMcpTool<I, O>(), MetaAwareTool<I, McpTool.ToolResult> {
+  abstract override suspend fun handle(input: I, meta: RequestMeta?): ToolResult
+
+  final override suspend fun handle(input: I): ToolResult = handle(input, null)
+}

--- a/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareTool.kt
+++ b/misk-mcp/src/main/kotlin/misk/mcp/MetaAwareTool.kt
@@ -1,0 +1,37 @@
+package misk.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import misk.annotation.ExperimentalMiskApi
+
+/**
+ * Capability interface declaring the meta-aware overload of [handle].
+ *
+ * This interface is the framework's hook for tools that need access to the inbound MCP request's
+ * `_meta` field ([RequestMeta]). The dispatcher branches on `tool is MetaAwareTool<*, *>` at
+ * invocation time, so non-meta-aware tools pay zero cost.
+ *
+ * Tool authors should not implement this interface directly — instead, extend the appropriate
+ * abstract bridge class for their base hierarchy:
+ *
+ * - [MetaAwareMcpTool] — for plain `McpTool` authors
+ * - [MetaAwareStructuredMcpTool] — for `StructuredMcpTool` authors
+ *
+ * The bridges hold a `final override` of the input-only `handle(input)` method that delegates to
+ * the meta-aware overload with `meta = null`, so meta-aware authors only override the
+ * meta-aware overload — single inheritance, single method.
+ *
+ * External base hierarchies (e.g. cash-server's `MoneybotTool`) can add their own bridge by
+ * implementing this interface and providing the same `final override` of the base's input-only
+ * method.
+ *
+ * Parameterized in [R] so it composes with bases that return covariant subtypes of `ToolResult`
+ * or external result types entirely.
+ *
+ * @param I The tool's input type.
+ * @param R The tool's return type.
+ */
+@ExperimentalMiskApi
+interface MetaAwareTool<I, R> {
+  /** Handles a tool invocation with the typed [input] and the request's optional [meta]. */
+  suspend fun handle(input: I, meta: RequestMeta?): R
+}

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
@@ -3,6 +3,7 @@
 package misk.mcp
 
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.buildCallToolRequest
@@ -12,6 +13,9 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
 import misk.annotation.ExperimentalMiskApi
 import org.junit.jupiter.api.Test
 
@@ -45,7 +49,9 @@ class McpToolHandleMetaTest {
       arguments { put("name", JsonPrimitive("alice")) }
       meta {
         progressToken("token-42")
-        put("custom-key", "custom-value")
+        put("custom-string", "custom-value")
+        put("custom-int", 42)
+        put("custom-bool", true)
       }
     }
 
@@ -53,7 +59,10 @@ class McpToolHandleMetaTest {
 
     assertEquals(1, tool.captureCount)
     val meta = assertNotNull(tool.capturedMeta, "meta should be forwarded from request")
-    assertEquals("\"custom-value\"", meta.json["custom-key"]?.toString())
+    assertEquals(RequestId.StringId("token-42"), meta.progressToken)
+    assertEquals("custom-value", meta.json["custom-string"]?.jsonPrimitive?.content)
+    assertEquals(42, meta.json["custom-int"]?.jsonPrimitive?.int)
+    assertEquals(true, meta.json["custom-bool"]?.jsonPrimitive?.boolean)
   }
 
   @Test

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
@@ -24,12 +24,11 @@ class McpToolHandleMetaTest {
   @Serializable data class CapturingInput(val name: String)
 
   /**
-   * Tool that mixes in [MetaAwareMcpTool] alongside [McpTool] and records what its meta-aware
-   * [handle] overload receives. The interface default fills the abstract no-meta `handle(input)`
-   * slot inherited from [McpTool].
+   * Tool that extends the [MetaAwareMcpTool] bridge and records what its meta-aware [handle]
+   * overload receives. The bridge's `final override` of `handle(input)` fills the framework's
+   * abstract slot, so this class only declares the meta-aware overload.
    */
-  private class CapturingTool :
-    McpTool<CapturingInput>(), MetaAwareMcpTool<CapturingInput, McpTool.ToolResult> {
+  private class CapturingTool : MetaAwareMcpTool<CapturingInput>() {
     override val name = "capturing"
     override val description = "captures the meta passed to handle()"
 
@@ -44,12 +43,6 @@ class McpToolHandleMetaTest {
       captureCount++
       return ToolResult(TextContent("ok"))
     }
-
-    // Kotlin requires explicit disambiguation when an abstract class method shares a signature
-    // with an interface default; delegate to the marker's default so direct callers of the
-    // no-meta overload still hit handle(input, null).
-    override suspend fun handle(input: CapturingInput): ToolResult =
-      super<MetaAwareMcpTool>.handle(input)
   }
 
   @Test

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
@@ -23,8 +23,13 @@ class McpToolHandleMetaTest {
 
   @Serializable data class CapturingInput(val name: String)
 
-  /** Tool that overrides only the meta-aware [McpTool.handle] overload and records what it receives. */
-  private class CapturingTool : McpTool<CapturingInput>() {
+  /**
+   * Tool that mixes in [MetaAwareMcpTool] alongside [McpTool] and records what its meta-aware
+   * [handle] overload receives. The interface default fills the abstract no-meta `handle(input)`
+   * slot inherited from [McpTool].
+   */
+  private class CapturingTool :
+    McpTool<CapturingInput>(), MetaAwareMcpTool<CapturingInput, McpTool.ToolResult> {
     override val name = "capturing"
     override val description = "captures the meta passed to handle()"
 
@@ -39,6 +44,12 @@ class McpToolHandleMetaTest {
       captureCount++
       return ToolResult(TextContent("ok"))
     }
+
+    // Kotlin requires explicit disambiguation when an abstract class method shares a signature
+    // with an interface default; delegate to the marker's default so direct callers of the
+    // no-meta overload still hit handle(input, null).
+    override suspend fun handle(input: CapturingInput): ToolResult =
+      super<MetaAwareMcpTool>.handle(input)
   }
 
   @Test

--- a/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
+++ b/misk-mcp/src/test/kotlin/misk/mcp/McpToolHandleMetaTest.kt
@@ -1,0 +1,72 @@
+@file:OptIn(ExperimentalMiskApi::class, ExperimentalMcpApi::class)
+
+package misk.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.buildCallToolRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+import misk.annotation.ExperimentalMiskApi
+import org.junit.jupiter.api.Test
+
+class McpToolHandleMetaTest {
+
+  @Serializable data class CapturingInput(val name: String)
+
+  /** Tool that overrides only the meta-aware [McpTool.handle] overload and records what it receives. */
+  private class CapturingTool : McpTool<CapturingInput>() {
+    override val name = "capturing"
+    override val description = "captures the meta passed to handle()"
+
+    var capturedMeta: RequestMeta? = null
+      private set
+
+    var captureCount = 0
+      private set
+
+    override suspend fun handle(input: CapturingInput, meta: RequestMeta?): ToolResult {
+      capturedMeta = meta
+      captureCount++
+      return ToolResult(TextContent("ok"))
+    }
+  }
+
+  @Test
+  fun `handle(input, meta) receives populated RequestMeta when request has _meta`() = runTest {
+    val tool = CapturingTool()
+    val request = buildCallToolRequest {
+      name = "capturing"
+      arguments { put("name", JsonPrimitive("alice")) }
+      meta {
+        progressToken("token-42")
+        put("custom-key", "custom-value")
+      }
+    }
+
+    tool.handler(request)
+
+    assertEquals(1, tool.captureCount)
+    val meta = assertNotNull(tool.capturedMeta, "meta should be forwarded from request")
+    assertEquals("\"custom-value\"", meta.json["custom-key"]?.toString())
+  }
+
+  @Test
+  fun `handle(input, meta) receives null when request has no _meta`() = runTest {
+    val tool = CapturingTool()
+    val request = buildCallToolRequest {
+      name = "capturing"
+      arguments { put("name", JsonPrimitive("alice")) }
+    }
+
+    tool.handler(request)
+
+    assertEquals(1, tool.captureCount)
+    assertNull(tool.capturedMeta)
+  }
+}


### PR DESCRIPTION
## Description

Adds opt-in access to the inbound MCP request's `_meta` field (`RequestMeta` — progress tokens, related task metadata, anything else carried on `CallToolRequest._meta`) without changing the signature of plain `McpTool` / `StructuredMcpTool` subclasses.

The shape:

- `MetaAwareTool<I, R>` — capability interface. Single method `suspend fun handle(input: I, meta: RequestMeta?): R`. The framework's dispatcher branches on `is MetaAwareTool<*, *>` and routes to the meta-aware overload when present; otherwise it calls plain `handle(input)`. Pulled out as an interface so it works beyond the misk-mcp class hierarchy — cash-server's `MoneybotTool` (and any other base) can implement this directly to opt into the same dispatch path.

- `MetaAwareMcpTool<I>` — abstract bridge class extending `McpTool<I>()` and implementing `MetaAwareTool<I, ToolResult>`. Authors override only `handle(input, meta)`; the bridge holds a `final override` of `handle(input)` that delegates to `handle(input, null)`. Use this when your input-only return type is `McpTool.ToolResult`.

- `MetaAwareStructuredMcpTool<I, O>` — abstract bridge class extending `StructuredMcpTool<I, O>()` and implementing `MetaAwareTool<I, ToolResult>`. Same shape as `MetaAwareMcpTool` but rooted in the structured base. Note R binds to `ToolResult`, NOT `StructuredToolResult<O>`, because `StructuredMcpTool.handle` does not covariantly narrow the return type — typed `O` is preserved at value-construction time via the inherited `ToolResult(result: O, ...)` factories, not at signature time.

Backwards-compatible: existing subclasses of `McpTool` / `StructuredMcpTool` are unaffected. Meta access is strictly opt-in by extending one of the bridge classes (or, for external base hierarchies, implementing `MetaAwareTool` directly).

## Testing Strategy

Added `McpToolHandleMetaTest` covering both branches of the dispatcher: one test extends `MetaAwareMcpTool<CapturingInput>` and asserts that a `_meta` block carrying a `progressToken` plus three primitive types (string, int, boolean) round-trips into the meta-aware overload; the other asserts that a request with no `_meta` block yields `meta = null` (consistent with the SDK's `@Nullable` annotation on `getMeta`). The full set of existing fixture-driven tests (8 tools that override only `handle(input)`) continues to pass and serves as the regression check that the non-meta-aware dispatch path is unchanged.

## Checklist

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.
