### PR TITLE
Update misk to jetty 11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -135,14 +135,14 @@ jerseyBom = { module = "org.glassfish.jersey:jersey-bom", version = "3.1.11" }
 jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "26.0.2-1" }
 jettyAlpnServer = { module = "org.eclipse.jetty:jetty-alpn-server" }
 jettyAlpnServerJava = { module = "org.eclipse.jetty:jetty-alpn-java-server" }
-jettyBom = { module = "org.eclipse.jetty:jetty-bom", version = "10.0.26" }
+jettyBom = { module = "org.eclipse.jetty:jetty-bom", version = "11.0.25" }
 jettyHttp = { module = "org.eclipse.jetty:jetty-http" }
 jettyHttp2 = { module = "org.eclipse.jetty.http2:http2-server" }
 jettyHttp2Common = { module = "org.eclipse.jetty.http2:http2-common" }
 jettyIo = { module = "org.eclipse.jetty:jetty-io" }
 jettyServer = { module = "org.eclipse.jetty:jetty-server" }
 jettyServlet = { module = "org.eclipse.jetty:jetty-servlet" }
-jettyServletApi = { module = "org.eclipse.jetty.toolchain:jetty-servlet-api", version = "4.0.6" }
+jettyServletApi = { module = "org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api", version = "5.0.2" }
 jettyServlets = { module = "org.eclipse.jetty:jetty-servlets" }
 jettyUds = { module = "org.eclipse.jetty:jetty-unixdomain-server" }
 jettyUnixSocket = { module = "org.eclipse.jetty:jetty-unixsocket-server" }
@@ -233,7 +233,7 @@ retrofitMoshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref
 retrofitProtobuf = { module = "com.squareup.retrofit2:converter-protobuf", version.ref = "retrofit" }
 retrofitScalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 retrofitWire = { module = "com.squareup.retrofit2:converter-wire", version.ref = "retrofit" }
-servletApi = { module = "javax.servlet:javax.servlet-api", version = "4.0.1" }
+servletApi = { module = "jakarta.servlet:jakarta.servlet-api", version = "5.0.0" }
 slf4jApi = { module = "org.slf4j:slf4j-api", version = "2.0.17" }
 sqldelightJdbcDriver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelightMysqlDialect = { module = "app.cash.sqldelight:mysql-dialect", version.ref = "sqldelight" }

--- a/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
+++ b/misk-testing/src/main/kotlin/misk/web/FakeHttpCall.kt
@@ -1,6 +1,6 @@
 package misk.web
 
-import javax.servlet.http.Cookie
+import jakarta.servlet.http.Cookie
 import misk.web.actions.WebSocket
 import misk.web.actions.WebSocketListener
 import okhttp3.Headers

--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -1043,7 +1043,7 @@ public final class misk/web/BoundAction {
 	public final fun hasIdenticalRouting (Lmisk/web/BoundAction;)Z
 	public final fun match (Lmisk/web/DispatchMechanism;Lokhttp3/MediaType;Ljava/util/List;Lokhttp3/HttpUrl;)Lmisk/web/BoundActionMatch;
 	public final fun matchByUrl (Lokhttp3/HttpUrl;)Lmisk/web/BoundActionMatch;
-	public final fun scopeAndHandle (Ljavax/servlet/http/HttpServletRequest;Lmisk/web/HttpCall;Ljava/util/regex/Matcher;)V
+	public final fun scopeAndHandle (Ljakarta/servlet/http/HttpServletRequest;Lmisk/web/HttpCall;Ljava/util/regex/Matcher;)V
 	public final fun scopeAndHandle (Lmisk/web/HttpCall;Ljava/util/regex/Matcher;)V
 	public fun toString ()Ljava/lang/String;
 }
