### PR TITLE
misk-aws / misk-aws2-sqs: expose SQS HTTP connection pool metrics

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ aws2Core = { module = "software.amazon.awssdk:aws-core", version.ref = "aws2" }
 aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version.ref = "aws2" }
 aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "aws2" }
 aws2HttpClientSpi = { module = "software.amazon.awssdk:http-client-spi", version.ref = "aws2" }
+aws2MetricsSpi = { module = "software.amazon.awssdk:metrics-spi", version.ref = "aws2" }
 aws2Regions = { module = "software.amazon.awssdk:regions", version.ref = "aws2" }
 aws2S3 = { module = "software.amazon.awssdk:s3", version.ref = "aws2" }
 aws2Sqs = { module = "software.amazon.awssdk:sqs", version.ref = "aws2" }

--- a/misk-aws/api/misk-aws.api
+++ b/misk-aws/api/misk-aws.api
@@ -79,8 +79,8 @@ public class misk/jobqueue/sqs/AwsSqsJobQueueModule : misk/inject/KAbstractModul
 	protected fun configure ()V
 	public fun configureClient (Lcom/amazonaws/client/builder/AwsClientBuilder;)V
 	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;Lmisk/jobqueue/sqs/AwsSqsJobQueueConfig;)Lmisk/tasks/RepeatedTaskQueue;
