### PR TITLE
misk-aws2-sqs: silence shutdown-time SyncTimeoutTask RejectedExecutionException

### DIFF
--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/coordinated/SqsJobConsumer.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -191,6 +192,15 @@ internal constructor(
         } catch (e: ApiCallAttemptTimeoutException) {
           log.info("timed out long polling for messages from ${queue.queueName}")
           emptyList<Message>()
+        } catch (e: RejectedExecutionException) {
+          // SqsClient.close() shuts down the SDK's per-attempt SyncTimeoutTask scheduler, so a
+          // long-poll racing pod shutdown can throw REE; only swallow it once we've stopped.
+          if (!shouldKeepRunning.get()) {
+            log.info("SQS client was shut down during long poll for ${queue.queueName}")
+            emptyList<Message>()
+          } else {
+            throw e
+          }
         }
 
       for (message in messages) {


### PR DESCRIPTION
## Summary

Fixes the post-shutdown Sentry noise observed after services migrate from AWS SDK v1 (`misk-aws`) to AWS SDK v2 (`misk-aws2-sqs` coordinated). 

## Root cause

AWS SDK v2 `SqsClient` schedules a per-attempt `SyncTimeoutTask` on its internal `ScheduledExecutorService` to enforce `apiCallAttemptTimeout` (25s for the receiving client). That executor is shut down by `SqsClient.close()`, which `RealSqsClientFactory.shutDown()` calls.

If the factory shuts down while a `receiveMessage` long-poll is in flight, the SDK's `RetryableStage` re-enters `ApiCallAttemptTimeoutTrackingStage` for the next attempt and tries to schedule a new `SyncTimeoutTask` on the now-terminated executor. `AbortPolicy` rejects → `RejectedExecutionException` propagates straight out of `client.receiveMessage(...)`, through the `CompletableFuture.join()` in `SqsJobConsumer.QueueReceiver.run()`, and into Sentry.

The SDK schedules the task with a bare, unguarded `timeoutExecutor.schedule(...)` call — see [`TimerUtils.timeSyncTaskIfNeeded` lines 75–89](https://github.com/aws/aws-sdk-java-v2/blob/0c5e331bd2544e7d43fabd3db046a95b94d0a2dd/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/TimerUtils.java#L75-L89), called from [`ApiCallAttemptTimeoutTrackingStage` line 69](https://github.com/aws/aws-sdk-java-v2/blob/0c5e331bd2544e7d43fabd3db046a95b94d0a2dd/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStage.java#L69) — so callers have to defend against this themselves.

The v1 `misk-aws` path didn't have this — v1 used Apache socket timeouts rather than a JVM `ScheduledExecutorService`, so closing the v1 client mid long-poll could not produce a `SyncTimeoutTask` rejection.

## Fix

Catch `RejectedExecutionException` alongside the existing `ApiCallAttemptTimeoutException` catch in `SqsJobConsumer.fetchMessages` and treat it as no-work. The receiver's `shouldKeepRunning` flag will flip on the next iteration and the polling task will exit cleanly.

```kotlin
} catch (e: RejectedExecutionException) {
  log.info("SQS client was shut down during long poll for \${queue.queueName}")
  emptyList<Message>()
}
```

## Why not service-ordering instead

I considered also declaring `AwsSqsJobHandlerSubscriptionService.dependsOn<RealSqsClientFactory>()` so the client closes only after the consumer drains. It doesn't fix the bug on its own: `SqsJobConsumer.shutDown()` calls `receivingThreads.shutdown()` + `awaitTermination(10s)`, which is graceful and doesn't interrupt running tasks. The in-flight `receiveMessage` runs for up to 25s, so the await times out and the receiving thread survives past the handler service's shutdown anyway. The defensive catch is sufficient and minimal.
