### PR TITLE
misk-hibernate: bind queried entity to authorized query class

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
@@ -72,7 +72,17 @@ constructor(
     transacter.transaction { session ->
       val dbEntity =
         transacter.entities().find { it.simpleName == request.entityClass }
-          ?: throw BadRequestException("[dbEntity=${metadata.entityClass}] is not an installed HibernateEntity")
+          ?: throw BadRequestException("[dbEntity=${request.entityClass}] is not an installed HibernateEntity")
+      // Authorization is performed against `queryClass` (and its bound `metadata.entityClass`), but the
+      // entity actually queried is taken from the user-controlled `request.entityClass`. Without the
+      // binding check below, a caller authorized for one query class could read any registered entity
+      // by setting `entityClass` to a different entity name. Enforce that the entity executed matches
+      // the entity the query class is authorized for.
+      if (dbEntity.simpleName != metadata.entityClass) {
+        throw UnauthorizedException(
+          "Requested entity [dbEntity=${request.entityClass}] does not match authorized query [queryClass=${request.queryClass}]"
+        )
+      }
       val (selectPaths, rows) = runDynamicQuery(session, principal, dbEntity, request)
       rows.map { row ->
         // TODO (adrw) sort the map based on DbEntity order

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicActionTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicActionTest.kt
@@ -70,6 +70,28 @@ class HibernateDatabaseQueryDynamicActionTest {
     }
   }
 
+  /**
+   * Regression: a caller authorized for `DbMovieDynamicQuery` must NOT be able to read a different
+   * registered entity (`DbActor`) by switching `entityClass`. Authorization is checked against
+   * `queryClass`, so the request passes the capability gate, but the binding check on the resolved
+   * entity must reject execution. Without that binding check, one allowed query class becomes a
+   * read primitive over every registered Hibernate entity in the service.
+   */
+  @Test
+  fun `entityClass not matching authorized queryClass throws unauthorized`() {
+    assertFailsWith<UnauthorizedException> {
+      realActionRequestExecuter.executeRequest(
+        HibernateDatabaseQueryDynamicAction.Request(
+          entityClass = DbActor::class.simpleName!!,
+          queryClass = "DbMovieDynamicQuery",
+          query = HibernateDatabaseQueryMetadataFactory.Companion.DynamicQuery(),
+        ),
+        user = "joey",
+        capabilities = AUTHORIZED_CAPABILITIES,
+      )
+    }
+  }
+
   @Test
   fun `default request`() {
     val results =


### PR DESCRIPTION
## Summary

`HibernateDatabaseQueryDynamicAction` authorizes the caller based on `request.queryClass` (which has a bound `metadata.entityClass`), but then executes the query against `request.entityClass` — a separate, user-controlled field. If a caller is authorized for one dynamic query, they can read any other registered Hibernate entity in the same `Transacter` by supplying a different `entityClass` in the request body.

This PR adds the missing binding check: after resolving `dbEntity` from `request.entityClass`, verify `dbEntity.simpleName == metadata.entityClass`. If not, throw `UnauthorizedException`.

## Changes

- `HibernateDatabaseQueryDynamicAction.kt` — enforce `dbEntity.simpleName == metadata.entityClass` after entity resolution. Also a small fix to the existing `BadRequestException` message so it reports `request.entityClass` (the user-supplied value that was actually invalid) rather than `metadata.entityClass`.
- `HibernateDatabaseQueryDynamicActionTest.kt` — regression test exercising the binding: a caller with `DbMovieDynamicQuery` capability who passes `entityClass = DbActor` is rejected with `UnauthorizedException`.

## Risk / Compatibility

Defensive check only. Legitimate callers always pass `entityClass` matching their `queryClass`, so existing usage is unaffected. The behavior change is limited to rejecting bypass attempts with `UnauthorizedException` instead of silently returning the wrong entity's data.

## Reported via

Reported through Block's bug bounty program (Bugcrowd) and tracked internally as VULN-78154.

CWE-863 (Incorrect Authorization), CWE-285 (Improper Authorization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)