### PR TITLE
Upgrade mysql-connector-j to 9.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -203,7 +203,7 @@ mockk = { module = "io.mockk:mockk", version = "1.14.5" }
 moshiAdapters = { module = "com.squareup.moshi:moshi-adapters", version = "1.15.2" }
 moshiCore = { module = "com.squareup.moshi:moshi", version = "1.15.2" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version = "1.15.2" }
-mysql = { module = "com.mysql:mysql-connector-j", version = "8.4.0" }
+mysql = { module = "com.mysql:mysql-connector-j", version = "9.7.0" }
 nettyBom = { module = "io.netty:netty-bom", version.ref = "netty" }
 nettyHandler = { module = "io.netty:netty-handler", version.ref = "netty" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }


### PR DESCRIPTION
## Why
Keep Misk's MySQL JDBC driver dependency current by upgrading `com.mysql:mysql-connector-j` to the latest release.

## What
- Bump `com.mysql:mysql-connector-j` from 8.4.0 to 9.7.0

## Risk Assessment
Medium — this updates a JDBC driver used by database-related modules and test tooling; focused compile and dependency resolution checks passed locally.

## References
- Maven Central latest/release version: 9.7.0
- Verified with focused Gradle compile tasks for direct MySQL connector consumers
- Verified `:misk-jooq:dependencyInsight --configuration jooqGenerator --dependency com.mysql:mysql-connector-j` resolves 9.7.0

Generated with Amp
