### PR TITLE
Bump micrometer to 1.17.0 via prometheus-simpleclient

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlinBinaryCompatibilityPlugin = "0.18.1"
 ktor = "3.3.0"
 mavenPublish = "0.34.0"
 mcp = "0.13.0"
-micrometer = "1.12.13"
+micrometer = "1.17.0"
 netty = "4.2.14.Final"
 okHttp = "5.4.0"
 okio = "3.16.4"
@@ -196,7 +196,7 @@ mcpKotlinSdkClient = { module = "io.modelcontextprotocol:kotlin-sdk-client", ver
 mcpKotlinSdkCore = { module = "io.modelcontextprotocol:kotlin-sdk-core", version.ref = "mcp" }
 mcpKotlinSdkServer = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcp" }
 micrometerCore = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
-micrometerRegistryPrometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+micrometerRegistryPrometheus = { module = "io.micrometer:micrometer-registry-prometheus-simpleclient", version.ref = "micrometer" }
 mockitoCore = { module = "org.mockito:mockito-core", version = "5.21.0" }
 mockitoKotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "6.0.0" }
 mockk = { module = "io.mockk:mockk", version = "1.14.5" }


### PR DESCRIPTION
Micrometer 1.13 moved the default registry artifact to Prometheus Java client 1.x (package io.micrometer.prometheusmetrics). Misk still uses io.prometheus.client (0.x) APIs heavily, so keep the 0.x-compatible registry by pointing micrometerRegistryPrometheus at micrometer-registry-prometheus-simpleclient — it ships at the same version and preserves the io.micrometer.prometheus package.

No source changes required: full build passes against 1.17.0.