### PR TITLE
Add graceful shutdown draining to aws2-sqs consumer

### DIFF
--- a/misk-aws2-sqs/README.md
+++ b/misk-aws2-sqs/README.md
@@ -271,6 +271,24 @@ Refer to the "threading model" section below for in-depth description.
     the caller's account. This setting is only needed for queues defined outside of your AWS account 
     (external queues)
 
+### Shutdown settings
+
+* `drain_timeout_ms`
+  * default value: null
+  * when set to a positive value, consumer shutdown drains the queue's in-flight work gracefully:
+    polling stops issuing new receive requests (cancelling any receive already in flight), jobs that
+    were already handed off keep their handlers and may finish and acknowledge within this deadline,
+    and only after the drain completes or times out does the service report stopped
+  * when null, zero, or negative, shutdown cancels polling and handling immediately (the legacy
+    behavior); in-flight messages stay invisible until their visibility timeout expires and are then
+    redelivered (or dead-lettered once the queue's maximum receive count is exhausted)
+  * choose a value lower than the termination grace your process actually has when it receives
+    SIGTERM (account for any Kubernetes `preStop` hook that runs first) and lower than the queue's
+    `visibility_timeout`; visibility is not extended while draining
+  * stopping new receives is best effort: SQS may have assigned messages to a receive request that
+    was cancelled at the drain instant; those messages become receivable again after their
+    visibility timeout
+
 **Note:** The `region` is automatically populated from the AWS environment if not explicitly specified 
 in either YAML or dynamic config. This means you typically don't need to specify the region unless 
 you're accessing queues in a different region than your service is deployed in.

--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -102,6 +102,13 @@ public class misk/aws2/sqs/jobqueue/SqsJobQueueModule : misk/inject/KAbstractMod
 public final class misk/aws2/sqs/jobqueue/SqsMetrics {
 	public final fun getBatchEnqueueSize ()Lio/prometheus/client/Histogram;
 	public final fun getChannelReceiveLag ()Lio/prometheus/client/Histogram;
+	public final fun getDrainAckFailures ()Lio/prometheus/client/Counter;
+	public final fun getDrainAcksSucceeded ()Lio/prometheus/client/Counter;
+	public final fun getDrainDuration ()Lio/prometheus/client/Histogram;
+	public final fun getDrainInFlightAtStart ()Lio/prometheus/client/Histogram;
+	public final fun getDrainJobsCancelled ()Lio/prometheus/client/Counter;
+	public final fun getDrainJobsCompleted ()Lio/prometheus/client/Counter;
+	public final fun getDrainsStarted ()Lio/prometheus/client/Counter;
 	public final fun getHandlerDispatchTime ()Lio/prometheus/client/Histogram;
 	public final fun getHandlerFailures ()Lio/prometheus/client/Counter;
 	public final fun getJobBatchEnqueueFailures ()Lio/prometheus/client/Counter;
@@ -116,6 +123,7 @@ public final class misk/aws2/sqs/jobqueue/SqsMetrics {
 	public final fun getJobsReceived ()Lio/prometheus/client/Counter;
 	public final fun getQueueFirstProcessingLag ()Lio/prometheus/client/Histogram;
 	public final fun getQueueProcessingLag ()Lio/prometheus/client/Histogram;
+	public final fun getReceiveAttemptsAfterDrain ()Lio/prometheus/client/Counter;
 	public final fun getSqsBatchSendTime ()Lio/prometheus/client/Histogram;
 	public final fun getSqsDeleteTime ()Lio/prometheus/client/Histogram;
 	public final fun getSqsReceiveFailures ()Lio/prometheus/client/Counter;
@@ -212,8 +220,10 @@ public final class misk/aws2/sqs/jobqueue/config/SqsQueueConfig {
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;)V
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/Long;
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()I
@@ -222,12 +232,13 @@ public final class misk/aws2/sqs/jobqueue/config/SqsQueueConfig {
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
-	public static synthetic fun copy$default (Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
+	public final fun copy (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
+	public static synthetic fun copy$default (Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccount_id ()Ljava/lang/String;
 	public final fun getChannel_capacity ()I
 	public final fun getConcurrency ()I
+	public final fun getDrain_timeout_ms ()Ljava/lang/Long;
 	public final fun getInstall_retry_queue ()Z
 	public final fun getMax_number_of_messages ()I
 	public final fun getParallelism ()I

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
@@ -9,10 +9,15 @@ import java.time.Clock
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
 import misk.inject.AsyncSwitch
 import misk.jobqueue.QueueName
@@ -39,6 +44,18 @@ import misk.testing.TestFixture
  * polling coroutine will wait until all the jobs from the last roundtrip are picked by the handlers before sending
  * another request to SQS. Use channel with a larger buffer size to prefetch messages. This can reduce the latency, but
  * increase the risk of hitting visibility timeout.
+ *
+ * On shutdown, queues configured with a positive `drain_timeout_ms` are drained gracefully: polling stops issuing new
+ * receive requests, jobs that were already received keep their handlers and are given up to the configured deadline to
+ * finish and acknowledge, and only then is the remaining work cancelled. The service reports stopped only after every
+ * queue's drain has completed or timed out. Queues without a drain timeout keep the legacy behavior of immediate
+ * cancellation. Visibility is not extended while draining; the drain deadline should be lower than the queue's
+ * visibility timeout.
+ *
+ * Stopping new receives is best effort: a receive request already in flight when the drain starts is cancelled, but SQS
+ * may have already assigned messages to it server-side. Such messages were never seen by this consumer and become
+ * receivable again once their visibility timeout expires. Draining removes the systematic abandonment of in-flight
+ * work; it does not make shutdown atomic with respect to a racing receive.
  */
 @Singleton
 class SqsJobConsumer
@@ -55,8 +72,11 @@ constructor(
   private val asyncSwitch: AsyncSwitch,
 ) : JobConsumer, AbstractService(), TestFixture {
   private val scope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
+  // Dedicated single-slot view so drain deadline enforcement and notifyStopped() cannot be starved by
+  // other work saturating the shared IO dispatcher.
+  private val stopScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
 
-  private val handlingScopes = ConcurrentHashMap<QueueName, CoroutineScope>()
+  private val subscriptions = ConcurrentHashMap<QueueName, Subscription>()
 
   override fun subscribe(queueName: QueueName, handler: JobHandler) {
     subscribe(queueName = queueName, handler = handler, queueConfig = SqsQueueConfig())
@@ -66,13 +86,14 @@ constructor(
     // We won't resolve dead letter queue yet to skip it for local development and testing
     val deadLetterQueueName = dlqProvider.deadLetterQueueFor(queueName)
 
+    val channel = Channel<SqsJob>(queueConfig.channel_capacity)
     val subscriber =
       Subscriber(
         queueName = queueName,
         queueConfig = queueConfig,
         deadLetterQueueName = deadLetterQueueName,
         handler = handler,
-        channel = Channel(queueConfig.channel_capacity),
+        channel = channel,
         client = sqsClientFactory.get(queueConfig.region!!),
         sqsQueueResolver = sqsQueueResolver,
         sqsMetrics = sqsMetrics,
@@ -83,19 +104,27 @@ constructor(
         asyncSwitch = asyncSwitch,
       )
 
-    scope.launch { subscriber.poll() }
-    handlingScopes[queueName] =
-      CoroutineScope(Dispatchers.IO.limitedParallelism(queueConfig.parallelism) + SupervisorJob())
-    repeat(queueConfig.concurrency) { handlingScopes[queueName]?.launch { subscriber.run() } }
+    val pollJob = scope.launch { subscriber.poll() }
+    val handlingScope = CoroutineScope(Dispatchers.IO.limitedParallelism(queueConfig.parallelism) + SupervisorJob())
+    val handlerJobs = List(queueConfig.concurrency) { handlingScope.launch { subscriber.run() } }
+    subscriptions[queueName] =
+      Subscription(
+        subscriber = subscriber,
+        channel = channel,
+        pollJob = pollJob,
+        handlingScope = handlingScope,
+        handlerJobs = handlerJobs,
+        queueConfig = queueConfig,
+      )
   }
 
   override fun unsubscribe(queueName: QueueName) {
-    handlingScopes[queueName]?.cancel()
+    subscriptions[queueName]?.handlingScope?.cancel()
   }
 
   /** Called automatically between every test to prevent long-running scopes or test timeouts. */
   override fun reset() {
-    handlingScopes.forEach { _, scope -> scope.cancel() }
+    subscriptions.values.forEach { it.handlingScope.cancel() }
   }
 
   override fun doStart() {
@@ -103,12 +132,83 @@ constructor(
   }
 
   override fun doStop() {
-    scope.cancel()
-    handlingScopes.values.forEach { it.cancel() }
-    notifyStopped()
+    val subs = subscriptions.values.toList()
+    // A subscription whose handling scope was already cancelled (unsubscribe/reset) has no handlers left
+    // to drain; waiting on it would burn the full drain deadline for nothing.
+    val (drainable, immediate) =
+      subs.partition { (it.queueConfig.drain_timeout_ms ?: 0) > 0 && it.handlingScope.isActive }
+    if (drainable.isEmpty()) {
+      scope.cancel()
+      subs.forEach { it.handlingScope.cancel() }
+      notifyStopped()
+      return
+    }
+
+    immediate.forEach {
+      it.pollJob.cancel()
+      it.handlingScope.cancel()
+    }
+    stopScope.launch {
+      try {
+        coroutineScope { drainable.forEach { subscription -> launch { drain(subscription) } } }
+        scope.cancel()
+        subs.forEach { it.handlingScope.cancel() }
+        notifyStopped()
+      } catch (t: Throwable) {
+        scope.cancel()
+        subs.forEach { it.handlingScope.cancel() }
+        notifyFailed(t)
+      }
+    }
   }
+
+  private suspend fun drain(subscription: Subscription) {
+    val queueName = subscription.subscriber.queueName.value
+    val drainTimeoutMs = subscription.queueConfig.drain_timeout_ms!!
+    val startMs = clock.millis()
+
+    val inFlightAtStart = subscription.subscriber.startDraining()
+    sqsMetrics.drainsStarted.labels(queueName).inc()
+    sqsMetrics.drainInFlightAtStart.labels(queueName).observe(inFlightAtStart.toDouble())
+    logger.info {
+      "Draining SQS consumer for queue $queueName: $inFlightAtStart job(s) in flight, deadline ${drainTimeoutMs}ms"
+    }
+
+    val drained =
+      withTimeoutOrNull(drainTimeoutMs) {
+        subscription.pollJob.join()
+        subscription.channel.close()
+        subscription.handlerJobs.joinAll()
+      } != null
+
+    if (drained) {
+      logger.info { "Drain of queue $queueName completed in ${clock.millis() - startMs}ms" }
+    } else {
+      val cancelledJobs = subscription.subscriber.inFlightCount()
+      sqsMetrics.drainJobsCancelled.labels(queueName).inc(cancelledJobs.toDouble())
+      subscription.pollJob.cancel()
+      subscription.channel.close()
+      subscription.handlingScope.cancel()
+      logger.warn {
+        "Drain of queue $queueName timed out after ${drainTimeoutMs}ms, cancelled $cancelledJobs in-flight job(s)"
+      }
+    }
+    val result = if (drained) DRAIN_RESULT_COMPLETED else DRAIN_RESULT_TIMEOUT
+    sqsMetrics.drainDuration.labels(queueName, result).observe((clock.millis() - startMs).toDouble())
+  }
+
+  private class Subscription(
+    val subscriber: Subscriber,
+    val channel: Channel<SqsJob>,
+    val pollJob: Job,
+    val handlingScope: CoroutineScope,
+    val handlerJobs: List<Job>,
+    val queueConfig: SqsQueueConfig,
+  )
 
   companion object {
     private val logger = getLogger<SqsJobConsumer>()
+    internal const val DRAIN_RESULT_COMPLETED = "completed"
+    internal const val DRAIN_RESULT_TIMEOUT = "timeout"
   }
 }

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsMetrics.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsMetrics.kt
@@ -141,4 +141,61 @@ class SqsMetrics @Inject internal constructor(metrics: Metrics) {
       "time a job spent it the channel between receiver and handler",
       listOf("QueueName"),
     )
+
+  val drainsStarted =
+    metrics.counter(
+      "jobs_sqs_drains_started_v2_total",
+      "total # of consumer shutdown drains started",
+      listOf("QueueName"),
+    )
+
+  val drainInFlightAtStart =
+    metrics.histogram(
+      "jobs_sqs_drain_in_flight_at_start_v2",
+      "# of active and queued-handoff jobs when a shutdown drain started",
+      listOf("QueueName"),
+    )
+
+  val drainJobsCompleted =
+    metrics.counter(
+      "jobs_sqs_drain_jobs_completed_v2_total",
+      "total # of jobs that finished handling during a shutdown drain, by handler result " +
+        "(ok, retry_later, retry_with_backoff, dead_letter, handler_failed)",
+      listOf("QueueName", "result"),
+    )
+
+  val drainJobsCancelled =
+    metrics.counter(
+      "jobs_sqs_drain_jobs_cancelled_v2_total",
+      "total # of in-flight jobs cancelled because the shutdown drain deadline passed",
+      listOf("QueueName"),
+    )
+
+  val drainDuration =
+    metrics.histogram(
+      "jobs_sqs_drain_duration_ms_v2",
+      "duration of consumer shutdown drains by terminal result",
+      listOf("QueueName", "result"),
+    )
+
+  val receiveAttemptsAfterDrain =
+    metrics.counter(
+      "jobs_sqs_receive_attempts_after_drain_v2_total",
+      "total # of SQS receive attempts made after a shutdown drain started",
+      listOf("QueueName"),
+    )
+
+  val drainAcksSucceeded =
+    metrics.counter(
+      "jobs_sqs_drain_acknowledged_v2_total",
+      "total # of jobs acknowledged during a shutdown drain",
+      listOf("QueueName"),
+    )
+
+  val drainAckFailures =
+    metrics.counter(
+      "jobs_sqs_drain_ack_failures_v2_total",
+      "total # of jobs that failed to acknowledge during a shutdown drain",
+      listOf("QueueName"),
+    )
 }

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -28,6 +28,7 @@ import misk.logging.getLogger
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
@@ -292,6 +293,14 @@ class Subscriber(
         }
       sqsMetrics.sqsReceiveTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
 
+      if (!asyncSwitch.isEnabled("sqs")) {
+        // The switch was disabled while this receive was in flight: a long poll issued while enabled can deliver
+        // messages after the switch flips. Handling them would violate the switch contract, so release them back to
+        // the queue immediately instead of letting them sit out their visibility timeout.
+        releaseMessages(queueName, queueUrl, response.messages())
+        continue
+      }
+
       sqsMetrics.jobsReceived.labels(queueName.value).inc(response.messages().size.toDouble())
       response.messages().forEach { message ->
         message.attributes()[MessageSystemAttributeName.SENT_TIMESTAMP]?.let {
@@ -314,6 +323,33 @@ class Subscriber(
             publishToChannelTimestamp = publishToChannelTimestamp,
           )
         )
+      }
+    }
+  }
+
+  /** Makes messages immediately receivable again by zeroing their visibility timeout. */
+  private suspend fun releaseMessages(queueName: QueueName, queueUrl: String, messages: List<Message>) {
+    if (messages.isEmpty()) return
+    logger.info {
+      "Async SQS tasks disabled while a receive was in flight; releasing ${messages.size} message(s) back to queue ${queueName.value}"
+    }
+    messages.forEach { message ->
+      try {
+        client
+          .changeMessageVisibility(
+            ChangeMessageVisibilityRequest.builder()
+              .queueUrl(queueUrl)
+              .receiptHandle(message.receiptHandle())
+              .visibilityTimeout(0)
+              .build()
+          )
+          .await()
+      } catch (e: Exception) {
+        // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+        currentCoroutineContext().ensureActive()
+        logger.warn(e) {
+          "Failed to release message back to queue ${queueName.value}; it will reappear after the visibility timeout"
+        }
       }
     }
   }

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -5,7 +5,11 @@ import io.opentracing.Tracer
 import io.opentracing.tag.Tags
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -50,43 +54,88 @@ class Subscriber(
   val asyncSwitch: AsyncSwitch,
 ) {
   private var wasDisabled = false
+  private val draining = AtomicBoolean(false)
+  private val inFlightReceives = ConcurrentHashMap.newKeySet<CompletableFuture<ReceiveMessageResponse>>()
+  private val activeJobs = AtomicInteger(0)
+  private val queuedHandoffs = AtomicInteger(0)
+
+  /**
+   * Puts the subscriber into draining mode: no new SQS receive requests are issued and any in-flight receive is
+   * cancelled. Jobs already handed off stay owned - they remain in the channel and are handled normally until the
+   * channel is closed and empty. Returns the number of in-flight jobs at drain start.
+   *
+   * Best effort: cancelling an in-flight receive is a race against SQS assigning messages to that request server-side.
+   * Messages inside a cancelled receive were never seen by this consumer but have started their visibility timeout;
+   * they become receivable again only after it expires. The alternative - waiting out the long poll - would delay
+   * shutdown by up to the configured wait timeout, so prompt exit is preferred and the window is accepted and
+   * documented rather than eliminated.
+   */
+  internal fun startDraining(): Int {
+    draining.set(true)
+    inFlightReceives.forEach { it.cancel(true) }
+    return inFlightCount()
+  }
+
+  /** Number of jobs that have been handed off from polling but have not finished handling. */
+  internal fun inFlightCount(): Int = activeJobs.get() + queuedHandoffs.get()
 
   suspend fun run() {
     while (true) {
-      val job = tracer.withSpan("channel-receive-queue-${queueName.value}") { channel.receive() }
-      tracer.withSpan("process-queue-${queueName.value}") {
-        val receiveFromChannelTimestamp = clock.millis()
-        sqsMetrics.channelReceiveLag
-          .labels(queueName.value)
-          .observe((receiveFromChannelTimestamp - job.publishToChannelTimestamp).toDouble())
-        val result =
-          try {
-            val startTime = clock.millis()
-            val result =
-              tracer.withSpan("handle-queue-${queueName.value}") {
-                when (handler) {
-                  is SuspendingJobHandler -> handler.handleJob(job)
-                  is BlockingJobHandler -> runInterruptible { handler.handleJob(job) }
-                }
+      val job =
+        try {
+          tracer.withSpan("channel-receive-queue-${queueName.value}") { channel.receive() }
+        } catch (e: ClosedReceiveChannelException) {
+          return
+        }
+      queuedHandoffs.decrementAndGet()
+      activeJobs.incrementAndGet()
+      try {
+        val result = process(job)
+        if (draining.get()) {
+          val label = result?.name?.lowercase() ?: "handler_failed"
+          sqsMetrics.drainJobsCompleted.labels(queueName.value, label).inc()
+        }
+      } finally {
+        activeJobs.decrementAndGet()
+      }
+    }
+  }
+
+  /** Handles a single job. Returns the handler's status, or null if the handler threw. */
+  private suspend fun process(job: SqsJob): JobStatus? {
+    return tracer.withSpan("process-queue-${queueName.value}") {
+      val receiveFromChannelTimestamp = clock.millis()
+      sqsMetrics.channelReceiveLag
+        .labels(queueName.value)
+        .observe((receiveFromChannelTimestamp - job.publishToChannelTimestamp).toDouble())
+      val result =
+        try {
+          val startTime = clock.millis()
+          val result =
+            tracer.withSpan("handle-queue-${queueName.value}") {
+              when (handler) {
+                is SuspendingJobHandler -> handler.handleJob(job)
+                is BlockingJobHandler -> runInterruptible { handler.handleJob(job) }
               }
-            sqsMetrics.handlerDispatchTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
-            result
-          } catch (e: Exception) {
-            // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
-            currentCoroutineContext().ensureActive()
-            logger.warn(e) { "Handler failed for job ${job.id} from queue ${job.queueName.value}" }
-            sqsMetrics.handlerFailures.labels(queueName.value).inc()
-            return@withSpan
-          }
-        when (result) {
-          JobStatus.OK -> deleteMessage(job)
-          JobStatus.DEAD_LETTER -> deadLetterMessage(job)
-          JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
-          JobStatus.RETRY_LATER -> {
-            /* no-op, will be retried after visibility timeout passes */
-          }
+            }
+          sqsMetrics.handlerDispatchTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
+          result
+        } catch (e: Exception) {
+          // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
+          currentCoroutineContext().ensureActive()
+          logger.warn(e) { "Handler failed for job ${job.id} from queue ${job.queueName.value}" }
+          sqsMetrics.handlerFailures.labels(queueName.value).inc()
+          return@withSpan null
+        }
+      when (result) {
+        JobStatus.OK -> deleteMessage(job)
+        JobStatus.DEAD_LETTER -> deadLetterMessage(job)
+        JobStatus.RETRY_WITH_BACKOFF -> retryWithBackoff(job)
+        JobStatus.RETRY_LATER -> {
+          /* no-op, will be retried after visibility timeout passes */
         }
       }
+      result
     }
   }
 
@@ -151,10 +200,16 @@ class Subscriber(
       currentCoroutineContext().ensureActive()
       logger.warn(e) { "Failed to acknowledge job ${job.idempotenceKey} from queue ${job.queueName.value}" }
       sqsMetrics.jobsFailedToAcknowledge.labels(queueName.value).inc()
+      if (draining.get()) {
+        sqsMetrics.drainAckFailures.labels(queueName.value).inc()
+      }
       return
     }
     sqsMetrics.sqsDeleteTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
     sqsMetrics.jobsAcknowledged.labels(queueName.value).inc()
+    if (draining.get()) {
+      sqsMetrics.drainAcksSucceeded.labels(queueName.value).inc()
+    }
   }
 
   private suspend fun deadLetterMessage(job: SqsJob) {
@@ -197,7 +252,7 @@ class Subscriber(
 
   private fun messageFlow(queueName: QueueName) = flow {
     val queueUrl = sqsQueueResolver.getQueueUrl(queueName)
-    while (true) {
+    while (!draining.get()) {
       if (!asyncSwitch.isEnabled("sqs")) {
         if (!wasDisabled) {
           logger.info { "Async SQS tasks disabled. Polling paused for queue ${queueName.value}." }
@@ -211,15 +266,29 @@ class Subscriber(
         wasDisabled = false
       }
       val startTime = clock.millis()
+      val future = fetchMessages(queueUrl)
+      inFlightReceives.add(future)
+      if (draining.get()) {
+        // The drain flag was set between the loop check and issuing the receive. startDraining may have missed
+        // this future when cancelling, so cancel it here and record that a receive raced with the drain.
+        sqsMetrics.receiveAttemptsAfterDrain.labels(queueName.value).inc()
+        future.cancel(true)
+      }
       val response =
         try {
-          fetchMessages(queueUrl).await()
+          future.await()
         } catch (e: Exception) {
           // Propagate cancellation of this subscriber, but recover if only the failed operation was canceled.
           currentCoroutineContext().ensureActive()
+          if (draining.get()) {
+            logger.info { "Polling stopped for queue ${queueName.value}: consumer is draining" }
+            break
+          }
           logger.warn(e) { "Failed to fetch messages from queue ${queueName.value}; retrying" }
           sqsMetrics.sqsReceiveFailures.labels(queueName.value).inc()
           continue
+        } finally {
+          inFlightReceives.remove(future)
         }
       sqsMetrics.sqsReceiveTime.labels(queueName.value).observe((clock.millis() - startTime).toDouble())
 
@@ -235,6 +304,7 @@ class Subscriber(
           sqsMetrics.queueProcessingLag.labels(queueName.value).observe(processingLag)
         }
         val publishToChannelTimestamp = clock.millis()
+        queuedHandoffs.incrementAndGet()
         emit(
           SqsJob(
             queueName = queueName,

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfig.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfig.kt
@@ -10,10 +10,10 @@ import misk.jobqueue.QueueName
  * overriding configuration for a given queue `buffered_batch_flush_frequency_ms` controls how often buffered messages
  * are flushed to SQS when using enqueueBuffered
  *
- * `config_feature_flag` allows specifying a dynamic config name that returns a JSON object matching the
- * structure of SqsConfig. When set, the dynamic config is evaluated at service startup and **completely replaces**
- * the YAML configuration. This allows dynamic configuration changes with a service restart (without requiring a code
- * deploy). If not set, or if the dynamic config returns null/empty, the YAML configuration is used.
+ * `config_feature_flag` allows specifying a dynamic config name that returns a JSON object matching the structure of
+ * SqsConfig. When set, the dynamic config is evaluated at service startup and **completely replaces** the YAML
+ * configuration. This allows dynamic configuration changes with a service restart (without requiring a code deploy). If
+ * not set, or if the dynamic config returns null/empty, the YAML configuration is used.
  */
 data class SqsConfig
 @JvmOverloads
@@ -22,9 +22,9 @@ constructor(
   val per_queue_overrides: Map<String, SqsQueueConfig> = emptyMap(),
   val buffered_batch_flush_frequency_ms: Long = 50,
   /**
-   * Dynamic config name that returns a JSON object matching SqsConfig structure.
-   * When set and returns a valid config, it completely replaces the YAML config.
-   * Example value: {"all_queues": {"concurrency": 10}, "per_queue_overrides": {"my_queue": {"concurrency": 20}}}
+   * Dynamic config name that returns a JSON object matching SqsConfig structure. When set and returns a valid config,
+   * it completely replaces the YAML config. Example value: {"all_queues": {"concurrency": 10}, "per_queue_overrides":
+   * {"my_queue": {"concurrency": 20}}}
    */
   val config_feature_flag: String? = null,
 ) : Config {
@@ -37,6 +37,7 @@ constructor(
         visibility_timeout = override.visibility_timeout ?: all_queues.visibility_timeout,
         region = override.region ?: all_queues.region,
         account_id = override.account_id ?: all_queues.account_id,
+        drain_timeout_ms = override.drain_timeout_ms ?: all_queues.drain_timeout_ms,
       )
     } else {
       all_queues

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsQueueConfig.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsQueueConfig.kt
@@ -11,6 +11,10 @@ package misk.aws2.sqs.jobqueue.config
  * will be invisible for subsequent requests. If configured to null, the queue settings will be used. `region` AWS
  * Region of the consumed queue, defaults to the current region. `account_id` AWS Account ID of the consumed queue,
  * defaults to the current account. `queue_name` AWS Queue Name, defaults to the application provided name of the queue.
+ * `drain_timeout_ms` defines how long consumer shutdown waits for in-flight jobs to finish handling and acknowledge
+ * before cancelling them. If null, zero, or negative, shutdown cancels polling and handling immediately (the legacy
+ * behavior). The configured value should be lower than the remaining pod termination grace period at the time the
+ * process receives SIGTERM (after any preStop hook) and lower than the queue visibility timeout.
  */
 data class SqsQueueConfig
 @JvmOverloads
@@ -24,4 +28,5 @@ constructor(
   val visibility_timeout: Int? = null,
   val region: String? = null,
   val account_id: String? = null,
+  val drain_timeout_ms: Long? = null,
 )

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
@@ -1,0 +1,420 @@
+package misk.aws2.sqs.jobqueue
+
+import com.google.common.util.concurrent.Service
+import com.squareup.moshi.Moshi
+import io.opentracing.Tracer
+import jakarta.inject.Inject
+import java.time.Clock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
+import misk.inject.AsyncSwitch
+import misk.jobqueue.QueueName
+import misk.jobqueue.v2.Job
+import misk.jobqueue.v2.JobStatus
+import misk.jobqueue.v2.SuspendingJobHandler
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+
+/**
+ * Tests for graceful consumer shutdown ([SqsQueueConfig.drain_timeout_ms]).
+ *
+ * These tests construct their own [SqsJobConsumer] instances instead of using the injected singleton so that stopping
+ * the consumer under test does not affect the shared, injector-managed service used by other tests.
+ */
+@MiskTest(startService = true)
+class SqsJobConsumerDrainTest {
+  @MiskExternalDependency private val dockerSqs = DockerSqs
+  @MiskTestModule private val module = SqsJobQueueTestModule(dockerSqs)
+
+  @Inject private lateinit var sqsClientFactory: SqsClientFactory
+  @Inject private lateinit var sqsQueueResolver: SqsQueueResolver
+  @Inject private lateinit var visibilityTimeoutCalculator: VisibilityTimeoutCalculator
+  @Inject private lateinit var moshi: Moshi
+  @Inject private lateinit var dlqProvider: DeadLetterQueueProvider
+  @Inject private lateinit var sqsMetrics: SqsMetrics
+  @Inject private lateinit var clock: Clock
+  @Inject private lateinit var tracer: Tracer
+  @Inject private lateinit var asyncSwitch: AsyncSwitch
+
+  private val consumers = mutableListOf<SqsJobConsumer>()
+
+  @AfterEach
+  fun stopConsumers() {
+    consumers.forEach { consumer ->
+      try {
+        consumer.stopAsync().awaitTerminated(30, SECONDS)
+      } catch (e: Exception) {
+        // Best effort: reset() cancels any scopes a failed stop left behind.
+      }
+      consumer.reset()
+    }
+  }
+
+  @Test
+  fun `in-flight job finishes and acknowledges during drain and the message is never redelivered`() {
+    val queueName = QueueName("drain-test-graceful")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    consumer.subscribe(queueName, handler, SqsQueueConfig(region = "us-west-2", drain_timeout_ms = 10_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+
+    // The handler is holding the only in-flight job, so shutdown must not complete yet.
+    consumer.stopAsync()
+    Thread.sleep(500)
+    assertNotEquals(Service.State.TERMINATED, consumer.state(), "stop must wait for the in-flight job")
+
+    handler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    // The job was acknowledged during the drain: nothing visible, and crucially nothing stuck in the
+    // visibility window waiting to be redelivered or dead-lettered.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible, "message should have been deleted, not left visible")
+    assertEquals(0, notVisible, "message should have been deleted, not abandoned in the visibility window")
+    assertEquals(1.0, sqsMetrics.drainsStarted.labels(queueName.value).get())
+    assertEquals(1.0, sqsMetrics.drainAcksSucceeded.labels(queueName.value).get())
+    assertEquals(1.0, sqsMetrics.drainJobsCompleted.labels(queueName.value, "ok").get())
+    assertEquals(0.0, sqsMetrics.drainJobsCancelled.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `handler exceeding the drain deadline is cancelled and shutdown terminates predictably`() {
+    val queueName = QueueName("drain-test-timeout")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val started = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          started.countDown()
+          delay(60_000)
+          return JobStatus.OK
+        }
+      }
+
+    // Visibility of 30s: an abandoned message stays in the not-visible window for the whole test.
+    consumer.subscribe(
+      queueName,
+      handler,
+      SqsQueueConfig(region = "us-west-2", visibility_timeout = 30, drain_timeout_ms = 1_000),
+    )
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(started.await(10, SECONDS), "handler did not start")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(stopMillis >= 1_000, "shutdown returned before the drain deadline: ${stopMillis}ms")
+    assertTrue(stopMillis < 8_000, "shutdown did not terminate promptly after the drain deadline: ${stopMillis}ms")
+
+    // The job was cancelled, so its message remains un-acknowledged in the visibility window.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible)
+    assertEquals(1, notVisible, "cancelled job's message should remain in the visibility window")
+    assertEquals(1.0, sqsMetrics.drainsStarted.labels(queueName.value).get())
+    assertEquals(1.0, sqsMetrics.drainJobsCancelled.labels(queueName.value).get())
+    assertEquals(0.0, sqsMetrics.drainAcksSucceeded.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `drain stops new receives and leaves no message invisibly stranded`() {
+    val queueName = QueueName("drain-test-no-new-receives")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    // One message at a time, rendezvous channel, single handler: the handler holds job 1 while the poller
+    // may have prefetched job 2 into the handoff. Job 3 (or 2 and 3) must never be received after drain.
+    consumer.subscribe(
+      queueName,
+      handler,
+      SqsQueueConfig(
+        region = "us-west-2",
+        parallelism = 1,
+        concurrency = 1,
+        channel_capacity = 0,
+        max_number_of_messages = 1,
+        visibility_timeout = 30,
+        drain_timeout_ms = 10_000,
+      ),
+    )
+    repeat(3) { sendMessage(queue.queueUrl, "message-$it") }
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+    // Give the poller a moment to issue its next receive so the drain interrupts a real in-flight handoff.
+    Thread.sleep(500)
+
+    consumer.stopAsync()
+    handler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    // Every message is either handled-and-deleted or still visible for the replacement pod. A message in the
+    // not-visible window would be exactly the orphaned in-flight delivery this feature exists to prevent.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, notVisible, "no message may be left stranded in the visibility window")
+    assertEquals(3 - handler.handled.get(), visible, "unhandled messages must remain visible")
+    assertTrue(handler.handled.get() >= 1, "the held job should have completed during the drain")
+  }
+
+  @Test
+  fun `queue without a drain timeout keeps the legacy immediate cancellation`() {
+    val queueName = QueueName("drain-test-legacy")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    consumer.subscribe(queueName, handler, SqsQueueConfig(region = "us-west-2", visibility_timeout = 30))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+    assertTrue(stopMillis < 5_000, "legacy shutdown should cancel immediately, took ${stopMillis}ms")
+
+    // Legacy behavior: the in-flight job is cancelled and its message stays in the visibility window.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible)
+    assertEquals(1, notVisible)
+    assertEquals(0.0, sqsMetrics.drainsStarted.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `mixed subscriptions drain configured queues and immediately cancel the rest`() {
+    val drainingQueueName = QueueName("drain-test-mixed-draining")
+    val legacyQueueName = QueueName("drain-test-mixed-legacy")
+    val drainingQueue = createQueue(drainingQueueName)
+    val legacyQueue = createQueue(legacyQueueName)
+    val consumer = newConsumer()
+    val drainingHandler = HoldingHandler()
+    val legacyHandler = HoldingHandler()
+
+    consumer.subscribe(
+      drainingQueueName,
+      drainingHandler,
+      SqsQueueConfig(region = "us-west-2", visibility_timeout = 30, drain_timeout_ms = 10_000),
+    )
+    consumer.subscribe(legacyQueueName, legacyHandler, SqsQueueConfig(region = "us-west-2", visibility_timeout = 30))
+    sendMessage(drainingQueue.queueUrl, "message")
+    sendMessage(legacyQueue.queueUrl, "message")
+    assertTrue(drainingHandler.started.await(10, SECONDS), "draining handler did not start")
+    assertTrue(legacyHandler.started.await(10, SECONDS), "legacy handler did not start")
+
+    consumer.stopAsync()
+    drainingHandler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    val (drainingVisible, drainingNotVisible) = queueDepths(drainingQueue.queueUrl)
+    assertEquals(0, drainingVisible)
+    assertEquals(0, drainingNotVisible, "drained queue's message should have been acknowledged")
+
+    val (legacyVisible, legacyNotVisible) = queueDepths(legacyQueue.queueUrl)
+    assertEquals(0, legacyVisible)
+    assertEquals(1, legacyNotVisible, "legacy queue's job should have been cancelled without acknowledgement")
+  }
+
+  @Test
+  fun `drain with no in-flight work terminates promptly without waiting for the deadline`() {
+    val queueName = QueueName("drain-test-idle")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handled = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handled.countDown()
+          return JobStatus.OK
+        }
+      }
+
+    consumer.subscribe(queueName, handler, SqsQueueConfig(region = "us-west-2", drain_timeout_ms = 30_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handled.await(10, SECONDS), "message was not handled")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(stopMillis < 8_000, "idle drain should not wait for the 30s deadline, took ${stopMillis}ms")
+    assertEquals(1.0, sqsMetrics.drainsStarted.labels(queueName.value).get())
+    assertEquals(0.0, sqsMetrics.drainJobsCancelled.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `concurrent stop calls are safe and idempotent`() {
+    val queueName = QueueName("drain-test-concurrent-stop")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    consumer.subscribe(queueName, handler, SqsQueueConfig(region = "us-west-2", drain_timeout_ms = 10_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+
+    val threads = List(4) { Thread { consumer.stopAsync() } }
+    threads.forEach { it.start() }
+    threads.forEach { it.join() }
+    handler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    assertEquals(1.0, sqsMetrics.drainsStarted.labels(queueName.value).get(), "the drain must run exactly once")
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible)
+    assertEquals(0, notVisible)
+  }
+
+  @Test
+  fun `stop after unsubscribe terminates promptly instead of waiting for the drain deadline`() {
+    val queueName = QueueName("drain-test-unsubscribed")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handled = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handled.countDown()
+          return JobStatus.OK
+        }
+      }
+
+    consumer.subscribe(queueName, handler, SqsQueueConfig(region = "us-west-2", drain_timeout_ms = 30_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handled.await(10, SECONDS), "message was not handled")
+
+    // Unsubscribing cancels the handling scope; a later stop has nothing to drain for this queue and
+    // must not burn the 30s drain deadline waiting on it.
+    consumer.unsubscribe(queueName)
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(
+      stopMillis < 8_000,
+      "stop after unsubscribe should not wait for the drain deadline, took ${stopMillis}ms",
+    )
+    assertEquals(0.0, sqsMetrics.drainsStarted.labels(queueName.value).get(), "unsubscribed queue must not be drained")
+  }
+
+  /** Holds the first job until [release] is called; any further jobs complete immediately. */
+  private class HoldingHandler : SuspendingJobHandler {
+    val started = CountDownLatch(1)
+
+    /** Jobs that ran to completion. A job cancelled mid-hold leaves its message visible and is not counted. */
+    val handled = AtomicInteger(0)
+    private val starts = AtomicInteger(0)
+    private val release = CountDownLatch(1)
+
+    override suspend fun handleJob(job: Job): JobStatus {
+      val first = starts.getAndIncrement() == 0
+      if (first) {
+        started.countDown()
+        while (release.count > 0) {
+          delay(25)
+        }
+      }
+      handled.incrementAndGet()
+      return JobStatus.OK
+    }
+
+    fun release() {
+      release.countDown()
+    }
+  }
+
+  private fun newConsumer(): SqsJobConsumer {
+    val consumer =
+      SqsJobConsumer(
+        sqsClientFactory = sqsClientFactory,
+        sqsQueueResolver = sqsQueueResolver,
+        visibilityTimeoutCalculator = visibilityTimeoutCalculator,
+        moshi = moshi,
+        dlqProvider = dlqProvider,
+        sqsMetrics = sqsMetrics,
+        clock = clock,
+        tracer = tracer,
+        asyncSwitch = asyncSwitch,
+      )
+    consumer.startAsync().awaitRunning()
+    consumers += consumer
+    return consumer
+  }
+
+  /** Returns (visible, notVisible) message counts. ElasticMQ reports these attributes exactly. */
+  private fun queueDepths(queueUrl: String): Pair<Int, Int> {
+    val attributes =
+      DockerSqs.client
+        .getQueueAttributes(
+          GetQueueAttributesRequest.builder()
+            .queueUrl(queueUrl)
+            .attributeNames(
+              QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES,
+              QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE,
+            )
+            .build()
+        )
+        .join()
+        .attributes()
+    return Pair(
+      attributes[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]!!.toInt(),
+      attributes[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE]!!.toInt(),
+    )
+  }
+
+  private fun createQueue(queueName: QueueName): CreatedQueues {
+    val result =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName(queueName.value)
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    val retryResult =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName("${queueName.value}_retryq")
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    val dlqResult =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName("${queueName.value}_dlq")
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    return CreatedQueues(result.queueUrl(), retryResult.queueUrl(), dlqResult.queueUrl())
+  }
+
+  private fun sendMessage(queueUrl: String, message: String) {
+    DockerSqs.client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(message).build()).join()
+  }
+
+  data class CreatedQueues(val queueUrl: String, val retryQueueUrl: String, val dlqQueueUrl: String)
+}

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -143,6 +144,94 @@ class SubscriberTest {
 
     pollingJob.cancelAndJoin()
     assertTrue(pollingJob.isCancelled)
+  }
+
+  @Test
+  fun `startDraining cancels the pending receive and polling stops without further receive attempts`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val pendingResponse = CompletableFuture<ReceiveMessageResponse>()
+    whenever(client.receiveMessage(any<ReceiveMessageRequest>())).thenReturn(pendingResponse)
+
+    val subscriber = subscriber(handler = { JobStatus.OK })
+    val pollingJob = backgroundScope.launch { subscriber.poll() }
+    runCurrent()
+
+    subscriber.startDraining()
+    runCurrent()
+
+    assertTrue(pendingResponse.isCancelled)
+    assertTrue(pollingJob.isCompleted)
+    verify(client, times(1)).receiveMessage(any<ReceiveMessageRequest>())
+    assertEquals(0.0, sqsMetrics.receiveAttemptsAfterDrain.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `jobs already handed off are processed and acknowledged during drain`() = runTest {
+    whenever(client.deleteMessage(any<DeleteMessageRequest>()))
+      .thenReturn(CompletableFuture.completedFuture(DeleteMessageResponse.builder().build()))
+    val handledJobs = mutableListOf<String>()
+    val subscriber =
+      subscriber(
+        handler = { job ->
+          handledJobs += job.id
+          JobStatus.OK
+        }
+      )
+
+    channel.send(job("job-1"))
+    channel.send(job("job-2"))
+    subscriber.startDraining()
+    val handlerJob = backgroundScope.launch { subscriber.run() }
+    channel.close()
+    runCurrent()
+
+    assertEquals(listOf("job-1", "job-2"), handledJobs)
+    verify(client, times(2)).deleteMessage(any<DeleteMessageRequest>())
+    assertTrue(handlerJob.isCompleted)
+    assertEquals(2.0, sqsMetrics.drainJobsCompleted.labels(queueName.value, "ok").get())
+    assertEquals(2.0, sqsMetrics.drainAcksSucceeded.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `acknowledgement failure during drain is recorded as a failure not a success`() = runTest {
+    whenever(client.deleteMessage(any<DeleteMessageRequest>()))
+      .thenReturn(
+        CompletableFuture.failedFuture<DeleteMessageResponse>(
+          SqsException.builder().message("delete failed").statusCode(500).build()
+        )
+      )
+    val subscriber = subscriber(handler = { JobStatus.OK })
+
+    channel.send(job("job-1"))
+    subscriber.startDraining()
+    val handlerJob = backgroundScope.launch { subscriber.run() }
+    channel.close()
+    runCurrent()
+
+    assertTrue(handlerJob.isCompleted)
+    assertEquals(1.0, sqsMetrics.jobsFailedToAcknowledge.labels(queueName.value).get())
+    assertEquals(1.0, sqsMetrics.drainAckFailures.labels(queueName.value).get())
+    assertEquals(0.0, sqsMetrics.drainAcksSucceeded.labels(queueName.value).get())
+  }
+
+  @Test
+  fun `a receive issued concurrently with drain start is cancelled and recorded`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val subscriber = subscriber(handler = { JobStatus.OK })
+    // Simulate the race where the drain flag is set after the polling loop's check but before the
+    // receive is registered: the first receive call flips the drain flag itself.
+    val pendingResponse = CompletableFuture<ReceiveMessageResponse>()
+    whenever(client.receiveMessage(any<ReceiveMessageRequest>())).thenAnswer {
+      subscriber.startDraining()
+      pendingResponse
+    }
+
+    val pollingJob = backgroundScope.launch { subscriber.poll() }
+    runCurrent()
+
+    assertTrue(pendingResponse.isCancelled)
+    assertTrue(pollingJob.isCompleted)
+    assertEquals(1.0, sqsMetrics.receiveAttemptsAfterDrain.labels(queueName.value).get())
   }
 
   private fun subscriber(

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
 import misk.inject.AlwaysEnabledSwitch
+import misk.inject.AsyncSwitch
+import misk.inject.FakeSwitch
 import misk.jobqueue.QueueName
 import misk.jobqueue.v2.Job
 import misk.jobqueue.v2.JobHandler
@@ -215,6 +217,31 @@ class SubscriberTest {
   }
 
   @Test
+  fun `messages delivered after the switch is disabled are released back to the queue, not handled`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val fakeSwitch = FakeSwitch().apply { enabledKeys.add("sqs") }
+    // Simulate the switch flipping while a receive is in flight: the receive call itself disables the
+    // switch, then delivers a message.
+    whenever(client.receiveMessage(any<ReceiveMessageRequest>())).thenAnswer {
+      fakeSwitch.enabledKeys.remove("sqs")
+      CompletableFuture.completedFuture(ReceiveMessageResponse.builder().messages(message("job-1")).build())
+    }
+    whenever(client.changeMessageVisibility(any<ChangeMessageVisibilityRequest>()))
+      .thenReturn(CompletableFuture.completedFuture(ChangeMessageVisibilityResponse.builder().build()))
+
+    val pollingJob = backgroundScope.launch { subscriber(handler = { JobStatus.OK }, asyncSwitch = fakeSwitch).poll() }
+    runCurrent()
+
+    assertTrue(channel.isEmpty)
+    assertTrue(pollingJob.isActive)
+    val visibilityRequest = argumentCaptor<ChangeMessageVisibilityRequest>()
+    verify(client).changeMessageVisibility(visibilityRequest.capture())
+    assertEquals("receipt-job-1", visibilityRequest.firstValue.receiptHandle())
+    assertEquals(0, visibilityRequest.firstValue.visibilityTimeout())
+    assertEquals(0.0, sqsMetrics.jobsReceived.labels(queueName.value).get())
+  }
+
+  @Test
   fun `a receive issued concurrently with drain start is cancelled and recorded`() = runTest {
     whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
     val subscriber = subscriber(handler = { JobStatus.OK })
@@ -237,6 +264,7 @@ class SubscriberTest {
   private fun subscriber(
     handler: JobHandler,
     queueConfig: SqsQueueConfig = SqsQueueConfig(install_retry_queue = false),
+    asyncSwitch: AsyncSwitch = AlwaysEnabledSwitch(),
   ) =
     Subscriber(
       queueName = queueName,
@@ -251,14 +279,18 @@ class SubscriberTest {
       clock = Clock.systemUTC(),
       tracer = ConcurrentMockTracer(),
       visibilityTimeoutCalculator = VisibilityTimeoutCalculator(),
-      asyncSwitch = AlwaysEnabledSwitch(),
+      asyncSwitch = asyncSwitch,
     )
 
-  private fun subscriber(handler: suspend (Job) -> JobStatus): Subscriber =
+  private fun subscriber(
+    handler: suspend (Job) -> JobStatus,
+    asyncSwitch: AsyncSwitch = AlwaysEnabledSwitch(),
+  ): Subscriber =
     subscriber(
       object : SuspendingJobHandler {
         override suspend fun handleJob(job: Job) = handler(job)
-      }
+      },
+      asyncSwitch = asyncSwitch,
     )
 
   private fun job(id: String) =

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfigTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfigTest.kt
@@ -44,9 +44,7 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig returns all_queues when no per_queue_override exists`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(concurrency = 10, parallelism = 5),
-    )
+    val config = SqsConfig(all_queues = SqsQueueConfig(concurrency = 10, parallelism = 5))
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
@@ -56,12 +54,11 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig returns per_queue_override when it exists`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(concurrency = 1, parallelism = 1),
-      per_queue_overrides = mapOf(
-        "test-queue" to SqsQueueConfig(concurrency = 20, parallelism = 10),
-      ),
-    )
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(concurrency = 1, parallelism = 1),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(concurrency = 20, parallelism = 10)),
+      )
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
@@ -71,17 +68,44 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig inherits nullable fields from all_queues`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(region = "us-west-2", wait_timeout = 20),
-      per_queue_overrides = mapOf(
-        "test-queue" to SqsQueueConfig(concurrency = 10),
-      ),
-    )
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(region = "us-west-2", wait_timeout = 20),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(concurrency = 10)),
+      )
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
     assertEquals(10, queueConfig.concurrency)
     assertEquals("us-west-2", queueConfig.region) // inherited from all_queues
     assertEquals(20, queueConfig.wait_timeout) // inherited from all_queues
+  }
+
+  @Test
+  fun `drain_timeout_ms defaults to null`() {
+    val config = SqsConfig()
+    assertEquals(null, config.getQueueConfig(misk.jobqueue.QueueName("test-queue")).drain_timeout_ms)
+  }
+
+  @Test
+  fun `drain_timeout_ms is inherited from all_queues when not overridden`() {
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(drain_timeout_ms = 5_000),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(concurrency = 10)),
+      )
+
+    assertEquals(5_000, config.getQueueConfig(misk.jobqueue.QueueName("test-queue")).drain_timeout_ms)
+  }
+
+  @Test
+  fun `drain_timeout_ms per-queue override wins over all_queues`() {
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(drain_timeout_ms = 5_000),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(drain_timeout_ms = 20_000)),
+      )
+
+    assertEquals(20_000, config.getQueueConfig(misk.jobqueue.QueueName("test-queue")).drain_timeout_ms)
   }
 }


### PR DESCRIPTION
## The problem

When a misk service using the aws2-sqs consumer shuts down (deploy, pod eviction, node drain), `SqsJobConsumer` cancels its handling scope immediately. Jobs that are mid-handler are killed on the spot: the work is lost, the messages stay invisible until their visibility timeout expires, and on queues with a low `maxReceiveCount` they go straight to the DLQ. For a service that deploys frequently, every rollout systematically abandons whatever was in flight — in Cash App's Rey service this is the dominant source of dead-lettered jobs (`maxReceiveCount: 1`, 30-minute visibility timeout).

## What this adds

A new **optional** per-queue setting, `drain_timeout_ms`:

```yaml
aws_sqs:
  per_queue_overrides:
    my_queue:
      drain_timeout_ms: 15000
```

When set to a positive value, consumer shutdown becomes a drain:

1. Polling stops issuing new receive requests.
2. Jobs already received keep their handlers and get up to the deadline to finish and acknowledge.
3. Only work still unfinished at the deadline is cancelled.

**Default behavior is unchanged.** The field defaults to `null`; null, zero, or negative keeps the legacy immediate-cancel path, as do subscriptions whose handling scope was already cancelled (unsubscribe/reset). The constructor is `@JvmOverloads` and the binary-compat API dump is regenerated, so existing callers and configs are untouched.

The drain deadline is enforced from a dedicated single-slot dispatcher view so it cannot be starved by work saturating the shared IO dispatcher. Operators should size the value below the pod's remaining termination grace after SIGTERM (accounting for any preStop hook) and below the queue's visibility timeout.

One caveat: stopping new receives is best effort. A receive request in flight when the drain starts is cancelled, but SQS may have assigned messages to it server-side; those become receivable again after their visibility timeout. Draining removes the systematic abandonment of in-flight work; it does not make shutdown atomic with a racing receive.

This PR also hardens a pre-existing race the new tests made reproducible: the async on/off switch only gated *issuing* a receive, so a long poll in flight when the switch was disabled would still hand its messages to handlers. Receives completing after disable now release their messages back to the queue via `ChangeMessageVisibility(0)` instead.

## Metrics

New counters/histograms for observing drain behavior: drains started, in-flight jobs at drain start, jobs completed during drain (labeled by handler result), jobs cancelled at deadline, drain duration (labeled completed/timeout), receive attempts after drain, and drain-scoped ack successes/failures.

## Testing

- `SqsJobConsumerDrainTest`: 8 integration tests against a real SQS container (drain completes early, deadline enforcement, opt-out queues keep legacy behavior, unsubscribe path, mixed-queue services, metrics).
- `SubscriberTest`: unit coverage of the drain path and the async-switch race (no handoff after disable, visibility zeroed).
- `SqsConfigTest`: per-queue override resolution for the new field.
- README documentation and regenerated API dump included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
