### PR TITLE
Define ActionScope.Instance.withOverrides

### DIFF
--- a/misk-action-scopes/api/misk-action-scopes.api
+++ b/misk-action-scopes/api/misk-action-scopes.api
@@ -38,6 +38,10 @@ public final class misk/scope/ActionScope$Instance : java/lang/AutoCloseable {
 	public fun close ()V
 	public final fun enter ()V
 	public final fun inScope (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun withOverrides ()Lmisk/scope/ActionScope$Instance;
+	public final fun withOverrides (Ljava/util/Map;)Lmisk/scope/ActionScope$Instance;
+	public final fun withOverrides (Ljava/util/Map;Ljava/util/Map;)Lmisk/scope/ActionScope$Instance;
+	public static synthetic fun withOverrides$default (Lmisk/scope/ActionScope$Instance;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lmisk/scope/ActionScope$Instance;
 }
 
 public abstract interface class misk/scope/ActionScopeListener {

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -89,7 +89,9 @@ internal constructor(
 
     val immediateValues = seedData.mapValues { (_, value) -> ImmediateLazy(value) }
 
-    val lazyValues = providers.mapValues { (key, _) -> SynchronizedLazy(providerFor(key)) }
+    val lazyValues = providers.mapValues { (key, _) ->
+      SynchronizedLazy(providerFor(key)) { providerFor(key) }
+    }
 
     val lazyOverrides = providerOverrides.mapValues { (_, provider) -> SynchronizedLazy(provider) }
 

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -210,18 +210,23 @@ internal constructor(
 
     /**
      * Returns a new [Instance] derived from this one with additional seed data and/or provider
-     * overrides layered on top. Already-initialized lazy values from this instance are preserved;
-     * entries in [seedData] and [providerOverrides] override matching keys. [seedData] takes
-     * precedence over [providerOverrides], matching the merge order of [ActionScope.create].
+     * overrides layered on top. Already-initialized lazy values from this instance are preserved
+     * and propagate to the returned instance; uncomputed lazy cells are copied so that computing
+     * them in the returned instance does not write back into this one. Entries in [seedData] and
+     * [providerOverrides] override matching keys, with [seedData] taking precedence over
+     * [providerOverrides], matching the merge order of [ActionScope.create].
      */
     @JvmOverloads
     fun withOverrides(
       seedData: Map<Key<*>, Any?> = emptyMap(),
       providerOverrides: Map<Key<*>, ActionScopedProvider<*>> = emptyMap(),
     ): Instance {
+      val isolatedLazyValues = lazyValues.mapValues { (_, lazy) ->
+        if (lazy is SynchronizedLazy && !lazy.isInitialized()) lazy.copy() else lazy
+      }
       val immediateValues = seedData.mapValues { (_, value) -> ImmediateLazy(value) }
       val lazyOverrides = providerOverrides.mapValues { (_, provider) -> SynchronizedLazy(provider) }
-      return Instance(lazyValues + lazyOverrides + immediateValues, scope)
+      return Instance(isolatedLazyValues + lazyOverrides + immediateValues, scope)
     }
   }
 

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -224,7 +224,7 @@ internal constructor(
       providerOverrides: Map<Key<*>, ActionScopedProvider<*>> = emptyMap(),
     ): Instance {
       val isolatedLazyValues = lazyValues.mapValues { (_, lazy) ->
-        if (lazy is SynchronizedLazy && !lazy.isInitialized()) lazy.copy() else lazy
+        if (lazy is SynchronizedLazy && !lazy.isInitialized()) { lazy.copy() } else { lazy }
       }
       val immediateValues = seedData.mapValues { (_, value) -> ImmediateLazy(value) }
       val lazyOverrides = providerOverrides.mapValues { (_, provider) -> SynchronizedLazy(provider) }

--- a/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/ActionScope.kt
@@ -207,6 +207,22 @@ internal constructor(
     fun enter() {
       scope.enter(this)
     }
+
+    /**
+     * Returns a new [Instance] derived from this one with additional seed data and/or provider
+     * overrides layered on top. Already-initialized lazy values from this instance are preserved;
+     * entries in [seedData] and [providerOverrides] override matching keys. [seedData] takes
+     * precedence over [providerOverrides], matching the merge order of [ActionScope.create].
+     */
+    @JvmOverloads
+    fun withOverrides(
+      seedData: Map<Key<*>, Any?> = emptyMap(),
+      providerOverrides: Map<Key<*>, ActionScopedProvider<*>> = emptyMap(),
+    ): Instance {
+      val immediateValues = seedData.mapValues { (_, value) -> ImmediateLazy(value) }
+      val lazyOverrides = providerOverrides.mapValues { (_, provider) -> SynchronizedLazy(provider) }
+      return Instance(lazyValues + lazyOverrides + immediateValues, scope)
+    }
   }
 
   private class WrappedKFunction<T>(

--- a/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
@@ -30,4 +30,6 @@ internal class SynchronizedLazy(private val provider: ActionScopedProvider<*>) :
   override fun isInitialized(): Boolean {
     return _value != UNINITIALIZED_VALUE
   }
+
+  internal fun copy(): SynchronizedLazy = SynchronizedLazy(provider)
 }

--- a/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
+++ b/misk-action-scopes/src/main/kotlin/misk/scope/SynchronizedLazy.kt
@@ -5,7 +5,10 @@ import kotlin.concurrent.withLock
 
 private object UNINITIALIZED_VALUE
 
-internal class SynchronizedLazy(private val provider: ActionScopedProvider<*>) : Lazy<Any?> {
+internal class SynchronizedLazy(
+  private val provider: ActionScopedProvider<*>,
+  private val providerFactory: () -> ActionScopedProvider<*> = { provider },
+) : Lazy<Any?> {
   @Volatile private var _value: Any? = UNINITIALIZED_VALUE
 
   private val lock = ReentrantLock()
@@ -31,5 +34,5 @@ internal class SynchronizedLazy(private val provider: ActionScopedProvider<*>) :
     return _value != UNINITIALIZED_VALUE
   }
 
-  internal fun copy(): SynchronizedLazy = SynchronizedLazy(provider)
+  internal fun copy(): SynchronizedLazy = SynchronizedLazy(providerFactory(), providerFactory)
 }

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -357,6 +357,35 @@ internal class ActionScopedTest {
   }
 
   @Test
+  fun `withOverrides does not write back into the receiver when child computes first`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val parent = scope.create(mapOf(keyOf<String>(Names.named("from-seed")) to "parent"))
+    val child = parent.withOverrides(
+      seedData = mapOf(keyOf<String>(Names.named("from-seed")) to "child"),
+    )
+
+    child.inScope { assertThat(foo.get()).isEqualTo("child and bar and foo!") }
+    parent.inScope { assertThat(foo.get()).isEqualTo("parent and bar and foo!") }
+  }
+
+  @Test
+  fun `withOverrides propagates already-computed values from the receiver`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val parent = scope.create(mapOf(keyOf<String>(Names.named("from-seed")) to "parent"))
+    parent.inScope { assertThat(foo.get()).isEqualTo("parent and bar and foo!") }
+
+    val child = parent.withOverrides(
+      seedData = mapOf(keyOf<String>(Names.named("from-seed")) to "child"),
+    )
+
+    child.inScope { assertThat(foo.get()).isEqualTo("parent and bar and foo!") }
+  }
+
+  @Test
   fun `withOverrides seed data takes precedence over provider overrides`() {
     val injector = Guice.createInjector(TestActionScopedProviderModule())
     injector.injectMembers(this)

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -404,4 +404,16 @@ internal class ActionScopedTest {
       )
       .inScope { assertThat(foo.get()).isEqualTo("from-seed-direct and bar and foo!") }
   }
+
+  @Test
+  fun `withOverrides gives uncomputed providers independent state from the receiver`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val parent = scope.create(emptyMap())
+    val child = parent.withOverrides()
+
+    child.inScope { assertThat(countingString.get()).isEqualTo("Called CountingProvider 1 time(s)") }
+    parent.inScope { assertThat(countingString.get()).isEqualTo("Called CountingProvider 1 time(s)") }
+  }
 }

--- a/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
+++ b/misk-action-scopes/src/test/kotlin/misk/scope/ActionScopedTest.kt
@@ -314,4 +314,65 @@ internal class ActionScopedTest {
     // Make sure that closing the scope when it isn't open doesn't call the listeners which would throw the exception
     scope.close()
   }
+
+  @Test
+  fun `withOverrides replaces seed data`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(keyOf<String>(Names.named("from-seed")) to "seed-value")
+
+    scope.create(seedData)
+      .withOverrides(seedData = mapOf(keyOf<String>(Names.named("from-seed")) to "overridden-seed"))
+      .inScope { assertThat(foo.get()).isEqualTo("overridden-seed and bar and foo!") }
+  }
+
+  @Test
+  fun `withOverrides replaces a provider`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(keyOf<String>(Names.named("from-seed")) to "seed-value")
+
+    val providerOverride =
+      object : ActionScopedProvider<String> {
+        override fun get(): String = "overridden-bar"
+      }
+
+    scope.create(seedData)
+      .withOverrides(providerOverrides = mapOf(keyOf<String>(Names.named("bar")) to providerOverride))
+      .inScope { assertThat(foo.get()).isEqualTo("overridden-bar and foo!") }
+  }
+
+  @Test
+  fun `withOverrides with no arguments preserves the original instance values`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(keyOf<String>(Names.named("from-seed")) to "seed-value")
+
+    scope.create(seedData)
+      .withOverrides()
+      .inScope { assertThat(foo.get()).isEqualTo("seed-value and bar and foo!") }
+  }
+
+  @Test
+  fun `withOverrides seed data takes precedence over provider overrides`() {
+    val injector = Guice.createInjector(TestActionScopedProviderModule())
+    injector.injectMembers(this)
+
+    val seedData: Map<Key<*>, Any> = mapOf(keyOf<String>(Names.named("from-seed")) to "initial-seed")
+
+    val seedKeyProviderOverride =
+      object : ActionScopedProvider<String> {
+        override fun get(): String = "from-provider"
+      }
+
+    scope.create(seedData)
+      .withOverrides(
+        seedData = mapOf(keyOf<String>(Names.named("from-seed")) to "from-seed-direct"),
+        providerOverrides = mapOf(keyOf<String>(Names.named("from-seed")) to seedKeyProviderOverride),
+      )
+      .inScope { assertThat(foo.get()).isEqualTo("from-seed-direct and bar and foo!") }
+  }
 }


