### PR TITLE
Use latest dot release for jetty 11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -135,7 +135,7 @@ jerseyBom = { module = "org.glassfish.jersey:jersey-bom", version = "3.1.11" }
 jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "26.0.2-1" }
 jettyAlpnServer = { module = "org.eclipse.jetty:jetty-alpn-server" }
 jettyAlpnServerJava = { module = "org.eclipse.jetty:jetty-alpn-java-server" }
-jettyBom = { module = "org.eclipse.jetty:jetty-bom", version = "11.0.25" }
+jettyBom = { module = "org.eclipse.jetty:jetty-bom", version = "11.0.26" }
 jettyHttp = { module = "org.eclipse.jetty:jetty-http" }
 jettyHttp2 = { module = "org.eclipse.jetty.http2:http2-server" }
 jettyHttp2Common = { module = "org.eclipse.jetty.http2:http2-common" }


### PR DESCRIPTION
Follow-up to #3830, I didn't actually verify my agent's conception of what the latest version was