### PR TITLE
Add transaction_isolation to DataSourceConfig

### DIFF
--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -248,7 +248,8 @@ public final class misk/jdbc/DataSourceConfig {
 	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;)V
 	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;Z)V
 	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;)V
-	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;Lmisk/jdbc/TransactionIsolationLevel;)V
+	public synthetic fun <init> (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;Lmisk/jdbc/TransactionIsolationLevel;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asReplica ()Lmisk/jdbc/DataSourceConfig;
 	public final fun buildJdbcUrl (Lwisp/deployment/Deployment;)Ljava/lang/String;
 	public final fun canRecoverOnReplica ()Z
@@ -283,14 +284,15 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun component35 ()Lmisk/jdbc/DeclarativeSchemaConfig;
 	public final fun component36 ()Z
 	public final fun component37 ()Ljava/lang/String;
+	public final fun component38 ()Lmisk/jdbc/TransactionIsolationLevel;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()I
 	public final fun component8 ()Ljava/time/Duration;
 	public final fun component9 ()Ljava/time/Duration;
-	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;)Lmisk/jdbc/DataSourceConfig;
-	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;IILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
+	public final fun copy (Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/DataSourceConfig;
+	public static synthetic fun copy$default (Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DataSourceType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZZLjava/util/Map;ZLmisk/jdbc/MigrationsFormat;Lmisk/jdbc/DeclarativeSchemaConfig;ZLjava/lang/String;Lmisk/jdbc/TransactionIsolationLevel;IILjava/lang/Object;)Lmisk/jdbc/DataSourceConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllow_public_key_retrieval ()Z
 	public final fun getClient_certificate_key_store_password ()Ljava/lang/String;
@@ -322,6 +324,7 @@ public final class misk/jdbc/DataSourceConfig {
 	public final fun getPort ()Ljava/lang/Integer;
 	public final fun getQuery_timeout ()Ljava/time/Duration;
 	public final fun getShow_sql ()Ljava/lang/String;
+	public final fun getTransaction_isolation ()Lmisk/jdbc/TransactionIsolationLevel;
 	public final fun getTrust_certificate_key_store_password ()Ljava/lang/String;
 	public final fun getTrust_certificate_key_store_path ()Ljava/lang/String;
 	public final fun getTrust_certificate_key_store_url ()Ljava/lang/String;
@@ -696,6 +699,17 @@ public abstract interface class misk/jdbc/Transacter {
 	public abstract fun retries (I)Lmisk/jdbc/Transacter;
 	public abstract fun transaction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun transactionWithSession (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class misk/jdbc/TransactionIsolationLevel : java/lang/Enum {
+	public static final field READ_COMMITTED Lmisk/jdbc/TransactionIsolationLevel;
+	public static final field READ_UNCOMMITTED Lmisk/jdbc/TransactionIsolationLevel;
+	public static final field REPEATABLE_READ Lmisk/jdbc/TransactionIsolationLevel;
+	public static final field SERIALIZABLE Lmisk/jdbc/TransactionIsolationLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getHikariValueName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/TransactionIsolationLevel;
+	public static fun values ()[Lmisk/jdbc/TransactionIsolationLevel;
 }
 
 public final class misk/jdbc/TruncateTablesService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -54,6 +54,20 @@ enum class MigrationsFormat {
   EXTERNALLY_MANAGED,
 }
 
+/**
+ * Session transaction isolation level applied to every connection in a datasource's pool.
+ *
+ * When configured, HikariCP applies the level as each connection is created and converges any connection whose
+ * isolation was changed at runtime back to this level when it is returned to the pool. When unset, connections use
+ * the database server's default (for MySQL, `REPEATABLE READ` unless overridden server-side).
+ */
+enum class TransactionIsolationLevel(val hikariValueName: String) {
+  READ_UNCOMMITTED("TRANSACTION_READ_UNCOMMITTED"),
+  READ_COMMITTED("TRANSACTION_READ_COMMITTED"),
+  REPEATABLE_READ("TRANSACTION_REPEATABLE_READ"),
+  SERIALIZABLE("TRANSACTION_SERIALIZABLE"),
+}
+
 /** Configuration element for an individual datasource */
 data class DataSourceConfig
 @JvmOverloads
@@ -127,6 +141,11 @@ constructor(
   val declarative_schema_config: DeclarativeSchemaConfig? = null,
   val mysql_use_aws_secret_for_credentials: Boolean = false,
   val mysql_aws_secret_name: String? = null,
+  /**
+   * Session transaction isolation level for every connection in the pool. When unset, connections use the database
+   * server's default. See [TransactionIsolationLevel].
+   */
+  val transaction_isolation: TransactionIsolationLevel? = null,
 ) {
   init {
     if (migrations_format == MigrationsFormat.DECLARATIVE) {
@@ -370,6 +389,7 @@ constructor(
       this.show_sql,
       this.generate_hibernate_stats,
       migrations_format = this.migrations_format,
+      transaction_isolation = this.transaction_isolation,
     )
   }
 

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -93,6 +93,12 @@ constructor(
       hikariConfig.isAutoCommit = false
     }
 
+    config.transaction_isolation?.let {
+      // Hikari applies this level as each connection is created, and resets any connection whose isolation was
+      // changed at runtime back to this level when it is returned to the pool.
+      hikariConfig.transactionIsolation = it.hikariValueName
+    }
+
     if (
       config.type == DataSourceType.MYSQL ||
         config.type == DataSourceType.VITESS_MYSQL ||

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
@@ -1,0 +1,83 @@
+package misk.jdbc
+
+import com.google.inject.util.Modules
+import jakarta.inject.Inject
+import java.sql.Connection
+import misk.MiskTestingServiceModule
+import misk.config.Config
+import misk.config.MiskConfig
+import misk.environment.DeploymentModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.testing.MockTracingBackendModule
+import misk.time.FakeClockModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import wisp.deployment.TESTING
+
+@MiskTest(startService = true)
+class DataSourceTransactionIsolationTest {
+  @MiskTestModule val module = TransactionIsolationTestModule(appName = "test_transaction_isolation")
+
+  @Inject @Movies lateinit var readCommittedTransacter: Transacter
+  @Inject @Movies2 lateinit var defaultTransacter: Transacter
+
+  @Test
+  fun `connections use the configured transaction isolation`() {
+    readCommittedTransacter.transactionWithSession { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
+    }
+  }
+
+  @Test
+  fun `connections use the server default when no isolation is configured`() {
+    defaultTransacter.transactionWithSession { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("REPEATABLE-READ")
+    }
+  }
+
+  @Test
+  fun `connections whose isolation was changed at runtime are reset to the configured level on checkin`() {
+    // The read-committed pool is configured with a single connection, so the connection dirtied here is
+    // deterministically the one every subsequent transaction checks out.
+    readCommittedTransacter.transactionWithSession { (connection) ->
+      connection.transactionIsolation = Connection.TRANSACTION_REPEATABLE_READ
+      assertThat(serverSessionIsolation(connection)).isEqualTo("REPEATABLE-READ")
+    }
+
+    readCommittedTransacter.transactionWithSession { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
+    }
+  }
+
+  private fun serverSessionIsolation(connection: Connection): String =
+    connection.createStatement().use { statement ->
+      statement.executeQuery("SELECT @@transaction_isolation").use { resultSet ->
+        resultSet.next()
+        resultSet.getString(1)
+      }
+    }
+
+  data class RootConfig(
+    val default_isolation_data_source: DataSourceConfig,
+    val read_committed_data_source: DataSourceConfig,
+  ) : Config
+
+  class TransactionIsolationTestModule(private val appName: String) : KAbstractModule() {
+    override fun configure() {
+      install(Modules.override(MiskTestingServiceModule()).with(FakeClockModule(), MockTracingBackendModule()))
+      install(DeploymentModule(TESTING))
+      val config = MiskConfig.load<RootConfig>(appName, TESTING)
+
+      install(JdbcTestingModule(Movies::class))
+      install(JdbcModule(Movies::class, config.read_committed_data_source))
+
+      install(JdbcTestingModule(Movies2::class))
+      install(JdbcModule(Movies2::class, config.default_isolation_data_source))
+    }
+  }
+}

--- a/misk-jdbc/src/test/resources/test_transaction_isolation-common.yaml
+++ b/misk-jdbc/src/test/resources/test_transaction_isolation-common.yaml
@@ -1,0 +1,16 @@
+default_isolation_data_source:
+  type: MYSQL
+  database: movies_mysql
+  username: root
+  password: ""
+  migrations_resource: classpath:/misk/jdbc/test_transacter-mysql-migrations
+
+read_committed_data_source:
+  type: MYSQL
+  database: movies_mysql
+  username: root
+  password: ""
+  migrations_resource: classpath:/misk/jdbc/test_transacter-mysql-migrations
+  use_fixed_pool_size: true
+  fixed_pool_size: 1
+  transaction_isolation: READ_COMMITTED


### PR DESCRIPTION
## What

Adds a first-class `transaction_isolation` field to `DataSourceConfig`, mapped to HikariCP's `transactionIsolation`:

```yaml
data_source:
  type: MYSQL
  ...
  transaction_isolation: READ_COMMITTED   # READ_UNCOMMITTED | READ_COMMITTED | REPEATABLE_READ | SERIALIZABLE
```

When configured, Hikari applies the level as each connection is created and **converges any connection whose isolation was changed at runtime back to the configured level when it returns to the pool**. When unset, behavior is unchanged: connections use the database server's default.

## Why

Infrastructure components that poll shared tables — concretely, transactional-outbox forwarders — can need `READ COMMITTED` to avoid REPEATABLE READ's gap locks on index ranges where application writers insert (an empty-range locking read under RR gap-locks exactly the insertion point of the range it scanned, and frequent polling starves writers' insert intention locks; we traced a production incident at Cash App to this).

Today a service has only two options, both bad:

- **Mutate session state per call** (`SET SESSION TRANSACTION ISOLATION LEVEL ...` around the operation): fragile — a mid-transaction `SET` doesn't affect the in-flight transaction, a failed reset leaks the override into a pool shared with application transactions, and the "previous value" read from a pooled connection has no provenance (it may itself be a leak).
- **Smuggle `sessionVariables=transaction_isolation=...` through `jdbc_url_query_parameters`**: driver-specific, invisible to Hikari's connection-state tracking, and not validated.

A declared pool-level isolation is explicit, reviewable, and self-healing — Hikari itself becomes the enforcement point, which is strictly stronger than any application-level set/reset discipline.

## Testing

New `DataSourceTransactionIsolationTest`, run against real MySQL:

- a configured pool's connections report the level both via `Connection.getTransactionIsolation` and `SELECT @@transaction_isolation`
- an unconfigured pool keeps the server default (REPEATABLE-READ)
- a connection deliberately dirtied at runtime (`setTransactionIsolation(REPEATABLE_READ)` inside one transaction, single-connection pool for determinism) is reset to the configured level on the next checkout

Also: `:misk-jdbc:test` green, `:misk-jdbc:apiDump` updated, `:misk-jdbc:apiCheck` green.

`asReplica()` carries the new field, so Vitess replica configs inherit the writer's configured isolation.