@@ -2231,7 +2231,7 @@ public abstract interface class misk/web/marshal/Unmarshaller$Factory {
 }
 
 public abstract interface class misk/web/mdc/LogContextProvider {
-	public abstract fun get (Ljavax/servlet/http/HttpServletRequest;)Ljava/lang/String;
+	public abstract fun get (Ljakarta/servlet/http/HttpServletRequest;)Ljava/lang/String;
 }
 
 public final class misk/web/metadata/guice/GuiceMetadata : misk/web/metadata/Metadata {

--- a/misk/src/main/kotlin/misk/security/ssl/CertificatesModule.kt
+++ b/misk/src/main/kotlin/misk/security/ssl/CertificatesModule.kt
@@ -2,8 +2,8 @@ package misk.security.ssl
 
 import com.google.inject.TypeLiteral
 import jakarta.inject.Inject
+import jakarta.servlet.http.HttpServletRequest
 import java.security.cert.X509Certificate
-import javax.servlet.http.HttpServletRequest
 import misk.scope.ActionScoped
 import misk.scope.ActionScopedProvider
 import misk.scope.ActionScopedProviderModule
@@ -34,7 +34,7 @@ internal class CertificatesModule : ActionScopedProviderModule() {
 
     override fun get(): Array<X509Certificate>? {
       @Suppress("UNCHECKED_CAST")
-      return request.get().getAttribute("javax.servlet.request.X509Certificate") as? Array<X509Certificate>
+      return request.get().getAttribute("jakarta.servlet.request.X509Certificate") as? Array<X509Certificate>
     }
   }
 

--- a/misk/src/main/kotlin/misk/web/BoundAction.kt
+++ b/misk/src/main/kotlin/misk/web/BoundAction.kt
@@ -2,8 +2,8 @@ package misk.web
 
 import com.google.inject.Key
 import com.google.inject.Provider
+import jakarta.servlet.http.HttpServletRequest
 import java.util.regex.Matcher
-import javax.servlet.http.HttpServletRequest
 import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import misk.Action

--- a/misk/src/main/kotlin/misk/web/HttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/HttpCall.kt
@@ -1,6 +1,6 @@
 package misk.web
 
-import javax.servlet.http.Cookie
+import jakarta.servlet.http.Cookie
 import misk.api.HttpRequest
 import misk.web.actions.WebSocket
 import misk.web.actions.WebSocketListener

--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -11,14 +11,14 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.wire.GrpcException
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
 import java.io.IOException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import javax.servlet.http.HttpServlet
-import javax.servlet.http.HttpServletRequest
 import kotlin.math.min
 import misk.Action
 import misk.ApplicationInterceptor

--- a/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
+++ b/misk/src/main/kotlin/misk/web/ServletHttpCall.kt
@@ -1,7 +1,7 @@
 package misk.web
 
-import javax.servlet.http.Cookie
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
 import misk.web.actions.WebSocket
 import misk.web.actions.WebSocketListener
 import misk.web.jetty.headers

--- a/misk/src/main/kotlin/misk/web/extractors/RequestCookieFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/web/extractors/RequestCookieFeatureBinding.kt
@@ -1,6 +1,6 @@
 package misk.web.extractors
 
-import javax.servlet.http.Cookie
+import jakarta.servlet.http.Cookie
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType

--- a/misk/src/main/kotlin/misk/web/interceptors/RequestLogContextInterceptor.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/RequestLogContextInterceptor.kt
@@ -2,7 +2,7 @@ package misk.web.interceptors
 
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import misk.Action
 import misk.MiskCaller
 import misk.scope.ActionScoped

--- a/misk/src/main/kotlin/misk/web/jetty/GenericServletUpstreamResponse.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/GenericServletUpstreamResponse.kt
@@ -1,6 +1,6 @@
 package misk.web.jetty
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 import misk.web.ServletHttpCall
 import misk.web.actions.WebSocketListener
 import okhttp3.Headers

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -7,6 +7,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.squareup.wire.internal.newMutableList
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.servlet.DispatcherType
 import java.io.File
 import java.io.IOException
 import java.lang.Thread.sleep
@@ -19,7 +20,6 @@ import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
-import javax.servlet.DispatcherType
 import misk.logging.getLogger
 import misk.security.ssl.CipherSuites
 import misk.security.ssl.SslLoader

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -2,10 +2,10 @@ package misk.web.jetty
 
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import java.net.HttpURLConnection
 import java.net.ProtocolException
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import misk.logging.getLogger
 import misk.web.BoundAction
 import misk.web.DispatchMechanism
@@ -49,9 +49,9 @@ constructor(
     val log = getLogger<WebActionsServlet>()
 
     /**
-     * Maximum bytes to drain from an unconsumed request body. If the body exceeds this, we stop
-     * draining and let Jetty send RST_STREAM for the remainder. This prevents a slow client from
-     * tying up the servlet thread indefinitely. Using 1 MB for bounding worst-case drain time.
+     * Maximum bytes to drain from an unconsumed request body. If the body exceeds this, we stop draining and let Jetty
+     * send RST_STREAM for the remainder. This prevents a slow client from tying up the servlet thread indefinitely.
+     * Using 1 MB for bounding worst-case drain time.
      */
     private const val MAX_DRAIN_BYTES = 1L * 1024 * 1024
   }
@@ -171,11 +171,11 @@ constructor(
   }
 
   /**
-   * Drains any unconsumed request body to prevent Jetty from sending RST_STREAM(CANCEL) on HTTP/2
-   * streams. When a servlet completes without fully reading the request body, Jetty resets the
-   * stream because the client's END_STREAM flag was never received. These server-initiated resets
-   * count toward the HTTP/2 frame rate limiter (CVE-2025-5115 / MadeYouReset mitigation), and
-   * exceeding the limit tears down the entire HTTP/2 connection, affecting all multiplexed streams.
+   * Drains any unconsumed request body to prevent Jetty from sending RST_STREAM(CANCEL) on HTTP/2 streams. When a
+   * servlet completes without fully reading the request body, Jetty resets the stream because the client's END_STREAM
+   * flag was never received. These server-initiated resets count toward the HTTP/2 frame rate limiter (CVE-2025-5115 /
+   * MadeYouReset mitigation), and exceeding the limit tears down the entire HTTP/2 connection, affecting all
+   * multiplexed streams.
    */
   private fun drainRequestBody(request: HttpServletRequest) {
     try {
@@ -192,8 +192,7 @@ constructor(
     } catch (e: Throwable) {
       if (e is org.eclipse.jetty.io.EofException && e.message?.startsWith("Reset no_error") == true)
         log.warn(e) { "Client reset stream while draining request body for ${request.method} ${request.requestURI}" }
-      else
-        log.warn(e) { "Failed to drain request body for ${request.method} ${request.requestURI}" }
+      else log.warn(e) { "Failed to drain request body for ${request.method} ${request.requestURI}" }
     }
   }
 
@@ -274,7 +273,8 @@ internal fun HttpServletRequest.httpUrl(): HttpUrl {
 /** @throws ProtocolException on unexpected methods. */
 internal fun HttpServletRequest.dispatchMechanism(): DispatchMechanism? {
   return when (method) {
-    HttpMethod.GET.name, HttpMethod.HEAD.name -> DispatchMechanism.GET
+    HttpMethod.GET.name,
+    HttpMethod.HEAD.name -> DispatchMechanism.GET
     HttpMethod.POST.name ->
       when (contentType()) {
         MediaTypes.APPLICATION_GRPC_MEDIA_TYPE,

--- a/misk/src/main/kotlin/misk/web/mdc/LogContextProvider.kt
+++ b/misk/src/main/kotlin/misk/web/mdc/LogContextProvider.kt
@@ -1,6 +1,6 @@
 package misk.web.mdc
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 interface LogContextProvider {
   fun get(request: HttpServletRequest): String?

--- a/misk/src/main/kotlin/misk/web/mdc/RequestHttpMethodLogContextProvider.kt
+++ b/misk/src/main/kotlin/misk/web/mdc/RequestHttpMethodLogContextProvider.kt
@@ -1,7 +1,7 @@
 package misk.web.mdc
 
 import jakarta.inject.Inject
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 internal class RequestHttpMethodLogContextProvider @Inject constructor() : LogContextProvider {
   override fun get(request: HttpServletRequest): String? = request.method

--- a/misk/src/main/kotlin/misk/web/mdc/RequestProtocolLogContextProvider.kt
+++ b/misk/src/main/kotlin/misk/web/mdc/RequestProtocolLogContextProvider.kt
@@ -1,7 +1,7 @@
 package misk.web.mdc
 
 import jakarta.inject.Inject
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 internal class RequestProtocolLogContextProvider @Inject constructor() : LogContextProvider {
   override fun get(request: HttpServletRequest): String? = request.protocol

--- a/misk/src/main/kotlin/misk/web/mdc/RequestRemoteAddressLogContextProvider.kt
+++ b/misk/src/main/kotlin/misk/web/mdc/RequestRemoteAddressLogContextProvider.kt
@@ -1,7 +1,7 @@
 package misk.web.mdc
 
 import jakarta.inject.Inject
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 internal class RequestRemoteAddressLogContextProvider @Inject constructor() : LogContextProvider {
   override fun get(request: HttpServletRequest) = "${request.remoteAddr}:${request.remotePort}"

--- a/misk/src/main/kotlin/misk/web/mdc/RequestURILogContextProvider.kt
+++ b/misk/src/main/kotlin/misk/web/mdc/RequestURILogContextProvider.kt
@@ -1,7 +1,7 @@
 package misk.web.mdc
 
 import jakarta.inject.Inject
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 internal class RequestURILogContextProvider @Inject constructor() : LogContextProvider {
   override fun get(request: HttpServletRequest): String? = request.requestURI

--- a/misk/src/test/kotlin/misk/web/extractors/RequestCookieParameterTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/RequestCookieParameterTest.kt
@@ -1,7 +1,7 @@
 package misk.web.extractors
 
 import jakarta.inject.Inject
-import javax.servlet.http.Cookie
+import jakarta.servlet.http.Cookie
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest

--- a/misk/src/test/kotlin/misk/web/extractors/RequestCookiesParameterTest.kt
+++ b/misk/src/test/kotlin/misk/web/extractors/RequestCookiesParameterTest.kt
@@ -1,7 +1,7 @@
 package misk.web.extractors
 
 import jakarta.inject.Inject
-import javax.servlet.http.Cookie
+import jakarta.servlet.http.Cookie
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest

--- a/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
+++ b/misk/src/test/kotlin/misk/web/ssl/Http2ConnectivityTest.kt
@@ -5,11 +5,11 @@ import com.google.inject.Guice
 import com.google.inject.Provides
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.servlet.http.HttpServletRequest
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
-import javax.servlet.http.HttpServletRequest
 import kotlin.test.assertFailsWith
 import misk.Action
 import misk.MiskDefault


### PR DESCRIPTION
This updates misk from jetty 10 to jetty 11. Jetty 11 is functionally the same as Jetty 10, but uses jakarta.servlet instead of javax.servlet APIs.