### PR TITLE
Prune old TestDatabasePool databases at startup

### DIFF
--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -637,9 +637,11 @@ public final class misk/jdbc/TableScanException : misk/jdbc/CheckException {
 public final class misk/jdbc/TestDatabasePool : misk/jdbc/DatabasePool {
 	public static final field Companion Lmisk/jdbc/TestDatabasePool$Companion;
 	public fun <init> (Lmisk/jdbc/TestDatabasePool$Backend;Ljava/time/Clock;)V
+	public fun <init> (Lmisk/jdbc/TestDatabasePool$Backend;Ljava/time/Clock;Ljava/time/Duration;)V
 	public final fun getBackend ()Lmisk/jdbc/TestDatabasePool$Backend;
 	public final fun getClock ()Ljava/time/Clock;
 	public final fun getPool (Lmisk/jdbc/DataSourceConfig;)Lmisk/jdbc/TestDatabasePool$ConfigSpecificPool;
+	public final fun getRetention ()Ljava/time/Duration;
 	public final fun pruneOldDatabases ()V
 	public final fun pruneOldDatabases (Ljava/time/Duration;)V
 	public static synthetic fun pruneOldDatabases$default (Lmisk/jdbc/TestDatabasePool;Ljava/time/Duration;ILjava/lang/Object;)V
@@ -654,6 +656,7 @@ public abstract interface class misk/jdbc/TestDatabasePool$Backend {
 }
 
 public final class misk/jdbc/TestDatabasePool$Companion {
+	public final fun getDEFAULT_RETENTION ()Ljava/time/Duration;
 }
 
 public final class misk/jdbc/TestDatabasePool$ConfigSpecificPool {

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -64,7 +64,7 @@ constructor(
   }
 
   private fun createDataSource(baseConfig: DataSourceConfig) {
-    // Rewrite the caller's config to get a database name like "movies__20190730__5" in tests.
+    // Rewrite the caller's config to get a database name like "movies__20190730140530__5" in tests.
     config = databasePool.takeDatabase(baseConfig)
 
     val hikariConfig = HikariConfig()

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/TestDatabasePoolTest.kt
@@ -7,6 +7,7 @@ import jakarta.inject.Singleton
 import java.sql.SQLException
 import java.time.Clock
 import java.time.Duration
+import java.time.ZoneId
 import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.testing.MiskTest
@@ -61,21 +62,83 @@ class TestDatabasePoolTest {
   }
 
   @Test
-  fun dropsDatabasesOlderThan48Hours() {
+  fun automaticallyDropsDatabasesOlderThanTwoHours() {
     backendHasDatabases()
     testDatabasePool.takeDatabase(config)
 
-    testDatabasePool.pruneOldDatabases()
-
     assertThat(getAllDatabasesFromPool())
       .containsExactly(
-        TestDatabasePool.DatabaseName("test", 20171230L, 1), // Existing
-        TestDatabasePool.DatabaseName("test", 20171231L, 1), // Existing
+        TestDatabasePool.DatabaseName("test", 20171231L, 1), // Existing legacy name retained conservatively.
+        TestDatabasePool.DatabaseName("test", 20180101000000L, 1), // New
         TestDatabasePool.DatabaseName("test", 20180101L, 1), // Existing
         TestDatabasePool.DatabaseName("test", 20180101L, 2), // Existing
         TestDatabasePool.DatabaseName("test", 20180101L, 3), // Existing
-        TestDatabasePool.DatabaseName("test", 20180101L, 4), // New
       )
+  }
+
+  @Test
+  fun appliesRetentionToTheCreationTime() {
+    backend.databases.add("test__20171231215959__1")
+    backend.databases.add("test__20171231220000__1")
+    backend.databases.add("test__20171231223000__1")
+
+    testDatabasePool.takeDatabase(config)
+
+    assertThat(getAllDatabasesFromPool())
+      .containsExactly(
+        TestDatabasePool.DatabaseName("test", 20171231220000L, 1),
+        TestDatabasePool.DatabaseName("test", 20171231223000L, 1),
+        TestDatabasePool.DatabaseName("test", 20180101000000L, 1),
+      )
+  }
+
+  @Test
+  fun retentionIsConfigurable() {
+    backend.databases.add("test__20171231200000__1")
+    backend.databases.add("test__20171231210000__1")
+
+    testDatabasePool = TestDatabasePool(backend, clock, Duration.ofHours(4))
+    testDatabasePool.takeDatabase(config)
+
+    assertThat(getAllDatabasesFromPool())
+      .containsExactly(
+        TestDatabasePool.DatabaseName("test", 20171231200000L, 1),
+        TestDatabasePool.DatabaseName("test", 20171231210000L, 1),
+        TestDatabasePool.DatabaseName("test", 20180101000000L, 1),
+      )
+  }
+
+  @Test
+  fun prunesOnlyOnceWhenPoolIsCreated() {
+    backend.databases.add("test__20171231220000__1")
+
+    testDatabasePool.takeDatabase(config)
+    backend.databases.add("test__20171231220000__2")
+    testDatabasePool.takeDatabase(config)
+
+    assertThat(backend.databases).contains("test__20171231220000__2")
+  }
+
+  @Test
+  fun ignoresMalformedDatabaseNames() {
+    backend.databases.add("test__00000000__1")
+    backend.databases.add("test__20179999__1")
+    backend.databases.add("test__20179999120000__1")
+    backend.databases.add("test__20171231215959__1")
+
+    testDatabasePool.takeDatabase(config)
+
+    assertThat(backend.databases)
+      .contains("test__00000000__1", "test__20179999__1", "test__20179999120000__1")
+      .doesNotContain("test__20171231215959__1")
+  }
+
+  @Test
+  fun timestampsAreUtc() {
+    val melbourneClock = clock.withZone(ZoneId.of("Australia/Melbourne"))
+    testDatabasePool = TestDatabasePool(backend, melbourneClock)
+
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__1")
   }
 
   @Test
@@ -85,10 +148,7 @@ class TestDatabasePoolTest {
     backend.databases.add("directors__20171225__1")
     backend.databases.add("actors__20171225__1")
 
-    // Do not register these with the database pool. The pool should be empty.
-    assertThat(getAllDatabasesFromPool()).isEmpty()
-
-    // This should be a no-op.
+    // Pruning before any pool is created should be a no-op.
     testDatabasePool.pruneOldDatabases()
 
     assertThat(backend.databases)
@@ -97,22 +157,22 @@ class TestDatabasePoolTest {
 
   @Test
   fun allocatesNewDatabasesWithIncrementalNames() {
-    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__1")
-    assertThat(backend.databases).containsExactly("test__20180101__1")
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__1")
+    assertThat(backend.databases).containsExactly("test__20180101000000__1")
 
     assertThat(getAllDatabasesFromPool())
-      .contains(TestDatabasePool.DatabaseName(name = "test", yearMonthDay = 20180101L, version = 1))
+      .contains(TestDatabasePool.DatabaseName(name = "test", yearMonthDay = 20180101000000L, version = 1))
 
-    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__2")
-    assertThat(backend.databases).containsExactly("test__20180101__1", "test__20180101__2")
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__2")
+    assertThat(backend.databases).containsExactly("test__20180101000000__1", "test__20180101000000__2")
   }
 
   @Test
   fun releasesDatabaseNamesForReuse() {
-    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__1")
-    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__2")
-    testDatabasePool.releaseDatabase(config.copy(database = "test__20180101__1"))
-    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__1")
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__1")
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__2")
+    testDatabasePool.releaseDatabase(config.copy(database = "test__20180101000000__1"))
+    assertThat(testDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__1")
   }
 
   @Test
@@ -122,7 +182,7 @@ class TestDatabasePoolTest {
     val writerConfig = sharedDatabasePool.takeDatabase(config)
     val readerConfig = sharedDatabasePool.takeDatabase(config)
 
-    assertThat(writerConfig.database).isEqualTo("test__20180101__1")
+    assertThat(writerConfig.database).isEqualTo("test__20180101000000__1")
     assertThat(readerConfig.database).isEqualTo(writerConfig.database)
     assertThat(testDatabasePool.getPool(config).pool).isEmpty()
 
@@ -132,7 +192,7 @@ class TestDatabasePoolTest {
 
     sharedDatabasePool.releaseDatabase(readerConfig)
 
-    assertThat(testDatabasePool.getPool(config).pool).containsExactly("test__20180101__1")
+    assertThat(testDatabasePool.getPool(config).pool).containsExactly("test__20180101000000__1")
   }
 
   @Test
@@ -143,8 +203,8 @@ class TestDatabasePoolTest {
     val firstConfig = sharedDatabasePool.takeDatabase(config)
     val otherLeasedConfig = sharedDatabasePool.takeDatabase(otherConfig)
 
-    assertThat(firstConfig.database).isEqualTo("test__20180101__1")
-    assertThat(otherLeasedConfig.database).isEqualTo("other__20180101__1")
+    assertThat(firstConfig.database).isEqualTo("test__20180101000000__1")
+    assertThat(otherLeasedConfig.database).isEqualTo("other__20180101000000__1")
   }
 
   @Test
@@ -154,21 +214,21 @@ class TestDatabasePoolTest {
     realDatabasePool.pruneOldDatabases(retention = Duration.ZERO)
 
     // Create a database. This will be the first one that the pool tries to create.
-    realDatabasePool.backend.createDatabase("test__20180101__1")
+    realDatabasePool.backend.createDatabase("test__20180101000000__1")
 
     // Demonstrate that attempting to create an existing database throws.
-    assertThrows<SQLException> { realDatabasePool.backend.createDatabase("test__20180101__1") }
+    assertThrows<SQLException> { realDatabasePool.backend.createDatabase("test__20180101000000__1") }
 
     // Assert that the database pool does not yet know about any database names.
     assertThat(realDatabasePool.getPool(config).pool).isEmpty()
 
-    // At this point, the pool has tried to allocate "test__20180101__1", failed, and bumped the
+    // At this point, the pool has tried to allocate "test__20180101000000__1", failed, and bumped the
     // sequence number.
-    assertThat(realDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__2")
+    assertThat(realDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__2")
 
     // If we return a name to the database pool, it will be the next database to be taken.
-    realDatabasePool.releaseDatabase(config.copy(database = "test__20180101__1"))
-    assertThat(realDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101__1")
+    realDatabasePool.releaseDatabase(config.copy(database = "test__20180101000000__1"))
+    assertThat(realDatabasePool.takeDatabase(config).database).isEqualTo("test__20180101000000__1")
   }
 
   private fun backendHasDatabases() {

--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
@@ -2,9 +2,12 @@ package misk.jdbc
 
 import java.sql.SQLException
 import java.time.Clock
+import java.time.DateTimeException
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
-import java.time.Period
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.LinkedBlockingDeque
@@ -13,6 +16,10 @@ import misk.logging.getLogger
 
 /**
  * A [DatabasePool] that is used in tests to get a unique database for each test suite.
+ *
+ * Databases older than two hours are pruned when each database key is first used. This limit must be longer than any
+ * test using the same MySQL server could possibly run for. Tests that need longer should create a [TestDatabasePool]
+ * with a longer retention duration.
  *
  * See [misk.hibernate.HibernateTestingModule] for usage instructions.
  */
@@ -77,14 +84,24 @@ class SharedLeaseDatabasePool(private val delegate: DatabasePool) : DatabasePool
 }
 
 /**
- * Manages an inventory of databases for testing. Databases are named like `movies__20190730__5` where `movies` is the
- * database name in a [DataSourceConfig], `20190730` is today's date, and 5 is a sequence number.
+ * Manages an inventory of databases for testing. Databases are named like `movies__20190730140530__5` where `movies` is
+ * the database name in a [DataSourceConfig], `20190730140530` is the creation timestamp, and 5 is a sequence number.
  *
- * These are used _only_ in tests, so that each test gets a reserved database to avoid parallelism issues.
+ * These are used _only_ in tests, so that each test gets a reserved database to avoid parallelism issues. Old date-only
+ * database names are also recognized and pruned conservatively for rolling upgrades.
+ *
+ * Old databases are pruned once per database key, immediately before its first database is allocated. [retention]
+ * must be longer than any test using the same MySQL server could possibly run for.
  *
  * Thread-safe.
  */
-class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
+class TestDatabasePool(val backend: Backend, val clock: Clock, val retention: Duration) : DatabasePool {
+  constructor(backend: Backend, clock: Clock) : this(backend, clock, DEFAULT_RETENTION)
+
+  init {
+    require(!retention.isNegative) { "retention must not be negative" }
+  }
+
   /** The key is the config's database name. */
   private val poolsByKey = Collections.synchronizedMap(mutableMapOf<String, ConfigSpecificPool>())
 
@@ -94,6 +111,7 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
     if (config.type != DataSourceType.MYSQL) return config
 
     val pooled = getPool(config)
+    pooled.pruneOldDatabasesOnStartup()
     return config.copy(database = pooled.takeDatabase())
   }
 
@@ -108,7 +126,7 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
    * @param retention Must be longer than any test could possibly run for.
    */
   @JvmOverloads
-  fun pruneOldDatabases(retention: Duration = Duration.ofDays(2)) {
+  fun pruneOldDatabases(retention: Duration = this.retention) {
     for (pool in poolsByKey.values) {
       pool.pruneOldDatabases(retention)
     }
@@ -128,19 +146,25 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
 
   /** A pool of databases for a particular config. Thread-safe. */
   inner class ConfigSpecificPool(val key: String, val type: DataSourceType) {
-    private val databaseNameRegex = Regex("""(${Pattern.quote(key)})__([0-9]{8})__([0-9]{1,5})""")
+    private val databaseNameRegex = Regex("""(${Pattern.quote(key)})__([0-9]{8}|[0-9]{14})__([0-9]{1,5})""")
 
-    private val formatter = DateTimeFormatter.BASIC_ISO_DATE
+    private val legacyDateFormatter = DateTimeFormatter.BASIC_ISO_DATE
+    private val timestampFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
 
     /** Database names that are available. */
     val pool = LinkedBlockingDeque<String>()
 
+    @Volatile private var prunedOnStartup = false
+
     /** Decodes a database name string. */
     fun decode(databaseName: String): DatabaseName? {
       val matchResult = databaseNameRegex.matchEntire(databaseName) ?: return null
+      val encodedTimestamp = matchResult.groups[2]!!.value
+      val timestamp = encodedTimestamp.toLong()
+      if (timestamp.toString() != encodedTimestamp || parseCreatedAt(encodedTimestamp) == null) return null
       return DatabaseName(
         matchResult.groups[1]!!.value,
-        matchResult.groups[2]!!.value.toLong(),
+        timestamp,
         matchResult.groups[3]!!.value.toInt(),
       )
     }
@@ -161,16 +185,24 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
       pool.add(databaseName)
     }
 
+    internal fun pruneOldDatabasesOnStartup() {
+      if (prunedOnStartup) return
+      synchronized(this) {
+        if (prunedOnStartup) return
+        pruneOldDatabases()
+        prunedOnStartup = true
+      }
+    }
+
     /** Creates a database and returns its name. */
     fun allocateDatabase(): String {
-      val today = LocalDate.now(clock)
-      val todayYearMonthDay = today.format(formatter).toLong()
+      val timestamp = timestampFormatter.format(clock.instant().atOffset(ZoneOffset.UTC)).toLong()
 
-      val todaysLatest = getDatabases().filter { it.yearMonthDay == todayYearMonthDay }.maxByOrNull { it.version }
+      val latest = getDatabases().filter { it.yearMonthDay == timestamp }.maxByOrNull { it.version }
 
-      val nextVersion = (todaysLatest?.version ?: 0) + 1
+      val nextVersion = (latest?.version ?: 0) + 1
 
-      var databaseName = DatabaseName(key, todayYearMonthDay, nextVersion)
+      var databaseName = DatabaseName(key, timestamp, nextVersion)
 
       // Keep trying to create a database until we have found an unused name.
       while (true) {
@@ -186,19 +218,37 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
       return databaseName.toString()
     }
 
-    fun pruneOldDatabases(retention: Duration = Duration.ofDays(2)) {
-      val evictBefore = LocalDate.now(clock).minus(Period.ofDays(retention.toDays().toInt()))
-      val evictBeforeYearMonthDay = evictBefore.format(formatter).toLong()
+    fun pruneOldDatabases(retention: Duration = this@TestDatabasePool.retention) {
+      require(!retention.isNegative) { "retention must not be negative" }
+      val evictBefore = Instant.now(clock).minus(retention)
 
       val oldDatabases =
         if (retention.isZero) {
           getDatabases()
         } else {
-          getDatabases().filter { it.yearMonthDay < evictBeforeYearMonthDay }
+          getDatabases().filter { it.createdAt()?.isBefore(evictBefore) == true }
         }
 
       for (database in oldDatabases) {
         backend.dropDatabase("$database")
+      }
+    }
+
+    private fun DatabaseName.createdAt() = parseCreatedAt(yearMonthDay.toString())
+
+    private fun parseCreatedAt(encodedTimestamp: String): Instant? {
+      return try {
+        when (encodedTimestamp.length) {
+          8 ->
+            LocalDate.parse(encodedTimestamp, legacyDateFormatter)
+              .plusDays(1)
+              .atStartOfDay(ZoneOffset.UTC)
+              .toInstant()
+          14 -> LocalDateTime.parse(encodedTimestamp, timestampFormatter).toInstant(ZoneOffset.UTC)
+          else -> null
+        }
+      } catch (_: DateTimeException) {
+        null
       }
     }
   }
@@ -224,6 +274,8 @@ class TestDatabasePool(val backend: Backend, val clock: Clock) : DatabasePool {
   }
 
   companion object {
+    val DEFAULT_RETENTION: Duration = Duration.ofHours(2)
+
     private val logger = getLogger<ConfigSpecificPool>()
   }
 

--- a/misk-jooq/src/test/kotlin/misk/jooq/JooqRenderMappingWithDatabasePoolTest.kt
+++ b/misk-jooq/src/test/kotlin/misk/jooq/JooqRenderMappingWithDatabasePoolTest.kt
@@ -24,7 +24,7 @@ import wisp.deployment.TESTING
  * Verifies that jOOQ's render mapping uses the pool-rewritten database name (from [DataSourceService.config]) rather
  * than the original [DataSourceConfig.database].
  *
- * When a [misk.jdbc.DatabasePool] renames the database (e.g. `my_db` → `my_db__20260827__1`), jOOQ's [MappedSchema]
+ * When a [misk.jdbc.DatabasePool] renames the database (e.g. `my_db` → `my_db__20260827210452__1`), jOOQ's [MappedSchema]
  * output must reflect the renamed database so that generated SQL references the correct schema. Otherwise jOOQ queries
  * hit the original (stale) database while [misk.jdbc.JdbcTestFixture] truncates the pool-allocated one, causing state
  * to leak between tests.
@@ -46,7 +46,7 @@ class JooqRenderMappingWithDatabasePoolTest {
     assertThat(actualDatabase)
       .describedAs("The database pool should have rewritten the database name")
       .isNotEqualTo("misk_jooq_pool_test")
-      .containsPattern("misk_jooq_pool_test__[0-9]{8}__[0-9]+")
+      .containsPattern("misk_jooq_pool_test__[0-9]{14}__[0-9]+")
 
     val configuration = configurationFactory.getConfiguration(JooqTransacter.TransacterOptions())
 


### PR DESCRIPTION
By default any database more than 2 hours old is deleted, but this is configurable.