### PR TITLE
misk-jooq: narrow JooqExceptionClassifier to retry only DataChangedException

### DIFF
--- a/misk-jooq/src/main/kotlin/misk/jooq/JooqExceptionClassifier.kt
+++ b/misk-jooq/src/main/kotlin/misk/jooq/JooqExceptionClassifier.kt
@@ -2,13 +2,23 @@ package misk.jooq
 
 import misk.jdbc.DataSourceType
 import misk.jdbc.retry.DefaultExceptionClassifier
-import org.jooq.exception.DataAccessException
+import org.jooq.exception.DataChangedException
 
 /**
  * Exception classifier for jOOQ transactions.
  *
  * Extends [DefaultExceptionClassifier] to add jOOQ-specific retryable exceptions:
- * - [DataAccessException]: jOOQ's wrapper for database exceptions
+ * - [DataChangedException]: jOOQ's optimistic-locking conflict raised by
+ *   `UpdatableRecord.store()`/`refresh()` when the underlying row has changed. Retrying re-reads
+ *   the latest state and re-applies the change.
+ *
+ * Other [org.jooq.exception.DataAccessException] subclasses are intentionally **not** retried as a
+ * class — they are deterministic failures (constraint violations, type/mapping errors, no-data /
+ * too-many-rows, dialect mismatches, etc.) and will not change on retry.
+ *
+ * A wrapping [org.jooq.exception.DataAccessException] is still retryable when its underlying cause
+ * is retryable (e.g. a [java.sql.SQLRecoverableException] or a Vitess "transaction not found"
+ * SQLException). The base classifier's cause-walking logic handles that path.
  */
 internal class JooqExceptionClassifier(
   dataSourceType: DataSourceType? = null
@@ -16,7 +26,7 @@ internal class JooqExceptionClassifier(
 
   override fun isRetryable(th: Throwable): Boolean {
     return when (th) {
-      is DataAccessException -> true
+      is DataChangedException -> true
       else -> super.isRetryable(th)
     }
   }

--- a/misk-jooq/src/test/kotlin/misk/jooq/JooqExceptionClassifierTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/JooqExceptionClassifierTest.kt
@@ -6,21 +6,77 @@ import misk.jdbc.DataSourceType
 import misk.jdbc.retry.RetryTransactionException
 import org.assertj.core.api.Assertions.assertThat
 import org.jooq.exception.DataAccessException
+import org.jooq.exception.DataChangedException
+import org.jooq.exception.DataTypeException
+import org.jooq.exception.IntegrityConstraintViolationException
+import org.jooq.exception.MappingException
+import org.jooq.exception.NoDataFoundException
+import org.jooq.exception.TooManyRowsException
 import org.junit.jupiter.api.Test
 
 class JooqExceptionClassifierTest {
 
   @Test
-  fun `DataAccessException is retryable`() {
+  fun `DataChangedException is retryable`() {
     val classifier = JooqExceptionClassifier()
-    assertThat(classifier.isRetryable(DataAccessException("error"))).isTrue()
+    assertThat(classifier.isRetryable(DataChangedException("optimistic lock conflict"))).isTrue()
   }
 
   @Test
-  fun `DataAccessException with SQL cause is retryable`() {
+  fun `DataChangedException wrapped in RuntimeException is retryable via cause-walking`() {
     val classifier = JooqExceptionClassifier()
-    val cause = SQLException("connection error")
+    val wrapper = RuntimeException("wrapper", DataChangedException("optimistic lock conflict"))
+    assertThat(classifier.isRetryable(wrapper)).isTrue()
+  }
+
+  @Test
+  fun `bare DataAccessException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(DataAccessException("error"))).isFalse()
+  }
+
+  @Test
+  fun `DataAccessException wrapping a retryable SQL cause is retryable`() {
+    val classifier = JooqExceptionClassifier()
+    val cause = SQLRecoverableException("connection broken")
     assertThat(classifier.isRetryable(DataAccessException("error", cause))).isTrue()
+  }
+
+  @Test
+  fun `DataAccessException wrapping a non-retryable SQL cause is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    val cause = SQLException("syntax error")
+    assertThat(classifier.isRetryable(DataAccessException("error", cause))).isFalse()
+  }
+
+  @Test
+  fun `IntegrityConstraintViolationException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(IntegrityConstraintViolationException("duplicate key"))).isFalse()
+  }
+
+  @Test
+  fun `NoDataFoundException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(NoDataFoundException("no row"))).isFalse()
+  }
+
+  @Test
+  fun `TooManyRowsException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(TooManyRowsException("multiple rows"))).isFalse()
+  }
+
+  @Test
+  fun `DataTypeException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(DataTypeException("type conversion"))).isFalse()
+  }
+
+  @Test
+  fun `MappingException is not retryable`() {
+    val classifier = JooqExceptionClassifier()
+    assertThat(classifier.isRetryable(MappingException("mapping"))).isFalse()
   }
 
   @Test
@@ -42,14 +98,6 @@ class JooqExceptionClassifierTest {
   }
 
   @Test
