### PR TITLE
Upgrade compile target to jvm 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,12 +252,12 @@ subprojects {
   plugins.withType<KotlinPluginWrapper> {
     tasks.withType<KotlinCompile>().configureEach {
       compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
-        freeCompilerArgs.add("-Xjdk-release=11")
+        jvmTarget.set(JvmTarget.JVM_17)
+        freeCompilerArgs.add("-Xjdk-release=17")
       }
     }
     tasks.withType<JavaCompile>().configureEach {
-      options.release.set(11)
+      options.release.set(17)
     }
 
     dependencies {


### PR DESCRIPTION
## Description

In order to migrate misk to use newer (non-EOL) versions of jetty, we need to update the compile target to be JVM 17 or higher.

## Testing Strategy

Passing in CI

## Communication Plan

- Will announce in the `#misk-external` slack channel. Note that is a breaking change; any consumers still targeting JVM 11 will be unable to use misk from this version onwards.