### PR TITLE
vitess: per-instance dockerNetworkName for VitessTestDb

### DIFF
--- a/misk-vitess-database-gradle-plugin/api/misk-vitess-database-gradle-plugin.api
+++ b/misk-vitess-database-gradle-plugin/api/misk-vitess-database-gradle-plugin.api
@@ -3,6 +3,7 @@ public abstract class misk/vitess/gradle/StartVitessDatabaseTask : org/gradle/ap
 	public abstract fun getAutoApplySchemaChanges ()Lorg/gradle/api/provider/Property;
 	public abstract fun getContainerName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDebugStartup ()Lorg/gradle/api/provider/Property;
+	public abstract fun getDockerNetworkName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableDeclarativeSchemaChanges ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableInMemoryStorage ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableScatters ()Lorg/gradle/api/provider/Property;

--- a/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/StartVitessDatabaseTask.kt
+++ b/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/StartVitessDatabaseTask.kt
@@ -19,6 +19,8 @@ abstract class StartVitessDatabaseTask : DefaultTask() {
 
   @get:Input abstract val debugStartup: Property<Boolean>
 
+  @get:Input abstract val dockerNetworkName: Property<String>
+
   @get:Input abstract val enableDeclarativeSchemaChanges: Property<Boolean>
 
   @get:Input abstract val enableInMemoryStorage: Property<Boolean>
@@ -56,6 +58,7 @@ abstract class StartVitessDatabaseTask : DefaultTask() {
         autoApplySchemaChanges = autoApplySchemaChanges.get(),
         containerName = containerName.get(),
         debugStartup = debugStartup.get(),
+        dockerNetworkName = dockerNetworkName.get(),
         enableDeclarativeSchemaChanges = enableDeclarativeSchemaChanges.get(),
         enableInMemoryStorage = enableInMemoryStorage.get(),
         enableScatters = enableScatters.get(),

--- a/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/VitessDatabasePlugin.kt
+++ b/misk-vitess-database-gradle-plugin/src/main/kotlin/misk/vitess/gradle/VitessDatabasePlugin.kt
@@ -13,6 +13,7 @@ class VitessDatabasePlugin : Plugin<Project> {
       it.autoApplySchemaChanges.convention(DefaultSettings.AUTO_APPLY_SCHEMA_CHANGES)
       it.containerName.convention(DefaultSettings.CONTAINER_NAME)
       it.debugStartup.convention(DefaultSettings.DEBUG_STARTUP)
+      it.dockerNetworkName.convention(DefaultSettings.VITESS_DOCKER_NETWORK_NAME)
       it.enableDeclarativeSchemaChanges.convention(DefaultSettings.ENABLE_DECLARATIVE_SCHEMA_CHANGES)
       it.enableInMemoryStorage.convention(DefaultSettings.ENABLE_IN_MEMORY_STORAGE)
       it.enableScatters.convention(DefaultSettings.ENABLE_SCATTERS)

--- a/misk-vitess/README.md
+++ b/misk-vitess/README.md
@@ -55,6 +55,7 @@ Other configurable parameters include:
 - `autoApplySchema` (default `true`): Whether to apply the schema on start-up. If set to `false`, the schema can be applied at run-time via `applySchema()` or externally.
 - `containerName` (default `vitess_test_db`): The name assigned to the Docker container that gets created.
 - `debugStartup` (default `false`): Whether to print debug logs during the startup process.
+- `dockerNetworkName` (default `vitess-network`): The name of the Docker bridge network the Vitess container and its sidecar `vtctldclient` containers attach to. The default network is shared across every `VitessTestDb` instance on the same Docker daemon. Highly-parallel CI environments running many `VitessTestDb` instances against one daemon can exhaust that single network's IPv4 address pool; in that case, set this to a unique value per instance (e.g. `"vitess-network-$containerName"`) so each instance gets its own bridge subnet.
 - `enableDeclarativeSchemaChanges` (default `false`): Whether to use declarative schema changes.
 - `enableInMemoryStorage` (default `false`): Whether to use in-memory storage (tmpfs) for faster performance.
 - `enableScatters` (default `true`): Whether to enable scatter queries, which are queries that fan out to all shards. Requires a Vitess image version >= 20.

--- a/misk-vitess/api/misk-vitess.api
+++ b/misk-vitess/api/misk-vitess.api
@@ -275,8 +275,8 @@ public final class misk/vitess/testing/VitessTableType : java/lang/Enum {
 public final class misk/vitess/testing/VitessTestDb {
 	public static final field Companion Lmisk/vitess/testing/VitessTestDb$Companion;
 	public fun <init> ()V
-	public fun <init> (ZLjava/lang/String;ZZZZLjava/lang/String;ZZLjava/lang/String;ILjava/lang/String;Ljava/lang/String;Lmisk/vitess/testing/TransactionIsolationLevel;Lmisk/vitess/testing/TransactionMode;Ljava/time/Duration;Ljava/lang/String;I)V
-	public synthetic fun <init> (ZLjava/lang/String;ZZZZLjava/lang/String;ZZLjava/lang/String;ILjava/lang/String;Ljava/lang/String;Lmisk/vitess/testing/TransactionIsolationLevel;Lmisk/vitess/testing/TransactionMode;Ljava/time/Duration;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/lang/String;ZLjava/lang/String;ZZZLjava/lang/String;ZZLjava/lang/String;ILjava/lang/String;Ljava/lang/String;Lmisk/vitess/testing/TransactionIsolationLevel;Lmisk/vitess/testing/TransactionMode;Ljava/time/Duration;Ljava/lang/String;I)V
+	public synthetic fun <init> (ZLjava/lang/String;ZLjava/lang/String;ZZZLjava/lang/String;ZZLjava/lang/String;ILjava/lang/String;Ljava/lang/String;Lmisk/vitess/testing/TransactionIsolationLevel;Lmisk/vitess/testing/TransactionMode;Ljava/time/Duration;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun Builder ()Lmisk/vitess/testing/VitessTestDb$Builder;
 	public final fun applySchema ()Lmisk/vitess/testing/ApplySchemaResult;
 	public final fun executeQuery (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
@@ -303,6 +303,7 @@ public final class misk/vitess/testing/VitessTestDb$Builder {
 	public final fun build ()Lmisk/vitess/testing/VitessTestDb;
 	public final fun containerName (Ljava/lang/String;)Lmisk/vitess/testing/VitessTestDb$Builder;
 	public final fun debugStartup (Z)Lmisk/vitess/testing/VitessTestDb$Builder;
+	public final fun dockerNetworkName (Ljava/lang/String;)Lmisk/vitess/testing/VitessTestDb$Builder;
 	public final fun enableDeclarativeSchemaChanges (Z)Lmisk/vitess/testing/VitessTestDb$Builder;
 	public final fun enableInMemoryStorage (Z)Lmisk/vitess/testing/VitessTestDb$Builder;
 	public final fun enableScatters (Z)Lmisk/vitess/testing/VitessTestDb$Builder;
@@ -482,8 +483,8 @@ public final class misk/vitess/testing/internal/VschemaAdapter {
 
 public final class misk/vitess/testing/utilities/DockerVitess : misk/testing/ExternalDependency {
 	public fun <init> ()V
-	public fun <init> (ZLmisk/vitess/testing/TransactionMode;Ljava/lang/String;I)V
-	public synthetic fun <init> (ZLmisk/vitess/testing/TransactionMode;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLmisk/vitess/testing/TransactionMode;Ljava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (ZLmisk/vitess/testing/TransactionMode;Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterEach ()V
 	public fun beforeEach ()V
 	public fun getId ()Ljava/lang/String;

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDb.kt
@@ -12,6 +12,12 @@ import misk.vitess.testing.internal.VitessQueryExecutor
  * @property autoApplySchemaChanges Whether to automatically apply schema changes. Default is `true`.
  * @property containerName The name of the container that runs the database. Default is `vitess_test_db`.
  * @property debugStartup Whether to print debug logs during the startup process. Default is `false`.
+ * @property dockerNetworkName The name of the Docker bridge network the Vitess container and its sidecar
+ *   `vtctldclient` containers are attached to. Default is `vitess-network` (shared across all `VitessTestDb`
+ *   instances). For highly-parallel CI environments running many `VitessTestDb` instances on the same Docker
+ *   daemon, set a unique name per instance (e.g. `"vitess-network-$containerName"`) so each instance gets its
+ *   own bridge subnet — Docker assigns one subnet per network and a single shared `/24` exhausts its IPv4
+ *   address pool around 8+ concurrent instances.
  * @property enableDeclarativeSchemaChanges Whether to use declarative schema changes. Default is `false`.
  * @property enableInMemoryStorage Whether to use in-memory storage (tmpfs) for faster performance. Default is `false`.
  * @property enableScatters Whether to enable scatter queries, which fan out to all shards. Default is `true`.
@@ -54,6 +60,7 @@ class VitessTestDb(
   private var autoApplySchemaChanges: Boolean = DefaultSettings.AUTO_APPLY_SCHEMA_CHANGES,
   val containerName: String = DefaultSettings.CONTAINER_NAME,
   private var debugStartup: Boolean = DefaultSettings.DEBUG_STARTUP,
+  private var dockerNetworkName: String = DefaultSettings.VITESS_DOCKER_NETWORK_NAME,
   private var enableDeclarativeSchemaChanges: Boolean = DefaultSettings.ENABLE_DECLARATIVE_SCHEMA_CHANGES,
   private var enableInMemoryStorage: Boolean = DefaultSettings.ENABLE_IN_MEMORY_STORAGE,
   private var enableScatters: Boolean = DefaultSettings.ENABLE_SCATTERS,
@@ -78,6 +85,7 @@ class VitessTestDb(
     private var autoApplySchemaChanges: Boolean = DefaultSettings.AUTO_APPLY_SCHEMA_CHANGES
     private var containerName: String = DefaultSettings.CONTAINER_NAME
     private var debugStartup: Boolean = DefaultSettings.DEBUG_STARTUP
+    private var dockerNetworkName: String = DefaultSettings.VITESS_DOCKER_NETWORK_NAME
     private var enableDeclarativeSchemaChanges: Boolean = DefaultSettings.ENABLE_DECLARATIVE_SCHEMA_CHANGES
     private var enableInMemoryStorage: Boolean = DefaultSettings.ENABLE_IN_MEMORY_STORAGE
     private var enableScatters: Boolean = DefaultSettings.ENABLE_SCATTERS
@@ -101,6 +109,8 @@ class VitessTestDb(
     fun containerName(containerName: String) = apply { this.containerName = containerName }
 
     fun debugStartup(debugStartup: Boolean) = apply { this.debugStartup = debugStartup }
+
+    fun dockerNetworkName(dockerNetworkName: String) = apply { this.dockerNetworkName = dockerNetworkName }
 
     fun enableDeclarativeSchemaChanges(enableDeclarativeSchemaChanges: Boolean) = apply {
       this.enableDeclarativeSchemaChanges = enableDeclarativeSchemaChanges
@@ -147,6 +157,7 @@ class VitessTestDb(
         autoApplySchemaChanges,
         containerName,
         debugStartup,
+        dockerNetworkName,
         enableDeclarativeSchemaChanges,
         enableInMemoryStorage,
         enableScatters,
@@ -358,6 +369,7 @@ class VitessTestDb(
         autoApplySchemaChanges = autoApplySchemaChanges,
         containerName = containerName,
         debugStartup = debugStartup,
+        dockerNetworkName = dockerNetworkName,
         enableDeclarativeSchemaChanges = enableDeclarativeSchemaChanges,
         enableInMemoryStorage = enableInMemoryStorage,
         enableScatters = enableScatters,

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessDockerContainer.kt
@@ -31,7 +31,6 @@ import misk.vitess.testing.ApplySchemaResult
 import misk.vitess.testing.DefaultSettings.CONTAINER_PORT_BASE
 import misk.vitess.testing.DefaultSettings.CONTAINER_PORT_MYSQL
 import misk.vitess.testing.DefaultSettings.CONTAINER_PORT_VTGATE
-import misk.vitess.testing.DefaultSettings.VITESS_DOCKER_NETWORK_NAME
 import misk.vitess.testing.DefaultSettings.VITESS_DOCKER_NETWORK_TYPE
 import misk.vitess.testing.DefaultSettings.VTGATE_USER
 import misk.vitess.testing.DefaultSettings.VTGATE_USER_PASSWORD
@@ -48,6 +47,7 @@ internal class VitessDockerContainer(
   private val autoApplySchemaChanges: Boolean,
   private val containerName: String,
   private val debugStartup: Boolean,
+  private val dockerNetworkName: String,
   private val enableDeclarativeSchemaChanges: Boolean,
   private val enableInMemoryStorage: Boolean,
   private val enableScatters: Boolean,
@@ -607,7 +607,7 @@ internal class VitessDockerContainer(
       HostConfig().apply {
         withPortBindings(portBindings)
         withBinds(Bind(vitessMyCnf.optionsFilePath.pathString, Volume(optionsFileDest)))
-        withNetworkMode(VITESS_DOCKER_NETWORK_NAME)
+        withNetworkMode(dockerNetworkName)
         withAutoRemove(
           !debugStartup // If `debugStartup` is `true`, we keep the container running to inspect logs.
         ) // Otherwise, remove container when it stops.
@@ -833,6 +833,7 @@ internal class VitessDockerContainer(
       dbaUserPassword = DBA_USER_PASSWORD,
       debugStartup = debugStartup,
       dockerClient = dockerClient,
+      dockerNetworkName = dockerNetworkName,
       enableDeclarativeSchemaChanges = enableDeclarativeSchemaChanges,
       hostname = hostname,
       keyspaces = vitessSchemaPreparer.keyspaces,
@@ -855,18 +856,18 @@ internal class VitessDockerContainer(
           val newNetworkId =
             dockerClient
               .createNetworkCmd()
-              .withName(VITESS_DOCKER_NETWORK_NAME)
+              .withName(dockerNetworkName)
               .withDriver(VITESS_DOCKER_NETWORK_TYPE)
               .exec()
               .id
           return newNetworkId
         } catch (conflictException: ConflictException) {
           // If we are in this state, the network was already created.
-          println("Network `$VITESS_DOCKER_NETWORK_NAME` was already created, attempting to find it.")
+          println("Network `$dockerNetworkName` was already created, attempting to find it.")
           existingNetwork = findExistingNetwork()
           if (existingNetwork == null) {
             throw VitessTestDbStartupException(
-              "Network `$VITESS_DOCKER_NETWORK_NAME` was created but not found.",
+              "Network `$dockerNetworkName` was created but not found.",
               conflictException,
             )
           }
@@ -876,7 +877,7 @@ internal class VitessDockerContainer(
       // Validate the existing network we found has the expected network type.
       if (existingNetwork!!.driver != VITESS_DOCKER_NETWORK_TYPE) {
         throw VitessTestDbStartupException(
-          "Network `$VITESS_DOCKER_NETWORK_NAME` exists for network id `${existingNetwork.id}` but is not of type `$VITESS_DOCKER_NETWORK_TYPE`. " +
+          "Network `$dockerNetworkName` exists for network id `${existingNetwork.id}` but is not of type `$VITESS_DOCKER_NETWORK_TYPE`. " +
             "Found type: `${existingNetwork.driver}`. Tear down the existing network to use this version of VitessTestDb."
         )
       }
@@ -887,7 +888,7 @@ internal class VitessDockerContainer(
 
   private fun findExistingNetwork(): Network? {
     val networks = dockerClient.listNetworksCmd().exec()
-    val existingNetwork = networks.find { it.name == VITESS_DOCKER_NETWORK_NAME }
+    val existingNetwork = networks.find { it.name == dockerNetworkName }
     return existingNetwork
   }
 

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaApplier.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VitessSchemaApplier.kt
@@ -26,7 +26,6 @@ import misk.vitess.testing.ApplySchemaResult
 import misk.vitess.testing.VitessTestDbException
 import misk.vitess.testing.DdlUpdate
 import misk.vitess.testing.DefaultSettings.CONTAINER_PORT_GRPC
-import misk.vitess.testing.DefaultSettings.VITESS_DOCKER_NETWORK_NAME
 import misk.vitess.testing.VSchemaUpdate
 import misk.vitess.testing.VitessTableType
 import misk.vitess.testing.VitessTestDbStartupException
@@ -41,6 +40,7 @@ internal class VitessSchemaApplier(
   private val dbaUserPassword: String,
   private val debugStartup: Boolean,
   private val dockerClient: DockerClient,
+  private val dockerNetworkName: String,
   private val enableDeclarativeSchemaChanges: Boolean,
   private val keyspaces: List<VitessKeyspace>,
   private val hostname: String,
@@ -312,9 +312,9 @@ internal class VitessSchemaApplier(
     }
 
     val networks = dockerClient.listNetworksCmd().exec()
-    networks.find { it.name == VITESS_DOCKER_NETWORK_NAME }
+    networks.find { it.name == dockerNetworkName }
       ?: throw VitessSchemaManagerException(
-        "VitessSchemaManager could not find the correct Docker Network named `$VITESS_DOCKER_NETWORK_NAME`. The network may have failed to initialize or VitessDockerContainer.createContainer may not have been run."
+        "VitessSchemaManager could not find the correct Docker Network named `$dockerNetworkName`. The network may have failed to initialize or VitessDockerContainer.createContainer may not have been run."
       )
 
     printDebug("Creating new vtctldclient container.")
@@ -322,7 +322,7 @@ internal class VitessSchemaApplier(
       dockerClient
         .createContainerCmd(deriveVtctldClientImage(vitessImage))
         .withName(vtctldClientContainerName)
-        .withHostConfig(HostConfig.newHostConfig().withNetworkMode(VITESS_DOCKER_NETWORK_NAME))
+        .withHostConfig(HostConfig.newHostConfig().withNetworkMode(dockerNetworkName))
         .withCmd(command)
         .withAttachStdout(true)
         .withAttachStdin(true)

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/utilities/DockerVitess.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/utilities/DockerVitess.kt
@@ -27,9 +27,17 @@ class DockerVitess(
   containerName: String = DefaultSettings.CONTAINER_NAME,
   /** The port to connect to the database, which represents the vtgate. */
   port: Int = DefaultSettings.PORT,
+  /** The Docker bridge network the Vitess container attaches to. See `VitessTestDb` for guidance. */
+  dockerNetworkName: String = DefaultSettings.VITESS_DOCKER_NETWORK_NAME,
 ) : ExternalDependency {
 
-  private val vitessTestDb = VitessTestDb(containerName = containerName, enableScatters = enableScatters, transactionMode = transactionMode, port = port)
+  private val vitessTestDb = VitessTestDb(
+    containerName = containerName,
+    dockerNetworkName = dockerNetworkName,
+    enableScatters = enableScatters,
+    transactionMode = transactionMode,
+    port = port,
+  )
 
   override fun startup() {
     vitessTestDb.run()


### PR DESCRIPTION
## Summary

Add a `dockerNetworkName` parameter to `VitessTestDb` (and the `vitess-database` Gradle plugin's `StartVitessDatabaseTask`) so that callers running many `VitessTestDb` instances on the same Docker daemon can give each instance its own bridge network instead of sharing the single hard-coded `vitess-network`.

Default value is unchanged (`DefaultSettings.VITESS_DOCKER_NETWORK_NAME` = `"vitess-network"`), so existing callers see no behavior change.

## Motivation

Each `VitessTestDb` attaches its `vttestserver` container and a sidecar `vtctldclient` container to a single Docker bridge network named `vitess-network`. Docker assigns one `/24` subnet per bridge network (≈254 usable IPv4s), and the per-test-instance container churn (vtctldclient is created/removed for every `applySchema()` call, plus the long-lived vttestserver container, plus any other containers attached to the same network) keeps a non-trivial number of address slots in flight at once.

In a highly-parallel CI environment, sharing one bridge network across many `VitessTestDb` instances on the same Docker daemon eventually exhausts that pool:

```
Error response from daemon: failed to set up container networking:
no available IPv4 addresses on this network's address pools: vitess-network
```

We hit this on Cash's Franklin CI at 8 concurrent test forks per agent. 7 forks ran cleanly across many builds; 8 forks worked for most builds but reliably hit the pool exhaustion above eventually.

Letting the caller pass a unique `dockerNetworkName` per instance (e.g. `"vitess-network-$containerName"`, where `containerName` is already unique per fork) gives each instance its own `/24` subnet and removes the shared-pool ceiling. Docker's default address pool (`172.17.0.0/16` ... `172.31.0.0/16`, plus `192.168.0.0/16`) provides hundreds of `/24`s, so this scales well past any realistic CI fork count.

## Change

- New `dockerNetworkName: String` parameter, defaulted to `DefaultSettings.VITESS_DOCKER_NETWORK_NAME`, threaded through:
  - `VitessTestDb` (constructor + `Builder.dockerNetworkName(...)`)
  - `VitessDockerContainer`
  - `VitessSchemaApplier` (used when looking up the network and when attaching the `vtctldclient` sidecar)
  - `DockerVitess` (the `ExternalDependency` wrapper)
  - `StartVitessDatabaseTask` Gradle task (with `convention(DefaultSettings.VITESS_DOCKER_NETWORK_NAME)` wired in `VitessDatabasePlugin`)
- Removed the now-unused `VITESS_DOCKER_NETWORK_NAME` imports from `VitessDockerContainer` and `VitessSchemaApplier`. The constant itself remains in `DefaultSettings` as the public default.
- KDoc on `VitessTestDb.dockerNetworkName` documents the highly-parallel-CI use case and recommends `"vitess-network-$containerName"` as the per-instance pattern.

## API impact

`misk-vitess.api` updated via `:misk-vitess:apiDump`. The primary `VitessTestDb` constructor and the `DockerVitess` constructor pick up an extra `String` parameter, so any caller positionally invoking the full constructor will need to recompile. The supported Java entrypoint — `VitessTestDb.Builder` — is purely additive (`Builder.dockerNetworkName(...)` is new; existing fluent calls are unchanged), and the no-arg constructor still resolves to the `vitess-network` default.

## Verification

- `:misk-vitess:compileTestFixturesKotlin`, `:misk-vitess:compileTestKotlin`, `:misk-vitess-database-gradle-plugin:compileKotlin`, `:misk-vitess-database-gradle-plugin:compileTestKotlin` all green.
- `:misk-vitess:apiDump` run; `misk-vitess/api/misk-vitess.api` reflects the new constructor signatures and the new `Builder.dockerNetworkName` method.
- No existing callers needed to change because the new parameter has a default that matches the previous hard-coded behavior.
