### PR TITLE
Add servlet filter multibind for pre-routing request modification

### DIFF
--- a/misk/src/main/kotlin/misk/web/MiskWebModule.kt
+++ b/misk/src/main/kotlin/misk/web/MiskWebModule.kt
@@ -176,6 +176,7 @@ constructor(private val config: WebConfig, private val jettyDependsOn: List<Key<
     newMultibinder<ApplicationInterceptor.Factory>()
     newMultibinder<StaticResourceEntry>()
     newMultibinder<WebProxyEntry>()
+    newMultibinder<jakarta.servlet.Filter>()
     val logContextProviderBinder = MapBinder.newMapBinder(binder(), String::class.java, LogContextProvider::class.java)
     logContextProviderBinder
       .addBinding(RequestLogContextInterceptor.MDC_HTTP_METHOD)

--- a/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyService.kt
@@ -72,6 +72,7 @@ internal constructor(
   private val statisticsHandler: StatisticsHandler,
   private val gzipHandler: GzipHandler,
   private val http2RateControlFactory: MeasuredWindowRateControl.Factory,
+  private val servletFilters: Set<jakarta.servlet.Filter>,
 ) : AbstractIdleService() {
   private val server = Server(threadPool)
   val healthServerUrl: HttpUrl?
@@ -352,6 +353,12 @@ internal constructor(
       holder.setInitParameter(CrossOriginFilter.CHAIN_PREFLIGHT_PARAM, corsConfig.chainPreflight.toString())
       holder.setInitParameter(CrossOriginFilter.EXPOSED_HEADERS_PARAM, corsConfig.exposedHeaders.joinToString(","))
       servletContextHandler.addFilter(holder, path, EnumSet.of(DispatcherType.REQUEST))
+    }
+
+    // Register application-provided servlet filters. These run before WebActionsServlet
+    // dispatches the request, allowing pre-routing request modification (e.g. URL normalization).
+    servletFilters.forEach { filter ->
+      servletContextHandler.addFilter(FilterHolder(filter), "/*", EnumSet.of(DispatcherType.REQUEST))
     }
 
     server.start()

--- a/misk/src/test/kotlin/misk/web/ServletFilterTest.kt
+++ b/misk/src/test/kotlin/misk/web/ServletFilterTest.kt
@@ -1,0 +1,121 @@
+package misk.web
+
+import jakarta.inject.Inject
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import misk.MiskTestingServiceModule
+import misk.inject.KAbstractModule
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.actions.WebAction
+import misk.web.jetty.JettyService
+import misk.web.mediatype.MediaTypes
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the [jakarta.servlet.Filter] multibind runs *before* [misk.web.jetty.WebActionsServlet] dispatches, so
+ * application filters can rewrite the request URL before route matching. This is the capability [NetworkInterceptor]
+ * cannot provide (those run after an action is already matched).
+ */
+@MiskTest(startService = true)
+class ServletFilterTest {
+  @MiskTestModule val module = TestModule()
+
+  @Inject lateinit var jetty: JettyService
+
+  @Test
+  fun `exact path still matches without any rewriting`() {
+    assertThat(get("/filter-target").code).isEqualTo(200)
+  }
+
+  @Test
+  fun `bound filter rewrites the url before routing so a trailing slash matches`() {
+    // "/filter-target/" does not match @Get("/filter-target"); it only returns 200 because the
+    // multibound filter strips the trailing slash before WebActionsServlet matches the route.
+    assertThat(get("/filter-target/").code).isEqualTo(200)
+  }
+
+  private fun get(path: String): Response =
+    OkHttpClient()
+      .newCall(Request.Builder().url(jetty.httpServerUrl.newBuilder().encodedPath(path).build()).get().build())
+      .execute()
+
+  class TargetAction @Inject constructor() : WebAction {
+    @Get("/filter-target") @ResponseContentType(MediaTypes.TEXT_PLAIN_UTF8) fun get(): String = "ok"
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<TargetAction>())
+      multibind<Filter>().to<TrailingSlashFilter>()
+    }
+  }
+}
+
+/**
+ * Control test: without the filter bound, a trailing-slash path does not match the exact route and falls through to
+ * a 404. This isolates the behavior added by the filter above.
+ */
+@MiskTest(startService = true)
+class ServletFilterAbsentTest {
+  @MiskTestModule val module = TestModule()
+
+  @Inject lateinit var jetty: JettyService
+
+  @Test
+  fun `trailing slash returns 404 when no rewriting filter is bound`() {
+    val response =
+      OkHttpClient()
+        .newCall(
+          Request.Builder().url(jetty.httpServerUrl.newBuilder().encodedPath("/filter-target/").build()).get().build()
+        )
+        .execute()
+    assertThat(response.code).isEqualTo(404)
+  }
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(WebServerTestingModule())
+      install(MiskTestingServiceModule())
+      install(WebActionModule.create<ServletFilterTest.TargetAction>())
+    }
+  }
+}
+
+/** Strips a single trailing slash from the request URL before Misk matches the route. */
+private class TrailingSlashFilter @Inject constructor() : Filter {
+  override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+    if (request is HttpServletRequest) {
+      val uri = request.requestURI
+      if (uri.length > 1 && uri.endsWith("/")) {
+        chain.doFilter(StrippedRequest(request, uri.dropLast(1)), response)
+        return
+      }
+    }
+    chain.doFilter(request, response)
+  }
+
+  private class StrippedRequest(delegate: HttpServletRequest, private val uri: String) :
+    HttpServletRequestWrapper(delegate) {
+    override fun getRequestURI(): String = uri
+
+    // Misk derives the route-matching URL from getRequestURL(), so it must be rewritten too.
+    override fun getRequestURL(): StringBuffer {
+      val url = super.getRequestURL()
+      if (url.isNotEmpty() && url.last() == '/') {
+        url.deleteCharAt(url.length - 1)
+      }
+      return url
+    }
+  }
+}

