### PR TITLE
feat: support Kotlin data classes in MiskWebFormBuilder

### DIFF
--- a/misk-admin/src/test/kotlin/misk/web/metadata/MiskWebFormBuilderTest.kt
+++ b/misk-admin/src/test/kotlin/misk/web/metadata/MiskWebFormBuilderTest.kt
@@ -12,6 +12,36 @@ import misk.web.MiskWebFormBuilder.Field
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+enum class TestColor {
+  RED,
+  GREEN,
+  BLUE,
+}
+
+data class SimpleDataClass(val name: String, val age: Int, val score: Double, val active: Boolean, val count: Long)
+
+data class NestedInner(val value: String, val count: Int)
+
+data class NestedDataClass(val label: String, val inner: NestedInner)
+
+data class DataClassWithCollections(
+  val tags: List<String>,
+  val counts: List<Int>,
+  val metadata: Map<String, String>,
+  val nested: List<NestedInner>,
+)
+
+data class DataClassWithEnum(val name: String, val color: TestColor)
+
+data class DataClassWithNullables(
+  val required: String,
+  val optional: String?,
+  val maybeCount: Int?,
+  val maybeInner: NestedInner?,
+)
+
+class NotADataClass(val value: String)
+
 internal class MiskWebFormBuilderTest {
   private val miskWebFormBuilder = MiskWebFormBuilder { "https://$it" }
 
@@ -214,5 +244,85 @@ internal class MiskWebFormBuilderTest {
           annotations = listOf("@com.squareup.protos.test.kt.SemanticDataTypeOption({ACCOUNT_TOKEN})"),
         )
       )
+  }
+
+  @Test
+  fun `handles simple data class with primitive fields`() {
+    val types = miskWebFormBuilder.calculateTypes(SimpleDataClass::class.createType())
+
+    assertThat(types).hasSize(1)
+    assertThat(types).containsKey(SimpleDataClass::class.qualifiedName)
+
+    val fields = types[SimpleDataClass::class.qualifiedName]!!.fields
+    assertThat(fields).contains(Field("name", "String", false))
+    assertThat(fields).contains(Field("age", "Int", false))
+    assertThat(fields).contains(Field("score", "Double", false))
+    assertThat(fields).contains(Field("active", "Boolean", false))
+    assertThat(fields).contains(Field("count", "Long", false))
+
+    assertThat(types[SimpleDataClass::class.qualifiedName]!!.documentationUrl).isNull()
+  }
+
+  @Test
+  fun `handles nested data classes`() {
+    val types = miskWebFormBuilder.calculateTypes(NestedDataClass::class.createType())
+
+    assertThat(types).hasSize(2)
+    assertThat(types).containsKey(NestedDataClass::class.qualifiedName)
+    assertThat(types).containsKey(NestedInner::class.qualifiedName)
+
+    val outerFields = types[NestedDataClass::class.qualifiedName]!!.fields
+    assertThat(outerFields).contains(Field("label", "String", false))
+    assertThat(outerFields).contains(Field("inner", NestedInner::class.qualifiedName!!, false))
+
+    val innerFields = types[NestedInner::class.qualifiedName]!!.fields
+    assertThat(innerFields).contains(Field("value", "String", false))
+    assertThat(innerFields).contains(Field("count", "Int", false))
+  }
+
+  @Test
+  fun `handles data class with list and map fields`() {
+    val types = miskWebFormBuilder.calculateTypes(DataClassWithCollections::class.createType())
+
+    assertThat(types).hasSize(2)
+    assertThat(types).containsKey(DataClassWithCollections::class.qualifiedName)
+    assertThat(types).containsKey(NestedInner::class.qualifiedName)
+
+    val fields = types[DataClassWithCollections::class.qualifiedName]!!.fields
+    assertThat(fields).contains(Field("tags", "String", true))
+    assertThat(fields).contains(Field("counts", "Int", true))
+    assertThat(fields).contains(Field("metadata", "String", true))
+    assertThat(fields).contains(Field("nested", NestedInner::class.qualifiedName!!, true))
+  }
+
+  @Test
+  fun `handles data class with enum fields`() {
+    val types = miskWebFormBuilder.calculateTypes(DataClassWithEnum::class.createType())
+
+    assertThat(types).hasSize(1)
+
+    val fields = types[DataClassWithEnum::class.qualifiedName]!!.fields
+    assertThat(fields).contains(Field("name", "String", false))
+    assertThat(fields).contains(Field("color", "Enum<misk.web.metadata.TestColor,RED,GREEN,BLUE>", false))
+  }
+
+  @Test
+  fun `handles data class with nullable fields`() {
+    val types = miskWebFormBuilder.calculateTypes(DataClassWithNullables::class.createType())
+
+    assertThat(types).hasSize(2)
+    assertThat(types).containsKey(DataClassWithNullables::class.qualifiedName)
+    assertThat(types).containsKey(NestedInner::class.qualifiedName)
+
+    val fields = types[DataClassWithNullables::class.qualifiedName]!!.fields
+    assertThat(fields).contains(Field("required", "String", false))
+    assertThat(fields).contains(Field("optional", "String", false))
+    assertThat(fields).contains(Field("maybeCount", "Int", false))
+    assertThat(fields).contains(Field("maybeInner", NestedInner::class.qualifiedName!!, false))
+  }
+
+  @Test
+  fun `non-data-class non-wire types still return empty`() {
+    assertThat(miskWebFormBuilder.calculateTypes(NotADataClass::class.createType())).isEmpty()
   }
 }

