### PR TITLE
Make vtctldclient ApplyVSchema timeouts env-configurable

### DIFF
--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/VitessTestDbSettingsTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/VitessTestDbSettingsTest.kt
@@ -1,0 +1,44 @@
+package misk.vitess.testing
+
+import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VitessTestDbSettingsTest {
+  @Test
+  fun `vtctldclient timeout defaults to ten seconds`() {
+    assertEquals(
+      Duration.ofSeconds(10),
+      vtctldClientTimeoutFromEnvironment(emptyMap()),
+    )
+  }
+
+  @Test
+  fun `vtctldclient timeout uses container wait environment value`() {
+    assertEquals(
+      Duration.ofSeconds(30),
+      vtctldClientTimeoutFromEnvironment(mapOf("VTCTLDCLIENT_CONTAINER_START_DELAY_MS" to "30000")),
+    )
+  }
+
+  @Test
+  fun `vtctldclient timeout uses apply vschema environment value`() {
+    assertEquals(
+      Duration.ofSeconds(30),
+      vtctldClientTimeoutFromEnvironment(mapOf("VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS" to "30000ms")),
+    )
+  }
+
+  @Test
+  fun `vtctldclient timeout uses larger value when both environment values are present`() {
+    assertEquals(
+      Duration.ofSeconds(45),
+      vtctldClientTimeoutFromEnvironment(
+        mapOf(
+          "VTCTLDCLIENT_CONTAINER_START_DELAY_MS" to "30000",
+          "VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS" to "45000ms",
+        )
+      ),
+    )
+  }
+}

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt
@@ -3,6 +3,10 @@ package misk.vitess.testing
 import java.time.Duration
 import misk.containers.ContainerUtil
 
+private val DEFAULT_VTCTLD_CLIENT_TIMEOUT = Duration.ofSeconds(10)
+private const val VTCTLDCLIENT_CONTAINER_START_DELAY_MS_ENV = "VTCTLDCLIENT_CONTAINER_START_DELAY_MS"
+private const val VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS_ENV = "VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS"
+
 object DefaultSettings {
   const val AUTO_APPLY_SCHEMA_CHANGES = true
   const val CONTAINER_NAME = "vitess_test_db"
@@ -26,7 +30,7 @@ object DefaultSettings {
   @JvmField var TRANSACTION_ISOLATION_LEVEL: TransactionIsolationLevel = TransactionIsolationLevel.REPEATABLE_READ
   @JvmField val TRANSACTION_MODE: TransactionMode = TransactionMode.MULTI
   @JvmField var TRANSACTION_TIMEOUT_SECONDS: Duration = Duration.ofSeconds(30)
-  @JvmField var VTCTLD_CLIENT_TIMEOUT: Duration = Duration.ofSeconds(10)
+  @JvmField var VTCTLD_CLIENT_TIMEOUT: Duration = vtctldClientTimeoutFromEnvironment()
   const val VITESS_DOCKER_NETWORK_NAME = "vitess-network"
   const val VITESS_DOCKER_NETWORK_TYPE = "bridge"
   const val VITESS_IMAGE = "ghcr.io/block/vitess/vttestserver:23.0.3-block.1-mysql84"
@@ -34,6 +38,21 @@ object DefaultSettings {
   const val VTCTLD_CLIENT_IMAGE = "ghcr.io/block/vitess/vtctldclient:23.0.3-block.1"
   const val VTGATE_USER = "root"
   const val VTGATE_USER_PASSWORD = ""
+}
+
+internal fun vtctldClientTimeoutFromEnvironment(
+  environment: Map<String, String> = System.getenv(),
+): Duration {
+  return listOfNotNull(
+    environment[VTCTLDCLIENT_CONTAINER_START_DELAY_MS_ENV]?.toMillisecondsDuration(),
+    environment[VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS_ENV]?.toMillisecondsDuration(),
+  ).maxOrNull() ?: DEFAULT_VTCTLD_CLIENT_TIMEOUT
+}
+
+private fun String.toMillisecondsDuration(): Duration? {
+  return removeSuffix("ms")
+    .toLongOrNull()
+    ?.let(Duration::ofMillis)
 }
 
 enum class TransactionIsolationLevel(val value: String) {


### PR DESCRIPTION
VitessTestDb's schema apply uses two hard-coded 10s timeouts in VitessSchemaApplier: the vtctldclient `ApplyVSchema --action_timeout` and the client-side `awaitStatusCode` wait for the vtctldclient container command. These defaults are not always generous enough — in some environments applying the vschema legitimately takes longer than 10s, surfacing as "Failed to await vtctld container command" failures that abort startup.

Read both values from environment variables (`VTCTLDCLIENT_CONTAINER_START_DELAY_MS` and `VTCTLDCLIENT_APPLY_VSCHEMA_TIMEOUT_MS`), defaulting to the existing 10s so behaviour is unchanged unless overridden.
