### PR TITLE
Fix cron log collector startup race

### DIFF
--- a/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
+++ b/misk-cron/src/test/kotlin/misk/cron/CronModuleTest.kt
@@ -14,6 +14,7 @@ import misk.inject.KAbstractModule
 import misk.inject.toKey
 import misk.logging.LogCollector
 import misk.logging.LogCollectorModule
+import misk.logging.LogCollectorService
 import misk.logging.getLogger
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -30,7 +31,7 @@ class CronModuleTest {
         install(FakeLeaseModule())
         install(MiskTestingServiceModule())
         install(LogCollectorModule())
-        install(ServiceModule<DependentService>().enhancedBy<ReadyService>())
+        install(ServiceModule<DependentService>().dependsOn<LogCollectorService>().enhancedBy<ReadyService>())
         install(FakeClusterWeightModule())
         install(
           CronModule(


### PR DESCRIPTION
## Why
`CronModuleTest.dependentServicesStartUpBeforeCron()` can miss the dependent service startup log if the log collector has not attached its appender yet. This makes the log-based ordering assertion flaky even when service startup ordering is correct.

## What
- Make the test-only `DependentService` depend on `LogCollectorService`
- Keep production cron service wiring unchanged

## Risk Assessment
Low — this only changes test service wiring for a single cron test to make its log capture deterministic.

## References
- Focused local test passed: `bin/gradle :misk-cron:test --tests "misk.cron.CronModuleTest.dependentServicesStartUpBeforeCron" --warn --console=plain --stacktrace --no-scan`

Generated with Amp
