### PR TITLE
feat: add lease acquire options

### DIFF
--- a/misk-clustering/api/misk-clustering.api
+++ b/misk-clustering/api/misk-clustering.api
@@ -158,6 +158,7 @@ public final class misk/clustering/fake/lease/FakeLeaderLeaseManager : misk/clus
 public final class misk/clustering/fake/lease/FakeLease : wisp/lease/Lease {
 	public fun <init> (Ljava/lang/String;Lmisk/clustering/fake/lease/FakeLeaseManager;)V
 	public fun acquire ()Z
+	public fun acquire (Lwisp/lease/AcquireOptions;)Z
 	public fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z
@@ -226,6 +227,7 @@ public final class misk/clustering/kubernetes/KubernetesConfig : misk/config/Con
 public final class misk/clustering/lease/ClusterAwareLease : wisp/lease/Lease {
 	public fun <init> (Ljava/lang/String;Lmisk/clustering/weights/ClusterWeightProvider;)V
 	public fun acquire ()Z
+	public fun acquire (Lwisp/lease/AcquireOptions;)Z
 	public fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z

--- a/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLease.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/fake/lease/FakeLease.kt
@@ -1,5 +1,6 @@
 package misk.clustering.fake.lease
 
+import wisp.lease.AcquireOptions
 import wisp.lease.Lease
 
 class FakeLease(override val name: String, private val manager: FakeLeaseManager) : Lease {
@@ -22,6 +23,8 @@ class FakeLease(override val name: String, private val manager: FakeLeaseManager
     }
     return result
   }
+
+  override fun acquire(options: AcquireOptions): Boolean = acquire()
 
   /** Release the lease. This will return true if released. Note that it will return false if the lease was not held. */
   override fun release(): Boolean {

--- a/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLease.kt
+++ b/misk-clustering/src/main/kotlin/misk/clustering/lease/ClusterAwareLease.kt
@@ -1,6 +1,7 @@
 package misk.clustering.lease
 
 import misk.clustering.weights.ClusterWeightProvider
+import wisp.lease.AcquireOptions
 import wisp.lease.Lease
 
 /**
@@ -14,6 +15,8 @@ class ClusterAwareLease(override val name: String, private val clusterWeightProv
   override fun acquire(): Boolean {
     return (clusterWeightProvider.get() != 0)
   }
+
+  override fun acquire(options: AcquireOptions): Boolean = acquire()
 
   override fun addListener(listener: Lease.StateChangeListener) {}
 

--- a/misk-clustering/src/test/kotlin/misk/clustering/fake/lease/FakeLeaseManagerTest.kt
+++ b/misk-clustering/src/test/kotlin/misk/clustering/fake/lease/FakeLeaseManagerTest.kt
@@ -1,7 +1,10 @@
 package misk.clustering.fake.lease
 
+import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.lease.AcquireOptions
+import wisp.lease.WaitMode
 
 internal class FakeLeaseManagerTest {
 
@@ -29,5 +32,15 @@ internal class FakeLeaseManagerTest {
     assertThat(lease.checkHeld()).isTrue()
     assertThat(otherLease.isHeld()).isTrue()
     assertThat(otherLease.checkHeld()).isTrue()
+  }
+
+  @Test
+  fun acquireWithWaitOptionsUsesFakeLeaseState() {
+    val lease = leaseManager.requestLease("my-lease")
+
+    assertThat(lease.acquire(AcquireOptions(wait = WaitMode.WaitForLeaseDuration))).isTrue()
+
+    leaseManager.markLeaseHeldElsewhere("my-lease")
+    assertThat(lease.acquire(AcquireOptions(wait = WaitMode.WaitUpTo(Duration.ofSeconds(1))))).isFalse()
   }
 }

--- a/misk-clustering/src/test/kotlin/misk/clustering/lease/ClusterAwareLeaseTest.kt
+++ b/misk-clustering/src/test/kotlin/misk/clustering/lease/ClusterAwareLeaseTest.kt
@@ -3,6 +3,7 @@ package misk.clustering.lease
 import com.google.inject.Module
 import com.google.inject.util.Modules
 import jakarta.inject.Inject
+import java.time.Duration
 import misk.MiskTestingServiceModule
 import misk.clustering.weights.FakeClusterWeight
 import misk.clustering.weights.FakeClusterWeightModule
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import wisp.lease.AcquireOptions
 import wisp.lease.LeaseManager
+import wisp.lease.WaitMode
 
 @MiskTest
 internal class ClusterAwareLeaseTest {
@@ -55,5 +58,22 @@ internal class ClusterAwareLeaseTest {
     assertFalse(lease.acquire())
     assertFalse(lease.isHeld())
     assertFalse(lease.checkHeld())
+  }
+
+  @Test
+  fun waitOptionsAreNoOpsInActiveCluster() {
+    val lease = leaseManager.requestLease("lease4")
+
+    assertTrue(lease.acquire(AcquireOptions(wait = WaitMode.WaitForLeaseDuration)))
+    assertTrue(lease.acquire(AcquireOptions(wait = WaitMode.WaitUpTo(Duration.ofSeconds(1)))))
+  }
+
+  @Test
+  fun waitOptionsAreNoOpsInPassiveCluster() {
+    clusterWeight.setClusterWeight(0)
+    val lease = leaseManager.requestLease("lease5")
+
+    assertFalse(lease.acquire(AcquireOptions(wait = WaitMode.WaitForLeaseDuration)))
+    assertFalse(lease.acquire(AcquireOptions(wait = WaitMode.WaitUpTo(Duration.ofSeconds(1)))))
   }
 }

--- a/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
+++ b/misk-lease-mysql/src/main/kotlin/misk/lease/mysql/SqlLeaseManager.kt
@@ -7,8 +7,11 @@ import java.time.Duration
 import java.time.Instant
 import misk.annotation.ExperimentalMiskApi
 import misk.logging.getLogger
+import wisp.lease.AcquireOptions
 import wisp.lease.Lease
 import wisp.lease.PersistentLeaseManager
+import wisp.lease.UnsupportedWaitBehavior
+import wisp.lease.WaitMode
 
 /** A LeaseManager that uses a SQL database to manage distributed leases. */
 @ExperimentalMiskApi
@@ -84,12 +87,33 @@ internal class SqlLeaseManager @Inject constructor(private val clock: Clock, pri
 
     /** Attempts to acquire the lease. Notifies listeners if successful. */
     override fun acquire(): Boolean {
+      if (isHeld()) {
+        notifyAfterAcquire()
+        return true
+      }
+
       val lease = requestLease(name)
       if (lease.isHeld()) {
         notifyAfterAcquire()
         return true
       }
       return false
+    }
+
+    override fun acquire(options: AcquireOptions): Boolean {
+      return when (options.wait) {
+        WaitMode.DoNotWait -> acquire()
+        WaitMode.WaitForLeaseDuration,
+        is WaitMode.WaitUpTo ->
+          when (options.unsupportedWaitBehavior) {
+            UnsupportedWaitBehavior.Fail -> {
+              if (isHeld()) release()
+              throw UnsupportedOperationException("Lease $name does not support waiting to acquire")
+            }
+
+            UnsupportedWaitBehavior.FallbackToNonBlocking -> acquire()
+          }
+      }
     }
 
     /** Releases the lease if held. Notifies listeners before releasing. */

--- a/misk-lease-mysql/src/test/kotlin/misk/lease/mysql/SqlLeaseManagerTest.kt
+++ b/misk-lease-mysql/src/test/kotlin/misk/lease/mysql/SqlLeaseManagerTest.kt
@@ -11,9 +11,14 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.time.FakeClock
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import wisp.deployment.TESTING
+import wisp.lease.AcquireOptions
 import wisp.lease.LeaseManager
+import wisp.lease.UnsupportedWaitBehavior
+import wisp.lease.WaitMode
+import wisp.lease.acquireOrNull
 
 @MiskTest(startService = true)
 class SqlLeaseManagerTest {
@@ -147,5 +152,40 @@ class SqlLeaseManagerTest {
     assertThat(defaultLease.checkHeld()).isTrue()
     assertThat(longLease.isHeld()).isTrue()
     assertThat(longLease.checkHeld()).isTrue()
+  }
+
+  @Test
+  fun acquireOrNullWithOptionsAcquiresSqlLease() {
+    val lease = leaseManager.acquireOrNull("acquire-or-null-with-options", AcquireOptions())
+
+    assertThat(lease).isNotNull()
+    lease!!.use { assertThat(it.isHeld()).isTrue() }
+  }
+
+  @Test
+  fun acquireOrNullWithUnsupportedWaitReleasesSqlLeaseBeforeThrowing() {
+    assertThatThrownBy {
+        leaseManager.acquireOrNull("unsupported-wait-releases", AcquireOptions(wait = WaitMode.WaitForLeaseDuration))
+      }
+      .isInstanceOf(UnsupportedOperationException::class.java)
+
+    val reacquired = leaseManager.requestLease("unsupported-wait-releases")
+    assertThat(reacquired.isHeld()).isTrue()
+    reacquired.release()
+  }
+
+  @Test
+  fun acquireOrNullWithFallbackToNonBlockingAcquiresSqlLease() {
+    val lease =
+      leaseManager.acquireOrNull(
+        "fallback-to-non-blocking",
+        AcquireOptions(
+          wait = WaitMode.WaitForLeaseDuration,
+          unsupportedWaitBehavior = UnsupportedWaitBehavior.FallbackToNonBlocking,
+        ),
+      )
+
+    assertThat(lease).isNotNull()
+    lease!!.use { assertThat(it.isHeld()).isTrue() }
   }
 }

--- a/wisp/wisp-lease-testing/api/wisp-lease-testing.api
+++ b/wisp/wisp-lease-testing/api/wisp-lease-testing.api
@@ -1,6 +1,7 @@
 public final class wisp/lease/FakeLease : wisp/lease/Lease {
 	public fun <init> (Ljava/lang/String;Lwisp/lease/FakeLeaseManager;)V
 	public fun acquire ()Z
+	public fun acquire (Lwisp/lease/AcquireOptions;)Z
 	public fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z

--- a/wisp/wisp-lease-testing/src/main/kotlin/wisp/lease/FakeLease.kt
+++ b/wisp/wisp-lease-testing/src/main/kotlin/wisp/lease/FakeLease.kt
@@ -21,6 +21,8 @@ class FakeLease(override val name: String, private val manager: FakeLeaseManager
     return result
   }
 
+  override fun acquire(options: AcquireOptions): Boolean = acquire()
+
   /** Release the lease. This will return true if released. Note that it will return false if the lease was not held. */
   override fun release(): Boolean {
     if (!isHeld()) {

--- a/wisp/wisp-lease-testing/src/test/kotlin/wisp/lease/FakeLeaseManagerTest.kt
+++ b/wisp/wisp-lease-testing/src/test/kotlin/wisp/lease/FakeLeaseManagerTest.kt
@@ -1,6 +1,9 @@
 package wisp.lease
 
+import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 internal class FakeLeaseManagerTest {
@@ -30,5 +33,60 @@ internal class FakeLeaseManagerTest {
     assertThat(lease.checkHeld()).isTrue()
     assertThat(otherLease.isHeld()).isTrue()
     assertThat(otherLease.checkHeld()).isTrue()
+  }
+
+  @Test
+  fun acquireWithWaitOptionsUsesFakeLeaseState() {
+    val lease = leaseManager.requestLease("my-lease")
+
+    assertThat(lease.acquire(AcquireOptions(wait = WaitMode.WaitForLeaseDuration))).isTrue()
+
+    leaseManager.markLeaseHeldElsewhere("my-lease")
+    assertThat(lease.acquire(AcquireOptions(wait = WaitMode.WaitUpTo(Duration.ofSeconds(1))))).isFalse()
+  }
+
+  @Test
+  fun unsupportedWaitBehaviorCanFallbackToNonBlockingAcquire() {
+    val lease = NonBlockingOnlyLease(acquires = true)
+
+    assertThatThrownBy { lease.acquire(AcquireOptions(wait = WaitMode.WaitForLeaseDuration)) }
+      .isInstanceOf(UnsupportedOperationException::class.java)
+
+    assertThat(
+        lease.acquire(
+          AcquireOptions(
+            wait = WaitMode.WaitForLeaseDuration,
+            unsupportedWaitBehavior = UnsupportedWaitBehavior.FallbackToNonBlocking,
+          )
+        )
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun waitUpToRequiresNonNegativeTimeout() {
+    assertThatIllegalArgumentException()
+      .isThrownBy { WaitMode.WaitUpTo(Duration.ofMillis(-1)) }
+      .withMessage("timeout must be non-negative")
+  }
+
+  private class NonBlockingOnlyLease(private val acquires: Boolean) : Lease {
+    override val name = "non-blocking-only"
+
+    override fun shouldHold() = true
+
+    override fun isHeld() = acquires
+
+    override fun checkHeld() = isHeld()
+
+    override fun checkHeldElsewhere() = !isHeld()
+
+    override fun acquire() = acquires
+
+    override fun release() = false
+
+    override fun release(lazy: Boolean) = release()
+
+    override fun addListener(listener: Lease.StateChangeListener) {}
   }
 }

--- a/wisp/wisp-lease/api/wisp-lease.api
+++ b/wisp/wisp-lease/api/wisp-lease.api
@@ -1,8 +1,25 @@
+public final class wisp/lease/AcquireOptions {
+	public fun <init> ()V
+	public fun <init> (Lwisp/lease/WaitMode;)V
+	public fun <init> (Lwisp/lease/WaitMode;Lwisp/lease/UnsupportedWaitBehavior;)V
+	public synthetic fun <init> (Lwisp/lease/WaitMode;Lwisp/lease/UnsupportedWaitBehavior;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lwisp/lease/WaitMode;
+	public final fun component2 ()Lwisp/lease/UnsupportedWaitBehavior;
+	public final fun copy (Lwisp/lease/WaitMode;Lwisp/lease/UnsupportedWaitBehavior;)Lwisp/lease/AcquireOptions;
+	public static synthetic fun copy$default (Lwisp/lease/AcquireOptions;Lwisp/lease/WaitMode;Lwisp/lease/UnsupportedWaitBehavior;ILjava/lang/Object;)Lwisp/lease/AcquireOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnsupportedWaitBehavior ()Lwisp/lease/UnsupportedWaitBehavior;
+	public final fun getWait ()Lwisp/lease/WaitMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class wisp/lease/AutoCloseableLease : java/lang/AutoCloseable, wisp/lease/Lease {
 	public fun <init> (Lwisp/lease/Lease;)V
 	public fun <init> (Lwisp/lease/Lease;Z)V
 	public synthetic fun <init> (Lwisp/lease/Lease;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acquire ()Z
+	public fun acquire (Lwisp/lease/AcquireOptions;)Z
 	public fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
 	public fun checkHeld ()Z
 	public fun checkHeldElsewhere ()Z
@@ -16,7 +33,10 @@ public final class wisp/lease/AutoCloseableLease : java/lang/AutoCloseable, wisp
 
 public final class wisp/lease/ExtensionsKt {
 	public static final fun acquireOrNull (Lwisp/lease/LeaseManager;Ljava/lang/String;)Lwisp/lease/AutoCloseableLease;
+	public static final fun acquireOrNull (Lwisp/lease/LeaseManager;Ljava/lang/String;Lwisp/lease/AcquireOptions;)Lwisp/lease/AutoCloseableLease;
+	public static final fun acquireOrNull (Lwisp/lease/LeaseManager;Ljava/lang/String;Lwisp/lease/AcquireOptions;Z)Lwisp/lease/AutoCloseableLease;
 	public static final fun acquireOrNull (Lwisp/lease/LeaseManager;Ljava/lang/String;Z)Lwisp/lease/AutoCloseableLease;
+	public static synthetic fun acquireOrNull$default (Lwisp/lease/LeaseManager;Ljava/lang/String;Lwisp/lease/AcquireOptions;ZILjava/lang/Object;)Lwisp/lease/AutoCloseableLease;
 	public static synthetic fun acquireOrNull$default (Lwisp/lease/LeaseManager;Ljava/lang/String;ZILjava/lang/Object;)Lwisp/lease/AutoCloseableLease;
 }
 
@@ -29,6 +49,7 @@ public final class wisp/lease/LeaderLeaseManager$DefaultImpls {
 
 public abstract interface class wisp/lease/Lease {
 	public abstract fun acquire ()Z
+	public fun acquire (Lwisp/lease/AcquireOptions;)Z
 	public abstract fun addListener (Lwisp/lease/Lease$StateChangeListener;)V
 	public abstract fun checkHeld ()Z
 	public abstract fun checkHeldElsewhere ()Z
@@ -37,6 +58,10 @@ public abstract interface class wisp/lease/Lease {
 	public abstract fun release ()Z
 	public abstract fun release (Z)Z
 	public abstract fun shouldHold ()Z
+}
+
+public final class wisp/lease/Lease$DefaultImpls {
+	public static fun acquire (Lwisp/lease/Lease;Lwisp/lease/AcquireOptions;)Z
 }
 
 public abstract interface class wisp/lease/Lease$StateChangeListener {
@@ -65,5 +90,41 @@ public abstract interface class wisp/lease/PersistentLeaseManager : wisp/lease/L
 
 public final class wisp/lease/PersistentLeaseManager$DefaultImpls {
 	public static fun releaseAll (Lwisp/lease/PersistentLeaseManager;)V
+}
+
+public final class wisp/lease/UnsupportedWaitBehavior : java/lang/Enum {
+	public static final field Fail Lwisp/lease/UnsupportedWaitBehavior;
+	public static final field FallbackToNonBlocking Lwisp/lease/UnsupportedWaitBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lwisp/lease/UnsupportedWaitBehavior;
+	public static fun values ()[Lwisp/lease/UnsupportedWaitBehavior;
+}
+
+public abstract interface class wisp/lease/WaitMode {
+}
+
+public final class wisp/lease/WaitMode$DoNotWait : wisp/lease/WaitMode {
+	public static final field INSTANCE Lwisp/lease/WaitMode$DoNotWait;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class wisp/lease/WaitMode$WaitForLeaseDuration : wisp/lease/WaitMode {
+	public static final field INSTANCE Lwisp/lease/WaitMode$WaitForLeaseDuration;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class wisp/lease/WaitMode$WaitUpTo : wisp/lease/WaitMode {
+	public fun <init> (Ljava/time/Duration;)V
+	public final fun component1 ()Ljava/time/Duration;
+	public final fun copy (Ljava/time/Duration;)Lwisp/lease/WaitMode$WaitUpTo;
+	public static synthetic fun copy$default (Lwisp/lease/WaitMode$WaitUpTo;Ljava/time/Duration;ILjava/lang/Object;)Lwisp/lease/WaitMode$WaitUpTo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTimeout ()Ljava/time/Duration;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/wisp/wisp-lease/src/main/kotlin/wisp/lease/Extensions.kt
+++ b/wisp/wisp-lease/src/main/kotlin/wisp/lease/Extensions.kt
@@ -26,3 +26,14 @@ fun LeaseManager.acquireOrNull(name: String, lazy: Boolean = false): AutoCloseab
   val lease = requestLease(name)
   return if (lease.acquire()) AutoCloseableLease(lease, lazy) else null
 }
+
+/**
+ * Attempts to acquire an [AutoCloseableLease] with [options].
+ *
+ * Optionally, the lease can be released lazily (if possible).
+ */
+@JvmOverloads
+fun LeaseManager.acquireOrNull(name: String, options: AcquireOptions, lazy: Boolean = false): AutoCloseableLease? {
+  val lease = requestLease(name)
+  return if (lease.acquire(options)) AutoCloseableLease(lease, lazy) else null
+}

--- a/wisp/wisp-lease/src/main/kotlin/wisp/lease/Lease.kt
+++ b/wisp/wisp-lease/src/main/kotlin/wisp/lease/Lease.kt
@@ -1,5 +1,31 @@
 package wisp.lease
 
+import java.time.Duration
+
+data class AcquireOptions
+@JvmOverloads
+constructor(
+  val wait: WaitMode = WaitMode.DoNotWait,
+  val unsupportedWaitBehavior: UnsupportedWaitBehavior = UnsupportedWaitBehavior.Fail,
+)
+
+enum class UnsupportedWaitBehavior {
+  Fail,
+  FallbackToNonBlocking,
+}
+
+sealed interface WaitMode {
+  data object DoNotWait : WaitMode
+
+  data object WaitForLeaseDuration : WaitMode
+
+  data class WaitUpTo(val timeout: Duration) : WaitMode {
+    init {
+      require(!timeout.isNegative) { "timeout must be non-negative" }
+    }
+  }
+}
+
 /**
  * A [Lease] is a cluster-wide, time-based lock on a given resource. Leases are retrieved via
  * [LeaseManager.requestLease].
@@ -47,6 +73,27 @@ interface Lease {
    * @return true if this process acquires the lease.
    */
   fun acquire(): Boolean
+
+  /**
+   * Attempts to acquire the lock on the lease with [options]. Implementations that do not support the requested options
+   * should fail rather than silently falling back to weaker acquire semantics, unless
+   * [AcquireOptions.unsupportedWaitBehavior] allows fallback.
+   *
+   * @return true if this process acquires the lease.
+   */
+  fun acquire(options: AcquireOptions): Boolean {
+    return when (options.wait) {
+      WaitMode.DoNotWait -> acquire()
+      WaitMode.WaitForLeaseDuration,
+      is WaitMode.WaitUpTo ->
+        when (options.unsupportedWaitBehavior) {
+          UnsupportedWaitBehavior.Fail ->
+            throw UnsupportedOperationException("Lease $name does not support waiting to acquire")
+
+          UnsupportedWaitBehavior.FallbackToNonBlocking -> acquire()
+        }
+    }
+  }
 
   /**
    * Release the lock on the lease. This will return true if released. Note that it will return false if the lease was


### PR DESCRIPTION
## Why
Expose a common way for lease callers to request stronger acquire behavior, such as blocking/waiting, while preserving the existing non-blocking `acquire()` API and source compatibility for existing lease implementations.

## What
- Add `AcquireOptions`, `WaitMode`, and `UnsupportedWaitBehavior` to Wisp leases
- Add `Lease.acquire(options)` with safe default behavior: no-wait delegates to `acquire()`, unsupported waits fail unless fallback is explicitly requested
- Add `LeaseManager.acquireOrNull(name, options, lazy)` for AutoCloseable lease acquisition with options
- Update fake, cluster-aware, and SQL lease implementations for the new options path
- Make SQL lease `acquire()` idempotent when `requestLease()` has already acquired the row
- Add SQL handling so unsupported waits release before throwing, while explicit fallback uses non-blocking acquisition
- Reject negative `WaitMode.WaitUpTo` durations

## Risk Assessment
Medium — this expands a public Wisp lease API and updates SQL lease edge-case behavior. Existing `acquire()` callers and existing source implementations remain compatible; unsupported wait behavior is fail-fast by default, and best-effort fallback requires an explicit opt-in.

## References
Validated locally:
- `bin/gradle :misk-lease-mysql:test --tests "misk.lease.mysql.SqlLeaseManagerTest" :misk-clustering:test --tests "misk.clustering.lease.ClusterAwareLeaseTest" :wisp:wisp-lease-testing:test --tests "wisp.lease.FakeLeaseManagerTest" --warn --console=plain --stacktrace --no-scan`
- `bin/gradle :wisp:wisp-lease:apiCheck :wisp:wisp-lease-testing:apiCheck :misk-clustering:apiCheck :misk-lease-mysql:apiCheck :wisp:wisp-lease:detektMain :wisp:wisp-lease-testing:detektMain :misk-clustering:detektMain :misk-lease-mysql:detektMain --warn --console=plain --stacktrace --no-scan`
- Commit hooks: `format`, `sadscan`

Generated with Amp