--- a/misk/src/test/kotlin/misk/web/jetty/JettyServiceTest.kt
+++ b/misk/src/test/kotlin/misk/web/jetty/JettyServiceTest.kt
@@ -68,6 +68,7 @@ class JettyServiceTest {
         statisticsHandler = mock(StatisticsHandler::class.java),
         gzipHandler = mock(GzipHandler::class.java),
         http2RateControlFactory = mock(MeasuredWindowRateControl.Factory::class.java),
+        servletFilters = emptySet(),
       )
 
     JettyService::class.java.getDeclaredField("server").apply {


### PR DESCRIPTION
## Summary

Adds a `Set<jakarta.servlet.Filter>` Guice multibind that allows Misk applications to register servlet filters that run **before** `WebActionsServlet` dispatches requests to matched routes.

### Problem

Misk's `NetworkInterceptor` runs **after** route matching — the `NetworkInterceptor.Factory.create(action: Action)` signature requires a matched action. This means interceptors cannot modify the request URL before route matching occurs.

For use cases like trailing-slash normalization (`/developers/` → `/developers`), the URL must be rewritten before Misk's `WebActionsServlet` attempts to match it against registered `@Get`/`@Post` routes. Without this, `/developers/` doesn't match `@Get("/developers")` and falls through to a catch-all 404 route.

### Solution

- Add `newMultibinder<jakarta.servlet.Filter>()` in `MiskWebModule` to initialize the empty set
- Inject `Set<jakarta.servlet.Filter>` in `JettyService`
- Register each filter on the `ServletContextHandler` with `/*` mapping and `DispatcherType.REQUEST`

This follows the same pattern already used for CORS filters in `JettyService`, which are registered via `servletContextHandler.addFilter()`.

### Usage

Applications can bind servlet filters in their Guice modules:

```kotlin
class MyModule : KAbstractModule() {
  override fun configure() {
    multibind<jakarta.servlet.Filter>().to<TrailingSlashFilter>()
  }
}
```

Where `TrailingSlashFilter` is a standard `jakarta.servlet.Filter` that wraps the request with an `HttpServletRequestWrapper` to modify the request URI before it reaches `WebActionsServlet`.

## Test plan
- [x] Verify existing Misk tests pass (no behavioral change when no filters are bound)