### PR TITLE
misk-aws2-sqs: match v1 connection pool / timeout settings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ apacheCommonsPool = { module = "org.apache.commons:commons-pool2", version = "2.
 assertj = { module = "org.assertj:assertj-core", version = "3.27.7" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 awaitilityKotlin = { module = "org.awaitility:awaitility-kotlin", version.ref = "awaitility" }
+aws2ApacheClient = { module = "software.amazon.awssdk:apache-client", version.ref = "aws2" }
 aws2Auth = { module = "software.amazon.awssdk:auth", version.ref = "aws2" }
 aws2Bom = { module = "software.amazon.awssdk:bom", version.ref = "aws2" }
 aws2Core = { module = "software.amazon.awssdk:aws-core", version.ref = "aws2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ aws2Bom = { module = "software.amazon.awssdk:bom", version.ref = "aws2" }
 aws2Core = { module = "software.amazon.awssdk:aws-core", version.ref = "aws2" }
 aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws2" }
 aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "aws2" }
+aws2HttpClientSpi = { module = "software.amazon.awssdk:http-client-spi", version.ref = "aws2" }
 aws2Regions = { module = "software.amazon.awssdk:regions", version.ref = "aws2" }
 aws2S3 = { module = "software.amazon.awssdk:s3", version.ref = "aws2" }
 aws2Sqs = { module = "software.amazon.awssdk:sqs", version.ref = "aws2" }

--- a/misk-aws2-sqs/build.gradle.kts
+++ b/misk-aws2-sqs/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   api(project(":wisp:wisp-token"))
   implementation(libs.aws2ApacheClient)
   implementation(libs.aws2Core)
+  implementation(libs.aws2HttpClientSpi)
   implementation(libs.aws2Regions)
   implementation(libs.awsSdkCore)
   implementation(libs.loggingApi)

--- a/misk-aws2-sqs/build.gradle.kts
+++ b/misk-aws2-sqs/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   api(project(":misk-testing-api"))
   api(project(":wisp:wisp-lease"))
   api(project(":wisp:wisp-token"))
+  implementation(libs.aws2ApacheClient)
   implementation(libs.aws2Core)
   implementation(libs.aws2Regions)
   implementation(libs.awsSdkCore)

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsClientFactory.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsClientFactory.kt
@@ -9,6 +9,7 @@ import misk.cloud.aws.AwsRegion
 import misk.logging.getLogger
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder
@@ -19,7 +20,9 @@ import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager
 
 internal interface SqsClientFactory {
   fun getForSending(region: AwsRegion): SqsClient
+
   fun getForReceiving(region: AwsRegion): SqsClient
+
   fun getBatchManager(region: AwsRegion): SqsAsyncBatchManager
 }
 
@@ -41,6 +44,7 @@ internal class RealSqsClientFactory(
         .credentialsProvider(credentialsProvider)
         .region(Region.of(region.name))
         .overrideConfiguration(sendingOverrideConfiguration())
+        .httpClientBuilder(sendingHttpClientBuilder())
         .also(configureSyncClient)
         .build()
     }
@@ -52,6 +56,7 @@ internal class RealSqsClientFactory(
         .credentialsProvider(credentialsProvider)
         .region(Region.of(region.name))
         .overrideConfiguration(receivingOverrideConfiguration())
+        .httpClientBuilder(receivingHttpClientBuilder())
         .also(configureSyncClient)
         .build()
     }
@@ -69,9 +74,7 @@ internal class RealSqsClientFactory(
             .client(getAsyncForSending(region))
             .scheduledExecutor(executor)
             .overrideConfiguration(
-              BatchOverrideConfiguration.builder()
-                .sendRequestFrequency(BUFFERED_SEND_FREQUENCY)
-                .build()
+              BatchOverrideConfiguration.builder().sendRequestFrequency(BUFFERED_SEND_FREQUENCY).build()
             )
             .build()
         scheduledExecutors[region] = executor
@@ -142,14 +145,29 @@ internal class RealSqsClientFactory(
   }
 
   private fun receivingOverrideConfiguration(): ClientOverrideConfiguration {
-    return ClientOverrideConfiguration.builder()
-      .apiCallAttemptTimeout(RECEIVING_ATTEMPT_TIMEOUT)
-      .build()
+    return ClientOverrideConfiguration.builder().apiCallAttemptTimeout(RECEIVING_ATTEMPT_TIMEOUT).build()
+  }
+
+  private fun sendingHttpClientBuilder(): ApacheHttpClient.Builder {
+    return ApacheHttpClient.builder()
+      .socketTimeout(Duration.ofMillis(config.sqs_sending_socket_timeout_ms.toLong()))
+      .connectionTimeout(Duration.ofMillis(config.sqs_sending_connect_timeout_ms.toLong()))
+  }
+
+  private fun receivingHttpClientBuilder(): ApacheHttpClient.Builder {
+    return ApacheHttpClient.builder()
+      .socketTimeout(RECEIVING_ATTEMPT_TIMEOUT)
+      .connectionTimeout(RECEIVING_CONNECTION_TIMEOUT)
+      // Do not artificially constrain the # of connections to SQS. Instead we rely on higher
+      // level resource limiting knobs (e.g # of parallel receivers).
+      // We only do this for receiving, as sending does not have equivalent knobs.
+      .maxConnections(Int.MAX_VALUE)
   }
 
   companion object {
     private val log = getLogger<RealSqsClientFactory>()
     private val BUFFERED_SEND_FREQUENCY = Duration.ofMillis(200)
     private val RECEIVING_ATTEMPT_TIMEOUT = Duration.ofMillis(25_000)
+    private val RECEIVING_CONNECTION_TIMEOUT = Duration.ofMillis(1_000)
   }
 }


### PR DESCRIPTION
## Summary

The v1 `misk.jobqueue.sqs.AwsSqsJobQueueModule` explicitly built the receiving SQS client with an unbounded Apache HTTP connection pool and a 1s connection timeout, and the sending client with the configured socket / connect timeouts.

The v2 `misk.aws2.sqs.jobqueue.coordinated` module dropped these and fell back to the AWS SDK v2 `ApacheHttpClient` defaults: `maxConnections=50` and `connectionAcquisitionTimeout=10s`.

Because both `ReceiveMessage` (long-polling, sized via the `pod-jobqueue-consumers` LD flag) and `DeleteMessage` (called from `SqsJob.acknowledge()`) share the same receiving `SqsClient`, services with more than ~50 concurrent consumers exhaust the pool and see:

```
software.amazon.awssdk.core.exception.SdkClientException:
  Unable to execute HTTP request: Timeout waiting for connection from pool
Caused by: org.apache.http.conn.ConnectionPoolTimeoutException:
  Timeout waiting for connection from pool
```

…on both `ReceiveMessage` and `DeleteMessage`. When ack fails the message is redelivered, eventually exceeding `maxReceiveCount` and dead-lettering — even though the handler had already done its real work.

## Change

Restore v1 parity in `RealSqsClientFactory` by setting an explicit `ApacheHttpClient.builder()` on both the sending and receiving `SqsClient` builders:

| | Receiving | Sending |
|---|---|---|
| `maxConnections` | `Int.MAX_VALUE` (matches v1's explicit override) | SDK default 50 (matches v1) |
| `connectionTimeout` | 1,000 ms (matches v1) | `config.sqs_sending_connect_timeout_ms` (matches v1) |
| `socketTimeout` | 25,000 ms (matches v1, also matches existing `apiCallAttemptTimeout`) | `config.sqs_sending_socket_timeout_ms` (matches v1) |

The user-provided `configureClient` hook on `CoordinatedAwsSqsJobQueueModule` still runs **after** these defaults via `.also(configureSyncClient)`, so callers can still override.

## Notes

- `software.amazon.awssdk:apache-client` was already on the runtime classpath transitively via `software.amazon.awssdk:sqs`. This PR just promotes it to an explicit `implementation` dependency so we can reference `ApacheHttpClient.builder()` from production code.
- No public API change; `SqsClientFactory` and `RealSqsClientFactory` remain `internal`.
- Tests pass: `bin/gradle :misk-aws2-sqs:test --warn`.