### PR TITLE
Revert Wire 7 alpha bumps (#3863, #3865)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "7.0.0-alpha06"
+wire = "7.0.0-alpha05"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "7.0.0-alpha05"
+wire = "6.0.0"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }

--- a/misk-admin/build.gradle.kts
+++ b/misk-admin/build.gradle.kts
@@ -3,7 +3,6 @@ import com.vanniktech.maven.publish.KotlinJvm
 import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
 import kotlin.jvm.java
-import org.gradle.api.file.SourceDirectorySet
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
 plugins {
@@ -121,17 +120,6 @@ afterEvaluate {
   kotlinSourceSets?.getByName("main")?.kotlin?.setSrcDirs(
     kotlinSourceSets.getByName("main").kotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
   )
-  // Wire 7+ registers Kotlin sources on the main source set's `generatedKotlin` source directory
-  // set when the Kotlin Gradle plugin provides one. It isn't part of KGP's public API yet, so
-  // access it reflectively, the same way Wire does.
-  kotlinSourceSets?.getByName("main")?.let { main ->
-    val generatedKotlin = runCatching {
-      main.javaClass.getMethod("getGeneratedKotlin").invoke(main) as SourceDirectorySet
-    }.getOrNull()
-    generatedKotlin?.setSrcDirs(
-      generatedKotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
-    )
-  }
   kotlinSourceSets?.getByName("test")?.kotlin?.srcDir(generatedSourceDir)
 
   // Explicit dependency for test scoped protos to be generated if need be.

--- a/misk-moshi/build.gradle.kts
+++ b/misk-moshi/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import org.gradle.api.file.SourceDirectorySet
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
 plugins {
@@ -55,17 +54,6 @@ afterEvaluate {
   kotlinSourceSets?.getByName("main")?.kotlin?.setSrcDirs(
     kotlinSourceSets.getByName("main").kotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
   )
-  // Wire 7+ registers Kotlin sources on the main source set's `generatedKotlin` source directory
-  // set when the Kotlin Gradle plugin provides one. It isn't part of KGP's public API yet, so
-  // access it reflectively, the same way Wire does.
-  kotlinSourceSets?.getByName("main")?.let { main ->
-    val generatedKotlin = runCatching {
-      main.javaClass.getMethod("getGeneratedKotlin").invoke(main) as SourceDirectorySet
-    }.getOrNull()
-    generatedKotlin?.setSrcDirs(
-      generatedKotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
-    )
-  }
   kotlinSourceSets?.getByName("test")?.kotlin?.srcDir(generatedSourceDir)
 
   // Explicit dependency for test scoped protos to be generated if need be.

--- a/misk/build.gradle.kts
+++ b/misk/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
-import org.gradle.api.file.SourceDirectorySet
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
 plugins {
@@ -152,17 +151,6 @@ afterEvaluate {
   kotlinSourceSets?.getByName("main")?.kotlin?.setSrcDirs(
     kotlinSourceSets.getByName("main").kotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
   )
-  // Wire 7+ registers Kotlin sources on the main source set's `generatedKotlin` source directory
-  // set when the Kotlin Gradle plugin provides one. It isn't part of KGP's public API yet, so
-  // access it reflectively, the same way Wire does.
-  kotlinSourceSets?.getByName("main")?.let { main ->
-    val generatedKotlin = runCatching {
-      main.javaClass.getMethod("getGeneratedKotlin").invoke(main) as SourceDirectorySet
-    }.getOrNull()
-    generatedKotlin?.setSrcDirs(
-      generatedKotlin.srcDirs.filter { !it.path.contains(generatedSourceDir) }
-    )
-  }
   kotlinSourceSets?.getByName("test")?.kotlin?.srcDir(generatedSourceDir)
 
   // Explicit dependency for test scoped protos to be generated if need be.


### PR DESCRIPTION
Reverts #3865 (536908a1a51bb3a1d246bfc470d18148a25c2631) and #3863 (ae12f63e1d819ddfac2603593b3283badde989c5), rolling Wire back from 7.0.0-alpha06/alpha05 to 6.x.