### PR TITLE
Add zrem to the Redis interface

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -52,6 +52,7 @@ public abstract interface class misk/redis/DeferredRedis {
 	public static synthetic fun zrange$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
 	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
 	public static synthetic fun zrangeWithScores$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
+	public abstract fun zrem (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
 	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
@@ -132,6 +133,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun zcard (Ljava/lang/String;)J
 	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
@@ -203,6 +205,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun zcard (Ljava/lang/String;)J
 	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
@@ -276,6 +279,7 @@ public abstract interface class misk/redis/Redis {
 	public static synthetic fun zrange$default (Lmisk/redis/Redis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/List;
 	public abstract fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public static synthetic fun zrangeWithScores$default (Lmisk/redis/Redis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/List;
+	public abstract fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
 	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
@@ -637,6 +641,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis, misk/testing
 	public fun zcard (Ljava/lang/String;)J
 	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
+	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
@@ -692,6 +697,7 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 	public fun zcard (Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun zrange (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
+	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -121,6 +121,8 @@ interface DeferredRedis {
     limit: Redis.ZRangeLimit? = null,
   ): Supplier<List<Pair<ByteString?, Double>>>
 
+  fun zrem(key: String, vararg members: String): Supplier<Long>
+
   fun zremRangeByRank(key: String, start: Redis.ZRangeRankMarker, stop: Redis.ZRangeRankMarker): Supplier<Long>
 
   fun llen(key: String): Supplier<Long>

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -529,6 +529,10 @@ class FakeRedis : Redis {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  override fun zrem(key: String, vararg members: String): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
   override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long {
     throw NotImplementedError("Fake client not implemented for this operation")
   }

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -432,6 +432,13 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     }
   }
 
+  override fun zrem(key: String, vararg members: String): Supplier<Long> {
+    val keyBytes = key.toByteArray(charset)
+    val memberBytes = Array(members.size) { members[it].toByteArray(charset) }
+    val response = pipeline.zrem(keyBytes, *memberBytes)
+    return Supplier { response.get() }
+  }
+
   override fun zremRangeByRank(
     key: String,
     start: Redis.ZRangeRankMarker,

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -480,6 +480,11 @@ class RealRedis(private val unifiedJedis: UnifiedJedis, private val clientMetric
     } ?: listOf()
   }
 
+  override fun zrem(key: String, vararg members: String): Long {
+    val memberBytes = Array(members.size) { members[it].toByteArray(charset) }
+    return unifiedJedis.zrem(key.toByteArray(charset), *memberBytes)
+  }
+
   override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long {
     return unifiedJedis.zremrangeByRank(key, start.longValue, stop.longValue)
   }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -581,6 +581,16 @@ interface Redis {
   ): List<Pair<ByteString?, Double>>
 
   /**
+   * Removes the specified [members] from the sorted set stored at [key]. Members that are not present in the sorted set
+   * are ignored.
+   *
+   * If [key] does not exist, 0 is returned. If the [key] exists but does not hold a sorted set, an error is returned.
+   *
+   * @return the number of members actually removed, not counting members that were not present.
+   */
+  fun zrem(key: String, vararg members: String): Long
+
+  /**
    * Removes all elements in the sorted set stored at [key] with rank between [start] and [stop]. Both start and stop
    * are 0 -based indexes with 0 being the element with the lowest score. These indexes can be negative numbers, where
    * they indicate offsets starting at the element with the highest score. For example: -1 is the element with the

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -1344,6 +1344,99 @@ abstract class AbstractRedisTest {
   }
 
   @Test
+  fun `zrem - removes a single member`() {
+    // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
+    redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    assertEquals(1, redis.zrem(key, "bb"))
+
+    assertEquals(
+      mapOf(ba_2_3Pair, bz_2_3Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zrem - removes several members at once`() {
+    // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
+    redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    assertEquals(3, redis.zrem(key, "ba", "c", "ad"))
+
+    assertEquals(
+      mapOf(bz_2_3Pair, bb_4_5Pair, b_5Pair, yy_6_7Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zrem - leaves the other member of a shared score alone`() {
+    // ba and bz both score 2.3. Removing one must not take the score's other member with it.
+    redis.zadd(key, mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair))
+
+    assertEquals(1, redis.zrem(key, "ba"))
+
+    assertNull(redis.zscore(key, "ba"))
+    assertEquals(2.3, redis.zscore(key, "bz"))
+    assertEquals(2, redis.zcard(key))
+  }
+
+  @Test
+  fun `zrem - members that are not present are ignored`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(0, redis.zrem(key, "not a member"))
+    // Only the member that was actually there counts towards the total.
+    assertEquals(1, redis.zrem(key, "not a member", "b", "also not a member"))
+    assertEquals(1, redis.zcard(key))
+  }
+
+  @Test
+  fun `zrem - naming a member twice removes it once`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(1, redis.zrem(key, "b", "b"))
+    assertEquals(1, redis.zcard(key))
+  }
+
+  @Test
+  fun `zrem - missing key returns zero`() {
+    assertEquals(0, redis.zrem("no such key", "b"))
+    assertFalse(redis.exists("no such key"))
+  }
+
+  @Test
+  fun `zrem - removing every member deletes the key`() {
+    redis.zadd(key, mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair))
+
+    assertEquals(3, redis.zrem(key, "ba", "bz", "bb"))
+
+    assertEquals(0, redis.zcard(key))
+    assertFalse(redis.exists(key))
+  }
+
+  @Test
+  fun `zrem - only touches the key it is given`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+    redis.zadd("another key", mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(2, redis.zrem(key, "b", "bb"))
+
+    assertEquals(2, redis.zcard("another key"))
+  }
+
+  @Test
+  fun `zrem - a removed member can be added back`() {
+    redis.zadd(key, mapOf(ba_2_3Pair, bb_4_5Pair))
+    assertEquals(1, redis.zrem(key, "ba"))
+
+    // A re-add is a fresh insert rather than a score update, so it counts as a new member.
+    assertEquals(1, redis.zadd(key, 7.0, "ba"))
+    assertEquals(7.0, redis.zscore(key, "ba"))
+    assertEquals(2, redis.zcard(key))
+  }
+
+  @Test
   fun `zcard`() {
     assertEquals(0, redis.zcard(key))
     redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
@@ -1524,12 +1617,15 @@ abstract class AbstractRedisTest {
           zadd("zkey", 1.0, "a"),
           zscore("zkey", "a"),
           zrangeWithScores("zkey", start = ZRangeIndexMarker(0), stop = ZRangeIndexMarker(-1)),
+          zadd("zkey", 2.0, "b"),
+          zrem("zkey", "b"),
           zremRangeByRank("zkey", start = ZRangeRankMarker(0), stop = ZRangeRankMarker(-1)),
           zcard("zkey"),
         )
       )
     }
-    assertThat(suppliers.map { it.get() }).containsExactly(1L, 1.0, listOf("a".encodeUtf8() to 1.0), 1L, 0L)
+    assertThat(suppliers.map { it.get() })
+      .containsExactly(1L, 1.0, listOf("a".encodeUtf8() to 1.0), 1L, 1L, 1L, 0L)
   }
 
   @Test

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -208,6 +208,8 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(private val unifiedJ
     limit: Redis.ZRangeLimit?,
   ): List<Pair<ByteString?, Double>> = runPipeline { zrangeWithScores(key, type, start, stop, reverse, limit) }
 
+  override fun zrem(key: String, vararg members: String): Long = runPipeline { zrem(key, *members) }
+
   override fun zremRangeByRank(key: String, start: Redis.ZRangeRankMarker, stop: Redis.ZRangeRankMarker): Long =
     runPipeline {
       zremRangeByRank(key, start, stop)

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -697,6 +697,10 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
       this@FakeRedis.zrangeWithScores(key, type, start, stop, reverse, limit)
     }
 
+    override fun zrem(key: String, vararg members: String): Supplier<Long> = Supplier {
+      this@FakeRedis.zrem(key, *members)
+    }
+
     override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Supplier<Long> =
       Supplier {
         this@FakeRedis.zremRangeByRank(key, start, stop)
@@ -875,6 +879,31 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
       }
 
     return ansWithScore
+  }
+
+  override fun zrem(key: String, vararg members: String): Long {
+    val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
+
+    var removed = 0L
+    for (member in members) {
+      // A member sits under exactly one score, so the first bucket holding it is the only one to touch. A member named
+      // twice is removed once, which is what Redis counts too.
+      for (entry in sortedSet.entries) {
+        if (entry.value.remove(member)) {
+          removed++
+          break
+        }
+      }
+    }
+
+    // Redis keeps neither an empty score nor an empty sorted set: the key goes away with its last member. The stored
+    // value is mutated rather than replaced so this does not disturb the key's expiry.
+    for (score in sortedSet.keys.toList()) {
+      if (sortedSet.getValue(score).isEmpty()) sortedSet.remove(score)
+    }
+    if (sortedSet.isEmpty()) keyValueStore.remove(key)
+
+    return removed
   }
 
   override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long {


### PR DESCRIPTION
misk's typed Redis API can add members to a sorted set and trim it by rank, but there is no way to remove a specific member. Redis has had ZREM since 1.0 and Jedis exposes it on both UnifiedJedis and the pipeline, so this wires `zrem(key, vararg members)` through `Redis`, `DeferredRedis`, and the real, pipelined and fake clients, covered in `AbstractRedisTest` so it runs against real Redis too.