--- a/misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaField
 import okio.ByteString
@@ -35,6 +36,9 @@ constructor(private val documentationProvider: ProtoDocumentationProvider? = nul
 
     val requestClass = requestType.classifier as KClass<*>
     if (Message::class !in requestClass.superclasses) {
+      if (requestClass.isData) {
+        return calculateDataClassTypes(requestClass)
+      }
       return mapOf()
     }
 
@@ -111,6 +115,73 @@ constructor(private val documentationProvider: ProtoDocumentationProvider? = nul
           )
         )
         stack.push(fieldClass.kotlin)
+      }
+    }
+  }
+
+  private fun calculateDataClassTypes(rootClass: KClass<*>): Map<String, Type> {
+    val typesMap = mutableMapOf<String, Type>()
+    val stack = LinkedList<KClass<*>>()
+    stack.push(rootClass)
+
+    while (stack.isNotEmpty()) {
+      val clazz = stack.pop()
+
+      if (typesMap.containsKey(clazz.java.canonicalName!!)) {
+        continue
+      }
+
+      val fields = mutableListOf<Field>()
+      val constructor = clazz.primaryConstructor
+
+      if (constructor != null) {
+        for (param in constructor.parameters) {
+          val paramName = param.name ?: continue
+          handleDataClassField(fieldType = param.type, fieldName = paramName, fields = fields, stack = stack)
+        }
+      }
+
+      typesMap[clazz.java.canonicalName!!] = Type(fields.toList())
+    }
+
+    return typesMap
+  }
+
+  private fun handleDataClassField(
+    fieldType: KType,
+    fieldName: String,
+    fields: MutableList<Field>,
+    stack: LinkedList<KClass<*>>,
+    repeated: Boolean = false,
+  ) {
+    val classifier = fieldType.classifier as? KClass<*> ?: return
+
+    when {
+      classifier == String::class -> fields.add(Field(fieldName, "String", repeated))
+      classifier == ByteString::class -> fields.add(Field(fieldName, "ByteString", repeated))
+      classifier == Char::class -> fields.add(Field(fieldName, "Char", repeated))
+      classifier == Byte::class -> fields.add(Field(fieldName, "Byte", repeated))
+      classifier == Short::class -> fields.add(Field(fieldName, "Short", repeated))
+      classifier == Int::class -> fields.add(Field(fieldName, "Int", repeated))
+      classifier == Long::class -> fields.add(Field(fieldName, "Long", repeated))
+      classifier == Float::class -> fields.add(Field(fieldName, "Float", repeated))
+      classifier == Double::class -> fields.add(Field(fieldName, "Double", repeated))
+      classifier == Boolean::class -> fields.add(Field(fieldName, "Boolean", repeated))
+      classifier == Instant::class -> fields.add(Field(fieldName, "Instant", repeated))
+      classifier == Duration::class -> fields.add(Field(fieldName, "Duration", repeated))
+      classifier == LocalDate::class -> fields.add(Field(fieldName, "LocalDate", repeated))
+      classifier.java.isEnum -> fields.add(createEnumField(classifier.java, fieldName, repeated))
+      classifier.isSubclassOf(List::class) -> {
+        val elementType = fieldType.arguments.firstOrNull()?.type ?: return
+        handleDataClassField(elementType, fieldName, fields, stack, true)
+      }
+      classifier.isSubclassOf(Map::class) -> {
+        val valueType = fieldType.arguments.getOrNull(1)?.type ?: return
+        handleDataClassField(valueType, fieldName, fields, stack, true)
+      }
+      classifier.isData -> {
+        fields.add(Field(fieldName, classifier.java.canonicalName!!, repeated))
+        stack.push(classifier)
       }
     }
   }


