### PR TITLE
Add zremRangeByScore to the Redis interface

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -54,6 +54,7 @@ public abstract interface class misk/redis/DeferredRedis {
 	public static synthetic fun zrangeWithScores$default (Lmisk/redis/DeferredRedis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/function/Supplier;
 	public abstract fun zrem (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public abstract fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)Ljava/util/function/Supplier;
 	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 
@@ -135,6 +136,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
+	public fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -207,6 +209,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
+	public fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -281,6 +284,7 @@ public abstract interface class misk/redis/Redis {
 	public static synthetic fun zrangeWithScores$default (Lmisk/redis/Redis;Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;ILjava/lang/Object;)Ljava/util/List;
 	public abstract fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public abstract fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
+	public abstract fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)J
 	public abstract fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -643,6 +647,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis, misk/testing
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/List;
 	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)J
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)J
+	public fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)J
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Double;
 }
 
@@ -699,6 +704,7 @@ public final class misk/redis/testing/FakeRedis$FakePipelinedRedis : misk/redis/
 	public fun zrangeWithScores (Ljava/lang/String;Lmisk/redis/Redis$ZRangeType;Lmisk/redis/Redis$ZRangeMarker;Lmisk/redis/Redis$ZRangeMarker;ZLmisk/redis/Redis$ZRangeLimit;)Ljava/util/function/Supplier;
 	public fun zrem (Ljava/lang/String;[Ljava/lang/String;)Ljava/util/function/Supplier;
 	public fun zremRangeByRank (Ljava/lang/String;Lmisk/redis/Redis$ZRangeRankMarker;Lmisk/redis/Redis$ZRangeRankMarker;)Ljava/util/function/Supplier;
+	public fun zremRangeByScore (Ljava/lang/String;Lmisk/redis/Redis$ZRangeScoreMarker;Lmisk/redis/Redis$ZRangeScoreMarker;)Ljava/util/function/Supplier;
 	public fun zscore (Ljava/lang/String;Ljava/lang/String;)Ljava/util/function/Supplier;
 }
 

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -125,6 +125,8 @@ interface DeferredRedis {
 
   fun zremRangeByRank(key: String, start: Redis.ZRangeRankMarker, stop: Redis.ZRangeRankMarker): Supplier<Long>
 
+  fun zremRangeByScore(key: String, start: Redis.ZRangeScoreMarker, stop: Redis.ZRangeScoreMarker): Supplier<Long>
+
   fun llen(key: String): Supplier<Long>
 
   fun zcard(key: String): Supplier<Long>

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -11,6 +11,7 @@ import kotlin.random.Random
 import misk.redis.Redis.ZRangeLimit
 import misk.redis.Redis.ZRangeMarker
 import misk.redis.Redis.ZRangeRankMarker
+import misk.redis.Redis.ZRangeScoreMarker
 import misk.redis.Redis.ZRangeType
 import okio.ByteString
 import okio.ByteString.Companion.encode
@@ -534,6 +535,10 @@ class FakeRedis : Redis {
   }
 
   override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long {
+    throw NotImplementedError("Fake client not implemented for this operation")
+  }
+
+  override fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Long {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -448,6 +448,20 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     return Supplier { response.get() }
   }
 
+  override fun zremRangeByScore(
+    key: String,
+    start: Redis.ZRangeScoreMarker,
+    stop: Redis.ZRangeScoreMarker,
+  ): Supplier<Long> {
+    val response =
+      pipeline.zremrangeByScore(
+        key.toByteArray(charset),
+        start.toString().toByteArray(charset),
+        stop.toString().toByteArray(charset),
+      )
+    return Supplier { response.get() }
+  }
+
   override fun zcard(key: String): Supplier<Long> {
     val response = pipeline.zcard(key)
     return Supplier { response.get() }

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -489,6 +489,16 @@ class RealRedis(private val unifiedJedis: UnifiedJedis, private val clientMetric
     return unifiedJedis.zremrangeByRank(key, start.longValue, stop.longValue)
   }
 
+  override fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Long {
+    // The string form of a marker is what carries the exclusive "(" prefix and the infinities, so this goes through
+    // the byte[] overload rather than the double one.
+    return unifiedJedis.zremrangeByScore(
+      key.toByteArray(charset),
+      start.toString().toByteArray(charset),
+      stop.toString().toByteArray(charset),
+    )
+  }
+
   override fun zcard(key: String): Long {
     return unifiedJedis.zcard(key)
   }

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -599,6 +599,19 @@ interface Redis {
   fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long
 
   /**
+   * Removes all elements in the sorted set stored at [key] whose score falls between [start] and [stop].
+   *
+   * The interval is closed at both ends by default; set [ZRangeScoreMarker.isIncluded] to false on either marker to
+   * make that end exclusive. The markers follow the same convention as [zrange] with [ZRangeType.SCORE], so
+   * [Double.MAX_VALUE] and [Double.MIN_VALUE] stand for +inf and -inf.
+   *
+   * If [key] does not exist, 0 is returned. If the [key] exists but does not hold a sorted set, an error is returned.
+   *
+   * @return the number of members removed.
+   */
+  fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Long
+
+  /**
    * Returns the length of the list stored at [key].
    *
    * @param key the key of the list

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTest.kt
@@ -1463,6 +1463,118 @@ abstract class AbstractRedisTest {
   }
 
   @Test
+  fun `zremRangeByScore - removes an inclusive range`() {
+    // sorted = ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, b_5Pair, c_5Pair, yy_6_7Pair, ad_9Pair
+    redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    assertEquals(3, redis.zremRangeByScore(key, ZRangeScoreMarker(4.5), ZRangeScoreMarker(5.0)))
+    assertEquals(
+      mapOf(ba_2_3Pair, bz_2_3Pair, yy_6_7Pair, ad_9Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zremRangeByScore - an excluded end is left alone`() {
+    redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    // (4.5, 5.0] takes the two members at 5.0 and leaves bb sitting on the excluded bound.
+    assertEquals(2, redis.zremRangeByScore(key, ZRangeScoreMarker(4.5, false), ZRangeScoreMarker(5.0)))
+    assertEquals(
+      mapOf(ba_2_3Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zremRangeByScore - both ends excluded`() {
+    redis.zadd(key, mapOf(b_5Pair, bz_2_3Pair, bb_4_5Pair, yy_6_7Pair, ad_9Pair, c_5Pair, ba_2_3Pair))
+
+    assertEquals(3, redis.zremRangeByScore(key, ZRangeScoreMarker(2.3, false), ZRangeScoreMarker(6.7, false)))
+    assertEquals(
+      mapOf(ba_2_3Pair, bz_2_3Pair, yy_6_7Pair, ad_9Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zremRangeByScore - one score removes every member holding it`() {
+    redis.zadd(key, mapOf(b_5Pair, c_5Pair, bb_4_5Pair))
+
+    // Naming the same score at both ends is how a caller drops a level it can identify only by score.
+    assertEquals(2, redis.zremRangeByScore(key, ZRangeScoreMarker(5.0), ZRangeScoreMarker(5.0)))
+    assertEquals(
+      mapOf(bb_4_5Pair).toEncodedListOfPairs(),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zremRangeByScore - a score nothing holds removes nothing`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(0, redis.zremRangeByScore(key, ZRangeScoreMarker(3.0), ZRangeScoreMarker(3.0)))
+    assertEquals(2, redis.zcard(key))
+  }
+
+  @Test
+  fun `zremRangeByScore - start after stop removes nothing`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(0, redis.zremRangeByScore(key, ZRangeScoreMarker(9.0), ZRangeScoreMarker(1.0)))
+    assertEquals(2, redis.zcard(key))
+  }
+
+  @Test
+  fun `zremRangeByScore - missing key returns zero`() {
+    assertEquals(0, redis.zremRangeByScore("no such key", ZRangeScoreMarker(0.0), ZRangeScoreMarker(1.0)))
+    assertFalse(redis.exists("no such key"))
+  }
+
+  @Test
+  fun `zremRangeByScore - removing every member deletes the key`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(
+      2,
+      redis.zremRangeByScore(key, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE)),
+    )
+    assertEquals(0, redis.zcard(key))
+    assertFalse(redis.exists(key))
+  }
+
+  @Test
+  fun `zremRangeByScore - the infinity markers reach scores at and below zero`() {
+    redis.zadd(key, mapOf("negative" to -1.0, "zero" to 0.0, "positive" to 5.0))
+
+    assertEquals(
+      3,
+      redis.zremRangeByScore(key, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(Double.MAX_VALUE)),
+    )
+    assertFalse(redis.exists(key))
+  }
+
+  @Test
+  fun `zremRangeByScore - negative infinity up to a negative bound`() {
+    redis.zadd(key, mapOf("low" to -9.0, "mid" to -5.0, "high" to 2.0))
+
+    assertEquals(2, redis.zremRangeByScore(key, ZRangeScoreMarker(Double.MIN_VALUE), ZRangeScoreMarker(-5.0)))
+    assertEquals(
+      listOf("high".encodeUtf8() to 2.0),
+      redis.zrangeWithScores(key, INDEX, ZRangeIndexMarker(0), ZRangeIndexMarker(-1)),
+    )
+  }
+
+  @Test
+  fun `zremRangeByScore - only touches the key it is given`() {
+    redis.zadd(key, mapOf(b_5Pair, bb_4_5Pair))
+    redis.zadd("another key", mapOf(b_5Pair, bb_4_5Pair))
+
+    assertEquals(2, redis.zremRangeByScore(key, ZRangeScoreMarker(4.0), ZRangeScoreMarker(6.0)))
+    assertEquals(2, redis.zcard("another key"))
+  }
+
+  @Test
   fun `zadd - re-adding a member at the score it already has keeps it`() {
     redis.zadd(key, 100.0, "m")
 
@@ -1689,12 +1801,15 @@ abstract class AbstractRedisTest {
           zrangeWithScores("zkey", start = ZRangeIndexMarker(0), stop = ZRangeIndexMarker(-1)),
           zadd("zkey", 2.0, "b"),
           zrem("zkey", "b"),
+          zadd("zkey", 3.0, "c"),
+          zremRangeByScore("zkey", start = ZRangeScoreMarker(3.0), stop = ZRangeScoreMarker(3.0)),
           zremRangeByRank("zkey", start = ZRangeRankMarker(0), stop = ZRangeRankMarker(-1)),
           zcard("zkey"),
         )
       )
     }
-    assertThat(suppliers.map { it.get() }).containsExactly(1L, 1.0, listOf("a".encodeUtf8() to 1.0), 1L, 1L, 1L, 0L)
+    assertThat(suppliers.map { it.get() })
+      .containsExactly(1L, 1.0, listOf("a".encodeUtf8() to 1.0), 1L, 1L, 1L, 1L, 1L, 0L)
   }
 
   @Test

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -215,6 +215,11 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(private val unifiedJ
       zremRangeByRank(key, start, stop)
     }
 
+  override fun zremRangeByScore(key: String, start: Redis.ZRangeScoreMarker, stop: Redis.ZRangeScoreMarker): Long =
+    runPipeline {
+      zremRangeByScore(key, start, stop)
+    }
+
   override fun zcard(key: String): Long = runPipeline { zcard(key) }
 
   companion object {

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -708,6 +708,11 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
       this@FakeRedis.zremRangeByRank(key, start, stop)
     }
 
+    override fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Supplier<Long> =
+      eager {
+        this@FakeRedis.zremRangeByScore(key, start, stop)
+      }
+
     override fun zcard(key: String): Supplier<Long> = eager { this@FakeRedis.zcard(key) }
 
     override fun close() {
@@ -931,6 +936,32 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
       if (members.isEmpty()) sortedSet.remove(score)
     }
     // Redis keeps neither an empty score nor an empty sorted set: the key goes away with its last member.
+    if (sortedSet.isEmpty()) keyValueStore.remove(key)
+
+    return removed
+  }
+
+  override fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Long {
+    val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
+
+    val minDouble = start.bound()
+    val maxDouble = stop.bound()
+    if (minDouble > maxDouble) return 0
+
+    // Matches how zrangeByScore reads the same markers, so a range that selects members there removes exactly those.
+    fun Double.inRange(): Boolean {
+      val aboveStart = if (start.included) this >= minDouble else this > minDouble
+      val belowStop = if (stop.included) this <= maxDouble else this < maxDouble
+      return aboveStart && belowStop
+    }
+
+    var removed = 0L
+    // Every member under one score shares that score, so a bucket is wholly in the range or wholly out of it.
+    for (score in sortedSet.keys.toList()) {
+      if (!score.inRange()) continue
+      removed += sortedSet.getValue(score).size
+      sortedSet.remove(score)
+    }
     if (sortedSet.isEmpty()) keyValueStore.remove(key)
 
     return removed


### PR DESCRIPTION
## Description

Adds a typed `zremRangeByScore` to `Redis` and `DeferredRedis`, so a caller can drop sorted-set members by score range without knowing the member values stored under them.