### PR DESCRIPTION
## Description

Overriding a few key values in an action scope is a pattern we use in several places within Faire, and it'd be a substantial migration to update all the different use cases.

https://github.com/cashapp/misk/pull/3691 removed the deprecated `snapshotActionScope()` and `asImmediateValues()` methods, which together enabled the `actionScope.create(actionScope.snapshotActionScope() + overrides).inScope(block)` mechanism we used for this. The new `Instance`-based API doesn't offer an alternative approach right now

This PR adds `ActionScope.Instance.withOverrides(seedData, providerOverrides)`, which returns a new `Instance` derived from the receiver with the given overrides layered on. Merge order matches `ActionScope.create()`: existing lazy values < provider overrides < seed data. Already-initialized lazy values from the source instance are preserved, so calling
`withOverrides` on a mid-flight snapshot does not re-compute providers that have already run.

Usage:

```kotlin
actionScope.snapshotActionScopeInstance().withOverrides(seedData).inScope(block)
```

## Testing Strategy

Added four unit tests in `ActionScopedTest` covering:
- replacing seed data via `withOverrides`
- replacing an `ActionScopedProvider` via `withOverrides`
- `withOverrides()` with no arguments — equivalent to the receiver
- precedence — `seedData` wins over `providerOverrides` when both map the same key

`./bin/gradle :misk-action-scopes:test --tests 'misk.scope.ActionScopedTest'` passes locally.

## Related Work

- https://github.com/cashapp/misk/pull/3691

## Screenshots

N/A — no visual changes; pure backend API addition in `misk-action-scopes`.

## Communication Plan

- This is a strict, additive API change in `misk-action-scopes` - no existing callers are affected. No broadcast announcement planned.

## Definition of Done

- A new release is cut with this feature.

## Rollout Strategy and Risk Mitigation

- No rollout planned. This is opt in logic.

## Checklist

- [ ] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.