### PR TITLE
Add DateAdapter to defaultMoshiAdapters

### DIFF
--- a/misk-moshi/api/misk-moshi.api
+++ b/misk-moshi/api/misk-moshi.api
@@ -33,6 +33,11 @@ public final class misk/moshi/okio/ByteStringAdapter {
 	public final fun toJson (Lokio/ByteString;)Ljava/lang/String;
 }
 
+public final class misk/moshi/time/DateAdapter : com/squareup/moshi/JsonAdapter$Factory {
+	public static final field INSTANCE Lmisk/moshi/time/DateAdapter;
+	public fun create (Ljava/lang/reflect/Type;Ljava/util/Set;Lcom/squareup/moshi/Moshi;)Lcom/squareup/moshi/JsonAdapter;
+}
+
 public final class misk/moshi/time/DurationAdapter {
 	public static final field INSTANCE Lmisk/moshi/time/DurationAdapter;
 	public final fun fromJson (Ljava/lang/String;)Ljava/time/Duration;

--- a/misk-moshi/src/main/kotlin/misk/moshi/MoshiModule.kt
+++ b/misk-moshi/src/main/kotlin/misk/moshi/MoshiModule.kt
@@ -2,13 +2,12 @@ package misk.moshi
 
 import com.google.inject.Provides
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.squareup.wire.WireJsonAdapterFactory as WireOnlyJsonAdapterFactory
 import jakarta.inject.Singleton
-import java.util.Date
 import misk.inject.KAbstractModule
 import misk.moshi.adapters.BigDecimalAdapter
 import misk.moshi.okio.ByteStringAdapter
+import misk.moshi.time.DateAdapter
 import misk.moshi.time.InstantAdapter
 import misk.moshi.time.LocalDateAdapter
 import misk.moshi.time.OffsetDateTimeAdapter
@@ -37,7 +36,6 @@ constructor(private val useWireToRead: Boolean = false, private val useWireToWri
       )
     )
 
-    install(MoshiAdapterModule<Date>(Rfc3339DateJsonAdapter()))
     defaultMoshiAdapters.forEach { install(MoshiAdapterModule(it)) }
   }
 
@@ -54,6 +52,7 @@ constructor(private val useWireToRead: Boolean = false, private val useWireToWri
     val defaultMoshiAdapters =
       listOf(
         ByteStringAdapter,
+        DateAdapter,
         InstantAdapter,
         BigDecimalAdapter,
         LocalDateAdapter,

--- a/misk-moshi/src/main/kotlin/misk/moshi/time/DateAdapter.kt
+++ b/misk-moshi/src/main/kotlin/misk/moshi/time/DateAdapter.kt
@@ -1,0 +1,16 @@
+package misk.moshi.time
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import java.lang.reflect.Type
+import java.util.Date
+
+object DateAdapter : JsonAdapter.Factory {
+  private val delegate = Rfc3339DateJsonAdapter()
+
+  override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
+    return if (Types.equals(type, Date::class.java)) delegate else null
+  }
+}

--- a/misk-moshi/src/test/kotlin/misk/moshi/BuiltInAdaptersTest.kt
+++ b/misk-moshi/src/test/kotlin/misk/moshi/BuiltInAdaptersTest.kt
@@ -3,6 +3,7 @@ package misk.moshi
 import com.squareup.moshi.Moshi
 import jakarta.inject.Inject
 import java.time.Instant
+import java.util.Date
 import misk.MiskTestingServiceModule
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -10,6 +11,7 @@ import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import wisp.moshi.buildMoshi
 
 @MiskTest(startService = false)
 internal class BuiltInAdaptersTest {
@@ -58,6 +60,21 @@ internal class BuiltInAdaptersTest {
     val value = Instant.ofEpochMilli(0L)
     assertThat(jsonAdapter.toJson(value)).isEqualTo(json)
     assertThat(jsonAdapter.fromJson(json)).isEqualTo(value)
+  }
+
+  @Test
+  fun defaultMoshiAdaptersIncludeDateAdapterRequiredByInstantAdapter() {
+    val moshi = buildMoshi(MoshiModule.defaultMoshiAdapters)
+
+    val dateAdapter = moshi.adapter<Date>()
+    assertThat(dateAdapter.toJson(Date.from(Instant.ofEpochMilli(0L))))
+      .isEqualTo("\"1970-01-01T00:00:00.000Z\"")
+
+    val instantAdapter = moshi.adapter<Instant>()
+    val json = "\"1970-01-01T00:00:00.000Z\""
+    val value = Instant.ofEpochMilli(0L)
+    assertThat(instantAdapter.toJson(value)).isEqualTo(json)
+    assertThat(instantAdapter.fromJson(json)).isEqualTo(value)
   }
 
   @Test


### PR DESCRIPTION
InstantAdapter serialises via java.util.Date internally, but MoshiModule.defaultMoshiAdapters doesn't provide an adapter for java.util.Date. This fixes that by adding an adapter.