### PR TITLE
Tolerate MySQL index/column visibility attributes in declarative schema validation

### DIFF
--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DeclarativeSchemaMigrator.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DeclarativeSchemaMigrator.kt
@@ -114,7 +114,7 @@ internal class DeclarativeSchemaMigrator(
 
       try {
         // Parse the file content
-        val statement = CCJSqlParserUtil.parse(fileContent)
+        val statement = CCJSqlParserUtil.parse(stripVisibilityAttributes(fileContent))
 
         // Check if the parsed statement is a CREATE TABLE statement
         if (statement is CreateTable) {
@@ -137,6 +137,17 @@ internal class DeclarativeSchemaMigrator(
 
     return tables
   }
+
+  /**
+   * Removes MySQL `VISIBLE`/`INVISIBLE` index and column attributes before parsing.
+   *
+   * JSqlParser does not understand MySQL visibility attributes and fails on statements like
+   * `KEY idx (col) INVISIBLE`, but this validation only extracts table and column names, which
+   * visibility never affects. Backtick-quoted identifiers are left untouched, so a column
+   * named `visible` or `invisible` still parses correctly.
+   */
+  private fun stripVisibilityAttributes(sql: String): String =
+    VISIBILITY_ATTRIBUTE_REGEX.replace(sql, "")
 
   /** Helper function to parse database and extract actual tables and columns */
   private fun appliedMigrations(): Map<String, Set<String>> {
@@ -169,5 +180,9 @@ internal class DeclarativeSchemaMigrator(
     }
 
     return actualTables
+  }
+
+  companion object {
+    private val VISIBILITY_ATTRIBUTE_REGEX = Regex("(?i)(?<![`\\w])(?:IN)?VISIBLE(?![`\\w])")
   }
 }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DeclarativeSchemaMigratorTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DeclarativeSchemaMigratorTest.kt
@@ -273,6 +273,31 @@ internal class DeclarativeSchemaMigratorTest {
   }
 
   @Test
+  fun passRequireAllWithInvisibleIndexes() {
+    val mainSource = config.migrations_resources!![0]
+
+    resourceLoader.put(
+      "$mainSource/t1.sql",
+      """
+      |CREATE TABLE `table_1` (
+      |  `id` bigint NOT NULL AUTO_INCREMENT,
+      |  `status` varchar(32) NOT NULL,
+      |  `quote_id` varchar(191) NOT NULL,
+      |  PRIMARY KEY (`id`),
+      |  KEY `idx_status` (`status`) INVISIBLE,
+      |  KEY `idx_quote_id` (`quote_id`) /*!80000 INVISIBLE */
+      |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      |"""
+        .trimMargin(),
+    )
+
+    assertThat(declarativeSchemaMigrator.applyAll("test")).isEqualTo(MigrationStatus.Success)
+
+    // Boot-time validation must tolerate both spellings of an invisible index.
+    assertThat(declarativeSchemaMigrator.requireAll()).isEqualTo(MigrationStatus.Success)
+  }
+
+  @Test
   fun testSqlParsing() {
     val mainSource = config.migrations_resources!![0]
     val librarySource = config.migrations_resources!![1]


### PR DESCRIPTION
## Summary

`DeclarativeSchemaMigrator.requireAll()` parses declarative `.sql` files with JSqlParser to extract expected table and column names. JSqlParser (5.3, the latest release) rejects MySQL 8 index/column visibility attributes, so a declarative table file containing a bare invisible index —

```sql
KEY `idx_status` (`status`) INVISIBLE
```

— failed boot-time validation with `Failed to parse SQL`, even though MySQL and the local apply path (Spirit) both accept it. Making an index invisible before dropping it is the standard way to retire an index safely, so declarative files need to be able to express it; today the only workaround is the conditional-comment spelling `/*!80000 INVISIBLE */`, which JSqlParser skips as a comment.

Since this validation only compares table and column *names* — which visibility never affects — the fix strips bare `VISIBLE`/`INVISIBLE` attribute keywords before parsing. Backtick-quoted identifiers are left untouched, so columns named `visible`/`invisible` still parse correctly.

Added `passRequireAllWithInvisibleIndexes`, which applies a table carrying both spellings via `applyAll()` (Spirit → real MySQL) and then validates it via `requireAll()`.

Note: this is more of a short-term workaround. Raised a long-term fix in this PR: https://github.com/JSQLParser/JSqlParser/pull/2449

🤖 Generated with [Claude Code](https://claude.com/claude-code)