-	public final fun provideSQSClient (Ljava/lang/String;Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;Lmisk/feature/FeatureFlags;)Lcom/amazonaws/services/sqs/AmazonSQS;
-	public final fun provideSQSClientForReceiving (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;)Lcom/amazonaws/services/sqs/AmazonSQS;
+	public final fun provideSQSClient (Ljava/lang/String;Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;Lmisk/feature/FeatureFlags;Lmisk/jobqueue/sqs/SqsConnectionPoolMetrics;)Lcom/amazonaws/services/sqs/AmazonSQS;
+	public final fun provideSQSClientForReceiving (Lmisk/cloud/aws/AwsRegion;Lcom/amazonaws/auth/AWSCredentialsProvider;Lmisk/jobqueue/sqs/SqsConnectionPoolMetrics;)Lcom/amazonaws/services/sqs/AmazonSQS;
 }
 
 public final class misk/jobqueue/sqs/AwsSqsJobQueueModule$Companion {
@@ -185,6 +185,13 @@ public final class misk/jobqueue/sqs/QueueResolverKt {
 	public static final fun getParentQueue (Lmisk/jobqueue/QueueName;)Lmisk/jobqueue/QueueName;
 	public static final fun getRetryQueue (Lmisk/jobqueue/QueueName;)Lmisk/jobqueue/QueueName;
 	public static final fun isRetryQueue (Lmisk/jobqueue/QueueName;)Z
+}
+
+public final class misk/jobqueue/sqs/SqsConnectionPoolMetrics {
+	public static final field Companion Lmisk/jobqueue/sqs/SqsConnectionPoolMetrics$Companion;
+}
+
+public final class misk/jobqueue/sqs/SqsConnectionPoolMetrics$Companion {
 }
 
 public final class misk/jobqueue/sqs/SqsConsumerAllocator {

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt
@@ -31,8 +31,9 @@ import wisp.lease.LeaseManager
 
 /** [AwsSqsJobQueueModule] installs job queue support provided by SQS. */
 @Deprecated(
-  message = "AWS SDK v1 SQS jobqueue is deprecated. Use the AWS SDK v2 SQS jobqueue in " +
-    "misk-aws2-sqs (misk.aws2.sqs.jobqueue.SqsJobQueueModule) instead."
+  message =
+    "AWS SDK v1 SQS jobqueue is deprecated. Use the AWS SDK v2 SQS jobqueue in " +
+      "misk-aws2-sqs (misk.aws2.sqs.jobqueue.SqsJobQueueModule) instead."
 )
 open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbstractModule() {
   override fun configure() {
@@ -77,6 +78,8 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
           .toProvider(AmazonSQSProvider(config, it, true, ::configureSyncClient, ::configureAsyncClient))
       }
 
+    bind<SqsConnectionPoolMetrics>().asEagerSingleton()
+
     // Bind the configs for external queues
     val externalQueueConfigBinder = newMapBinder<QueueName, AwsSqsQueueConfig>()
     config.external_queues
@@ -84,9 +87,7 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
       .forEach { (queueName, config) -> externalQueueConfigBinder.addBinding(queueName).toInstance(config) }
 
     install(DefaultAsyncSwitchModule())
-    install(
-      ServiceModule<RepeatedTaskQueue, ForSqsHandling>().dependsOn<ReadyService>()
-    )
+    install(ServiceModule<RepeatedTaskQueue, ForSqsHandling>().dependsOn<ReadyService>())
   }
 
   open fun <BuilderT : AwsClientBuilder<BuilderT, ClientT>, ClientT> configureClient(builder: BuilderT) {}
@@ -102,15 +103,20 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
     region: AwsRegion,
     credentials: AWSCredentialsProvider,
     features: FeatureFlags,
+    connectionPoolMetrics: SqsConnectionPoolMetrics,
   ): AmazonSQS {
-    return buildClient(appName, config, credentials, region, features, ::configureAsyncClient)
+    return buildClient(appName, config, credentials, region, features, connectionPoolMetrics, ::configureAsyncClient)
   }
 
   @Provides
   @Singleton
   @ForSqsReceiving
-  fun provideSQSClientForReceiving(region: AwsRegion, credentials: AWSCredentialsProvider): AmazonSQS {
-    return buildReceivingClient(credentials, region, ::configureSyncClient)
+  fun provideSQSClientForReceiving(
+    region: AwsRegion,
+    credentials: AWSCredentialsProvider,
+    connectionPoolMetrics: SqsConnectionPoolMetrics,
+  ): AmazonSQS {
+    return buildReceivingClient(credentials, region, connectionPoolMetrics, ::configureSyncClient)
   }
 
   @Provides
@@ -139,11 +145,13 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
 
     @Inject @AppName lateinit var appName: String
 
+    @Inject lateinit var connectionPoolMetrics: SqsConnectionPoolMetrics
+
     override fun get(): AmazonSQS {
       return if (forSqsReceiving) {
-        buildReceivingClient(credentials, region, configureClient)
+        buildReceivingClient(credentials, region, connectionPoolMetrics, configureClient)
       } else {
-        buildClient(appName, config, credentials, region, features, configureAsyncClient)
+        buildClient(appName, config, credentials, region, features, connectionPoolMetrics, configureAsyncClient)
       }
     }
   }
@@ -153,6 +161,7 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
     private fun buildReceivingClient(
       credentials: AWSCredentialsProvider,
       region: AwsRegion,
+      connectionPoolMetrics: SqsConnectionPoolMetrics,
       configureClient: (AmazonSQSClientBuilder) -> Unit,
     ): AmazonSQS {
       // We don't need any buffering functionality for receiving; build a regular sync client.
@@ -160,6 +169,7 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
         AmazonSQSClientBuilder.standard()
           .withCredentials(credentials)
           .withRegion(region.name)
+          .withMetricsCollector(connectionPoolMetrics.collectorFor(SqsConnectionPoolMetrics.ClientType.RECEIVING))
           .withClientConfiguration(
             ClientConfiguration()
               .withSocketTimeout(25_000)
@@ -180,6 +190,7 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
       credentials: AWSCredentialsProvider,
       region: AwsRegion,
       features: FeatureFlags,
+      connectionPoolMetrics: SqsConnectionPoolMetrics,
       configureAsyncClient: (AmazonSQSAsyncClientBuilder) -> Unit,
     ): AmazonSQS {
       // Use a buffered client for sending, to group enqueues and deletes into batches.
@@ -191,6 +202,7 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
         AmazonSQSAsyncClientBuilder.standard()
           .withCredentials(credentials)
           .withRegion(region.name)
+          .withMetricsCollector(connectionPoolMetrics.collectorFor(SqsConnectionPoolMetrics.ClientType.SENDING))
           .withClientConfiguration(
             ClientConfiguration()
               .withSocketTimeout(config.sqs_sending_socket_timeout_ms)
@@ -218,8 +230,9 @@ open class AwsSqsJobQueueModule(private val config: AwsSqsJobQueueConfig) : KAbs
 
 /** Modify a [QueueBufferConfig] to disable all receive pre-fetching settings. */
 @Deprecated(
-  message = "AWS SDK v1 SQS jobqueue is deprecated. Use the AWS SDK v2 SQS jobqueue in " +
-    "misk-aws2-sqs (misk.aws2.sqs.jobqueue) instead."
+  message =
+    "AWS SDK v1 SQS jobqueue is deprecated. Use the AWS SDK v2 SQS jobqueue in " +
+      "misk-aws2-sqs (misk.aws2.sqs.jobqueue) instead."
 )
 fun QueueBufferConfig.withNoPrefetching(): QueueBufferConfig {
   return withMaxInflightReceiveBatches(0).withAdapativePrefetching(false).withMaxDoneReceiveBatches(0)

--- a/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConnectionPoolMetrics.kt
+++ b/misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConnectionPoolMetrics.kt
@@ -1,0 +1,76 @@
+package misk.jobqueue.sqs
+
+import com.amazonaws.Request
+import com.amazonaws.Response
+import com.amazonaws.metrics.RequestMetricCollector
+import com.amazonaws.util.AWSRequestMetrics
+import com.amazonaws.util.TimingInfo
+import io.prometheus.client.Gauge
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.metrics.v2.Metrics
+
+/**
+ * Prometheus gauges for the underlying AWS SDK v1 HTTP connection pool used by SQS clients.
+ *
+ * The values are reported per-request by the AWS SDK v1 metrics facility (`HttpClientPool*` fields on
+ * [AWSRequestMetrics.Field]) and reflect the most recent observation. Each pool is labelled by [CLIENT_TYPE_LABEL]:
+ * "sending" or "receiving" (the receiving client also serves `DeleteMessage` calls in this module).
+ */
+@Singleton
+class SqsConnectionPoolMetrics @Inject internal constructor(metrics: Metrics) {
+  internal val activeConnections: Gauge =
+    metrics.gauge(
+      name = ACTIVE_CONNECTIONS,
+      help = "Current number of leased (in-use) HTTP connections for the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal val idleConnections: Gauge =
+    metrics.gauge(
+      name = IDLE_CONNECTIONS,
+      help = "Current number of idle HTTP connections available in the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal val pendingConnections: Gauge =
+    metrics.gauge(
+      name = PENDING_CONNECTIONS,
+      help = "Current number of requests waiting to acquire an HTTP connection from the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal fun collectorFor(clientType: ClientType): RequestMetricCollector = HttpPoolMetricCollector(clientType.label)
+
+  internal enum class ClientType(val label: String) {
+    SENDING("sending"),
+    RECEIVING("receiving"),
+  }
+
+  private inner class HttpPoolMetricCollector(private val clientTypeLabel: String) : RequestMetricCollector() {
+    override fun collectMetrics(request: Request<*>?, response: Response<*>?) {
+      val metrics = request?.awsRequestMetrics?.timingInfo ?: return
+      lastValueOf(metrics, AWSRequestMetrics.Field.HttpClientPoolLeasedCount)?.let {
+        activeConnections.labels(clientTypeLabel).set(it)
+      }
+      lastValueOf(metrics, AWSRequestMetrics.Field.HttpClientPoolAvailableCount)?.let {
+        idleConnections.labels(clientTypeLabel).set(it)
+      }
+      lastValueOf(metrics, AWSRequestMetrics.Field.HttpClientPoolPendingCount)?.let {
+        pendingConnections.labels(clientTypeLabel).set(it)
+      }
+    }
+
+    private fun lastValueOf(timingInfo: TimingInfo, field: AWSRequestMetrics.Field): Double? {
+      val counter: Number = timingInfo.getCounter(field.name) ?: return null
+      return counter.toDouble()
+    }
+  }
+
+  companion object {
+    internal const val CLIENT_TYPE_LABEL = "client_type"
+    internal const val ACTIVE_CONNECTIONS = "sqs_client_active_connections"
+    internal const val IDLE_CONNECTIONS = "sqs_client_idle_connections"
+    internal const val PENDING_CONNECTIONS = "sqs_client_pending_connections"
+  }
+}

--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -335,6 +335,13 @@ public class misk/aws2/sqs/jobqueue/coordinated/CoordinatedAwsSqsJobQueueModule 
 	public final fun consumerRepeatedTaskQueue (Lmisk/tasks/RepeatedTaskQueueFactory;Lmisk/aws2/sqs/jobqueue/coordinated/AwsSqsJobQueueConfig;)Lmisk/tasks/RepeatedTaskQueue;
 }
 
+public final class misk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics {
+	public static final field Companion Lmisk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics$Companion;
+}
+
+public final class misk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics$Companion {
+}
+
 public final class misk/aws2/sqs/jobqueue/coordinated/SqsConsumerAllocator {
 	public static final field Companion Lmisk/aws2/sqs/jobqueue/coordinated/SqsConsumerAllocator$Companion;
 	public fun <init> (Lwisp/lease/LeaseManager;Lmisk/feature/FeatureFlags;)V

--- a/misk-aws2-sqs/build.gradle.kts
+++ b/misk-aws2-sqs/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation(libs.aws2ApacheClient)
   implementation(libs.aws2Core)
   implementation(libs.aws2HttpClientSpi)
+  implementation(libs.aws2MetricsSpi)
   implementation(libs.aws2Regions)
   implementation(libs.awsSdkCore)
   implementation(libs.loggingApi)

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/CoordinatedAwsSqsJobQueueModule.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/CoordinatedAwsSqsJobQueueModule.kt
@@ -54,8 +54,11 @@ open class CoordinatedAwsSqsJobQueueModule(private val config: AwsSqsJobQueueCon
 
   @Provides
   @Singleton
-  internal fun realSqsClientFactory(credentials: AwsCredentialsProvider): RealSqsClientFactory {
-    return RealSqsClientFactory(config, credentials, ::configureClient, ::configureClient)
+  internal fun realSqsClientFactory(
+    credentials: AwsCredentialsProvider,
+    connectionPoolMetrics: SqsConnectionPoolMetrics,
+  ): RealSqsClientFactory {
+    return RealSqsClientFactory(config, credentials, connectionPoolMetrics, ::configureClient, ::configureClient)
   }
 
   @Provides

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsClientFactory.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsClientFactory.kt
@@ -29,6 +29,7 @@ internal interface SqsClientFactory {
 internal class RealSqsClientFactory(
   private val config: AwsSqsJobQueueConfig,
   private val credentialsProvider: AwsCredentialsProvider,
+  private val connectionPoolMetrics: SqsConnectionPoolMetrics,
   private val configureSyncClient: (SqsClientBuilder) -> Unit,
   private val configureAsyncClient: (SqsAsyncClientBuilder) -> Unit,
 ) : SqsClientFactory, AbstractIdleService() {
@@ -141,11 +142,15 @@ internal class RealSqsClientFactory(
     return ClientOverrideConfiguration.builder()
       .apiCallAttemptTimeout(Duration.ofMillis(config.sqs_sending_socket_timeout_ms.toLong()))
       .apiCallTimeout(Duration.ofMillis(config.sqs_sending_request_timeout_ms.toLong()))
+      .addMetricPublisher(connectionPoolMetrics.publisherFor(SqsConnectionPoolMetrics.ClientType.SENDING))
       .build()
   }
 
   private fun receivingOverrideConfiguration(): ClientOverrideConfiguration {
-    return ClientOverrideConfiguration.builder().apiCallAttemptTimeout(RECEIVING_ATTEMPT_TIMEOUT).build()
+    return ClientOverrideConfiguration.builder()
+      .apiCallAttemptTimeout(RECEIVING_ATTEMPT_TIMEOUT)
+      .addMetricPublisher(connectionPoolMetrics.publisherFor(SqsConnectionPoolMetrics.ClientType.RECEIVING))
+      .build()
   }
 
   private fun sendingHttpClientBuilder(): ApacheHttpClient.Builder {

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics.kt
@@ -1,0 +1,86 @@
+package misk.aws2.sqs.jobqueue.coordinated
+
+import io.prometheus.client.Gauge
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import misk.metrics.v2.Metrics
+import software.amazon.awssdk.http.HttpMetric
+import software.amazon.awssdk.metrics.MetricCollection
+import software.amazon.awssdk.metrics.MetricPublisher
+
+/**
+ * Prometheus gauges for the underlying AWS SDK v2 HTTP connection pool used by SQS clients.
+ *
+ * The values are reported by the AWS SDK v2 [HttpMetric] facility on every API call and reflect the most recent
+ * observation. Each pool is labelled by [CLIENT_TYPE_LABEL]: "sending" or "receiving" (the receiving client also serves
+ * `DeleteMessage` calls in this module).
+ */
+@Singleton
+class SqsConnectionPoolMetrics @Inject internal constructor(metrics: Metrics) {
+  internal val maxConnections: Gauge =
+    metrics.gauge(
+      name = MAX_CONNECTIONS,
+      help = "Configured maximum number of HTTP connections for the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal val activeConnections: Gauge =
+    metrics.gauge(
+      name = ACTIVE_CONNECTIONS,
+      help = "Current number of leased (in-use) HTTP connections for the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal val idleConnections: Gauge =
+    metrics.gauge(
+      name = IDLE_CONNECTIONS,
+      help = "Current number of idle HTTP connections available in the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal val pendingConnections: Gauge =
+    metrics.gauge(
+      name = PENDING_CONNECTIONS,
+      help = "Current number of requests waiting to acquire an HTTP connection from the SQS client connection pool.",
+      labelNames = listOf(CLIENT_TYPE_LABEL),
+    )
+
+  internal fun publisherFor(clientType: ClientType): MetricPublisher = HttpPoolMetricPublisher(clientType.label)
+
+  internal enum class ClientType(val label: String) {
+    SENDING("sending"),
+    RECEIVING("receiving"),
+  }
+
+  private inner class HttpPoolMetricPublisher(private val clientTypeLabel: String) : MetricPublisher {
+    override fun publish(metricCollection: MetricCollection) {
+      visit(metricCollection)
+    }
+
+    override fun close() {}
+
+    private fun visit(collection: MetricCollection) {
+      collection.metricValues(HttpMetric.MAX_CONCURRENCY).lastOrNull()?.let {
+        maxConnections.labels(clientTypeLabel).set(it.toDouble())
+      }
+      collection.metricValues(HttpMetric.LEASED_CONCURRENCY).lastOrNull()?.let {
+        activeConnections.labels(clientTypeLabel).set(it.toDouble())
+      }
+      collection.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).lastOrNull()?.let {
+        idleConnections.labels(clientTypeLabel).set(it.toDouble())
+      }
+      collection.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).lastOrNull()?.let {
+        pendingConnections.labels(clientTypeLabel).set(it.toDouble())
+      }
+      collection.children().forEach { visit(it) }
+    }
+  }
+
+  companion object {
+    internal const val CLIENT_TYPE_LABEL = "client_type"
+    internal const val MAX_CONNECTIONS = "sqs_client_max_connections"
+    internal const val ACTIVE_CONNECTIONS = "sqs_client_active_connections"
+    internal const val IDLE_CONNECTIONS = "sqs_client_idle_connections"
+    internal const val PENDING_CONNECTIONS = "sqs_client_pending_connections"
+  }
+}


### PR DESCRIPTION
## Summary

After the recent AWS SDK v1 → v2 migration of the SQS jobqueue and the v1‑parity fix in #3811, services that exhausted the underlying Apache HTTP connection pool only discovered the issue via downstream symptoms (DLQ growth, `SdkClientException: Timeout waiting for connection from pool`). There were no direct gauges for the pool itself.

This PR adds Prometheus gauges for the SQS HTTP connection pool, in both `misk-aws` (v1) and `misk-aws2-sqs` (v2 coordinated):

| Metric | v1 | v2 | Description |
|---|---|---|---|
| `sqs_client_max_connections` | — | ✅ | Configured max HTTP connections (SDK v1 doesn't expose this counter) |
| `sqs_client_active_connections` | ✅ | ✅ | Leased / in‑use connections |
| `sqs_client_idle_connections` | ✅ | ✅ | Idle connections available in the pool |
| `sqs_client_pending_connections` | ✅ | ✅ | Requests waiting to acquire a connection |

All gauges are labelled `client_type` = `sending` or `receiving` (the receiving client also serves `DeleteMessage` calls in this module).

Naming follows the existing `redis_client_*` convention from `RedisClientMetrics` / `misk-redis-lettuce`.

## Implementation

**v2** ([`SqsConnectionPoolMetrics`](misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsConnectionPoolMetrics.kt) + [`SqsClientFactory`](misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsClientFactory.kt)) — wires an SDK v2 `MetricPublisher` onto each `SqsClient` via `ClientOverrideConfiguration.addMetricPublisher`. The publisher recursively walks the `MetricCollection` and updates the gauges from `HttpMetric.MAX_CONCURRENCY`, `LEASED_CONCURRENCY`, `AVAILABLE_CONCURRENCY`, `PENDING_CONCURRENCY_ACQUIRES`.

**v1** ([`SqsConnectionPoolMetrics`](misk-aws/src/main/kotlin/misk/jobqueue/sqs/SqsConnectionPoolMetrics.kt) + [`AwsSqsJobQueueModule`](misk-aws/src/main/kotlin/misk/jobqueue/sqs/AwsSqsJobQueueModule.kt)) — wires an SDK v1 `RequestMetricCollector` onto each `AmazonSQS` client via `withMetricsCollector`. The collector reads `HttpClientPoolLeasedCount`, `HttpClientPoolAvailableCount` and `HttpClientPoolPendingCount` from the per‑request `TimingInfo`. SDK v1 doesn't expose a max counter, so that gauge is omitted.

Both implementations update gauges on every SQS API call (snapshot view), matching the SDK's own reporting cadence.

## Notes

- New transitive deps promoted to `implementation` in misk‑aws2‑sqs to satisfy `projectHealth`: `software.amazon.awssdk:metrics-spi`. (`apache-client` and `http-client-spi` were added in #3811.)
- `apiDump` regenerated for both modules. The class is exposed; gauges are kept `internal`.
- No public API change beyond adding the new `SqsConnectionPoolMetrics` class.
- Tests pass: `bin/gradle :misk-aws:test :misk-aws2-sqs:test --warn`.