### PR TITLE
feat: add per-transaction isolation option to misk.jdbc.Transacter

### DIFF
--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -562,6 +562,7 @@ public final class misk/jdbc/RealTransacter : misk/jdbc/Transacter {
 	public fun retries (I)Lmisk/jdbc/Transacter;
 	public fun transaction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun transactionWithSession (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun transactionWithSession (Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class misk/jdbc/RealTransacter$Companion {
@@ -699,6 +700,11 @@ public abstract interface class misk/jdbc/Transacter {
 	public abstract fun retries (I)Lmisk/jdbc/Transacter;
 	public abstract fun transaction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun transactionWithSession (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun transactionWithSession (Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class misk/jdbc/Transacter$DefaultImpls {
+	public static fun transactionWithSession (Lmisk/jdbc/Transacter;Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class misk/jdbc/TransactionIsolationLevel : java/lang/Enum {
@@ -708,8 +714,22 @@ public final class misk/jdbc/TransactionIsolationLevel : java/lang/Enum {
 	public static final field SERIALIZABLE Lmisk/jdbc/TransactionIsolationLevel;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getHikariValueName ()Ljava/lang/String;
+	public final fun getJdbcLevel ()I
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/TransactionIsolationLevel;
 	public static fun values ()[Lmisk/jdbc/TransactionIsolationLevel;
+}
+
+public final class misk/jdbc/TransactionOptions {
+	public fun <init> ()V
+	public fun <init> (Lmisk/jdbc/TransactionIsolationLevel;)V
+	public synthetic fun <init> (Lmisk/jdbc/TransactionIsolationLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lmisk/jdbc/TransactionIsolationLevel;
+	public final fun copy (Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/TransactionOptions;
+	public static synthetic fun copy$default (Lmisk/jdbc/TransactionOptions;Lmisk/jdbc/TransactionIsolationLevel;ILjava/lang/Object;)Lmisk/jdbc/TransactionOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIsolationLevel ()Lmisk/jdbc/TransactionIsolationLevel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class misk/jdbc/TruncateTablesService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -558,11 +558,11 @@ public final class misk/jdbc/RealTransacter : misk/jdbc/Transacter {
 	public fun <init> (Lmisk/jdbc/DataSourceService;)V
 	public fun <init> (Lmisk/jdbc/DataSourceService;Lmisk/jdbc/DataSourceConfig;)V
 	public fun getInTransaction ()Z
+	public fun isolationLevel (Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/Transacter;
 	public fun noRetries ()Lmisk/jdbc/Transacter;
 	public fun retries (I)Lmisk/jdbc/Transacter;
 	public fun transaction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun transactionWithSession (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun transactionWithSession (Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class misk/jdbc/RealTransacter$Companion {
@@ -696,15 +696,15 @@ public final class misk/jdbc/TracingDataSourceDecorator : misk/jdbc/DataSourceDe
 
 public abstract interface class misk/jdbc/Transacter {
 	public abstract fun getInTransaction ()Z
+	public fun isolationLevel (Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/Transacter;
 	public abstract fun noRetries ()Lmisk/jdbc/Transacter;
 	public abstract fun retries (I)Lmisk/jdbc/Transacter;
 	public abstract fun transaction (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun transactionWithSession (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun transactionWithSession (Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class misk/jdbc/Transacter$DefaultImpls {
-	public static fun transactionWithSession (Lmisk/jdbc/Transacter;Lmisk/jdbc/TransactionOptions;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun isolationLevel (Lmisk/jdbc/Transacter;Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/Transacter;
 }
 
 public final class misk/jdbc/TransactionIsolationLevel : java/lang/Enum {
@@ -717,19 +717,6 @@ public final class misk/jdbc/TransactionIsolationLevel : java/lang/Enum {
 	public final fun getJdbcLevel ()I
 	public static fun valueOf (Ljava/lang/String;)Lmisk/jdbc/TransactionIsolationLevel;
 	public static fun values ()[Lmisk/jdbc/TransactionIsolationLevel;
-}
-
-public final class misk/jdbc/TransactionOptions {
-	public fun <init> ()V
-	public fun <init> (Lmisk/jdbc/TransactionIsolationLevel;)V
-	public synthetic fun <init> (Lmisk/jdbc/TransactionIsolationLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lmisk/jdbc/TransactionIsolationLevel;
-	public final fun copy (Lmisk/jdbc/TransactionIsolationLevel;)Lmisk/jdbc/TransactionOptions;
-	public static synthetic fun copy$default (Lmisk/jdbc/TransactionOptions;Lmisk/jdbc/TransactionIsolationLevel;ILjava/lang/Object;)Lmisk/jdbc/TransactionOptions;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getIsolationLevel ()Lmisk/jdbc/TransactionIsolationLevel;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class misk/jdbc/TruncateTablesService : com/google/common/util/concurrent/AbstractIdleService {

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -1,5 +1,6 @@
 package misk.jdbc
 
+import java.sql.Connection
 import java.time.Duration
 import java.util.Properties
 import misk.config.Config
@@ -58,14 +59,17 @@ enum class MigrationsFormat {
  * Session transaction isolation level applied to every connection in a datasource's pool.
  *
  * When configured, HikariCP applies the level as each connection is created and converges any connection whose
- * isolation was changed at runtime back to this level when it is returned to the pool. When unset, connections use
- * the database server's default (for MySQL, `REPEATABLE READ` unless overridden server-side).
+ * isolation was changed at runtime back to this level when it is returned to the pool. When unset, connections use the
+ * database server's default (for MySQL, `REPEATABLE READ` unless overridden server-side).
+ *
+ * The same levels are also reusable per-transaction via [TransactionOptions]; [jdbcLevel] is the corresponding
+ * [java.sql.Connection] constant for [java.sql.Connection.setTransactionIsolation].
  */
-enum class TransactionIsolationLevel(val hikariValueName: String) {
-  READ_UNCOMMITTED("TRANSACTION_READ_UNCOMMITTED"),
-  READ_COMMITTED("TRANSACTION_READ_COMMITTED"),
-  REPEATABLE_READ("TRANSACTION_REPEATABLE_READ"),
-  SERIALIZABLE("TRANSACTION_SERIALIZABLE"),
+enum class TransactionIsolationLevel(val hikariValueName: String, val jdbcLevel: Int) {
+  READ_UNCOMMITTED("TRANSACTION_READ_UNCOMMITTED", Connection.TRANSACTION_READ_UNCOMMITTED),
+  READ_COMMITTED("TRANSACTION_READ_COMMITTED", Connection.TRANSACTION_READ_COMMITTED),
+  REPEATABLE_READ("TRANSACTION_REPEATABLE_READ", Connection.TRANSACTION_REPEATABLE_READ),
+  SERIALIZABLE("TRANSACTION_SERIALIZABLE", Connection.TRANSACTION_SERIALIZABLE),
 }
 
 /** Configuration element for an individual datasource */

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceConfig.kt
@@ -62,8 +62,8 @@ enum class MigrationsFormat {
  * isolation was changed at runtime back to this level when it is returned to the pool. When unset, connections use the
  * database server's default (for MySQL, `REPEATABLE READ` unless overridden server-side).
  *
- * The same levels are also reusable per-transaction via [TransactionOptions]; [jdbcLevel] is the corresponding
- * [java.sql.Connection] constant for [java.sql.Connection.setTransactionIsolation].
+ * [jdbcLevel] is the matching [java.sql.Connection] constant, used by [Transacter.isolationLevel] to set a level per
+ * transacter.
  */
 enum class TransactionIsolationLevel(val hikariValueName: String, val jdbcLevel: Int) {
   READ_UNCOMMITTED("TRANSACTION_READ_UNCOMMITTED", Connection.TRANSACTION_READ_UNCOMMITTED),

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/Transacter.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/Transacter.kt
@@ -36,18 +36,50 @@ interface Transacter {
   fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T
 
   /**
+   * Like [transactionWithSession], but applies the per-transaction [options] to this single transaction only.
+   *
+   * The default implementation ignores [options] and behaves identically to [transactionWithSession]; implementations
+   * that support per-transaction options (such as [RealTransacter]) override it. See [TransactionOptions].
+   */
+  fun <T> transactionWithSession(options: TransactionOptions, work: (session: JDBCSession) -> T): T =
+    transactionWithSession(work)
+
+  /**
    * Returns a new transacter configured to retry transactions up to [maxAttempts] times on retryable exceptions.
    * Default is 3 attempts.
    */
   fun retries(maxAttempts: Int): Transacter
 
-  /**
-   * Returns a new transacter configured to not retry transactions.
-   */
+  /** Returns a new transacter configured to not retry transactions. */
   fun noRetries(): Transacter
 }
 
-class RealTransacter private constructor(
+/**
+ * Options that apply to a single [Transacter.transactionWithSession] call.
+ *
+ * Unlike [Transacter.retries]/[Transacter.noRetries], which return a reconfigured transacter, these options are scoped
+ * to the one transaction they are passed to and never affect other transactions sharing the pool.
+ */
+data class TransactionOptions
+@JvmOverloads
+constructor(
+  /**
+   * Isolation level to apply to this transaction only.
+   *
+   * It is set on the connection after it is acquired and before the transaction begins. Misk begins transactions lazily
+   * — the database transaction starts on the first statement — so the level takes effect before the transaction begins,
+   * which matters on MySQL where `setTransactionIsolation` issues `SET SESSION ...` and is a no-op for an
+   * already-started transaction. The connection's previous level is restored before it is returned to the pool, so the
+   * change never leaks to the next borrower, regardless of whether the pool configures
+   * [DataSourceConfig.transaction_isolation].
+   *
+   * When `null` (the default) the connection's isolation is left unchanged.
+   */
+  val isolationLevel: TransactionIsolationLevel? = null
+)
+
+class RealTransacter
+private constructor(
   private val dataSourceService: DataSourceService,
   private val config: DataSourceConfig?,
   private val options: TransacterOptions,
@@ -55,17 +87,14 @@ class RealTransacter private constructor(
   private val transacting = ThreadLocal.withInitial { false }
   private val exceptionClassifier = DefaultExceptionClassifier(config?.type)
 
-  constructor(dataSourceService: DataSourceService) : this(
-    dataSourceService = dataSourceService,
-    config = null,
-    options = TransacterOptions(),
-  )
+  constructor(
+    dataSourceService: DataSourceService
+  ) : this(dataSourceService = dataSourceService, config = null, options = TransacterOptions())
 
-  constructor(dataSourceService: DataSourceService, config: DataSourceConfig) : this(
-    dataSourceService = dataSourceService,
-    config = config,
-    options = TransacterOptions(),
-  )
+  constructor(
+    dataSourceService: DataSourceService,
+    config: DataSourceConfig,
+  ) : this(dataSourceService = dataSourceService, config = config, options = TransacterOptions())
 
   override val inTransaction: Boolean
     get() = transacting.get()
@@ -75,24 +104,29 @@ class RealTransacter private constructor(
     session.useConnection(work)
   }
 
-  override fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T {
-    return transactionWithRetries { transactionInternal(work) }
+  override fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T =
+    transactionWithSession(TransactionOptions(), work)
+
+  override fun <T> transactionWithSession(options: TransactionOptions, work: (session: JDBCSession) -> T): T {
+    return transactionWithRetries { transactionInternal(options, work) }
   }
 
   private fun <T> transactionWithRetries(block: () -> T): T {
-    val backoff = ExponentialBackoff(
-      baseDelay = Duration.ofMillis(options.minRetryDelayMillis),
-      maxDelay = Duration.ofMillis(options.maxRetryDelayMillis),
-      jitter = Duration.ofMillis(options.retryJitterMillis)
-    )
-    val retryConfig = RetryConfig.Builder(options.maxAttempts, backoff)
-      .shouldRetry { exceptionClassifier.isRetryable(it) }
-      .onRetry { attempt, e -> logger.info(e) { "JDBC transaction failed, retrying (attempt $attempt)" } }
-      .build()
+    val backoff =
+      ExponentialBackoff(
+        baseDelay = Duration.ofMillis(options.minRetryDelayMillis),
+        maxDelay = Duration.ofMillis(options.maxRetryDelayMillis),
+        jitter = Duration.ofMillis(options.retryJitterMillis),
+      )
+    val retryConfig =
+      RetryConfig.Builder(options.maxAttempts, backoff)
+        .shouldRetry { exceptionClassifier.isRetryable(it) }
+        .onRetry { attempt, e -> logger.info(e) { "JDBC transaction failed, retrying (attempt $attempt)" } }
+        .build()
     return retry(retryConfig) { block() }
   }
 
-  private fun <T> transactionInternal(work: (session: JDBCSession) -> T): T {
+  private fun <T> transactionInternal(options: TransactionOptions, work: (session: JDBCSession) -> T): T {
     check(!transacting.get()) { "The current thread is already in a transaction" }
     transacting.set(true)
 
@@ -105,23 +139,38 @@ class RealTransacter private constructor(
          * do rollback on exception
          */
 
-        // BEGIN
-        if (connection.autoCommit) {
-          connection.autoCommit = false
+        // Apply a caller-requested isolation level for this transaction only. Misk begins transactions lazily (the
+        // database transaction starts on the first statement), so setting it here — after acquiring the connection and
+        // before any work runs — takes effect before the transaction begins. We capture the connection's prior level
+        // and restore it once the transaction completes so the change never leaks to the next borrower of this pooled
+        // connection, independent of whether the pool configures transaction_isolation (Hikari's reset-on-return only
+        // fires when it is).
+        val isolationToRestore: Int? =
+          options.isolationLevel?.let { requested ->
+            connection.transactionIsolation.also { connection.transactionIsolation = requested.jdbcLevel }
+          }
+
+        try {
+          // BEGIN
+          if (connection.autoCommit) {
+            connection.autoCommit = false
+          }
+
+          // Do stuff
+          session = JDBCSession(connection)
+          val result =
+            runCatching { work(session) }
+              .onFailure { e -> session.onSessionClose { session.executeRollbackHooks(e) } }
+              .getOrThrow()
+
+          // COMMIT
+          session.executePreCommitHooks()
+          connection.commit()
+          session.executePostCommitHooks()
+          result
+        } finally {
+          isolationToRestore?.let { connection.transactionIsolation = it }
         }
-
-        // Do stuff
-        session = JDBCSession(connection)
-        val result =
-          runCatching { work(session) }
-            .onFailure { e -> session.onSessionClose { session.executeRollbackHooks(e) } }
-            .getOrThrow()
-
-        // COMMIT
-        session.executePreCommitHooks()
-        connection.commit()
-        session.executePostCommitHooks()
-        result
       }
     } finally {
       transacting.set(false)
@@ -129,11 +178,12 @@ class RealTransacter private constructor(
     }
   }
 
-  override fun retries(maxAttempts: Int): Transacter = RealTransacter(
-    dataSourceService = dataSourceService,
-    config = config,
-    options = options.copy(maxAttempts = maxAttempts),
-  )
+  override fun retries(maxAttempts: Int): Transacter =
+    RealTransacter(
+      dataSourceService = dataSourceService,
+      config = config,
+      options = options.copy(maxAttempts = maxAttempts),
+    )
 
   override fun noRetries(): Transacter = retries(1)
 

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/Transacter.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/Transacter.kt
@@ -36,15 +36,6 @@ interface Transacter {
   fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T
 
   /**
-   * Like [transactionWithSession], but applies the per-transaction [options] to this single transaction only.
-   *
-   * The default implementation ignores [options] and behaves identically to [transactionWithSession]; implementations
-   * that support per-transaction options (such as [RealTransacter]) override it. See [TransactionOptions].
-   */
-  fun <T> transactionWithSession(options: TransactionOptions, work: (session: JDBCSession) -> T): T =
-    transactionWithSession(work)
-
-  /**
    * Returns a new transacter configured to retry transactions up to [maxAttempts] times on retryable exceptions.
    * Default is 3 attempts.
    */
@@ -52,31 +43,17 @@ interface Transacter {
 
   /** Returns a new transacter configured to not retry transactions. */
   fun noRetries(): Transacter
-}
 
-/**
- * Options that apply to a single [Transacter.transactionWithSession] call.
- *
- * Unlike [Transacter.retries]/[Transacter.noRetries], which return a reconfigured transacter, these options are scoped
- * to the one transaction they are passed to and never affect other transactions sharing the pool.
- */
-data class TransactionOptions
-@JvmOverloads
-constructor(
   /**
-   * Isolation level to apply to this transaction only.
+   * Returns a transacter that runs its transactions at the given isolation [level], restoring the connection's prior
+   * level afterwards so it never leaks to others sharing the pool.
    *
-   * It is set on the connection after it is acquired and before the transaction begins. Misk begins transactions lazily
-   * — the database transaction starts on the first statement — so the level takes effect before the transaction begins,
-   * which matters on MySQL where `setTransactionIsolation` issues `SET SESSION ...` and is a no-op for an
-   * already-started transaction. The connection's previous level is restored before it is returned to the pool, so the
-   * change never leaks to the next borrower, regardless of whether the pool configures
-   * [DataSourceConfig.transaction_isolation].
-   *
-   * When `null` (the default) the connection's isolation is left unchanged.
+   * The default implementation throws; an implementation that doesn't support per-transaction isolation must override
+   * this to opt out explicitly.
    */
-  val isolationLevel: TransactionIsolationLevel? = null
-)
+  fun isolationLevel(level: TransactionIsolationLevel): Transacter =
+    throw UnsupportedOperationException("${this::class.simpleName} does not support isolationLevel($level)")
+}
 
 class RealTransacter
 private constructor(
@@ -104,11 +81,8 @@ private constructor(
     session.useConnection(work)
   }
 
-  override fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T =
-    transactionWithSession(TransactionOptions(), work)
-
-  override fun <T> transactionWithSession(options: TransactionOptions, work: (session: JDBCSession) -> T): T {
-    return transactionWithRetries { transactionInternal(options, work) }
+  override fun <T> transactionWithSession(work: (session: JDBCSession) -> T): T {
+    return transactionWithRetries { transactionInternal(work) }
   }
 
   private fun <T> transactionWithRetries(block: () -> T): T {
@@ -126,7 +100,7 @@ private constructor(
     return retry(retryConfig) { block() }
   }
 
-  private fun <T> transactionInternal(options: TransactionOptions, work: (session: JDBCSession) -> T): T {
+  private fun <T> transactionInternal(work: (session: JDBCSession) -> T): T {
     check(!transacting.get()) { "The current thread is already in a transaction" }
     transacting.set(true)
 
@@ -139,12 +113,9 @@ private constructor(
          * do rollback on exception
          */
 
-        // Apply a caller-requested isolation level for this transaction only. Misk begins transactions lazily (the
-        // database transaction starts on the first statement), so setting it here — after acquiring the connection and
-        // before any work runs — takes effect before the transaction begins. We capture the connection's prior level
-        // and restore it once the transaction completes so the change never leaks to the next borrower of this pooled
-        // connection, independent of whether the pool configures transaction_isolation (Hikari's reset-on-return only
-        // fires when it is).
+        // Set isolation before the transaction begins; on MySQL it's a no-op once started, and misk begins lazily on
+        // the first statement. Restore the prior level afterwards so it doesn't leak to the next user of the
+        // connection.
         val isolationToRestore: Int? =
           options.isolationLevel?.let { requested ->
             connection.transactionIsolation.also { connection.transactionIsolation = requested.jdbcLevel }
@@ -187,11 +158,19 @@ private constructor(
 
   override fun noRetries(): Transacter = retries(1)
 
+  override fun isolationLevel(level: TransactionIsolationLevel): Transacter =
+    RealTransacter(
+      dataSourceService = dataSourceService,
+      config = config,
+      options = options.copy(isolationLevel = level),
+    )
+
   internal data class TransacterOptions(
     val maxAttempts: Int = RetryDefaults.MAX_ATTEMPTS,
     val minRetryDelayMillis: Long = RetryDefaults.MIN_RETRY_DELAY_MILLIS,
     val maxRetryDelayMillis: Long = RetryDefaults.MAX_RETRY_DELAY_MILLIS,
     val retryJitterMillis: Long = RetryDefaults.RETRY_JITTER_MILLIS,
+    val isolationLevel: TransactionIsolationLevel? = null,
   )
 
   companion object {

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
@@ -56,23 +56,20 @@ class DataSourceTransactionIsolationTest {
   }
 
   @Test
-  fun `per-transaction isolation is applied for the call on a pool with no configured isolation`() {
-    perTransactionTransacter.transactionWithSession(
-      TransactionOptions(isolationLevel = TransactionIsolationLevel.READ_COMMITTED)
-    ) { (connection) ->
+  fun `isolationLevel is applied for the transaction on a pool with no configured isolation`() {
+    perTransactionTransacter.isolationLevel(TransactionIsolationLevel.READ_COMMITTED).transactionWithSession {
+      (connection) ->
       assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
       assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
     }
   }
 
   @Test
-  fun `per-transaction isolation is restored on return and does not leak to later transactions`() {
-    // This pool has no transaction_isolation configured, so Hikari's reset-on-return never fires. It is also a single
-    // connection, so the connection used below is deterministically reused by the following transaction. This proves
-    // the transacter itself captures and restores the prior level rather than relying on the pool.
-    perTransactionTransacter.transactionWithSession(
-      TransactionOptions(isolationLevel = TransactionIsolationLevel.READ_COMMITTED)
-    ) { (connection) ->
+  fun `isolationLevel is restored on return and does not leak to later transactions`() {
+    // No pool isolation (so Hikari can't reset it) and a single connection (reused by the next transaction): proves
+    // the transacter restores the level itself.
+    perTransactionTransacter.isolationLevel(TransactionIsolationLevel.READ_COMMITTED).transactionWithSession {
+      (connection) ->
       assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
     }
 
@@ -83,20 +80,10 @@ class DataSourceTransactionIsolationTest {
   }
 
   @Test
-  fun `transaction without options leaves the connection at the server default`() {
-    perTransactionTransacter.transactionWithSession(TransactionOptions()) { (connection) ->
-      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ)
-      assertThat(serverSessionIsolation(connection)).isEqualTo("REPEATABLE-READ")
-    }
-  }
-
-  @Test
-  fun `per-transaction isolation overrides a pool-configured level and restores it afterwards`() {
-    // The read-committed pool defaults each connection to READ COMMITTED. A single transaction can opt into a stricter
-    // level, and the connection returns to the pool's configured level for the next borrower.
-    readCommittedTransacter.transactionWithSession(
-      TransactionOptions(isolationLevel = TransactionIsolationLevel.SERIALIZABLE)
-    ) { (connection) ->
+  fun `isolationLevel overrides a pool-configured level and restores it afterwards`() {
+    // Opt a transacter into a stricter level than the pool default; the connection returns to the pool level after.
+    readCommittedTransacter.isolationLevel(TransactionIsolationLevel.SERIALIZABLE).transactionWithSession { (connection)
+      ->
       assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_SERIALIZABLE)
       assertThat(serverSessionIsolation(connection)).isEqualTo("SERIALIZABLE")
     }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
@@ -22,6 +22,7 @@ class DataSourceTransactionIsolationTest {
 
   @Inject @Movies lateinit var readCommittedTransacter: Transacter
   @Inject @Movies2 lateinit var defaultTransacter: Transacter
+  @Inject @Movies3 lateinit var perTransactionTransacter: Transacter
 
   @Test
   fun `connections use the configured transaction isolation`() {
@@ -54,6 +55,58 @@ class DataSourceTransactionIsolationTest {
     }
   }
 
+  @Test
+  fun `per-transaction isolation is applied for the call on a pool with no configured isolation`() {
+    perTransactionTransacter.transactionWithSession(
+      TransactionOptions(isolationLevel = TransactionIsolationLevel.READ_COMMITTED)
+    ) { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
+    }
+  }
+
+  @Test
+  fun `per-transaction isolation is restored on return and does not leak to later transactions`() {
+    // This pool has no transaction_isolation configured, so Hikari's reset-on-return never fires. It is also a single
+    // connection, so the connection used below is deterministically reused by the following transaction. This proves
+    // the transacter itself captures and restores the prior level rather than relying on the pool.
+    perTransactionTransacter.transactionWithSession(
+      TransactionOptions(isolationLevel = TransactionIsolationLevel.READ_COMMITTED)
+    ) { (connection) ->
+      assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
+    }
+
+    perTransactionTransacter.transactionWithSession { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("REPEATABLE-READ")
+    }
+  }
+
+  @Test
+  fun `transaction without options leaves the connection at the server default`() {
+    perTransactionTransacter.transactionWithSession(TransactionOptions()) { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("REPEATABLE-READ")
+    }
+  }
+
+  @Test
+  fun `per-transaction isolation overrides a pool-configured level and restores it afterwards`() {
+    // The read-committed pool defaults each connection to READ COMMITTED. A single transaction can opt into a stricter
+    // level, and the connection returns to the pool's configured level for the next borrower.
+    readCommittedTransacter.transactionWithSession(
+      TransactionOptions(isolationLevel = TransactionIsolationLevel.SERIALIZABLE)
+    ) { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_SERIALIZABLE)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("SERIALIZABLE")
+    }
+
+    readCommittedTransacter.transactionWithSession { (connection) ->
+      assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
+      assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
+    }
+  }
+
   private fun serverSessionIsolation(connection: Connection): String =
     connection.createStatement().use { statement ->
       statement.executeQuery("SELECT @@transaction_isolation").use { resultSet ->
@@ -65,6 +118,7 @@ class DataSourceTransactionIsolationTest {
   data class RootConfig(
     val default_isolation_data_source: DataSourceConfig,
     val read_committed_data_source: DataSourceConfig,
+    val per_transaction_data_source: DataSourceConfig,
   ) : Config
 
   class TransactionIsolationTestModule(private val appName: String) : KAbstractModule() {
@@ -78,6 +132,9 @@ class DataSourceTransactionIsolationTest {
 
       install(JdbcTestingModule(Movies2::class))
       install(JdbcModule(Movies2::class, config.default_isolation_data_source))
+
+      install(JdbcTestingModule(Movies3::class))
+      install(JdbcModule(Movies3::class, config.per_transaction_data_source))
     }
   }
 }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorServiceTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/SchemaMigratorServiceTest.kt
@@ -128,3 +128,5 @@ internal abstract class SchemaMigratorServiceTest(val type: DataSourceType) {
 @Qualifier @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION) internal annotation class Movies
 
 @Qualifier @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION) internal annotation class Movies2
+
+@Qualifier @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION) internal annotation class Movies3

--- a/misk-jdbc/src/test/resources/test_transaction_isolation-common.yaml
+++ b/misk-jdbc/src/test/resources/test_transaction_isolation-common.yaml
@@ -14,3 +14,14 @@ read_committed_data_source:
   use_fixed_pool_size: true
   fixed_pool_size: 1
   transaction_isolation: READ_COMMITTED
+
+# A single-connection pool with no transaction_isolation configured, so Hikari's reset-on-return does not fire. Used to
+# prove the per-transaction isolation is applied and explicitly restored on the same reused connection.
+per_transaction_data_source:
+  type: MYSQL
+  database: movies_mysql
+  username: root
+  password: ""
+  migrations_resource: classpath:/misk/jdbc/test_transacter-mysql-migrations
+  use_fixed_pool_size: true
+  fixed_pool_size: 1


### PR DESCRIPTION
## What

Adds a fluent `Transacter.isolationLevel(level)` that returns a transacter running its transactions at the given JDBC isolation level. The level is applied per transaction — set on the connection after it's acquired and before the transaction begins, then restored when the transaction returns — so it never leaks to other transactions sharing the pool.

This complements pool-level `transaction_isolation` (#3844) with an opt-in choice, and mirrors the fluent `isolationLevel()` on misk-jooq's transacter as well as misk-jdbc's own `retries()` / `noRetries()`.

### Motivation

An outbox-forwarder poll (`SELECT … FOR UPDATE SKIP LOCKED`) must run at `READ COMMITTED`. At `REPEATABLE READ` (the inherited MySQL server default) its range scan takes next-key/gap locks that can starve writer inserts and cause a same-partition-key reorder (a committed front-of-segment row gets skipped by `SKIP LOCKED`). The isolation must be set **before** the transaction begins, because MySQL's `setTransactionIsolation` issues `SET SESSION …`, which is a no-op for an already-started transaction. This replaces the fragile in-lambda `setTransactionIsolation` approach.

## Changes

- **`TransactionIsolationLevel`** gains `jdbcLevel` (the `java.sql.Connection.TRANSACTION_*` constant) used to set the level on a connection.
- **New `Transacter.isolationLevel(level: TransactionIsolationLevel)`** returning a reconfigured transacter. It's a default interface method (binary-compatible — external implementers don't have to implement it) that **throws `UnsupportedOperationException` unless overridden**, so an implementation that doesn't support per-transaction isolation fails fast rather than silently ignoring the request. The base (un-decorated) transacter inherits the pool/server default.
- **`RealTransacter`** stores the level in its `TransacterOptions` (like `maxAttempts` for `retries()`); per transaction it captures the connection's prior isolation, sets the requested level before any work runs (misk begins transactions lazily, so this lands before the txn starts), and restores it in a `finally`. Correct whether or not the pool configures `transaction_isolation`; HikariCP's reset-on-return is only a complementary safety net.

Usage: `transacter.isolationLevel(READ_COMMITTED).transactionWithSession { … }`

## Compatibility

`misk-jdbc.api` was regenerated — additive only (`isolationLevel` default interface method + `Transacter$DefaultImpls`, and `TransactionIsolationLevel.jdbcLevel`), so this is binary-backwards-compatible.

## Testing

- `DataSourceTransactionIsolationTest` — **6/6 pass**, including 3 new cases: on a single-connection pool with **no** `transaction_isolation` configured (so HikariCP's reset-on-return never fires) the level is applied, restored on return, and doesn't leak to later transactions; plus override-and-restore over a pool-configured level.
- `MySQLRealTransacterTest` — **18/18 pass**, confirming the `transactionInternal` change preserved existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
