### PR TITLE
Add atomic Redis transaction blocks

### DIFF
--- a/misk-redis/api/misk-redis.api
+++ b/misk-redis/api/misk-redis.api
@@ -127,6 +127,7 @@ public final class misk/redis/FakeRedis : misk/redis/Redis {
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
+	public fun transaction (Lkotlin/jvm/functions/Function1;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
@@ -200,6 +201,7 @@ public final class misk/redis/RealRedis : misk/redis/Redis {
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
+	public fun transaction (Lkotlin/jvm/functions/Function1;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
@@ -273,6 +275,7 @@ public abstract interface class misk/redis/Redis {
 	public abstract fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
 	public abstract fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public abstract fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
+	public abstract fun transaction (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun unwatch ([Ljava/lang/String;)V
 	public abstract fun watch ([Ljava/lang/String;)V
 	public abstract fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J
@@ -638,6 +641,7 @@ public final class misk/redis/testing/FakeRedis : misk/redis/Redis, misk/testing
 	public fun setnx (Ljava/lang/String;Ljava/time/Duration;Lokio/ByteString;)Z
 	public fun setnx (Ljava/lang/String;Lokio/ByteString;)Z
 	public fun subscribe (Lredis/clients/jedis/JedisPubSub;Ljava/lang/String;)V
+	public fun transaction (Lkotlin/jvm/functions/Function1;)V
 	public fun unwatch ([Ljava/lang/String;)V
 	public fun watch ([Ljava/lang/String;)V
 	public fun zadd (Ljava/lang/String;DLjava/lang/String;[Lmisk/redis/Redis$ZAddOptions;)J

--- a/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/DeferredRedis.kt
@@ -5,7 +5,7 @@ import java.util.function.Supplier
 import okio.ByteString
 import redis.clients.jedis.args.ListDirection
 
-/** Like [Redis], but returns [Supplier]s to defer value retrieval. **Does not support transactions or pubsub.** */
+/** Like [Redis], but returns [Supplier]s to defer value retrieval in a pipeline or transaction. */
 interface DeferredRedis {
   fun del(key: String): Supplier<Boolean>
 

--- a/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/FakeRedis.kt
@@ -465,6 +465,10 @@ class FakeRedis : Redis {
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  override fun transaction(block: DeferredRedis.() -> Unit) {
+    throw NotImplementedError("Use the fake from misk.redis.testing instead.")
+  }
+
   @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
     throw NotImplementedError("Fake client not implemented for this operation")

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -4,11 +4,11 @@ import java.time.Duration
 import java.util.function.Supplier
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
-import redis.clients.jedis.AbstractPipeline
-import redis.clients.jedis.AbstractTransaction
 import redis.clients.jedis.ClusterPipeline
+import redis.clients.jedis.Pipeline
 import redis.clients.jedis.PipeliningBase
 import redis.clients.jedis.Response
+import redis.clients.jedis.Transaction
 import redis.clients.jedis.args.ListDirection
 import redis.clients.jedis.params.SetParams
 import redis.clients.jedis.params.ZRangeParams
@@ -16,6 +16,12 @@ import redis.clients.jedis.resps.Tuple
 import redis.clients.jedis.util.JedisClusterCRC16
 
 internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : DeferredRedis {
+  init {
+    check(pipeline is Pipeline || pipeline is ClusterPipeline || pipeline is Transaction) {
+      "Unknown deferred Redis type: $pipeline"
+    }
+  }
+
   private fun checkSlot(op: String, keys: List<ByteArray>): Throwable? {
     if (pipeline !is ClusterPipeline) {
       return null
@@ -33,12 +39,14 @@ internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : Deferr
     val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
     val responses =
       when (pipeline) {
+        is Pipeline,
+        is Transaction -> listOf(pipeline.del(*keysBytes))
         is ClusterPipeline -> {
           keysBytes
             .groupBy { JedisClusterCRC16.getSlot(it) }
             .map { (_, slottedKeys) -> pipeline.del(*slottedKeys.toTypedArray()) }
         }
-        else -> listOf(pipeline.del(*keysBytes))
+        else -> error("Unknown deferred Redis type: $pipeline")
       }
     return Supplier { responses.fold(0) { acc, response -> acc + response.get().toInt() } }
   }
@@ -47,6 +55,11 @@ internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : Deferr
     val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
 
     return when (pipeline) {
+      is Pipeline,
+      is Transaction -> {
+        val response = pipeline.mget(*keysBytes)
+        Supplier { response.get().map { it?.toByteString() } }
+      }
       is ClusterPipeline -> {
         val responses =
           keysBytes
@@ -66,10 +79,7 @@ internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : Deferr
           keys.map { keyToValueMap[it] }
         }
       }
-      else -> {
-        val response = pipeline.mget(*keysBytes)
-        Supplier { response.get().map { it?.toByteString() } }
-      }
+      else -> error("Unknown deferred Redis type: $pipeline")
     }
   }
 
@@ -82,13 +92,15 @@ internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : Deferr
 
     val responses =
       when (pipeline) {
+        is Pipeline,
+        is Transaction -> listOf(pipeline.mset(*keyValuePairs.toTypedArray()))
         is ClusterPipeline -> {
           keyValuePairs
             .chunked(2)
             .groupBy { JedisClusterCRC16.getSlot(it.first()) }
             .map { (_, slottedKeyValues) -> pipeline.mset(*slottedKeyValues.flatten().toTypedArray()) }
         }
-        else -> listOf(pipeline.mset(*keyValuePairs.toTypedArray()))
+        else -> error("Unknown deferred Redis type: $pipeline")
       }
     return Supplier { responses.map { it.get() } }
   }
@@ -556,8 +568,9 @@ internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : Deferr
 
   override fun close() {
     when (pipeline) {
-      is AbstractPipeline -> pipeline.close()
-      is AbstractTransaction -> pipeline.close()
+      is Pipeline -> pipeline.close()
+      is ClusterPipeline -> pipeline.close()
+      is Transaction -> pipeline.close()
       else -> error("Unknown deferred Redis type: $pipeline")
     }
   }

--- a/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealPipelinedRedis.kt
@@ -5,8 +5,9 @@ import java.util.function.Supplier
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import redis.clients.jedis.AbstractPipeline
+import redis.clients.jedis.AbstractTransaction
 import redis.clients.jedis.ClusterPipeline
-import redis.clients.jedis.Pipeline
+import redis.clients.jedis.PipeliningBase
 import redis.clients.jedis.Response
 import redis.clients.jedis.args.ListDirection
 import redis.clients.jedis.params.SetParams
@@ -14,7 +15,7 @@ import redis.clients.jedis.params.ZRangeParams
 import redis.clients.jedis.resps.Tuple
 import redis.clients.jedis.util.JedisClusterCRC16
 
-internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : DeferredRedis {
+internal class RealPipelinedRedis(private val pipeline: PipeliningBase) : DeferredRedis {
   private fun checkSlot(op: String, keys: List<ByteArray>): Throwable? {
     if (pipeline !is ClusterPipeline) {
       return null
@@ -32,13 +33,12 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
     val responses =
       when (pipeline) {
-        is Pipeline -> listOf(pipeline.del(*keysBytes))
         is ClusterPipeline -> {
           keysBytes
             .groupBy { JedisClusterCRC16.getSlot(it) }
             .map { (_, slottedKeys) -> pipeline.del(*slottedKeys.toTypedArray()) }
         }
-        else -> error("Unknown pipeline type: $pipeline")
+        else -> listOf(pipeline.del(*keysBytes))
       }
     return Supplier { responses.fold(0) { acc, response -> acc + response.get().toInt() } }
   }
@@ -47,10 +47,6 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
     val keysBytes = keys.map { it.toByteArray(charset) }.toTypedArray()
 
     return when (pipeline) {
-      is Pipeline -> {
-        val response = pipeline.mget(*keysBytes)
-        Supplier { response.get().map { it?.toByteString() } }
-      }
       is ClusterPipeline -> {
         val responses =
           keysBytes
@@ -70,7 +66,10 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
           keys.map { keyToValueMap[it] }
         }
       }
-      else -> error("Unknown pipeline type: $pipeline")
+      else -> {
+        val response = pipeline.mget(*keysBytes)
+        Supplier { response.get().map { it?.toByteString() } }
+      }
     }
   }
 
@@ -83,14 +82,13 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
 
     val responses =
       when (pipeline) {
-        is Pipeline -> listOf(pipeline.mset(*keyValuePairs.toTypedArray()))
         is ClusterPipeline -> {
           keyValuePairs
             .chunked(2)
             .groupBy { JedisClusterCRC16.getSlot(it.first()) }
             .map { (_, slottedKeyValues) -> pipeline.mset(*slottedKeyValues.flatten().toTypedArray()) }
         }
-        else -> error("Unknown pipeline type: $pipeline")
+        else -> listOf(pipeline.mset(*keyValuePairs.toTypedArray()))
       }
     return Supplier { responses.map { it.get() } }
   }
@@ -557,7 +555,11 @@ internal class RealPipelinedRedis(private val pipeline: AbstractPipeline) : Defe
   }
 
   override fun close() {
-    pipeline.close()
+    when (pipeline) {
+      is AbstractPipeline -> pipeline.close()
+      is AbstractTransaction -> pipeline.close()
+      else -> error("Unknown deferred Redis type: $pipeline")
+    }
   }
 
   companion object {

--- a/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/RealRedis.kt
@@ -400,6 +400,21 @@ class RealRedis(private val unifiedJedis: UnifiedJedis, private val clientMetric
       ?: error("Transactions aren't supported in misk-redis with ${unifiedJedis.javaClass} at this time.")
   }
 
+  override fun transaction(block: DeferredRedis.() -> Unit) {
+    when (unifiedJedis) {
+      is JedisPooled ->
+        unifiedJedis.pool.resource.use { connection ->
+          Transaction(connection, false).use { transaction ->
+            transaction.multi()
+            block(RealPipelinedRedis(transaction))
+            transaction.exec()
+          }
+        }
+
+      else -> error("Transactions aren't supported in misk-redis with ${unifiedJedis.javaClass} at this time.")
+    }
+  }
+
   // Pipelined requests do not get client histogram metrics right now.
   // pipelined() returns the jedis to the pool, despite returning a Pipeline that holds a reference
   // to the borrowed jedis connection.

--- a/misk-redis/src/main/kotlin/misk/redis/Redis.kt
+++ b/misk-redis/src/main/kotlin/misk/redis/Redis.kt
@@ -483,6 +483,14 @@ interface Redis {
   /** Marks the start of a transaction block. Subsequent commands will be queued for atomic execution using EXEC. */
   fun multi(): Transaction
 
+  /**
+   * Runs [block]'s commands atomically using MULTI/EXEC. Command responses are not available until the transaction
+   * completes. Save their [Supplier]s and read them after this method returns.
+   *
+   * Transactions are not supported in Redis Cluster mode.
+   */
+  fun transaction(block: DeferredRedis.() -> Unit)
+
   /** Begin a pipeline operation to batch together several updates for optimal performance */
   @Deprecated("Use pipelining instead.") fun pipelined(): Pipeline
 

--- a/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTransactionTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/AbstractRedisTransactionTest.kt
@@ -1,0 +1,46 @@
+package misk.redis
+
+import java.util.function.Supplier
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.Test
+
+abstract class AbstractRedisTransactionTest : AbstractRedisTest() {
+  @Test
+  fun `transaction queues commands and resolves responses after commit`() {
+    redis.zadd("book", 100.0, "old")
+    lateinit var removed: Supplier<Long>
+    lateinit var added: Supplier<Long>
+
+    redis.transaction {
+      removed = zremRangeByScore("book", Redis.ZRangeScoreMarker(100.0), Redis.ZRangeScoreMarker(100.0))
+      added = zadd("book", 100.0, "new")
+
+      assertFails { removed.get() }
+      assertEquals(100.0, redis.zscore("book", "old"))
+      assertNull(redis.zscore("book", "new"))
+    }
+
+    assertEquals(1L, removed.get())
+    assertEquals(1L, added.get())
+    assertNull(redis.zscore("book", "old"))
+    assertEquals(100.0, redis.zscore("book", "new"))
+  }
+
+  @Test
+  fun `transaction discards queued commands when the block fails`() {
+    redis["transaction-key"] = "before".encodeUtf8()
+
+    assertFailsWith<IllegalStateException> {
+      redis.transaction {
+        set("transaction-key", "after".encodeUtf8())
+        error("boom")
+      }
+    }
+
+    assertEquals("before".encodeUtf8(), redis["transaction-key"])
+  }
+}

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -2,7 +2,6 @@ package misk.redis
 
 import jakarta.inject.Inject
 import java.time.Duration
-import java.util.function.Supplier
 import kotlin.random.Random
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -23,7 +22,7 @@ import org.junit.jupiter.api.Test
 import redis.clients.jedis.args.ListDirection
 
 @MiskTest
-class FakeRedisTest : AbstractRedisTest() {
+class FakeRedisTest : AbstractRedisTransactionTest() {
   @Suppress("unused")
   @MiskTestModule
   private val module =
@@ -37,37 +36,6 @@ class FakeRedisTest : AbstractRedisTest() {
 
   @Inject lateinit var clock: FakeClock
   @Inject override lateinit var redis: Redis
-
-  @Test
-  fun `transaction queues commands and resolves responses after commit`() {
-    redis["transaction-key"] = "before".encodeUtf8()
-    lateinit var removed: Supplier<Boolean>
-
-    redis.transaction {
-      removed = del("transaction-key")
-      set("transaction-key", "after".encodeUtf8())
-
-      assertFails { removed.get() }
-      assertEquals("before".encodeUtf8(), redis["transaction-key"])
-    }
-
-    assertTrue(removed.get())
-    assertEquals("after".encodeUtf8(), redis["transaction-key"])
-  }
-
-  @Test
-  fun `transaction discards queued commands when the block fails`() {
-    redis["transaction-key"] = "before".encodeUtf8()
-
-    assertFails {
-      redis.transaction {
-        set("transaction-key", "after".encodeUtf8())
-        error("boom")
-      }
-    }
-
-    assertEquals("before".encodeUtf8(), redis["transaction-key"])
-  }
 
   @Test
   fun expireInOneSecond() {

--- a/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/FakeRedisTest.kt
@@ -2,6 +2,7 @@ package misk.redis
 
 import jakarta.inject.Inject
 import java.time.Duration
+import java.util.function.Supplier
 import kotlin.random.Random
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -36,6 +37,37 @@ class FakeRedisTest : AbstractRedisTest() {
 
   @Inject lateinit var clock: FakeClock
   @Inject override lateinit var redis: Redis
+
+  @Test
+  fun `transaction queues commands and resolves responses after commit`() {
+    redis["transaction-key"] = "before".encodeUtf8()
+    lateinit var removed: Supplier<Boolean>
+
+    redis.transaction {
+      removed = del("transaction-key")
+      set("transaction-key", "after".encodeUtf8())
+
+      assertFails { removed.get() }
+      assertEquals("before".encodeUtf8(), redis["transaction-key"])
+    }
+
+    assertTrue(removed.get())
+    assertEquals("after".encodeUtf8(), redis["transaction-key"])
+  }
+
+  @Test
+  fun `transaction discards queued commands when the block fails`() {
+    redis["transaction-key"] = "before".encodeUtf8()
+
+    assertFails {
+      redis.transaction {
+        set("transaction-key", "after".encodeUtf8())
+        error("boom")
+      }
+    }
+
+    assertEquals("before".encodeUtf8(), redis["transaction-key"])
+  }
 
   @Test
   fun expireInOneSecond() {

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -3,7 +3,6 @@ package misk.redis
 import com.google.inject.Module
 import jakarta.inject.Inject
 import java.time.Duration
-import java.util.function.Supplier
 import misk.MiskTestingServiceModule
 import misk.environment.DeploymentModule
 import misk.inject.KAbstractModule
@@ -21,7 +20,7 @@ import redis.clients.jedis.ReliableTransaction
 import wisp.deployment.TESTING
 
 @MiskTest
-class RealRedisTest : AbstractRedisTest() {
+class RealRedisTest : AbstractRedisTransactionTest() {
   @Suppress("unused")
   @MiskTestModule
   private val module: Module =
@@ -89,38 +88,6 @@ class RealRedisTest : AbstractRedisTest() {
 
     assertThat(redis["key5"]).isEqualTo("value5".encodeUtf8())
     assertThat(redis["key6"]).isNull()
-  }
-
-  @Test
-  fun `transaction block executes queued commands and resolves responses`() {
-    redis.zadd("book", 100.0, "old")
-    lateinit var removed: Supplier<Long>
-    lateinit var added: Supplier<Long>
-
-    redis.transaction {
-      removed = zremRangeByScore("book", Redis.ZRangeScoreMarker(100.0), Redis.ZRangeScoreMarker(100.0))
-      added = zadd("book", 100.0, "new")
-    }
-
-    assertThat(removed.get()).isEqualTo(1L)
-    assertThat(added.get()).isEqualTo(1L)
-    assertThat(redis.zscore("book", "old")).isNull()
-    assertThat(redis.zscore("book", "new")).isEqualTo(100.0)
-  }
-
-  @Test
-  fun `transaction block discards queued commands when the block fails`() {
-    redis["transaction-key"] = "before".encodeUtf8()
-
-    assertThatThrownBy {
-        redis.transaction {
-          set("transaction-key", "after".encodeUtf8())
-          error("boom")
-        }
-      }
-      .isInstanceOf(IllegalStateException::class.java)
-
-    assertThat(redis["transaction-key"]).isEqualTo("before".encodeUtf8())
   }
 
   @Test

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -3,6 +3,7 @@ package misk.redis
 import com.google.inject.Module
 import jakarta.inject.Inject
 import java.time.Duration
+import java.util.function.Supplier
 import misk.MiskTestingServiceModule
 import misk.environment.DeploymentModule
 import misk.inject.KAbstractModule
@@ -12,6 +13,7 @@ import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import redis.clients.jedis.ConnectionPoolConfig
 import wisp.deployment.TESTING
@@ -85,6 +87,38 @@ class RealRedisTest : AbstractRedisTest() {
 
     assertThat(redis["key5"]).isEqualTo("value5".encodeUtf8())
     assertThat(redis["key6"]).isNull()
+  }
+
+  @Test
+  fun `transaction block executes queued commands and resolves responses`() {
+    redis.zadd("book", 100.0, "old")
+    lateinit var removed: Supplier<Long>
+    lateinit var added: Supplier<Long>
+
+    redis.transaction {
+      removed = zremRangeByScore("book", Redis.ZRangeScoreMarker(100.0), Redis.ZRangeScoreMarker(100.0))
+      added = zadd("book", 100.0, "new")
+    }
+
+    assertThat(removed.get()).isEqualTo(1L)
+    assertThat(added.get()).isEqualTo(1L)
+    assertThat(redis.zscore("book", "old")).isNull()
+    assertThat(redis.zscore("book", "new")).isEqualTo(100.0)
+  }
+
+  @Test
+  fun `transaction block discards queued commands when the block fails`() {
+    redis["transaction-key"] = "before".encodeUtf8()
+
+    assertThatThrownBy {
+        redis.transaction {
+          set("transaction-key", "after".encodeUtf8())
+          error("boom")
+        }
+      }
+      .isInstanceOf(IllegalStateException::class.java)
+
+    assertThat(redis["transaction-key"]).isEqualTo("before".encodeUtf8())
   }
 
   @Test

--- a/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/RealRedisTest.kt
@@ -15,7 +15,9 @@ import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import redis.clients.jedis.Connection
 import redis.clients.jedis.ConnectionPoolConfig
+import redis.clients.jedis.ReliableTransaction
 import wisp.deployment.TESTING
 
 @MiskTest
@@ -119,6 +121,15 @@ class RealRedisTest : AbstractRedisTest() {
       .isInstanceOf(IllegalStateException::class.java)
 
     assertThat(redis["transaction-key"]).isEqualTo("before".encodeUtf8())
+  }
+
+  @Test
+  fun `deferred Redis rejects unknown Jedis implementations`() {
+    val unsupported = ReliableTransaction(Connection(), false)
+
+    assertThatThrownBy { RealPipelinedRedis(unsupported) }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("Unknown deferred Redis type")
   }
 
   @Test

--- a/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
+++ b/misk-redis/src/test/kotlin/misk/redis/TestAlwaysPipelinedRedis.kt
@@ -149,6 +149,10 @@ internal class TestAlwaysPipelinedRedis @Inject constructor(private val unifiedJ
     error("multi is not supported in TestAlwaysPipelinedRedis")
   }
 
+  override fun transaction(block: DeferredRedis.() -> Unit) {
+    error("transaction is not supported in TestAlwaysPipelinedRedis")
+  }
+
   @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
     error("pipelined is not supported in TestAlwaysPipelinedRedis")

--- a/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
+++ b/misk-redis/src/testFixtures/kotlin/misk/redis/testing/FakeRedis.kt
@@ -44,7 +44,7 @@ import redis.clients.jedis.args.ListDirection
  * - You need fine-grained control over key-expiry in tests
  *
  * Caveats:
- * - FakeRedis does not currently support [Redis.multi] transactions
+ * - FakeRedis does not support the Jedis-specific [Redis.multi] API. Use [Redis.transaction] instead.
  */
 class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis private val random: Random) :
   Redis, TestFixture {
@@ -99,6 +99,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
   /** Acts as the Redis key-value store. */
   private val keyValueStore = KeyValueStore(ConcurrentHashMap<String, Value>())
 
+  @Synchronized
   override fun reset() {
     keyValueStore.clear()
   }
@@ -380,7 +381,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return keyValueStore.getTyped<Value.List>(key)?.data?.size?.toLong() ?: 0L
   }
 
-  override fun rpop(key: String): ByteString? = rpop(key, count = 1).firstOrNull()
+  @Synchronized override fun rpop(key: String): ByteString? = rpop(key, count = 1).firstOrNull()
 
   @Synchronized
   override fun lrange(key: String, start: Long, stop: Long): List<ByteString?> {
@@ -411,6 +412,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     keyValueStore[key] = Value.List(data = trimmedList, expiryInstant = expiry)
   }
 
+  @Synchronized
   override fun lrem(key: String, count: Long, element: ByteString): Long {
     val value = keyValueStore.getTyped<Value.List>(key) ?: return 0L
     val expiry = value.expiryInstant
@@ -439,14 +441,17 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
   override fun rpoplpush(sourceKey: String, destinationKey: String) =
     lmove(sourceKey = sourceKey, destinationKey = destinationKey, from = ListDirection.RIGHT, to = ListDirection.LEFT)
 
+  @Synchronized
   override fun exists(key: String): Boolean {
     return keyValueStore.containsKey(key)
   }
 
+  @Synchronized
   override fun exists(vararg key: String): Long {
     return key.sumOf { if (exists(it)) 1L else 0L }
   }
 
+  @Synchronized
   override fun persist(key: String): Boolean {
     val value = keyValueStore[key]
 
@@ -497,6 +502,12 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  override fun transaction(block: DeferredRedis.() -> Unit) {
+    val commands = TransactionCommands()
+    FakeDeferredRedis(commands).block()
+    commands.execute()
+  }
+
   @Deprecated("Use pipelining instead.")
   override fun pipelined(): Pipeline {
     throw NotImplementedError("Use pipelining instead.")
@@ -511,16 +522,55 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
    * each one runs as it is called rather than when the block closes. What a caller observes after the block are a real
    * pipeline's semantics — every command ran exactly once, in order.
    */
-  inner class FakePipelinedRedis : DeferredRedis {
-    /**
-     * Runs [block] now and replays its outcome to every read of the returned supplier. A real pipeline sends each
-     * queued command exactly once when the block closes, so by the time anyone reads a reply it is already fixed: a
-     * supplier that re-ran the command would execute it again on every read, and one never read at all would skip it
-     * entirely. A failure is held rather than thrown here, because a real pipeline reports it from the reply too.
-     */
-    private fun <T> eager(block: () -> T): Supplier<T> {
+  inner class FakePipelinedRedis : DeferredRedis by FakeDeferredRedis(EagerCommandDefer)
+
+  private interface CommandDefer {
+    fun <T> defer(block: () -> T): Supplier<T>
+  }
+
+  private object EagerCommandDefer : CommandDefer {
+    override fun <T> defer(block: () -> T): Supplier<T> {
       val outcome = runCatching(block)
       return Supplier { outcome.getOrThrow() }
+    }
+  }
+
+  private class QueuedResponse<T> : Supplier<T> {
+    private var outcome: Result<T>? = null
+
+    override fun get(): T {
+      return checkNotNull(outcome) { "Transaction response is not available until the transaction completes" }
+        .getOrThrow()
+    }
+
+    fun execute(block: () -> T) {
+      outcome = runCatching(block)
+    }
+  }
+
+  private inner class TransactionCommands : CommandDefer {
+    private val commands = mutableListOf<() -> Unit>()
+
+    override fun <T> defer(block: () -> T): Supplier<T> {
+      val response = QueuedResponse<T>()
+      commands += { response.execute(block) }
+      return response
+    }
+
+    fun execute() {
+      synchronized(this@FakeRedis) { commands.forEach { it() } }
+    }
+  }
+
+  private inner class FakeDeferredRedis(private val commandDefer: CommandDefer) : DeferredRedis {
+    /**
+     * Defers [block] according to the enclosing pipeline or transaction and replays its outcome to every read of the
+     * returned supplier. A supplier that re-ran the command would execute it again on every read, and one never read at
+     * all would skip it entirely. A failure is held rather than thrown here, because Redis reports command failures
+     * from replies too.
+     */
+    private fun <T> eager(block: () -> T): Supplier<T> {
+      return commandDefer.defer(block)
     }
 
     override fun del(key: String): Supplier<Boolean> = eager { this@FakeRedis.del(key) }
@@ -732,10 +782,12 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     throw NotImplementedError("Fake client not implemented for this operation")
   }
 
+  @Synchronized
   override fun flushAll() {
     keyValueStore.clear()
   }
 
+  @Synchronized
   override fun flushDB() {
     flushAll()
   }
@@ -823,14 +875,17 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return false
   }
 
+  @Synchronized
   override fun zadd(key: String, score: Double, member: String, vararg options: Redis.ZAddOptions): Long {
     return zaddInternal(key, score, member, options)
   }
 
+  @Synchronized
   override fun zadd(key: String, scoreMembers: Map<String, Double>, vararg options: Redis.ZAddOptions): Long {
     return scoreMembers.entries.sumOf { (member, score) -> zaddInternal(key, score, member, options) }
   }
 
+  @Synchronized
   override fun zscore(key: String, member: String): Double? {
     val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key) ?: return null
 
@@ -845,6 +900,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return currentScore
   }
 
+  @Synchronized
   override fun zrange(
     key: String,
     type: ZRangeType,
@@ -856,6 +912,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return zrangeWithScores(key, type, start, stop, reverse, limit).map { (member, _) -> member }.toList()
   }
 
+  @Synchronized
   override fun zrangeWithScores(
     key: String,
     type: ZRangeType,
@@ -889,6 +946,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return ansWithScore
   }
 
+  @Synchronized
   override fun zrem(key: String, vararg members: String): Long {
     val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
 
@@ -914,6 +972,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return removed
   }
 
+  @Synchronized
   override fun zremRangeByRank(key: String, start: ZRangeRankMarker, stop: ZRangeRankMarker): Long {
     val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
 
@@ -941,6 +1000,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return removed
   }
 
+  @Synchronized
   override fun zremRangeByScore(key: String, start: ZRangeScoreMarker, stop: ZRangeScoreMarker): Long {
     val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
 
@@ -967,6 +1027,7 @@ class FakeRedis @Inject constructor(private val clock: Clock, @ForFakeRedis priv
     return removed
   }
 
+  @Synchronized
   override fun zcard(key: String): Long {
     val sortedSet = keyValueStore.getTyped<Value.SortedSet>(key)?.data ?: return 0
     var length = 0L


### PR DESCRIPTION
## Why
misk-redis exposes Jedis transactions whose pooled connection lifetime is unsafe, while its test fixture fake cannot exercise atomic multi-command updates.

## What
- Add a Misk-owned `transaction { ... }` API that retains one connection through `MULTI/EXEC`
- Reuse deferred Redis commands for transaction blocks and preserve deferred replies
- Accept only known Jedis `Pipeline`, `ClusterPipeline`, and `Transaction` queue types
- Queue fake transaction commands and commit them atomically, discarding them if block construction fails

## Risk Assessment
Low — this adds an opt-in standalone Redis API. Existing pipeline behavior is unchanged, unknown queue types fail fast, and Redis Cluster transactions remain unsupported.

Generated with Codex

---
**Update Aug 11, 14:08 PDT:** Added a shared transaction contract for real and fake Redis
- Run identical order-book replacement and failed-block tests against both implementations
- Risk remains low: this follow-up changes test structure only.