### PR TITLE
Bump Wire to 7.0.0-alpha07

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "6.0.0"
+wire = "7.0.0-alpha07"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }


### PR DESCRIPTION
This restores the Wire 7 bump that #3866 reverted. It now uses the released 7.0.0-alpha07 instead of a local build. The test protos live in dedicated modules since #3902, which is merged, so this PR is a one-line change to libs.versions.toml.

Verification:
- 61 tests pass, 0 fail, in misk-grpc-tests, misk-grpc-reflect, misk-moshi, and misk-actions.
- Remote resolution is proven with dependencyInsight: com.squareup.wire:wire-runtime:7.0.0-alpha07 resolves with org.gradle.status=release from Maven Central, not mavenLocal.
- The three test-protos modules build and compileTestKotlin passes for misk, misk-admin, and misk-moshi with 7.0.0-alpha07.
