### PR TITLE
vitess: derive vtctldclient image from vttestserver image

### DIFF
--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VitessImageUtilsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VitessImageUtilsTest.kt
@@ -1,0 +1,55 @@
+package misk.vitess.testing.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VitessImageUtilsTest {
+
+  @Test
+  fun `derives vtctldclient from ghcr block image`() {
+    assertEquals(
+      "ghcr.io/block/vitess/vtctldclient:23.0.3-block.1",
+      deriveVtctldClientImage("ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84"),
+    )
+  }
+
+  @Test
+  fun `derives vtctldclient from upstream vitess image`() {
+    assertEquals(
+      "vitess/vtctldclient:v21.0.4",
+      deriveVtctldClientImage("vitess/vttestserver:v21.0.4-mysql80"),
+    )
+  }
+
+  @Test
+  fun `derives vtctldclient from custom registry image`() {
+    assertEquals(
+      "my-registry.example.com/vitess/vtctldclient:23.0.3-block.1",
+      deriveVtctldClientImage("my-registry.example.com/vitess/vttestserver:23.0.3-block.1-mysql84"),
+    )
+  }
+
+  @Test
+  fun `derives vtctldclient with mysql80 suffix`() {
+    assertEquals(
+      "vitess/vtctldclient:v22.0.2",
+      deriveVtctldClientImage("vitess/vttestserver:v22.0.2-mysql80"),
+    )
+  }
+
+  @Test
+  fun `derives vtctldclient without mysql suffix is unchanged`() {
+    assertEquals(
+      "vitess/vtctldclient:v23.0.3",
+      deriveVtctldClientImage("vitess/vttestserver:v23.0.3"),
+    )
+  }
+
+  @Test
+  fun `derives vtctldclient from docker hub image`() {
+    assertEquals(
+      "docker.io/vitess/vtctldclient:v23.0.3",
+      deriveVtctldClientImage("docker.io/vitess/vttestserver:v23.0.3-mysql84"),
+    )
+  }
+}

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
@@ -838,6 +838,7 @@ internal class VitessDockerContainer(
       keyspaces = vitessSchemaPreparer.keyspaces,
       mysqlPort = mysqlPort,
       schemaDir = schemaDir,
+      vitessImage = vitessImage,
       vtgatePort = vtgatePort,
       vtgateUser = VTGATE_USER,
       vtgateUserPassword = VTGATE_USER_PASSWORD,

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessImageUtils.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessImageUtils.kt
@@ -1,0 +1,14 @@
+package misk.vitess.testing.internal
+
+/**
+ * Derives the vtctldclient image URL from the vttestserver image URL.
+ * Swaps `vttestserver` -> `vtctldclient` and strips the `-mysql{version}` suffix from the tag.
+ *
+ * Example: `ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84`
+ *       -> `ghcr.io/block/vitess/vtctldclient:23.0.3-block.1`
+ */
+internal fun deriveVtctldClientImage(vttestserverImage: String): String {
+  return vttestserverImage
+    .replace("vttestserver", "vtctldclient")
+    .replace(Regex("-mysql\\d+$"), "")
+}

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaApplier.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaApplier.kt
@@ -27,7 +27,6 @@ import misk.vitess.testing.VitessTestDbException
 import misk.vitess.testing.DdlUpdate
 import misk.vitess.testing.DefaultSettings.CONTAINER_PORT_GRPC
 import misk.vitess.testing.DefaultSettings.VITESS_DOCKER_NETWORK_NAME
-import misk.vitess.testing.DefaultSettings.VTCTLD_CLIENT_IMAGE
 import misk.vitess.testing.VSchemaUpdate
 import misk.vitess.testing.VitessTableType
 import misk.vitess.testing.VitessTestDbStartupException
@@ -47,14 +46,11 @@ internal class VitessSchemaApplier(
   private val hostname: String,
   private val mysqlPort: Int,
   private val schemaDir: String,
+  private val vitessImage: String,
   private val vtgatePort: Int,
   private val vtgateUser: String,
   private val vtgateUserPassword: String,
 ) {
-  private companion object {
-    const val VTCTLDCLIENT_CONTAINER_START_DELAY_MS = 10000L
-    const val VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS = "10000ms"
-  }
 
   private val spirit = Spirit()
 
@@ -324,7 +320,7 @@ internal class VitessSchemaApplier(
     printDebug("Creating new vtctldclient container.")
     val createContainerResponse =
       dockerClient
-        .createContainerCmd(VTCTLD_CLIENT_IMAGE)
+        .createContainerCmd(deriveVtctldClientImage(vitessImage))
         .withName(vtctldClientContainerName)
         .withHostConfig(HostConfig.newHostConfig().withNetworkMode(VITESS_DOCKER_NETWORK_NAME))
         .withCmd(command)
@@ -475,11 +471,17 @@ internal class VitessSchemaApplier(
       .sortedBy { it.first }
 
   private fun prepareVtctldClientImage() {
-    val images: List<Image> = dockerClient.listImagesCmd().withReferenceFilter(VTCTLD_CLIENT_IMAGE).exec()
+    val vtctldClientImage = deriveVtctldClientImage(vitessImage)
+    val images: List<Image> = dockerClient.listImagesCmd().withReferenceFilter(vtctldClientImage).exec()
     if (images.isEmpty()) {
-      printDebug("vtctldclient image `$VTCTLD_CLIENT_IMAGE` does not exist, proceeding to pull.")
-      dockerClient.pullImageCmd(VTCTLD_CLIENT_IMAGE).start().awaitCompletion()
+      printDebug("vtctldclient image `$vtctldClientImage` does not exist, proceeding to pull.")
+      dockerClient.pullImageCmd(vtctldClientImage).start().awaitCompletion()
     }
+  }
+
+  private companion object {
+    const val VTCTLDCLIENT_CONTAINER_START_DELAY_MS = 10000L
+    const val VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS = "10000ms"
   }
 
   private fun findExistingContainer(containerName: String): Container? {


### PR DESCRIPTION
## Summary

The `vtctldclient` image used by `VitessSchemaApplier` was hardcoded to a specific `ghcr.io` URL. This meant it was always pulled directly from `ghcr.io`, even when the `vttestserver` image was configured to use a different registry.

This change derives the `vtctldclient` image URL from the `vttestserver` image that's already passed through the chain, by swapping `vttestserver` → `vtctldclient` and stripping the `-mysql{version}` suffix from the tag. This ensures both images are pulled from the same registry.