### PR TITLE
misk-slack: add unfurl_links and unfurl_media to PostMessageRequest

### DIFF
--- a/misk-slack/api/misk-slack.api
+++ b/misk-slack/api/misk-slack.api
@@ -591,19 +591,25 @@ public final class misk/slack/webapi/helpers/MrkdwnBuilderKt {
 public final class misk/slack/webapi/helpers/PostMessageRequest {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lmisk/slack/webapi/helpers/PostMessageRequest;
-	public static synthetic fun copy$default (Lmisk/slack/webapi/helpers/PostMessageRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lmisk/slack/webapi/helpers/PostMessageRequest;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lmisk/slack/webapi/helpers/PostMessageRequest;
+	public static synthetic fun copy$default (Lmisk/slack/webapi/helpers/PostMessageRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lmisk/slack/webapi/helpers/PostMessageRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBlocks ()Ljava/util/List;
 	public final fun getChannel ()Ljava/lang/String;
 	public final fun getResponse_type ()Ljava/lang/String;
 	public final fun getThread_ts ()Ljava/lang/String;
+	public final fun getUnfurl_links ()Ljava/lang/Boolean;
+	public final fun getUnfurl_media ()Ljava/lang/Boolean;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/misk-slack/src/main/kotlin/misk/slack/webapi/helpers/SlackJson.kt
+++ b/misk-slack/src/main/kotlin/misk/slack/webapi/helpers/SlackJson.kt
@@ -12,6 +12,21 @@ constructor(
   val response_type: String? = "in_channel",
   val blocks: List<Any>,
   val thread_ts: String? = null,
+  /**
+   * Pass false to stop Slack expanding text-based links in this message into previews. Note that a link to a Slack
+   * message is text-based, and unfurls into a copy of the linked message, so this is the field to set when linking to
+   * other Slack posts. Null leaves Slack's default behaviour in place.
+   *
+   * https://docs.slack.dev/messaging/unfurling-links-in-messages
+   */
+  val unfurl_links: Boolean? = null,
+  /**
+   * Pass false to stop Slack expanding media links (images and video) in this message into previews. Null leaves
+   * Slack's default behaviour in place.
+   *
+   * https://docs.slack.dev/messaging/unfurling-links-in-messages
+   */
+  val unfurl_media: Boolean? = null,
 )
 
 /**

--- a/misk-slack/src/test/kotlin/misk/slack/webapi/RealSlackClientTest.kt
+++ b/misk-slack/src/test/kotlin/misk/slack/webapi/RealSlackClientTest.kt
@@ -2,6 +2,7 @@ package misk.slack.webapi
 
 import com.google.inject.name.Names
 import com.google.inject.util.Modules
+import com.squareup.moshi.Moshi
 import jakarta.inject.Inject
 import misk.MiskTestingServiceModule
 import misk.ServiceModule
@@ -60,6 +61,7 @@ class RealSlackClientTest {
 
   @Inject lateinit var slackApi: SlackApi
   @Inject lateinit var server: MockSlackServer
+  @Inject lateinit var moshi: Moshi
 
   @Test
   fun `post message`() {
@@ -67,6 +69,25 @@ class RealSlackClientTest {
 
     val response = slackApi.postMessage(samplePostMessageJson).execute()
     assertThat(response.isSuccessful()).isTrue()
+  }
+
+  @Test
+  fun `post message omits the unfurl fields unless they are set`() {
+    // Left unset so that Slack applies its own defaults rather than this client choosing for every caller.
+    val json = moshi.adapter(PostMessageRequest::class.java).toJson(samplePostMessageJson)
+
+    assertThat(json).doesNotContain("unfurl_links").doesNotContain("unfurl_media")
+  }
+
+  @Test
+  fun `post message sends the unfurl fields when they are set`() {
+    // Slack unfurls a link to one of its own messages into a full copy of that message, so a caller linking to another
+    // Slack post needs unfurl_links to suppress it.
+    val request = samplePostMessageJson.copy(unfurl_links = false, unfurl_media = false)
+
+    val json = moshi.adapter(PostMessageRequest::class.java).toJson(request)
+
+    assertThat(json).contains("\"unfurl_links\":false").contains("\"unfurl_media\":false")
   }
 
   @Test


### PR DESCRIPTION
## Problem

`chat.postMessage` accepts [`unfurl_links` and `unfurl_media`](https://docs.slack.dev/messaging/unfurling-links-in-messages), but `PostMessageRequest` doesn't carry them, so callers can't control link previews. Retrofit serialises the declared body type, so there's no way to pass the fields through `SlackApi.postMessage` either.

This matters most when a message links to **another Slack message**: Slack unfurls that into a full copy of the linked message. A service posting a digest that links to its own posts in other channels ends up inlining each of those posts in full, ending in a literal `Slack Conversation` label. `unfurl_links` is the field that suppresses it — per the docs it covers text-based unfurls (which is what a message link produces), while `unfurl_media` covers images and video.

## Change

Two nullable fields on `PostMessageRequest`, defaulting to `null` so Slack's own defaults apply and existing callers are unaffected.

`apiDump` shows the change is additive — every existing constructor is preserved, so this is source and binary compatible:

```diff
 public final class misk/slack/webapi/helpers/PostMessageRequest {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public fun <init> (…Ljava/lang/Boolean;)V
+	public fun <init> (…Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public final fun getUnfurl_links ()Ljava/lang/Boolean;
+	public final fun getUnfurl_media ()Ljava/lang/Boolean;
 }
```

## Prior art — two services already work around this

Both in `squareup/cash-server`:

- **`cash-flag-admin`** deliberately bypasses `misk.slack.webapi` and hand-rolls its own Retrofit `SlackApi` + `PostMessageJson(… unfurl_links: Boolean = false)`, wired over `TypedHttpClientModule`, with its own interceptors and fake — about 7 files.
- **`cash-automation-tooling`** forks these DTOs into the service (same `…webapi.helpers` package layout) purely to add `unfurl_links` and `unfurl_media`.

Meanwhile ~176 files across cash-server import `misk.slack.webapi.*` unmodified. Working around the gap is also more involved than it first appears: `SlackClientInterceptor` only attaches the bearer token when the Retrofit `Invocation`'s declaring class is exactly `misk.slack.webapi.SlackApi`, so a custom interface silently posts unauthenticated and gets `not_authed` unless it reimplements auth too. That's a sharp edge worth removing.

## Testing

`bin/gradle :misk-slack:check` passes (tests + `apiCheck` + detekt).

Two tests assert the serialised body: the fields are **omitted** when unset (so Slack's defaults still apply for every existing caller), and **present** when set. I verified the first test genuinely fails if the defaults are changed to non-null, rather than passing vacuously.

The assertions go through the injected `Moshi` rather than `MockSlackServer`, because the existing tests in this class point the `slack` HTTP client at `https://hooks.slack.com/` and only assert `isSuccessful`, so requests don't actually reach the mock server and `takeRequest()` blocks. Happy to wire the client at the mock server's URL and assert on the recorded request instead if you'd prefer — it'd be a slightly larger change to the test module, and would make the surrounding tests meaningfully stronger too.
