### PR TITLE
misk-vitess: allow multi_shard_autocommit param in VschemaLinter lookup vindex params

### DIFF
--- a/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VschemaLinterTest.kt
+++ b/misk-vitess/src/test/kotlin/misk/vitess/testing/internal/VschemaLinterTest.kt
@@ -173,6 +173,35 @@ class VschemaLinterTest {
   }
 
   @Test
+  fun `test sharded vschema with valid lookup vindex with multi_shard_autocommit`() {
+    val vschemaJson =
+      vschemaAdapter.fromJson(
+        """
+            {
+                "sharded": true,
+                "vindexes": {
+                    "customers_email_lookup": {
+                        "type": "lookup",
+                        "params": {
+                            "autocommit": "true",
+                            "from": "email",
+                            "ignore_nulls": "true",
+                            "multi_shard_autocommit": "true",
+                            "table": "customers_email_lookup",
+                            "to": "keyspace_id"
+                        },
+                        "owner": "customers"
+                    }
+                },
+                "tables": {}
+            }
+        """
+      )!!
+
+    assertDoesNotThrow { linter.lint(vschemaJson, "sharded") }
+  }
+
+  @Test
   fun `test sharded vschema with valid lookup vindex with no_verify`() {
     val vschemaJson =
       vschemaAdapter.fromJson(

--- a/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VschemaLinter.kt
+++ b/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/internal/VschemaLinter.kt
@@ -52,6 +52,9 @@ internal class VschemaLinter(val vschemaAdapter: VschemaAdapter) {
           val vindexParamsMap = vschemaAdapter.toMap(vindexMap["params"])
           vindexParamsMap.let { params ->
             val orderedParamsFields = mutableListOf("autocommit", "from", "ignore_nulls", "table", "to")
+            if (params.containsKey("multi_shard_autocommit")) {
+              orderedParamsFields.add(orderedParamsFields.indexOf("table"), "multi_shard_autocommit")
+            }
             if (params.containsKey("no_verify")) {
               orderedParamsFields.add(orderedParamsFields.indexOf("table"), "no_verify")
             }


### PR DESCRIPTION
## Problem

Vitess supports the `multi_shard_autocommit` param on lookup vindexes (v15+), which makes vtgate send lookup-table inserts with a `/*vt+ MULTI_SHARD_AUTOCOMMIT=1 */` directive — independent per-shard autocommit statements instead of a transaction.

This param is **required** when vtgate runs with `transaction_mode=SINGLE` and an insert creates lookup rows spanning multiple shards: with only `autocommit=true`, the lookup insert is still an ordinary multi-shard transaction (just a separate one), and SINGLE mode rejects it with `lookup.Create: multi-db transaction attempted` (see `lookup_internal.go` in vitess).

`VschemaLinter` currently hardcodes the allowed lookup params and throws `VitessTestDbSchemaLintException` for any vschema using `multi_shard_autocommit`, forcing services that need it to disable `lintSchema` entirely.

## Change

Accept `multi_shard_autocommit` in its alphabetical position in the ordered params list, following the existing conditional handling for `no_verify`.

Verified with `bin/gradle :misk-vitess:test --tests 'misk.vitess.testing.internal.VschemaLinterTest'` including a new test case.

## Context

Found while enabling `TransactionMode.SINGLE` in `StartVitessDatabaseTask` for cash-server's contacts service to match its production vtgate settings (squareup/cash-server#118654).