-  fun `wrapped DataAccessException is retryable`() {
-    val classifier = JooqExceptionClassifier()
-    val cause = DataAccessException("db error")
-    val wrapper = RuntimeException("wrapper", cause)
-    assertThat(classifier.isRetryable(wrapper)).isTrue()
-  }
-
-  @Test
   fun `inherits database-specific behavior from base classifier`() {
     val classifier = JooqExceptionClassifier(DataSourceType.VITESS_MYSQL)
     val exception = SQLException(
@@ -65,5 +113,14 @@ class JooqExceptionClassifierTest {
       "vttablet: rpc error: code = Aborted desc = transaction 123: not found"
     )
     assertThat(classifier.isRetryable(exception)).isFalse()
+  }
+
+  @Test
+  fun `DataAccessException wrapping a Vitess SQL cause is retryable for VITESS_MYSQL`() {
+    val classifier = JooqExceptionClassifier(DataSourceType.VITESS_MYSQL)
+    val cause = SQLException(
+      "vttablet: rpc error: code = Aborted desc = transaction 123: not found"
+    )
+    assertThat(classifier.isRetryable(DataAccessException("error", cause))).isTrue()
   }
 }

--- a/misk-jooq/src/test/kotlin/misk/jooq/JooqTransacterTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/JooqTransacterTest.kt
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jooq.exception.DataAccessException
+import org.jooq.exception.DataChangedException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -33,26 +34,26 @@ internal class JooqTransacterTest {
   @Inject @JooqDBReadOnlyIdentifier private lateinit var readTransacter: JooqTransacter
 
   @Test
-  fun `retries to the max number of retries in case of a data access exception`() {
+  fun `retries to the max number of retries in case of an optimistic lock conflict`() {
     var numberOfRetries = 0
-    assertThatExceptionOfType(DataAccessException::class.java).isThrownBy {
+    assertThatExceptionOfType(DataChangedException::class.java).isThrownBy {
       transacter.transaction {
         numberOfRetries++
-        throw DataAccessException("")
+        throw DataChangedException("optimistic lock conflict")
       }
     }
     assertThat(numberOfRetries).isEqualTo(3)
   }
 
   @Test
-  fun `retries and succeeds after the first attempt in case of a data access exception`() {
+  fun `retries and succeeds after the first attempt in case of an optimistic lock conflict`() {
     var numberOfRetries = 0
     assertThatCode {
         transacter.transaction {
           numberOfRetries++
           // Throw an exception only once
           if (numberOfRetries <= 1) {
-            throw DataAccessException("")
+            throw DataChangedException("optimistic lock conflict")
           }
         }
       }
@@ -62,7 +63,19 @@ internal class JooqTransacterTest {
   }
 
   @Test
-  fun `does not retry in case of any other exception except DataAccessException`() {
+  fun `does not retry bare DataAccessException without a retryable cause`() {
+    var numberOfAttempts = 0
+    assertThatExceptionOfType(DataAccessException::class.java).isThrownBy {
+      transacter.transaction {
+        numberOfAttempts++
+        throw DataAccessException("syntax error")
+      }
+    }
+    assertThat(numberOfAttempts).isEqualTo(1)
+  }
+
+  @Test
+  fun `does not retry in case of any other exception`() {
     var numberOfRetries = 0
     assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy {
       transacter.transaction {

--- a/misk-jooq/src/test/kotlin/misk/jooq/transacter/UnifiedTransacterTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/transacter/UnifiedTransacterTest.kt
@@ -15,6 +15,7 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.jooq.exception.DataAccessException
+import org.jooq.exception.DataChangedException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -32,10 +33,10 @@ class UnifiedTransacterTest {
   @Test
   fun `retries respects max attempts`() {
     var attempts = 0
-    assertThrows<DataAccessException> {
+    assertThrows<DataChangedException> {
       transacter.maxAttempts(2).transaction {
         attempts++
-        throw DataAccessException("boom")
+        throw DataChangedException("optimistic lock conflict")
       }
     }
     assertThat(attempts).isEqualTo(2)


### PR DESCRIPTION
## Summary

Follow-up to #3681 to make jOOQ retry behavior more selective.

`JooqExceptionClassifier` previously returned `true` for any `DataAccessException`, which sweeps in deterministic failures like `IntegrityConstraintViolationException`, `TooManyRowsException`, `NoDataFoundException`, `DataTypeException`, and `MappingException`. Retrying those just wastes time, slows the calling request, and obscures the real failure.

This change narrows the classifier to retry **only `DataChangedException`** — jOOQ's optimistic-lock signal raised by `UpdatableRecord.store()`/`refresh()` when the underlying row changed. Everything else falls through to `DefaultExceptionClassifier`, which walks the cause chain — so a wrapping `DataAccessException` is still retried when its underlying cause is retryable (e.g. `SQLRecoverableException`, `SQLTransientException`, or a Vitess "transaction not found" `SQLException`).

## Behavioral change

| Exception | Before | After |
|---|---|---|
| `DataChangedException` | retry | retry |
| `DataAccessException(cause = SQLRecoverableException)` | retry | retry (via cause) |
| `DataAccessException(cause = SQLException("vttablet ... transaction ... not found"))` (Vitess) | retry | retry (via cause) |
| bare `DataAccessException("...")` | retry | **no retry** |
| `IntegrityConstraintViolationException` | retry | **no retry** |
| `TooManyRowsException`, `NoDataFoundException`, `DataTypeException`, `MappingException` | retry | **no retry** |
| `RetryTransactionException`, `SQLRecoverableException`, `SQLTransientException` | retry | retry (unchanged) |