### PR TITLE
Make misk-hibernate compatible with kotlin 2.3

### DIFF
--- a/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/ReflectionQueryFactory.kt
@@ -23,7 +23,6 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.full.allSupertypes
-import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
@@ -504,9 +503,12 @@ internal class ReflectionQuery<T : DbEntity<T>>(
 
     companion object {
       // Primitives are special. We have to ensure we are using the boxed types.
-      private val doubleType = Double::class.createType(nullable = true).typeLiteral().rawType
-      private val longType = Long::class.createType(nullable = true).typeLiteral().rawType
-      private val numberType = Number::class.createType(nullable = true).typeLiteral().rawType
+      // Kotlin 2.3 kotlin-reflect resolves `Long::class.createType(nullable = true).javaType`
+      // back to the primitive `long.class` instead of `java.lang.Long`, so we reference the
+      // boxed wrappers directly.
+      private val doubleType: Class<*> = java.lang.Double::class.java
+      private val longType: Class<*> = java.lang.Long::class.java
+      private val numberType: Class<*> = java.lang.Number::class.java
 
       private fun typeToString(type: Class<*>): String = "${type.simpleName}?"
 


### PR DESCRIPTION
## Description

This code was using a roundabout approach to get the class of the boxed wrappers, using a nullability flag that was effectively dropped on the final value (because the java Class doesn't store nullability information). The roundabout approach breaks in kotlin 2.3 and causes Long/long mismatches in downstream code. This PR uses a more direct approach to get the boxed wrapper type that is compatible with kotlin 2.3.

## Testing Strategy

Used a version of misk patched with this PR in downstream code to validate it works as intended with both kotlin 2.2 and kotlin 2.3. Without this patch, kotlin 2.3 consumers get errors like so:

```
  Caused by: java.lang.IllegalArgumentException: Query class com.example.service.allocations.LoanAllocationQuery has problems:
    com.example.service.allocations.AllocationTotalsNullable#count element type must be long? for COUNT aggregations, but was java.lang.Long
      at misk.hibernate.ReflectionQuery$Factory.queryMethodHandlers(ReflectionQueryFactory.kt:420)
      at misk.hibernate.ReflectionQuery$Factory.access$queryMethodHandlers(ReflectionQueryFactory.kt:377)
      at misk.hibernate.ReflectionQuery$Factory$queryMethodHandlersCache$1.load(ReflectionQueryFactory.kt:384)
      at misk.hibernate.ReflectionQuery$Factory$queryMethodHandlersCache$1.load(ReflectionQueryFactory.kt:383)
```