### PR TITLE
Drain aws2-sqs consumers on shutdown by stopping the polling loops

### DIFF
--- a/misk-aws2-sqs/README.md
+++ b/misk-aws2-sqs/README.md
@@ -254,6 +254,14 @@ Refer to the "threading model" section below for in-depth description.
     If no value is provided, queue settings will be used
   * note: if the value is smaller than typical processing time, it may result in the job being processed
     multiple times
+* `drain_timeout_ms`
+  * default value: null
+  * when set to a positive value, consumer shutdown drains the queue's in-flight work instead of cancelling
+    it: polling stops issuing new receives, jobs already received get up to this deadline to finish and
+    acknowledge, and only work still unfinished at the deadline is cancelled
+  * when null (the default), zero or negative, shutdown cancels all in-flight work immediately (legacy behavior),
+    leaving the messages invisible until their visibility timeout expires
+  * see "Graceful shutdown draining" below for sizing guidance
 
 ### Connection settings
 
@@ -349,6 +357,36 @@ How the configuration impacts the processing:
 It's advised to start with the default settings and adjust based on specific workloads.
 
 ![image](concurrency.jpg)
+
+## Graceful shutdown draining
+
+By default, stopping the consumer (deploy, pod eviction, node drain) cancels the polling and handling
+coroutines immediately. Jobs that are mid-handler are cancelled: their messages stay invisible until the
+visibility timeout expires, and on queues with a low `maxReceiveCount` they can land in the DLQ.
+
+Setting `drain_timeout_ms` to a positive value turns shutdown into a drain for that queue:
+
+```yaml
+aws_sqs:
+  per_queue_overrides:
+    my_queue:
+      drain_timeout_ms: 15000
+```
+
+1. The polling loops stop issuing new receive requests. A receive already in flight is allowed to complete,
+   and its messages are still handed to the handlers rather than left stranded in the visibility window.
+2. The channel between polling and handling is closed; handlers finish the jobs already received and
+   acknowledge them as usual.
+3. Work still unfinished at the deadline is cancelled, matching the legacy behavior.
+
+Sizing guidance:
+- The drain waits for the in-flight receive to finish, so an idle queue can take up to `wait_timeout`
+  (or the queue's *ReceiveMessageWaitTimeSeconds*) to drain. Services that deploy often may want a lower
+  `wait_timeout` alongside the drain.
+- Size `drain_timeout_ms` below the pod's remaining termination grace after SIGTERM (accounting for any
+  preStop hook) and below the queue's visibility timeout.
+- Draining only helps on orderly shutdown. If the process crashes, in-flight messages still wait out
+  their visibility timeout.
 
 ## Differences to the previous misk-aws implementation
 

