### PR TITLE
Keep SQS subscribers running after failures

### DIFF
--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -111,11 +111,14 @@ public final class misk/aws2/sqs/jobqueue/SqsMetrics {
 	public final fun getJobsDeadLettered ()Lio/prometheus/client/Counter;
 	public final fun getJobsEnqueued ()Lio/prometheus/client/Counter;
 	public final fun getJobsFailedToAcknowledge ()Lio/prometheus/client/Counter;
+	public final fun getJobsFailedToDeadLetter ()Lio/prometheus/client/Counter;
+	public final fun getJobsFailedToRetryWithBackoff ()Lio/prometheus/client/Counter;
 	public final fun getJobsReceived ()Lio/prometheus/client/Counter;
 	public final fun getQueueFirstProcessingLag ()Lio/prometheus/client/Histogram;
 	public final fun getQueueProcessingLag ()Lio/prometheus/client/Histogram;
 	public final fun getSqsBatchSendTime ()Lio/prometheus/client/Histogram;
 	public final fun getSqsDeleteTime ()Lio/prometheus/client/Histogram;
+	public final fun getSqsReceiveFailures ()Lio/prometheus/client/Counter;
 	public final fun getSqsReceiveTime ()Lio/prometheus/client/Histogram;
 	public final fun getSqsSendTime ()Lio/prometheus/client/Histogram;
 	public final fun getVisibilityTime ()Lio/prometheus/client/Histogram;

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsMetrics.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsMetrics.kt
@@ -62,6 +62,20 @@ class SqsMetrics @Inject internal constructor(metrics: Metrics) {
       listOf("QueueName"),
     )
 
+  val jobsFailedToDeadLetter =
+    metrics.counter(
+      "jobs_failed_dead_letter_v2_total",
+      "total # of jobs that we failed to move to the dead letter queueName",
+      listOf("QueueName"),
+    )
+
+  val jobsFailedToRetryWithBackoff =
+    metrics.counter(
+      "jobs_failed_retry_with_backoff_v2_total",
+      "total # of jobs that we failed to retry with backoff",
+      listOf("QueueName"),
+    )
+
   val visibilityTime =
     metrics.histogram(
       "jobs_visibility_time_v2",
@@ -90,6 +104,13 @@ class SqsMetrics @Inject internal constructor(metrics: Metrics) {
     metrics.histogram(
       "jobs_sqs_receive_latency_v2",
       "the round trip time to receive messages from SQS",
+      listOf("QueueName"),
+    )
+
+  val sqsReceiveFailures =
+    metrics.counter(
+      "jobs_sqs_receive_failures_v2_total",
+      "total # of failed requests to receive messages from SQS",
       listOf("QueueName"),
     )
 

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -5,6 +5,7 @@ import io.opentracing.Tracer
 import io.opentracing.tag.Tags
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
@@ -69,21 +70,29 @@ class Subscriber(
               }
             sqsMetrics.handlerDispatchTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
             result
+          } catch (e: CancellationException) {
+            throw e
           } catch (e: Exception) {
             logger.warn(e) { "Handler failed for job ${job.id} from queue ${job.queueName.value}" }
             sqsMetrics.handlerFailures.labels(queueName.value).inc()
             return@withSpan
           }
-        when (result) {
-          JobStatus.OK -> deleteMessage(job)
-          JobStatus.DEAD_LETTER -> {
-            deadLetterMessage(job)
-            deleteMessage(job)
+        try {
+          when (result) {
+            JobStatus.OK -> deleteMessage(job)
+            JobStatus.DEAD_LETTER -> {
+              deadLetterMessage(job)
+              deleteMessage(job)
+            }
+            JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
+            JobStatus.RETRY_LATER -> {
+              /* no-op, will be retried after visibility timeout passes */
+            }
           }
-          JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
-          JobStatus.RETRY_LATER -> {
-            /* no-op, will be retried after visibility timeout passes */
-          }
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          logger.warn(e) { "Failed to apply status $result to job ${job.id} from queue ${job.queueName.value}" }
         }
       }
     }
@@ -138,6 +147,8 @@ class Subscriber(
           DeleteMessageRequest.builder().queueUrl(job.queueUrl).receiptHandle(job.message.receiptHandle()).build()
         )
         .await()
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       logger.warn(e) { "Failed to acknowledge job ${job.idempotenceKey} from queue ${job.queueName.value}" }
       sqsMetrics.jobsFailedToAcknowledge.labels(queueName.value).inc()
@@ -191,7 +202,15 @@ class Subscriber(
         wasDisabled = false
       }
       val startTime = clock.millis()
-      val response = fetchMessages(queueUrl).await()
+      val response =
+        try {
+          fetchMessages(queueUrl).await()
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          logger.warn(e) { "Failed to fetch messages from queue ${queueName.value}; retrying" }
+          continue
+        }
       sqsMetrics.sqsReceiveTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
 
       sqsMetrics.jobsReceived.labels(queueName.value).inc(response.messages().size.toDouble())

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -5,9 +5,10 @@ import io.opentracing.Tracer
 import io.opentracing.tag.Tags
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.future.await
@@ -70,29 +71,20 @@ class Subscriber(
               }
             sqsMetrics.handlerDispatchTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
             result
-          } catch (e: CancellationException) {
-            throw e
           } catch (e: Exception) {
+            // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+            currentCoroutineContext().ensureActive()
             logger.warn(e) { "Handler failed for job ${job.id} from queue ${job.queueName.value}" }
             sqsMetrics.handlerFailures.labels(queueName.value).inc()
             return@withSpan
           }
-        try {
-          when (result) {
-            JobStatus.OK -> deleteMessage(job)
-            JobStatus.DEAD_LETTER -> {
-              deadLetterMessage(job)
-              deleteMessage(job)
-            }
-            JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
-            JobStatus.RETRY_LATER -> {
-              /* no-op, will be retried after visibility timeout passes */
-            }
+        when (result) {
+          JobStatus.OK -> deleteMessage(job)
+          JobStatus.DEAD_LETTER -> deadLetterMessage(job)
+          JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
+          JobStatus.RETRY_LATER -> {
+            /* no-op, will be retried after visibility timeout passes */
           }
-        } catch (e: CancellationException) {
-          throw e
-        } catch (e: Exception) {
-          logger.warn(e) { "Failed to apply status $result to job ${job.id} from queue ${job.queueName.value}" }
         }
       }
     }
@@ -113,24 +105,31 @@ class Subscriber(
   }
 
   private suspend fun retryWithBackoff(job: SqsJob) {
-    val visibilityTime =
-      visibilityTimeoutCalculator.calculateVisibilityTimeout(
-        currentReceiveCount =
-          job.message.attributes()[MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT]?.toInt() ?: 1,
-        queueVisibilityTimeout = queueConfig.visibility_timeout ?: 1,
-      )
+    try {
+      val visibilityTime =
+        visibilityTimeoutCalculator.calculateVisibilityTimeout(
+          currentReceiveCount =
+            job.message.attributes()[MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT]?.toInt() ?: 1,
+          queueVisibilityTimeout = queueConfig.visibility_timeout ?: 1,
+        )
 
-    client
-      .changeMessageVisibility(
-        ChangeMessageVisibilityRequest.builder()
-          .queueUrl(job.queueUrl)
-          .receiptHandle(job.message.receiptHandle())
-          .visibilityTimeout(visibilityTime)
-          .build()
-      )
-      .await()
+      client
+        .changeMessageVisibility(
+          ChangeMessageVisibilityRequest.builder()
+            .queueUrl(job.queueUrl)
+            .receiptHandle(job.message.receiptHandle())
+            .visibilityTimeout(visibilityTime)
+            .build()
+        )
+        .await()
 
-    sqsMetrics.visibilityTime.labels(queueName.value).observe(visibilityTime.toDouble())
+      sqsMetrics.visibilityTime.labels(queueName.value).observe(visibilityTime.toDouble())
+    } catch (e: Exception) {
+      // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+      currentCoroutineContext().ensureActive()
+      logger.warn(e) { "Failed to retry job ${job.id} with backoff from queue ${job.queueName.value}" }
+      sqsMetrics.jobsFailedToRetryWithBackoff.labels(queueName.value).inc()
+    }
   }
 
   /**
@@ -147,9 +146,9 @@ class Subscriber(
           DeleteMessageRequest.builder().queueUrl(job.queueUrl).receiptHandle(job.message.receiptHandle()).build()
         )
         .await()
-    } catch (e: CancellationException) {
-      throw e
     } catch (e: Exception) {
+      // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+      currentCoroutineContext().ensureActive()
       logger.warn(e) { "Failed to acknowledge job ${job.idempotenceKey} from queue ${job.queueName.value}" }
       sqsMetrics.jobsFailedToAcknowledge.labels(queueName.value).inc()
       return
@@ -159,10 +158,10 @@ class Subscriber(
   }
 
   private suspend fun deadLetterMessage(job: SqsJob) {
-    val deadLetterQueueUrl = sqsQueueResolver.getQueueUrl(deadLetterQueueName)
-    val startTime = clock.millis()
+    try {
+      val deadLetterQueueUrl = sqsQueueResolver.getQueueUrl(deadLetterQueueName)
+      val startTime = clock.millis()
 
-    val response =
       client
         .sendMessage(
           SendMessageRequest.builder()
@@ -172,8 +171,18 @@ class Subscriber(
             .build()
         )
         .await()
-    sqsMetrics.sqsSendTime.labels(deadLetterQueueName.value).observe((clock.millis() - startTime).toDouble())
-    sqsMetrics.jobsDeadLettered.labels(queueName.value).inc()
+      sqsMetrics.sqsSendTime.labels(deadLetterQueueName.value).observe((clock.millis() - startTime).toDouble())
+      sqsMetrics.jobsDeadLettered.labels(queueName.value).inc()
+    } catch (e: Exception) {
+      // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+      currentCoroutineContext().ensureActive()
+      logger.warn(e) { "Failed to dead-letter job ${job.id} from queue ${job.queueName.value}" }
+      sqsMetrics.jobsFailedToDeadLetter.labels(queueName.value).inc()
+      return
+    }
+
+    // Follow by removing the message from the queue
+    deleteMessage(job)
   }
 
   /** Polls the messages from both the regular and the retry queue. */
@@ -205,10 +214,11 @@ class Subscriber(
       val response =
         try {
           fetchMessages(queueUrl).await()
-        } catch (e: CancellationException) {
-          throw e
         } catch (e: Exception) {
+          // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+          currentCoroutineContext().ensureActive()
           logger.warn(e) { "Failed to fetch messages from queue ${queueName.value}; retrying" }
+          sqsMetrics.sqsReceiveFailures.labels(queueName.value).inc()
           continue
         }
       sqsMetrics.sqsReceiveTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
@@ -22,6 +23,7 @@ import misk.metrics.v2.Metrics
 import misk.testing.ConcurrentMockTracer
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -34,6 +36,8 @@ import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
 import software.amazon.awssdk.services.sqs.model.SqsException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -52,7 +56,7 @@ class SubscriberTest {
     )
 
   @Test
-  fun `status application failure does not stop subscriber`() = runTest {
+  fun `retry with backoff failure does not stop subscriber`() = runTest {
     val handledJobs = mutableListOf<String>()
     val statuses = ArrayDeque(listOf(JobStatus.RETRY_WITH_BACKOFF, JobStatus.OK))
     val handler =
@@ -79,15 +83,52 @@ class SubscriberTest {
     assertEquals(listOf("job-1", "job-2"), handledJobs)
     verify(client).changeMessageVisibility(any<ChangeMessageVisibilityRequest>())
     verify(client).deleteMessage(any<DeleteMessageRequest>())
+    assertEquals(1.0, sqsMetrics.jobsFailedToRetryWithBackoff.labels(queueName.value).get())
     assertTrue(subscriberJob.isActive)
   }
 
   @Test
-  fun `fetch failure does not stop polling`() = runTest {
+  fun `dead letter failure does not acknowledge job or stop subscriber`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName.deadLetterQueue)).thenReturn("$queueUrl-dlq")
+    val handledJobs = mutableListOf<String>()
+    val statuses = ArrayDeque(listOf(JobStatus.DEAD_LETTER, JobStatus.OK))
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handledJobs += job.id
+          return statuses.removeFirst()
+        }
+      }
+    whenever(client.sendMessage(any<SendMessageRequest>()))
+      .thenReturn(
+        CompletableFuture.failedFuture<SendMessageResponse>(
+          SqsException.builder().message("send failed").statusCode(500).build()
+        )
+      )
+    whenever(client.deleteMessage(any<DeleteMessageRequest>()))
+      .thenReturn(CompletableFuture.completedFuture(DeleteMessageResponse.builder().build()))
+
+    val subscriberJob = backgroundScope.launch { subscriber(handler).run() }
+    channel.send(job("job-1"))
+    channel.send(job("job-2"))
+    runCurrent()
+
+    assertEquals(listOf("job-1", "job-2"), handledJobs)
+    verify(client).sendMessage(any<SendMessageRequest>())
+    val deleteRequest = argumentCaptor<DeleteMessageRequest>()
+    verify(client).deleteMessage(deleteRequest.capture())
+    assertEquals("receipt-job-2", deleteRequest.firstValue.receiptHandle())
+    assertEquals(1.0, sqsMetrics.jobsFailedToDeadLetter.labels(queueName.value).get())
+    assertTrue(subscriberJob.isActive)
+  }
+
+  @Test
+  fun `canceled fetch does not stop polling unless subscriber is canceled`() = runTest {
     whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val canceledResponse = CompletableFuture<ReceiveMessageResponse>().apply { cancel(false) }
     val pendingResponse = CompletableFuture<ReceiveMessageResponse>()
     whenever(client.receiveMessage(any<ReceiveMessageRequest>()))
-      .thenReturn(CompletableFuture.failedFuture(IllegalStateException("fetch failed")))
+      .thenReturn(canceledResponse)
       .thenReturn(
         CompletableFuture.completedFuture(ReceiveMessageResponse.builder().messages(message("job-1")).build())
       )
@@ -98,6 +139,10 @@ class SubscriberTest {
 
     assertEquals("job-1", channel.receive().id)
     assertTrue(pollingJob.isActive)
+    assertEquals(1.0, sqsMetrics.sqsReceiveFailures.labels(queueName.value).get())
+
+    pollingJob.cancelAndJoin()
+    assertTrue(pollingJob.isCancelled)
   }
 
   private fun subscriber(

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
@@ -1,0 +1,146 @@
+package misk.aws2.sqs.jobqueue
+
+import com.squareup.moshi.Moshi
+import io.prometheus.client.CollectorRegistry
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
+import misk.inject.AlwaysEnabledSwitch
+import misk.jobqueue.QueueName
+import misk.jobqueue.v2.Job
+import misk.jobqueue.v2.JobHandler
+import misk.jobqueue.v2.JobStatus
+import misk.jobqueue.v2.SuspendingJobHandler
+import misk.metrics.v2.Metrics
+import misk.testing.ConcurrentMockTracer
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import software.amazon.awssdk.services.sqs.model.SqsException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SubscriberTest {
+  private val queueName = QueueName("test-queue")
+  private val queueUrl = "https://sqs.us-west-2.amazonaws.com/123456789/test-queue"
+  private val channel = Channel<SqsJob>(Channel.UNLIMITED)
+  private val client = mock<SqsAsyncClient>()
+  private val sqsQueueResolver = mock<SqsQueueResolver>()
+  private val moshi = Moshi.Builder().build()
+  private val sqsMetrics =
+    SqsMetrics(
+      object : Metrics {
+        override fun getRegistry() = CollectorRegistry()
+      }
+    )
+
+  @Test
+  fun `status application failure does not stop subscriber`() = runTest {
+    val handledJobs = mutableListOf<String>()
+    val statuses = ArrayDeque(listOf(JobStatus.RETRY_WITH_BACKOFF, JobStatus.OK))
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handledJobs += job.id
+          return statuses.removeFirst()
+        }
+      }
+    whenever(client.changeMessageVisibility(any<ChangeMessageVisibilityRequest>()))
+      .thenReturn(
+        CompletableFuture.failedFuture<ChangeMessageVisibilityResponse>(
+          SqsException.builder().message("ReceiptHandle is invalid").statusCode(400).build()
+        )
+      )
+    whenever(client.deleteMessage(any<DeleteMessageRequest>()))
+      .thenReturn(CompletableFuture.completedFuture(DeleteMessageResponse.builder().build()))
+
+    val subscriberJob = backgroundScope.launch { subscriber(handler).run() }
+    channel.send(job("job-1"))
+    channel.send(job("job-2"))
+    runCurrent()
+
+    assertEquals(listOf("job-1", "job-2"), handledJobs)
+    verify(client).changeMessageVisibility(any<ChangeMessageVisibilityRequest>())
+    verify(client).deleteMessage(any<DeleteMessageRequest>())
+    assertTrue(subscriberJob.isActive)
+  }
+
+  @Test
+  fun `fetch failure does not stop polling`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val pendingResponse = CompletableFuture<ReceiveMessageResponse>()
+    whenever(client.receiveMessage(any<ReceiveMessageRequest>()))
+      .thenReturn(CompletableFuture.failedFuture(IllegalStateException("fetch failed")))
+      .thenReturn(
+        CompletableFuture.completedFuture(ReceiveMessageResponse.builder().messages(message("job-1")).build())
+      )
+      .thenReturn(pendingResponse)
+
+    val pollingJob = backgroundScope.launch { subscriber(handler = { JobStatus.OK }).poll() }
+    runCurrent()
+
+    assertEquals("job-1", channel.receive().id)
+    assertTrue(pollingJob.isActive)
+  }
+
+  private fun subscriber(
+    handler: JobHandler,
+    queueConfig: SqsQueueConfig = SqsQueueConfig(install_retry_queue = false),
+  ) =
+    Subscriber(
+      queueName = queueName,
+      queueConfig = queueConfig,
+      deadLetterQueueName = queueName.deadLetterQueue,
+      handler = handler,
+      channel = channel,
+      client = client,
+      sqsQueueResolver = sqsQueueResolver,
+      sqsMetrics = sqsMetrics,
+      moshi = moshi,
+      clock = Clock.systemUTC(),
+      tracer = ConcurrentMockTracer(),
+      visibilityTimeoutCalculator = VisibilityTimeoutCalculator(),
+      asyncSwitch = AlwaysEnabledSwitch(),
+    )
+
+  private fun subscriber(handler: suspend (Job) -> JobStatus): Subscriber =
+    subscriber(
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job) = handler(job)
+      }
+    )
+
+  private fun job(id: String) =
+    SqsJob(
+      queueName = queueName,
+      moshi = moshi,
+      message = message(id),
+      queueUrl = queueUrl,
+      publishToChannelTimestamp = Clock.systemUTC().millis(),
+    )
+
+  private fun message(id: String) =
+    Message.builder()
+      .messageId(id)
+      .body("body-$id")
+      .receiptHandle("receipt-$id")
+      .attributes(mapOf(MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT to "1"))
+      .build()
+}


### PR DESCRIPTION
## Description

Prevent AWS2 SQS v2 subscriber coroutines from terminating when applying a returned `JobStatus` or fetching messages fails. Cancellation still propagates normally, and handler-failure metrics remain limited to handler exceptions.

## Testing Strategy

- `bin/gradle :misk-aws2-sqs:test --tests 'misk.aws2.sqs.jobqueue.SubscriberTest' --warn` (2 tests pass)
- Kotlin formatter and `git diff --check`

## Rollout Strategy and Risk Mitigation

Medium risk because this changes failure handling in a shared subscriber. The regression tests recreate a stale receipt handle and a failed receive, then verify the same coroutine continues processing.

## Checklist

- [x] Tests cover both recovered exception paths
- [x] Review polling retry behavior described in the PR comment

Generated with Amp