### PR TITLE
Bump HikariCP to 7.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,7 +114,7 @@ guiceTestLib = { module = "com.google.inject.extensions:guice-testlib" }
 hash4j = { module = "com.dynatrace.hash4j:hash4j", version = "0.26.0" }
 hibernate5Core = { module = "org.hibernate:hibernate-core", version = "5.6.15.Final" }
 hibernateJpaApi = { module = "javax.persistence:javax.persistence-api", version = "2.2" }
-hikariCp = { module = "com.zaxxer:HikariCP", version = "6.2.1" }
+hikariCp = { module = "com.zaxxer:HikariCP", version = "7.1.0" }
 hopliteCore = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "hoplite" }
 hopliteHocon = { module = "com.sksamuel.hoplite:hoplite-hocon", version.ref = "hoplite" }
 hopliteJson = { module = "com.sksamuel.hoplite:hoplite-json", version.ref = "hoplite" }


### PR DESCRIPTION
## Why
Keep Misk on the latest stable HikariCP release and pick up upstream fixes made since 6.2.1.

## What
- Upgrade `com.zaxxer:HikariCP` from 6.2.1 to 7.1.0

## Risk Assessment
Moderate risk because this is a major-version upgrade to the JDBC connection pool. Misk’s HikariCP API usages remain compatible, and the affected modules compile successfully.

Generated with Amp