### PR TITLE
Bump Wire to 7.0.0-alpha09

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "7.0.0-alpha08"
+wire = "7.0.0-alpha09"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "7.0.0-alpha07"
+wire = "7.0.0-alpha08"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }


### PR DESCRIPTION
Bumps Wire from 7.0.0-alpha07 to 7.0.0-alpha09.

7.0.0-alpha09 is available on Maven Central. Compared to alpha08, it only reverts Wire's build to Kotlin 2.3.21 (square/wire#3693). This restores the JVM internal-member name mangling. The generated code surface is unchanged.

Verification:
- The published wire-runtime-jvm 7.0.0-alpha09 jar contains META-INF/wire-runtime.kotlin_module, and javap of com.squareup.wire.Message shows getCachedSerializedSize$wire_runtime.
- At the previous head (alpha08, same codegen surface): misk-grpc-tests rerun with --rerun-tasks --refresh-dependencies resolving from Maven Central, 11 tests, 0 failures. Earlier full pass: misk-proto, misk-test-protos, misk-admin-test-protos, misk-moshi-test-protos, and samples/exemplar builds; tests green in misk-grpc-tests (11), misk-grpc-reflect (4), misk-moshi (36), misk-actions (10); misk compileTestKotlin.
- samples/exemplar MySQL and Redis rate-limiter tests fail identically on master without this change (they need local MySQL and Redis services). They are environmental, not Wire-related.