--- a/misk-aws2-sqs/api/misk-aws2-sqs.api
+++ b/misk-aws2-sqs/api/misk-aws2-sqs.api
@@ -152,6 +152,7 @@ public final class misk/aws2/sqs/jobqueue/Subscriber {
 	public final fun getVisibilityTimeoutCalculator ()Lmisk/aws2/sqs/jobqueue/VisibilityTimeoutCalculator;
 	public final fun poll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun stopPolling ()V
 }
 
 public final class misk/aws2/sqs/jobqueue/Subscriber$Companion {
@@ -212,8 +213,10 @@ public final class misk/aws2/sqs/jobqueue/config/SqsQueueConfig {
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;)V
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
 	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/Long;
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()I
@@ -222,12 +225,13 @@ public final class misk/aws2/sqs/jobqueue/config/SqsQueueConfig {
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
-	public static synthetic fun copy$default (Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
+	public final fun copy (IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
+	public static synthetic fun copy$default (Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;IIIIZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lmisk/aws2/sqs/jobqueue/config/SqsQueueConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccount_id ()Ljava/lang/String;
 	public final fun getChannel_capacity ()I
 	public final fun getConcurrency ()I
+	public final fun getDrain_timeout_ms ()Ljava/lang/Long;
 	public final fun getInstall_retry_queue ()Z
 	public final fun getMax_number_of_messages ()I
 	public final fun getParallelism ()I

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
@@ -8,6 +8,7 @@ import io.opentracing.Tracer
 import jakarta.inject.Inject
 import java.time.Clock
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.thread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,6 +18,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
 import misk.inject.AsyncSwitch
@@ -131,11 +133,13 @@ constructor(
     }
 
     draining.forEach { it.subscriber.stopPolling() }
-    // The drain waits on the polling scope's own children, so it runs on a scope of its own.
-    CoroutineScope(Dispatchers.IO).launch {
+    // A dedicated thread keeps doStop() non-blocking (per AbstractService guidance, so ServiceManager can keep
+    // stopping other services) while runBlocking waits for the per-queue drain coroutines it launches.
+    // ServiceManager itself waits on the drain through notifyStopped().
+    thread(name = "sqs-consumer-drain") {
       try {
-        draining
-          .map { subscription ->
+        runBlocking {
+          draining.forEach { subscription ->
             launch {
               val timeoutMs = subscription.subscriber.queueConfig.drain_timeout_ms!!
               val drained =
@@ -153,7 +157,7 @@ constructor(
               subscription.handlingScope.cancel()
             }
           }
-          .joinAll()
+        }
       } finally {
         scope.cancel()
         notifyStopped()

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
@@ -1,6 +1,7 @@
 package misk.aws2.sqs.jobqueue
 
 import com.google.common.util.concurrent.AbstractService
+import com.google.common.util.concurrent.Service
 import com.google.inject.Singleton
 import com.squareup.moshi.Moshi
 import io.opentracing.Tracer
@@ -72,6 +73,12 @@ constructor(
   }
 
   fun subscribe(queueName: QueueName, handler: JobHandler, queueConfig: SqsQueueConfig) {
+    // A subscription created after shutdown began would be invisible to doStop() and outlive the service.
+    val state = state()
+    check(state != Service.State.STOPPING && state != Service.State.TERMINATED && state != Service.State.FAILED) {
+      "Cannot subscribe to queue ${queueName.value}: SqsJobConsumer is $state"
+    }
+
     // We won't resolve dead letter queue yet to skip it for local development and testing
     val deadLetterQueueName = dlqProvider.deadLetterQueueFor(queueName)
 

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumer.kt
@@ -9,10 +9,14 @@ import java.time.Clock
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
 import misk.inject.AsyncSwitch
 import misk.jobqueue.QueueName
@@ -39,6 +43,11 @@ import misk.testing.TestFixture
  * polling coroutine will wait until all the jobs from the last roundtrip are picked by the handlers before sending
  * another request to SQS. Use channel with a larger buffer size to prefetch messages. This can reduce the latency, but
  * increase the risk of hitting visibility timeout.
+ *
+ * On shutdown, queues configured with a positive `drain_timeout_ms` are drained instead of cancelled: their polling
+ * loops stop issuing new receives, the jobs already handed to the handlers get up to the deadline to finish, and only
+ * work still unfinished at the deadline is cancelled. Queues without the setting keep the legacy immediate
+ * cancellation.
  */
 @Singleton
 class SqsJobConsumer
@@ -56,7 +65,7 @@ constructor(
 ) : JobConsumer, AbstractService(), TestFixture {
   private val scope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
 
-  private val handlingScopes = ConcurrentHashMap<QueueName, CoroutineScope>()
+  private val subscriptions = ConcurrentHashMap<QueueName, Subscription>()
 
   override fun subscribe(queueName: QueueName, handler: JobHandler) {
     subscribe(queueName = queueName, handler = handler, queueConfig = SqsQueueConfig())
@@ -83,19 +92,19 @@ constructor(
         asyncSwitch = asyncSwitch,
       )
 
-    scope.launch { subscriber.poll() }
-    handlingScopes[queueName] =
-      CoroutineScope(Dispatchers.IO.limitedParallelism(queueConfig.parallelism) + SupervisorJob())
-    repeat(queueConfig.concurrency) { handlingScopes[queueName]?.launch { subscriber.run() } }
+    val pollingJob = scope.launch { subscriber.poll() }
+    val handlingScope = CoroutineScope(Dispatchers.IO.limitedParallelism(queueConfig.parallelism) + SupervisorJob())
+    val handlingJobs = List(queueConfig.concurrency) { handlingScope.launch { subscriber.run() } }
+    subscriptions[queueName] = Subscription(subscriber, pollingJob, handlingScope, handlingJobs)
   }
 
   override fun unsubscribe(queueName: QueueName) {
-    handlingScopes[queueName]?.cancel()
+    subscriptions[queueName]?.handlingScope?.cancel()
   }
 
   /** Called automatically between every test to prevent long-running scopes or test timeouts. */
   override fun reset() {
-    handlingScopes.forEach { _, scope -> scope.cancel() }
+    subscriptions.forEach { _, subscription -> subscription.handlingScope.cancel() }
   }
 
   override fun doStart() {
@@ -103,9 +112,57 @@ constructor(
   }
 
   override fun doStop() {
-    scope.cancel()
-    handlingScopes.values.forEach { it.cancel() }
-    notifyStopped()
+    val (draining, immediate) = subscriptions.values.partition { it.isDrainable }
+    immediate.forEach {
+      it.pollingJob.cancel()
+      it.handlingScope.cancel()
+    }
+    if (draining.isEmpty()) {
+      scope.cancel()
+      notifyStopped()
+      return
+    }
+
+    draining.forEach { it.subscriber.stopPolling() }
+    // The drain waits on the polling scope's own children, so it runs on a scope of its own.
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+        draining
+          .map { subscription ->
+            launch {
+              val timeoutMs = subscription.subscriber.queueConfig.drain_timeout_ms!!
+              val drained =
+                withTimeoutOrNull(timeoutMs) {
+                  subscription.pollingJob.join()
+                  subscription.handlingJobs.joinAll()
+                }
+              if (drained == null) {
+                logger.warn {
+                  "Queue ${subscription.subscriber.queueName.value} did not drain within ${timeoutMs}ms, " +
+                    "cancelling its remaining work"
+                }
+              }
+              subscription.pollingJob.cancel()
+              subscription.handlingScope.cancel()
+            }
+          }
+          .joinAll()
+      } finally {
+        scope.cancel()
+        notifyStopped()
+      }
+    }
+  }
+
+  private class Subscription(
+    val subscriber: Subscriber,
+    val pollingJob: Job,
+    val handlingScope: CoroutineScope,
+    val handlingJobs: List<Job>,
+  ) {
+    /** An unsubscribed queue's handlers are already cancelled, there is nothing left to drain. */
+    val isDrainable: Boolean
+      get() = (subscriber.queueConfig.drain_timeout_ms ?: 0) > 0 && handlingScope.isActive
   }
 
   companion object {

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/Subscriber.kt
@@ -50,10 +50,21 @@ class Subscriber(
   val asyncSwitch: AsyncSwitch,
 ) {
   private var wasDisabled = false
+  @Volatile private var stopPollingRequested = false
+
+  /**
+   * Signals the polling loops to stop instead of issuing another receive. A receive already in flight completes
+   * normally and its messages are still handed to the handlers. Once the loops exit, [poll] closes the channel, so
+   * [run] handles whatever is already buffered and then returns.
+   */
+  fun stopPolling() {
+    stopPollingRequested = true
+  }
 
   suspend fun run() {
     while (true) {
-      val job = tracer.withSpan("channel-receive-queue-${queueName.value}") { channel.receive() }
+      val job =
+        tracer.withSpan("channel-receive-queue-${queueName.value}") { channel.receiveCatching() }.getOrNull() ?: return
       tracer.withSpan("process-queue-${queueName.value}") {
         val receiveFromChannelTimestamp = clock.millis()
         sqsMetrics.channelReceiveLag
@@ -187,17 +198,21 @@ class Subscriber(
 
   /** Polls the messages from both the regular and the retry queue. */
   suspend fun poll() {
-    if (queueConfig.install_retry_queue) {
-        merge(messageFlow(queueName), messageFlow(queueName.retryQueue))
-      } else {
-        messageFlow(queueName)
-      }
-      .collect { received -> channel.send(received) }
+    try {
+      if (queueConfig.install_retry_queue) {
+          merge(messageFlow(queueName), messageFlow(queueName.retryQueue))
+        } else {
+          messageFlow(queueName)
+        }
+        .collect { received -> channel.send(received) }
+    } finally {
+      channel.close()
+    }
   }
 
   private fun messageFlow(queueName: QueueName) = flow {
     val queueUrl = sqsQueueResolver.getQueueUrl(queueName)
-    while (true) {
+    while (!stopPollingRequested) {
       if (!asyncSwitch.isEnabled("sqs")) {
         if (!wasDisabled) {
           logger.info { "Async SQS tasks disabled. Polling paused for queue ${queueName.value}." }

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfig.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfig.kt
@@ -10,10 +10,10 @@ import misk.jobqueue.QueueName
  * overriding configuration for a given queue `buffered_batch_flush_frequency_ms` controls how often buffered messages
  * are flushed to SQS when using enqueueBuffered
  *
- * `config_feature_flag` allows specifying a dynamic config name that returns a JSON object matching the
- * structure of SqsConfig. When set, the dynamic config is evaluated at service startup and **completely replaces**
- * the YAML configuration. This allows dynamic configuration changes with a service restart (without requiring a code
- * deploy). If not set, or if the dynamic config returns null/empty, the YAML configuration is used.
+ * `config_feature_flag` allows specifying a dynamic config name that returns a JSON object matching the structure of
+ * SqsConfig. When set, the dynamic config is evaluated at service startup and **completely replaces** the YAML
+ * configuration. This allows dynamic configuration changes with a service restart (without requiring a code deploy). If
+ * not set, or if the dynamic config returns null/empty, the YAML configuration is used.
  */
 data class SqsConfig
 @JvmOverloads
@@ -22,9 +22,9 @@ constructor(
   val per_queue_overrides: Map<String, SqsQueueConfig> = emptyMap(),
   val buffered_batch_flush_frequency_ms: Long = 50,
   /**
-   * Dynamic config name that returns a JSON object matching SqsConfig structure.
-   * When set and returns a valid config, it completely replaces the YAML config.
-   * Example value: {"all_queues": {"concurrency": 10}, "per_queue_overrides": {"my_queue": {"concurrency": 20}}}
+   * Dynamic config name that returns a JSON object matching SqsConfig structure. When set and returns a valid config,
+   * it completely replaces the YAML config. Example value: {"all_queues": {"concurrency": 10}, "per_queue_overrides":
+   * {"my_queue": {"concurrency": 20}}}
    */
   val config_feature_flag: String? = null,
 ) : Config {
@@ -37,6 +37,7 @@ constructor(
         visibility_timeout = override.visibility_timeout ?: all_queues.visibility_timeout,
         region = override.region ?: all_queues.region,
         account_id = override.account_id ?: all_queues.account_id,
+        drain_timeout_ms = override.drain_timeout_ms ?: all_queues.drain_timeout_ms,
       )
     } else {
       all_queues

--- a/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsQueueConfig.kt
+++ b/misk-aws2-sqs/src/main/kotlin/misk/aws2/sqs/jobqueue/config/SqsQueueConfig.kt
@@ -11,6 +11,8 @@ package misk.aws2.sqs.jobqueue.config
  * will be invisible for subsequent requests. If configured to null, the queue settings will be used. `region` AWS
  * Region of the consumed queue, defaults to the current region. `account_id` AWS Account ID of the consumed queue,
  * defaults to the current account. `queue_name` AWS Queue Name, defaults to the application provided name of the queue.
+ * `drain_timeout_ms` defines how long consumer shutdown will wait for polling to stop and already-received jobs to be
+ * handled before cancelling them. Defaults to null, which cancels all work immediately on shutdown.
  */
 data class SqsQueueConfig
 @JvmOverloads
@@ -24,4 +26,5 @@ constructor(
   val visibility_timeout: Int? = null,
   val region: String? = null,
   val account_id: String? = null,
+  val drain_timeout_ms: Long? = null,
 )

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.delay
 import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
 import misk.inject.AsyncSwitch
@@ -125,8 +126,11 @@ class SqsJobConsumerDrainTest {
     val consumer = newConsumer()
     val handler = HoldingHandler()
 
-    // One message at a time, rendezvous channel, single handler: the handler holds job 1 while the poller
-    // waits to hand off job 2. Any message received before the drain must be handled, not stranded.
+    // One message at a time, rendezvous channel, single handler: the handler holds job 1 while the rest of the
+    // pipeline backs up behind it. The exact split is scheduling-dependent: the merge over (queue, retryQueue)
+    // decouples the receive loop from the rendezvous handoff, and the drain deliberately lets an in-flight
+    // receive complete, so the poller may legitimately prefetch the third message before or during the drain.
+    // The assertions below therefore check the drain invariants that hold under every legal scheduling.
     consumer.subscribe(
       queueName,
       handler,
@@ -141,23 +145,28 @@ class SqsJobConsumerDrainTest {
     )
     repeat(3) { sendMessage(queue.queueUrl, "message-$it") }
     assertTrue(handler.started.await(10, SECONDS), "handler did not start")
-    // Wait until the poller has received message 2 into the handoff (both received messages invisible),
-    // so the drain deterministically interrupts a real in-flight handoff. Message 3 must not have been
-    // received: the poller is suspended handing off message 2 and only receives one message at a time.
-    awaitQueueDepths(queue.queueUrl, expectedVisible = 1, expectedNotVisible = 2)
+    // Stage a genuinely backed-up pipeline before draining: at least messages 1 and 2 received (not visible)
+    // and the depths stable, i.e. the poller is parked in a handoff or an empty long poll.
+    awaitStableQueueDepths(queue.queueUrl, minNotVisible = 2)
 
     consumer.stopAsync()
     handler.release()
     consumer.awaitTerminated(10, SECONDS)
 
-    // The two received messages were handled-and-deleted; message 3 was never received after the drain
-    // started and remains visible for the replacement pod. A message in the not-visible window would be
-    // exactly the orphaned in-flight delivery this feature exists to prevent, and a third handled message
-    // would mean polling kept receiving after shutdown.
-    assertEquals(2, handler.handled.get(), "exactly the two received jobs should have been handled")
+    val handled = handler.handled.get()
     val (visible, notVisible) = queueDepths(queue.queueUrl)
+    // THE invariant this feature exists for: a message in the not-visible window would be exactly the orphaned
+    // in-flight delivery a drain must prevent.
     assertEquals(0, notVisible, "no message may be left stranded in the visibility window")
-    assertEquals(1, visible, "the never-received message must remain visible")
+    // Conservation: every message was either fully handled-and-deleted, or never consumed and still visible
+    // for the replacement pod.
+    assertEquals(3, handled + visible, "every message must be handled or still visible, got handled=$handled")
+    assertTrue(handled >= 2, "the messages received before the drain must have been handled, got $handled")
+
+    // Polling provably stopped: a message still visible stays visible. 3s is well past the 1s receive
+    // wait_timeout, so a poller that survived shutdown would have consumed it by now.
+    Thread.sleep(3_000)
+    assertEquals(Pair(visible, 0), queueDepths(queue.queueUrl), "polling must not continue after the drain")
   }
 
   @Test
@@ -353,14 +362,21 @@ class SqsJobConsumerDrainTest {
     return consumer
   }
 
-  private fun awaitQueueDepths(queueUrl: String, expectedVisible: Int, expectedNotVisible: Int) {
+  /**
+   * Waits until the poll pipeline has saturated: at least [minNotVisible] messages received (in the not-visible window)
+   * and the depths unchanged across several consecutive samples. The exact visible/not-visible split is
+   * scheduling-dependent (the poller may prefetch beyond the rendezvous handoff), so callers must not assume one.
+   */
+  private fun awaitStableQueueDepths(queueUrl: String, minNotVisible: Int) {
     val deadline = System.nanoTime() + SECONDS.toNanos(10)
-    while (queueDepths(queueUrl) != Pair(expectedVisible, expectedNotVisible)) {
-      if (System.nanoTime() > deadline) {
-        assertEquals(Pair(expectedVisible, expectedNotVisible), queueDepths(queueUrl), "queue depths never settled")
-        return
-      }
-      Thread.sleep(25)
+    var stableSamples = 0
+    var last = queueDepths(queueUrl)
+    while (stableSamples < 5) {
+      if (System.nanoTime() > deadline) fail("queue depths never saturated and settled, last=$last")
+      Thread.sleep(100)
+      val current = queueDepths(queueUrl)
+      stableSamples = if (current == last && current.second >= minNotVisible) stableSamples + 1 else 0
+      last = current
     }
   }
 

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
@@ -1,0 +1,398 @@
+package misk.aws2.sqs.jobqueue
+
+import com.google.common.util.concurrent.Service
+import com.squareup.moshi.Moshi
+import io.opentracing.Tracer
+import jakarta.inject.Inject
+import java.time.Clock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import misk.aws2.sqs.jobqueue.config.SqsQueueConfig
+import misk.inject.AsyncSwitch
+import misk.jobqueue.QueueName
+import misk.jobqueue.v2.Job
+import misk.jobqueue.v2.JobStatus
+import misk.jobqueue.v2.SuspendingJobHandler
+import misk.testing.MiskExternalDependency
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+
+@MiskTest(startService = true)
+class SqsJobConsumerDrainTest {
+  @MiskExternalDependency private val dockerSqs = DockerSqs
+  @MiskTestModule private val module = SqsJobQueueTestModule(dockerSqs)
+
+  @Inject private lateinit var sqsClientFactory: SqsClientFactory
+  @Inject private lateinit var sqsQueueResolver: SqsQueueResolver
+  @Inject private lateinit var visibilityTimeoutCalculator: VisibilityTimeoutCalculator
+  @Inject private lateinit var moshi: Moshi
+  @Inject private lateinit var dlqProvider: DeadLetterQueueProvider
+  @Inject private lateinit var sqsMetrics: SqsMetrics
+  @Inject private lateinit var clock: Clock
+  @Inject private lateinit var tracer: Tracer
+  @Inject private lateinit var asyncSwitch: AsyncSwitch
+
+  private val consumers = mutableListOf<SqsJobConsumer>()
+
+  @AfterEach
+  fun stopConsumers() {
+    consumers.forEach { consumer ->
+      try {
+        consumer.stopAsync().awaitTerminated(30, SECONDS)
+      } catch (e: Exception) {
+        // Best effort: reset() cancels any scopes a failed stop left behind.
+      }
+      consumer.reset()
+    }
+  }
+
+  @Test
+  fun `in-flight job finishes and acknowledges during drain and the message is never redelivered`() {
+    val queueName = QueueName("drain-test-graceful")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    consumer.subscribe(queueName, handler, drainingConfig(drain_timeout_ms = 10_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+
+    // The handler is holding the only in-flight job, so shutdown must not complete yet.
+    consumer.stopAsync()
+    Thread.sleep(500)
+    assertNotEquals(Service.State.TERMINATED, consumer.state(), "stop must wait for the in-flight job")
+
+    handler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    // The job was acknowledged during the drain: nothing visible, and crucially nothing stuck in the
+    // visibility window waiting to be redelivered or dead-lettered.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible, "message should have been deleted, not left visible")
+    assertEquals(0, notVisible, "message should have been deleted, not abandoned in the visibility window")
+  }
+
+  @Test
+  fun `handler exceeding the drain deadline is cancelled and shutdown terminates predictably`() {
+    val queueName = QueueName("drain-test-timeout")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val started = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          started.countDown()
+          delay(60_000)
+          return JobStatus.OK
+        }
+      }
+
+    // Visibility of 30s: an abandoned message stays in the not-visible window for the whole test.
+    consumer.subscribe(queueName, handler, drainingConfig(drain_timeout_ms = 1_000, visibility_timeout = 30))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(started.await(10, SECONDS), "handler did not start")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(stopMillis >= 1_000, "shutdown returned before the drain deadline: ${stopMillis}ms")
+    assertTrue(stopMillis < 8_000, "shutdown did not terminate promptly after the drain deadline: ${stopMillis}ms")
+
+    // The job was cancelled, so its message remains un-acknowledged in the visibility window.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible)
+    assertEquals(1, notVisible, "cancelled job's message should remain in the visibility window")
+  }
+
+  @Test
+  fun `drain stops new receives and leaves no message invisibly stranded`() {
+    val queueName = QueueName("drain-test-no-new-receives")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    // One message at a time, rendezvous channel, single handler: the handler holds job 1 while the poller
+    // waits to hand off job 2. Any message received before the drain must be handled, not stranded.
+    consumer.subscribe(
+      queueName,
+      handler,
+      drainingConfig(
+        drain_timeout_ms = 10_000,
+        visibility_timeout = 30,
+        parallelism = 1,
+        concurrency = 1,
+        channel_capacity = 0,
+        max_number_of_messages = 1,
+      ),
+    )
+    repeat(3) { sendMessage(queue.queueUrl, "message-$it") }
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+    // Give the poller a moment to receive the next message so the drain interrupts a real in-flight handoff.
+    Thread.sleep(500)
+
+    consumer.stopAsync()
+    handler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    // Every message is either handled-and-deleted or still visible for the replacement pod. A message in the
+    // not-visible window would be exactly the orphaned in-flight delivery this feature exists to prevent.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, notVisible, "no message may be left stranded in the visibility window")
+    assertEquals(3 - handler.handled.get(), visible, "unhandled messages must remain visible")
+    assertTrue(handler.handled.get() >= 1, "the held job should have completed during the drain")
+  }
+
+  @Test
+  fun `queue without a drain timeout keeps the legacy immediate cancellation`() {
+    val queueName = QueueName("drain-test-legacy")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handler = HoldingHandler()
+
+    consumer.subscribe(queueName, handler, drainingConfig(drain_timeout_ms = null, visibility_timeout = 30))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handler.started.await(10, SECONDS), "handler did not start")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+    assertTrue(stopMillis < 5_000, "legacy shutdown should cancel immediately, took ${stopMillis}ms")
+
+    // Legacy behavior: the in-flight job is cancelled and its message stays in the visibility window.
+    val (visible, notVisible) = queueDepths(queue.queueUrl)
+    assertEquals(0, visible)
+    assertEquals(1, notVisible)
+  }
+
+  @Test
+  fun `mixed subscriptions drain configured queues and immediately cancel the rest`() {
+    val drainingQueueName = QueueName("drain-test-mixed-draining")
+    val legacyQueueName = QueueName("drain-test-mixed-legacy")
+    val drainingQueue = createQueue(drainingQueueName)
+    val legacyQueue = createQueue(legacyQueueName)
+    val consumer = newConsumer()
+    val drainingHandler = HoldingHandler()
+    val legacyHandler = HoldingHandler()
+
+    consumer.subscribe(
+      drainingQueueName,
+      drainingHandler,
+      drainingConfig(drain_timeout_ms = 10_000, visibility_timeout = 30),
+    )
+    consumer.subscribe(legacyQueueName, legacyHandler, drainingConfig(drain_timeout_ms = null, visibility_timeout = 30))
+    sendMessage(drainingQueue.queueUrl, "message")
+    sendMessage(legacyQueue.queueUrl, "message")
+    assertTrue(drainingHandler.started.await(10, SECONDS), "draining handler did not start")
+    assertTrue(legacyHandler.started.await(10, SECONDS), "legacy handler did not start")
+
+    consumer.stopAsync()
+    drainingHandler.release()
+    consumer.awaitTerminated(10, SECONDS)
+
+    val (drainingVisible, drainingNotVisible) = queueDepths(drainingQueue.queueUrl)
+    assertEquals(0, drainingVisible)
+    assertEquals(0, drainingNotVisible, "drained queue's message should have been acknowledged")
+
+    val (legacyVisible, legacyNotVisible) = queueDepths(legacyQueue.queueUrl)
+    assertEquals(0, legacyVisible)
+    assertEquals(1, legacyNotVisible, "legacy queue's job should have been cancelled without acknowledgement")
+  }
+
+  @Test
+  fun `drain with no in-flight work terminates promptly without waiting for the deadline`() {
+    val queueName = QueueName("drain-test-idle")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handled = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handled.countDown()
+          return JobStatus.OK
+        }
+      }
+
+    consumer.subscribe(queueName, handler, drainingConfig(drain_timeout_ms = 30_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handled.await(10, SECONDS), "message was not handled")
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(stopMillis < 8_000, "idle drain should not wait for the 30s deadline, took ${stopMillis}ms")
+  }
+
+  @Test
+  fun `stop after unsubscribe terminates promptly instead of waiting for the drain deadline`() {
+    val queueName = QueueName("drain-test-unsubscribed")
+    val queue = createQueue(queueName)
+    val consumer = newConsumer()
+    val handled = CountDownLatch(1)
+    val handler =
+      object : SuspendingJobHandler {
+        override suspend fun handleJob(job: Job): JobStatus {
+          handled.countDown()
+          return JobStatus.OK
+        }
+      }
+
+    consumer.subscribe(queueName, handler, drainingConfig(drain_timeout_ms = 30_000))
+    sendMessage(queue.queueUrl, "message")
+    assertTrue(handled.await(10, SECONDS), "message was not handled")
+
+    // Unsubscribing cancels the handling scope; a later stop has nothing to drain for this queue and
+    // must not burn the 30s drain deadline waiting on it.
+    consumer.unsubscribe(queueName)
+
+    val stopStart = System.nanoTime()
+    consumer.stopAsync()
+    consumer.awaitTerminated(10, SECONDS)
+    val stopMillis = (System.nanoTime() - stopStart) / 1_000_000
+
+    assertTrue(
+      stopMillis < 8_000,
+      "stop after unsubscribe should not wait for the drain deadline, took ${stopMillis}ms",
+    )
+  }
+
+  /** Holds the first job until [release] is called; any further jobs complete immediately. */
+  private class HoldingHandler : SuspendingJobHandler {
+    val started = CountDownLatch(1)
+
+    /** Jobs that ran to completion. A job cancelled mid-hold leaves its message visible and is not counted. */
+    val handled = AtomicInteger(0)
+    private val starts = AtomicInteger(0)
+    private val release = CountDownLatch(1)
+
+    override suspend fun handleJob(job: Job): JobStatus {
+      val first = starts.getAndIncrement() == 0
+      if (first) {
+        started.countDown()
+        while (release.count > 0) {
+          delay(25)
+        }
+      }
+      handled.incrementAndGet()
+      return JobStatus.OK
+    }
+
+    fun release() {
+      release.countDown()
+    }
+  }
+
+  /**
+   * A short wait_timeout keeps the tests fast and deterministic: the drain lets an in-flight receive complete, so with
+   * the queue-default 20s long poll every drain would wait out the poll instead.
+   */
+  private fun drainingConfig(
+    drain_timeout_ms: Long?,
+    visibility_timeout: Int? = null,
+    parallelism: Int = 1,
+    concurrency: Int = 1,
+    channel_capacity: Int = 0,
+    max_number_of_messages: Int = 10,
+  ) =
+    SqsQueueConfig(
+      region = "us-west-2",
+      wait_timeout = 1,
+      drain_timeout_ms = drain_timeout_ms,
+      visibility_timeout = visibility_timeout,
+      parallelism = parallelism,
+      concurrency = concurrency,
+      channel_capacity = channel_capacity,
+      max_number_of_messages = max_number_of_messages,
+    )
+
+  private fun newConsumer(): SqsJobConsumer {
+    val consumer =
+      SqsJobConsumer(
+        sqsClientFactory = sqsClientFactory,
+        sqsQueueResolver = sqsQueueResolver,
+        visibilityTimeoutCalculator = visibilityTimeoutCalculator,
+        moshi = moshi,
+        dlqProvider = dlqProvider,
+        sqsMetrics = sqsMetrics,
+        clock = clock,
+        tracer = tracer,
+        asyncSwitch = asyncSwitch,
+      )
+    consumer.startAsync().awaitRunning()
+    consumers += consumer
+    return consumer
+  }
+
+  /** Returns (visible, notVisible) message counts. ElasticMQ reports these attributes exactly. */
+  private fun queueDepths(queueUrl: String): Pair<Int, Int> {
+    val attributes =
+      DockerSqs.client
+        .getQueueAttributes(
+          GetQueueAttributesRequest.builder()
+            .queueUrl(queueUrl)
+            .attributeNames(
+              QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES,
+              QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE,
+            )
+            .build()
+        )
+        .join()
+        .attributes()
+    return Pair(
+      attributes[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]!!.toInt(),
+      attributes[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE]!!.toInt(),
+    )
+  }
+
+  private fun createQueue(queueName: QueueName): CreatedQueues {
+    val result =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName(queueName.value)
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    val retryResult =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName("${queueName.value}_retryq")
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    val dlqResult =
+      DockerSqs.client
+        .createQueue(
+          CreateQueueRequest.builder()
+            .queueName("${queueName.value}_dlq")
+            .attributes(mapOf(QueueAttributeName.RECEIVE_MESSAGE_WAIT_TIME_SECONDS to "20"))
+            .build()
+        )
+        .join()
+    return CreatedQueues(result.queueUrl(), retryResult.queueUrl(), dlqResult.queueUrl())
+  }
+
+  private fun sendMessage(queueUrl: String, message: String) {
+    DockerSqs.client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(message).build()).join()
+  }
+
+  data class CreatedQueues(val queueUrl: String, val retryQueueUrl: String, val dlqQueueUrl: String)
+}

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SqsJobConsumerDrainTest.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.delay
@@ -140,19 +141,23 @@ class SqsJobConsumerDrainTest {
     )
     repeat(3) { sendMessage(queue.queueUrl, "message-$it") }
     assertTrue(handler.started.await(10, SECONDS), "handler did not start")
-    // Give the poller a moment to receive the next message so the drain interrupts a real in-flight handoff.
-    Thread.sleep(500)
+    // Wait until the poller has received message 2 into the handoff (both received messages invisible),
+    // so the drain deterministically interrupts a real in-flight handoff. Message 3 must not have been
+    // received: the poller is suspended handing off message 2 and only receives one message at a time.
+    awaitQueueDepths(queue.queueUrl, expectedVisible = 1, expectedNotVisible = 2)
 
     consumer.stopAsync()
     handler.release()
     consumer.awaitTerminated(10, SECONDS)
 
-    // Every message is either handled-and-deleted or still visible for the replacement pod. A message in the
-    // not-visible window would be exactly the orphaned in-flight delivery this feature exists to prevent.
+    // The two received messages were handled-and-deleted; message 3 was never received after the drain
+    // started and remains visible for the replacement pod. A message in the not-visible window would be
+    // exactly the orphaned in-flight delivery this feature exists to prevent, and a third handled message
+    // would mean polling kept receiving after shutdown.
+    assertEquals(2, handler.handled.get(), "exactly the two received jobs should have been handled")
     val (visible, notVisible) = queueDepths(queue.queueUrl)
     assertEquals(0, notVisible, "no message may be left stranded in the visibility window")
-    assertEquals(3 - handler.handled.get(), visible, "unhandled messages must remain visible")
-    assertTrue(handler.handled.get() >= 1, "the held job should have completed during the drain")
+    assertEquals(1, visible, "the never-received message must remain visible")
   }
 
   @Test
@@ -271,6 +276,16 @@ class SqsJobConsumerDrainTest {
     )
   }
 
+  @Test
+  fun `subscribing after shutdown began is rejected instead of creating an undrainable subscription`() {
+    val consumer = newConsumer()
+    consumer.stopAsync().awaitTerminated(10, SECONDS)
+
+    assertFailsWith<IllegalStateException> {
+      consumer.subscribe(QueueName("drain-test-late"), HoldingHandler(), drainingConfig(drain_timeout_ms = null))
+    }
+  }
+
   /** Holds the first job until [release] is called; any further jobs complete immediately. */
   private class HoldingHandler : SuspendingJobHandler {
     val started = CountDownLatch(1)
@@ -336,6 +351,17 @@ class SqsJobConsumerDrainTest {
     consumer.startAsync().awaitRunning()
     consumers += consumer
     return consumer
+  }
+
+  private fun awaitQueueDepths(queueUrl: String, expectedVisible: Int, expectedNotVisible: Int) {
+    val deadline = System.nanoTime() + SECONDS.toNanos(10)
+    while (queueDepths(queueUrl) != Pair(expectedVisible, expectedNotVisible)) {
+      if (System.nanoTime() > deadline) {
+        assertEquals(Pair(expectedVisible, expectedNotVisible), queueDepths(queueUrl), "queue depths never settled")
+        return
+      }
+      Thread.sleep(25)
+    }
   }
 
   /** Returns (visible, notVisible) message counts. ElasticMQ reports these attributes exactly. */

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/SubscriberTest.kt
@@ -5,6 +5,7 @@ import io.prometheus.client.CollectorRegistry
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -143,6 +145,57 @@ class SubscriberTest {
 
     pollingJob.cancelAndJoin()
     assertTrue(pollingJob.isCancelled)
+  }
+
+  @Test
+  fun `stopPolling lets the in-flight receive finish, hands off its messages, then closes the channel`() = runTest {
+    whenever(sqsQueueResolver.getQueueUrl(queueName)).thenReturn(queueUrl)
+    val pendingResponse = CompletableFuture<ReceiveMessageResponse>()
+    whenever(client.receiveMessage(any<ReceiveMessageRequest>())).thenReturn(pendingResponse)
+
+    val subscriber = subscriber(handler = { JobStatus.OK })
+    val pollingJob = backgroundScope.launch { subscriber.poll() }
+    runCurrent()
+
+    subscriber.stopPolling()
+    runCurrent()
+    // The in-flight receive is not cancelled, polling is still waiting on it.
+    assertFalse(pollingJob.isCompleted)
+
+    pendingResponse.complete(ReceiveMessageResponse.builder().messages(message("job-1")).build())
+    runCurrent()
+
+    // The in-flight receive's message is handed off rather than stranded, then polling stops for good.
+    assertEquals("job-1", channel.receive().id)
+    runCurrent()
+    assertTrue(pollingJob.isCompleted)
+    assertFalse(pollingJob.isCancelled)
+    assertTrue(channel.isClosedForReceive)
+    verify(client, times(1)).receiveMessage(any<ReceiveMessageRequest>())
+  }
+
+  @Test
+  fun `run handles the jobs already in the channel and completes when the channel closes`() = runTest {
+    whenever(client.deleteMessage(any<DeleteMessageRequest>()))
+      .thenReturn(CompletableFuture.completedFuture(DeleteMessageResponse.builder().build()))
+    val handledJobs = mutableListOf<String>()
+
+    val subscriber =
+      subscriber(
+        handler = {
+          handledJobs += it.id
+          JobStatus.OK
+        }
+      )
+    val subscriberJob = backgroundScope.launch { subscriber.run() }
+    channel.send(job("job-1"))
+    channel.send(job("job-2"))
+    channel.close()
+    runCurrent()
+
+    assertEquals(listOf("job-1", "job-2"), handledJobs)
+    assertTrue(subscriberJob.isCompleted)
+    assertFalse(subscriberJob.isCancelled)
   }
 
   private fun subscriber(

--- a/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfigTest.kt
+++ b/misk-aws2-sqs/src/test/kotlin/misk/aws2/sqs/jobqueue/config/SqsConfigTest.kt
@@ -44,9 +44,7 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig returns all_queues when no per_queue_override exists`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(concurrency = 10, parallelism = 5),
-    )
+    val config = SqsConfig(all_queues = SqsQueueConfig(concurrency = 10, parallelism = 5))
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
@@ -56,12 +54,11 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig returns per_queue_override when it exists`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(concurrency = 1, parallelism = 1),
-      per_queue_overrides = mapOf(
-        "test-queue" to SqsQueueConfig(concurrency = 20, parallelism = 10),
-      ),
-    )
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(concurrency = 1, parallelism = 1),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(concurrency = 20, parallelism = 10)),
+      )
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
@@ -71,17 +68,39 @@ class SqsConfigTest {
 
   @Test
   fun `getQueueConfig inherits nullable fields from all_queues`() {
-    val config = SqsConfig(
-      all_queues = SqsQueueConfig(region = "us-west-2", wait_timeout = 20),
-      per_queue_overrides = mapOf(
-        "test-queue" to SqsQueueConfig(concurrency = 10),
-      ),
-    )
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(region = "us-west-2", wait_timeout = 20),
+        per_queue_overrides = mapOf("test-queue" to SqsQueueConfig(concurrency = 10)),
+      )
 
     val queueConfig = config.getQueueConfig(misk.jobqueue.QueueName("test-queue"))
 
     assertEquals(10, queueConfig.concurrency)
     assertEquals("us-west-2", queueConfig.region) // inherited from all_queues
     assertEquals(20, queueConfig.wait_timeout) // inherited from all_queues
+  }
+
+  @Test
+  fun `drain_timeout_ms has null default`() {
+    val config = SqsConfig()
+    assertEquals(null, config.getQueueConfig(misk.jobqueue.QueueName("test-queue")).drain_timeout_ms)
+  }
+
+  @Test
+  fun `getQueueConfig inherits drain_timeout_ms from all_queues and allows overriding it`() {
+    val config =
+      SqsConfig(
+        all_queues = SqsQueueConfig(drain_timeout_ms = 15_000),
+        per_queue_overrides =
+          mapOf(
+            "inheriting-queue" to SqsQueueConfig(concurrency = 10),
+            "overriding-queue" to SqsQueueConfig(drain_timeout_ms = 5_000),
+          ),
+      )
+
+    assertEquals(15_000, config.getQueueConfig(misk.jobqueue.QueueName("inheriting-queue")).drain_timeout_ms)
+    assertEquals(5_000, config.getQueueConfig(misk.jobqueue.QueueName("overriding-queue")).drain_timeout_ms)
+    assertEquals(15_000, config.getQueueConfig(misk.jobqueue.QueueName("unlisted-queue")).drain_timeout_ms)
   }
 }


### PR DESCRIPTION
## What this is

A simpler alternative to #3892, following @mateuszmrozewski's feedback in [#misk-discuss](https://sq-block.slack.com/archives/C01M5M297T7/p1786572865121529?thread_ts=1786456653.714679&cid=C01M5M297T7): rather than cancelling scopes and spinning up new ones to track in-flight work, shutdown now *breaks the loops* and waits for the coroutines to finish, in the spirit of the v1 `SqsJobConsumer`'s `ExecutorService.shutdown()`/await approach.

If maintainers prefer this approach I'll close #3892 in favor of this PR.

## The problem (same as #3892)

When a misk service using the aws2-sqs consumer shuts down (deploy, pod eviction, node drain), `SqsJobConsumer` cancels its scopes immediately. Jobs mid-handler are killed: the work is lost, the messages stay invisible until their visibility timeout expires, and on queues with a low `maxReceiveCount` they go straight to the DLQ. In Cash App's Rey service this is the dominant source of dead-lettered jobs (`maxReceiveCount: 1`, 30-minute visibility timeout), and it also causes re-processing that burns scarce external API rate limits.

## How it works

The config surface is the same as #3892 — an optional per-queue `drain_timeout_ms`, defaulting to null (legacy immediate cancellation):

```yaml
aws_sqs:
  per_queue_overrides:
    my_queue:
      drain_timeout_ms: 15000
```

The mechanism is now just the natural completion of the existing loops:

1. `doStop()` sets a flag on each draining subscriber (`Subscriber.stopPolling()`).
2. The `messageFlow` loops check the flag instead of looping forever (`while (!stopPollingRequested)`). A receive already in flight completes normally and its messages are still handed to the handlers — the "at least one more roundtrip" — rather than being left stranded in the visibility window.
3. When the flows complete, `poll()` closes the channel.
4. `run()` handles whatever the channel still holds and returns when the channel is closed and empty (`receiveCatching`).
5. `doStop()` joins the polling and handling jobs with `withTimeoutOrNull(drain_timeout_ms)`; only work still unfinished at the deadline is cancelled. `notifyStopped()` fires once all queues have drained or timed out, so `ServiceManager` ordering still holds.

No new scopes are launched while others are cancelled, no in-flight tracking structures, no drain metrics; the only bookkeeping added is keeping the `Job` handles that `subscribe()` already creates so `doStop()` can join them.

**Default behavior is unchanged**: queues without `drain_timeout_ms` (and unsubscribed/reset ones) keep the immediate-cancel path, and `notifyStopped()` is synchronous when nothing drains.

## Trade-offs vs #3892

- The in-flight receive is allowed to finish rather than being cancelled, so draining an *idle* queue can take up to `wait_timeout` (bounded by `drain_timeout_ms`). Services that deploy often may want a lower `wait_timeout` alongside the drain; the README documents this.
- Because receives are never cancelled mid-drain, the racy "receive completes after shutdown" window that #3892 patched with `ChangeMessageVisibility(0)` doesn't arise during a drain — those messages are simply handled.
- Draining only helps on orderly shutdown; a crashed process still waits out visibility timeouts (inherent to SQS semantics).

## Testing

- `SqsJobConsumerDrainTest` (real SQS container): in-flight job finishes and is acknowledged with nothing left in the visibility window; deadline is enforced and shutdown terminates predictably; no message is stranded invisibly mid-handoff; default keeps legacy behavior; mixed drain/legacy subscriptions; idle drain terminates promptly; stop after unsubscribe doesn't burn the deadline.
- `SubscriberTest`: `stopPolling()` lets the in-flight receive finish, hands off its messages, and closes the channel; `run()` drains the channel and completes on close.
- `SqsConfigTest`: `drain_timeout_ms` default and per-queue override/inheritance.
- README documentation and regenerated API dump included.

## Adversarial review

An adversarial model review of this branch surfaced two issues that are now fixed: `subscribe()` after shutdown began would create a subscription invisible to `doStop()` (now rejected with `IllegalStateException`), and the no-new-receives test could pass even with post-shutdown receives (now deterministic with exact assertions).

One acknowledged trade-off it flagged: adding a field to the `SqsQueueConfig` data class changes the JVM descriptors of Kotlin's `copy`/`copy$default` and the synthetic defaults constructor. `@JvmOverloads` preserves the positional constructors, and this matches how fields have previously been added to these config classes (the regenerated API dump reflects it), but callers compiled against the old `copy` signature would need a recompile.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
