### PR TITLE
feat: Add reader support to TestDatabasePool

### DIFF
--- a/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
+++ b/misk-hibernate-testing/src/main/kotlin/misk/hibernate/HibernateTestingModule.kt
@@ -14,6 +14,12 @@ import misk.jdbc.JdbcTestingModule
  *
  *     install(HibernateModule(MyDatabase::class, dataSourceConfig, SHARED_TEST_DATABASE_POOL))
  *
+ * If a test configures writer and reader data sources against the same local database, wrap the shared pool so both
+ * data sources use the same leased database:
+ *
+ *     val databasePool = SharedLeaseDatabasePool(SHARED_TEST_DATABASE_POOL)
+ *     install(HibernateModule(MyDatabase::class, MyDatabaseReader::class, cluster, databasePool))
+ *
  * See [misk.jdbc.SHARED_TEST_DATABASE_POOL].
  */
 @Deprecated("Use JdbcTestingModule instead")

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -601,6 +601,12 @@ public abstract interface class misk/jdbc/Session {
 	public abstract fun useConnection (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
+public final class misk/jdbc/SharedLeaseDatabasePool : misk/jdbc/DatabasePool {
+	public fun <init> (Lmisk/jdbc/DatabasePool;)V
+	public fun releaseDatabase (Lmisk/jdbc/DataSourceConfig;)V
+	public fun takeDatabase (Lmisk/jdbc/DataSourceConfig;)Lmisk/jdbc/DataSourceConfig;
+}
+
 public final class misk/jdbc/SpanInjector : misk/jdbc/DataSourceDecorator, net/ttddyy/dsproxy/transform/QueryTransformer {
 	public fun <init> (Lio/opentracing/Tracer;Lmisk/jdbc/DataSourceConfig;)V
 	public fun decorate (Ljavax/sql/DataSource;)Ljavax/sql/DataSource;

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
@@ -116,6 +116,38 @@ class TestDatabasePoolTest {
   }
 
   @Test
+  fun sharedLeaseDatabasePoolSharesLeaseUntilAllReferencesAreReleased() {
+    val sharedDatabasePool = SharedLeaseDatabasePool(testDatabasePool)
+
+    val writerConfig = sharedDatabasePool.takeDatabase(config)
+    val readerConfig = sharedDatabasePool.takeDatabase(config)
+
+    assertThat(writerConfig.database).isEqualTo("test__20180101__1")
+    assertThat(readerConfig.database).isEqualTo(writerConfig.database)
+    assertThat(testDatabasePool.getPool(config).pool).isEmpty()
+
+    sharedDatabasePool.releaseDatabase(writerConfig)
+
+    assertThat(testDatabasePool.getPool(config).pool).isEmpty()
+
+    sharedDatabasePool.releaseDatabase(readerConfig)
+
+    assertThat(testDatabasePool.getPool(config).pool).containsExactly("test__20180101__1")
+  }
+
+  @Test
+  fun sharedLeaseDatabasePoolKeepsDifferentDatabasesIndependent() {
+    val sharedDatabasePool = SharedLeaseDatabasePool(testDatabasePool)
+    val otherConfig = config.copy(database = "other")
+
+    val firstConfig = sharedDatabasePool.takeDatabase(config)
+    val otherLeasedConfig = sharedDatabasePool.takeDatabase(otherConfig)
+
+    assertThat(firstConfig.database).isEqualTo("test__20180101__1")
+    assertThat(otherLeasedConfig.database).isEqualTo("other__20180101__1")
+  }
+
+  @Test
   fun integrationTest() {
     val realDatabasePool = TestDatabasePool(MySqlTestDatabasePoolBackend(config), clock)
     realDatabasePool.getPool(config)

--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/JdbcTestingModule.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/JdbcTestingModule.kt
@@ -20,6 +20,12 @@ import misk.time.ForceUtcTimeZoneService
  *
  *     install(JdbcModule(MyDatabase::class, dataSourceConfig, SHARED_TEST_DATABASE_POOL))
  *
+ * If a test configures multiple data sources against the same local database, for example a writer and reader in one
+ * database cluster, wrap the shared pool so both data sources use the same leased database:
+ *
+ *     val databasePool = SharedLeaseDatabasePool(SHARED_TEST_DATABASE_POOL)
+ *     install(JdbcModule(MyDatabase::class, dataSourceConfig, databasePool))
+ *
  * See [misk.jdbc.SHARED_TEST_DATABASE_POOL].
  */
 class JdbcTestingModule(

--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
@@ -23,6 +23,60 @@ val SHARED_TEST_DATABASE_POOL =
   )
 
 /**
+ * Shares a single database lease across multiple data sources for the same test database.
+ *
+ * Use this for tests that configure a writer and reader against the same local database. The wrapped pool still
+ * isolates independent test suites, but concurrent writer and reader data sources in one test injector point at the
+ * same leased database.
+ */
+class SharedLeaseDatabasePool(private val delegate: DatabasePool) : DatabasePool {
+  private val leasesByKey = mutableMapOf<LeaseKey, Lease>()
+
+  override fun takeDatabase(config: DataSourceConfig): DataSourceConfig =
+    synchronized(this) {
+      val key = config.leaseKey()
+      val existingLease = leasesByKey[key]
+      if (existingLease != null) {
+        existingLease.referenceCount += 1
+        config.copy(database = existingLease.config.database)
+      } else {
+        val leasedConfig = delegate.takeDatabase(config)
+        leasesByKey[key] = Lease(config = leasedConfig, referenceCount = 1)
+        leasedConfig
+      }
+    }
+
+  override fun releaseDatabase(config: DataSourceConfig): Unit =
+    synchronized(this) {
+      val key =
+        leasesByKey.entries
+          .firstOrNull { (_, lease) -> lease.config.database == config.database }
+          ?.key ?: return
+
+      val lease = leasesByKey.getValue(key)
+      lease.referenceCount -= 1
+      if (lease.referenceCount == 0) {
+        leasesByKey.remove(key)
+        delegate.releaseDatabase(lease.config)
+      }
+    }
+
+  private fun DataSourceConfig.leaseKey() = LeaseKey(type = type, host = host, port = port, database = database)
+
+  private data class Lease(
+    val config: DataSourceConfig,
+    var referenceCount: Int,
+  )
+
+  private data class LeaseKey(
+    val type: DataSourceType,
+    val host: String?,
+    val port: Int?,
+    val database: String?,
+  )
+}
+
+/**
  * Manages an inventory of databases for testing. Databases are named like `movies__20190730__5` where `movies` is the
  * database name in a [DataSourceConfig], `20190730` is today's date, and 5 is a sequence number.
  *


### PR DESCRIPTION
Allows TestDatabasePool to be used by services that configure a separate DataSource for a read replica