### PR DESCRIPTION
## feat: support Kotlin data classes in MiskWebFormBuilder

### Summary

Extends `MiskWebFormBuilder.calculateTypes()` to introspect Kotlin data class request types, not just Wire proto `Message` subclasses. Previously, the Web Actions admin dashboard tab only pre-populated request JSON fields for actions whose request type extended `com.squareup.wire.Message` — actions with Kotlin data class request types got an empty `types` map and the UI showed no form fields.

### What changed

**`misk/src/main/kotlin/misk/web/MiskWebFormBuilder.kt`**

- After the existing Wire `Message` check, added a branch for `requestClass.isData` that delegates to a new `calculateDataClassTypes()` method
- `calculateDataClassTypes()` mirrors the existing stack-based traversal pattern: it walks the type graph starting from the root class, using each data class's primary constructor parameters to discover fields
- `handleDataClassField()` maps Kotlin types to the same primitive type names the frontend already understands:
  - Primitives: `String`, `Int`, `Long`, `Double`, `Float`, `Boolean`, `Byte`, `Short`, `Char`
  - Binary: `ByteString`
  - Temporal: `Instant`, `Duration`, `LocalDate`
  - Enums: reuses the existing `createEnumField` helper to produce `Enum<qualified.Name,VALUE1,VALUE2>` format
  - `List<T>`: unwraps element type and marks field as `repeated`
  - `Map<K, V>`: unwraps value type and marks field as `repeated` (same as Wire map handling)
  - Nested data classes: adds field with canonical class name and pushes onto the traversal stack
  - Nullable types: handled transparently — `KType.classifier` already strips nullability

**`misk-admin/src/test/kotlin/misk/web/metadata/MiskWebFormBuilderTest.kt`**

Added 6 new test cases:
- Simple data class with primitive fields (`String`, `Int`, `Double`, `Boolean`, `Long`)
- Nested data classes (verifies recursive type discovery)
- Data class with `List` and `Map` fields (verifies repeated field handling)
- Data class with enum fields (verifies `Enum<...>` type string)
- Data class with nullable fields (verifies nullable types are treated as their non-null counterparts)
- Non-data-class, non-Wire type still returns empty map (existing behavior preserved)

### What didn't change

- All existing Wire proto handling is untouched — the data class branch only triggers when the request type is *not* a `Message` subclass
- The `Type` and `Field` data classes are unchanged
- The frontend consumes the same `Map<String, Type>` structure, so no UI changes are needed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>