### PR TITLE
[HOOD-4502] misk-admin: make Web Actions tab deeplinkable via URL hash slug

### DIFF
--- a/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
+++ b/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
@@ -10,6 +10,7 @@ import RealMetadataClient from '@web-actions/api/RealMetadataClient';
 import { appEvents, APP_EVENTS } from '@web-actions/events/appEvents';
 import {
   buildSlugIndex,
+  clearSlugFromUrl,
   onSlugChange,
   readSlugFromUrl,
   writeSlugToUrl,
@@ -181,6 +182,8 @@ export default class EndpointSelection extends React.Component<Props, State> {
       const slug = this.slugIndex?.slugByRoute.get(value.value);
       if (slug !== undefined) {
         writeSlugToUrl(slug);
+      } else {
+        clearSlugFromUrl();
       }
       appEvents.emit(APP_EVENTS.ENDPOINT_SELECTED, value.value);
     }

--- a/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
+++ b/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
@@ -8,6 +8,12 @@ import Select, {
 import { MiskRoute } from '@web-actions/api/responseTypes';
 import RealMetadataClient from '@web-actions/api/RealMetadataClient';
 import { appEvents, APP_EVENTS } from '@web-actions/events/appEvents';
+import {
+  buildSlugIndex,
+  readSlugFromUrl,
+  writeSlugToUrl,
+  SlugIndex,
+} from '@web-actions/utils/deepLink';
 
 export interface EndpointOption {
   value: MiskRoute;
@@ -29,6 +35,7 @@ export default class EndpointSelection extends React.Component<Props, State> {
   private selectRef = React.createRef<any>();
   private metadataClient = new RealMetadataClient();
   private options: EndpointOption[] = [];
+  private slugIndex: SlugIndex | null = null;
 
   constructor(props: Props) {
     super(props);
@@ -93,9 +100,31 @@ export default class EndpointSelection extends React.Component<Props, State> {
         value: actionGroup,
       }));
 
+      this.slugIndex = buildSlugIndex(
+        this.options.map((option) => option.value),
+      );
+
       this.setState({ filteredOptions: this.options });
-      this.focusSelect();
+
+      const deepLinkedOption = this.findDeepLinkedOption();
+      if (deepLinkedOption) {
+        this.selectRef.current?.setValue(deepLinkedOption, 'select-option');
+      } else {
+        this.focusSelect();
+      }
     });
+  }
+
+  private findDeepLinkedOption(): EndpointOption | null {
+    const slug = readSlugFromUrl();
+    if (slug === null) {
+      return null;
+    }
+    const route = this.slugIndex?.routeBySlug.get(slug);
+    if (route === undefined) {
+      return null;
+    }
+    return this.options.find((option) => option.value === route) ?? null;
   }
 
   componentDidUpdate(_: any, prevState: State) {
@@ -127,6 +156,10 @@ export default class EndpointSelection extends React.Component<Props, State> {
 
   handleChange = (value: OnChangeValue<EndpointOption, false>) => {
     if (value) {
+      const slug = this.slugIndex?.slugByRoute.get(value.value);
+      if (slug !== undefined) {
+        writeSlugToUrl(slug);
+      }
       appEvents.emit(APP_EVENTS.ENDPOINT_SELECTED, value.value);
     }
   };

--- a/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
+++ b/misk-admin/web-actions/src/web-actions/ui/EndpointSelection.tsx
@@ -10,6 +10,7 @@ import RealMetadataClient from '@web-actions/api/RealMetadataClient';
 import { appEvents, APP_EVENTS } from '@web-actions/events/appEvents';
 import {
   buildSlugIndex,
+  onSlugChange,
   readSlugFromUrl,
   writeSlugToUrl,
   SlugIndex,
@@ -36,6 +37,7 @@ export default class EndpointSelection extends React.Component<Props, State> {
   private metadataClient = new RealMetadataClient();
   private options: EndpointOption[] = [];
   private slugIndex: SlugIndex | null = null;
+  private stopSlugListener: (() => void) | null = null;
 
   constructor(props: Props) {
     super(props);
@@ -113,7 +115,27 @@ export default class EndpointSelection extends React.Component<Props, State> {
         this.focusSelect();
       }
     });
+
+    this.stopSlugListener = onSlugChange(this.applyDeepLink);
   }
+
+  componentWillUnmount() {
+    this.stopSlugListener?.();
+  }
+
+  private applyDeepLink = () => {
+    const option = this.findDeepLinkedOption();
+    if (option === null) {
+      return;
+    }
+    // Re-selecting the current action would reset the request editor and
+    // discard the user's draft, so only act on an actual change.
+    const selected = this.selectRef.current?.getValue()?.[0];
+    if (selected?.value === option.value) {
+      return;
+    }
+    this.selectRef.current?.setValue(option, 'select-option');
+  };
 
   private findDeepLinkedOption(): EndpointOption | null {
     const slug = readSlugFromUrl();

--- a/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
@@ -1,6 +1,7 @@
 import { MiskRoute } from '@web-actions/api/responseTypes';
 import {
   buildSlugIndex,
+  clearSlugFromUrl,
   onSlugChange,
   writeSlugToUrl,
 } from '@web-actions/utils/deepLink';
@@ -105,6 +106,36 @@ describe('writeSlugToUrl', () => {
       existingState,
       '',
       '#MyAction:GET',
+    );
+  });
+});
+
+describe('clearSlugFromUrl', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window;
+  });
+
+  it('removes the hash while preserving the query and history state', () => {
+    const replaceState = jest.fn();
+    const existingState = { turbo: 'restoration-identifier' };
+    const win: any = {
+      history: { state: existingState, replaceState },
+      location: {
+        href: 'http://localhost/_admin/web-actions/?tab=all#OldAction',
+        hash: '#OldAction',
+        pathname: '/_admin/web-actions/',
+        search: '?tab=all',
+      },
+    };
+    win.top = win;
+    (globalThis as Record<string, unknown>).window = win;
+
+    clearSlugFromUrl();
+
+    expect(replaceState).toHaveBeenCalledWith(
+      existingState,
+      '',
+      '/_admin/web-actions/?tab=all',
     );
   });
 });

--- a/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
@@ -1,0 +1,68 @@
+import { MiskRoute } from '@web-actions/api/responseTypes';
+import { buildSlugIndex } from '@web-actions/utils/deepLink';
+
+function route(
+  actionName: string,
+  httpMethod: string,
+  path: string,
+): MiskRoute {
+  return { actionName, httpMethod, path } as MiskRoute;
+}
+
+describe('buildSlugIndex', () => {
+  it('uses the simple class name when unique', () => {
+    const myAction = route('com.squareup.MyAction', 'GET', '/my-action');
+    const otherAction = route('com.squareup.OtherAction', 'POST', '/other');
+    const { routeBySlug, slugByRoute } = buildSlugIndex([
+      myAction,
+      otherAction,
+    ]);
+
+    expect(routeBySlug.get('MyAction')).toBe(myAction);
+    expect(routeBySlug.get('OtherAction')).toBe(otherAction);
+    expect(slugByRoute.get(myAction)).toBe('MyAction');
+    expect(slugByRoute.get(otherAction)).toBe('OtherAction');
+  });
+
+  it('appends the http method when class names collide', () => {
+    const getAction = route('com.squareup.MyAction', 'GET', '/my-action');
+    const postAction = route('com.other.MyAction', 'POST', '/my-action');
+    const { routeBySlug, slugByRoute } = buildSlugIndex([
+      getAction,
+      postAction,
+    ]);
+
+    expect(routeBySlug.get('MyAction')).toBeUndefined();
+    expect(routeBySlug.get('MyAction:GET')).toBe(getAction);
+    expect(routeBySlug.get('MyAction:POST')).toBe(postAction);
+    expect(slugByRoute.get(getAction)).toBe('MyAction:GET');
+    expect(slugByRoute.get(postAction)).toBe('MyAction:POST');
+  });
+
+  it('appends the path when class names and methods collide', () => {
+    const oldAction = route('com.squareup.MyAction', 'GET', '/old');
+    const newAction = route('com.other.MyAction', 'GET', '/new');
+    const { routeBySlug, slugByRoute } = buildSlugIndex([oldAction, newAction]);
+
+    expect(routeBySlug.get('MyAction')).toBeUndefined();
+    expect(routeBySlug.get('MyAction:GET')).toBeUndefined();
+    expect(routeBySlug.get('MyAction:GET:/old')).toBe(oldAction);
+    expect(routeBySlug.get('MyAction:GET:/new')).toBe(newAction);
+    expect(slugByRoute.get(oldAction)).toBe('MyAction:GET:/old');
+    expect(slugByRoute.get(newAction)).toBe('MyAction:GET:/new');
+  });
+
+  it('only disambiguates the colliding group', () => {
+    const getAction = route('com.squareup.MyAction', 'GET', '/my-action');
+    const postAction = route('com.other.MyAction', 'POST', '/my-action');
+    const uniqueAction = route('com.squareup.UniqueAction', 'GET', '/unique');
+    const { slugByRoute } = buildSlugIndex([
+      getAction,
+      postAction,
+      uniqueAction,
+    ]);
+
+    expect(slugByRoute.get(uniqueAction)).toBe('UniqueAction');
+    expect(slugByRoute.get(getAction)).toBe('MyAction:GET');
+  });
+});

--- a/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
@@ -1,5 +1,5 @@
 import { MiskRoute } from '@web-actions/api/responseTypes';
-import { buildSlugIndex } from '@web-actions/utils/deepLink';
+import { buildSlugIndex, writeSlugToUrl } from '@web-actions/utils/deepLink';
 
 function route(
   actionName: string,
@@ -64,5 +64,43 @@ describe('buildSlugIndex', () => {
 
     expect(slugByRoute.get(uniqueAction)).toBe('UniqueAction');
     expect(slugByRoute.get(getAction)).toBe('MyAction:GET');
+  });
+
+  it('assigns no slug when routes are ambiguous even with the path', () => {
+    const jsonAction = route('com.squareup.MyAction', 'POST', '/my-action');
+    const protoAction = route('com.other.MyAction', 'POST', '/my-action');
+    const { routeBySlug, slugByRoute } = buildSlugIndex([
+      jsonAction,
+      protoAction,
+    ]);
+
+    expect(routeBySlug.size).toBe(0);
+    expect(slugByRoute.get(jsonAction)).toBeUndefined();
+    expect(slugByRoute.get(protoAction)).toBeUndefined();
+  });
+});
+
+describe('writeSlugToUrl', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window;
+  });
+
+  it('preserves the existing history state', () => {
+    const replaceState = jest.fn();
+    const existingState = { turbo: 'restoration-identifier' };
+    const win: any = {
+      history: { state: existingState, replaceState },
+      location: { href: 'http://localhost/_admin/web-actions/', hash: '' },
+    };
+    win.top = win;
+    (globalThis as Record<string, unknown>).window = win;
+
+    writeSlugToUrl('MyAction:GET');
+
+    expect(replaceState).toHaveBeenCalledWith(
+      existingState,
+      '',
+      '#MyAction:GET',
+    );
   });
 });

--- a/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/__test__/deepLink.spec.ts
@@ -1,5 +1,9 @@
 import { MiskRoute } from '@web-actions/api/responseTypes';
-import { buildSlugIndex, writeSlugToUrl } from '@web-actions/utils/deepLink';
+import {
+  buildSlugIndex,
+  onSlugChange,
+  writeSlugToUrl,
+} from '@web-actions/utils/deepLink';
 
 function route(
   actionName: string,
@@ -102,5 +106,67 @@ describe('writeSlugToUrl', () => {
       '',
       '#MyAction:GET',
     );
+  });
+});
+
+describe('onSlugChange', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window;
+  });
+
+  function fakeWindow() {
+    const listeners = new Map<string, Set<() => void>>();
+    const win: any = {
+      location: { href: 'http://localhost/_admin/web-actions/', hash: '' },
+      addEventListener: (type: string, fn: () => void) => {
+        if (!listeners.has(type)) {
+          listeners.set(type, new Set());
+        }
+        listeners.get(type)!.add(fn);
+      },
+      removeEventListener: (type: string, fn: () => void) => {
+        listeners.get(type)?.delete(fn);
+      },
+      dispatch: (type: string) => {
+        listeners.get(type)?.forEach((fn) => fn());
+      },
+      count: (type: string) => listeners.get(type)?.size ?? 0,
+    };
+    win.top = win;
+    return win;
+  }
+
+  it('invokes the listener on hashchange and stops after cleanup', () => {
+    const win = fakeWindow();
+    (globalThis as Record<string, unknown>).window = win;
+
+    const listener = jest.fn();
+    const cleanup = onSlugChange(listener);
+
+    win.dispatch('hashchange');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    win.dispatch('hashchange');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(win.count('pagehide')).toBe(0);
+    expect(win.count('pageshow')).toBe(0);
+  });
+
+  it('detaches on pagehide and reattaches on pageshow', () => {
+    const win = fakeWindow();
+    (globalThis as Record<string, unknown>).window = win;
+
+    const listener = jest.fn();
+    onSlugChange(listener);
+
+    win.dispatch('pagehide');
+    win.dispatch('hashchange');
+    expect(listener).not.toHaveBeenCalled();
+    expect(win.count('hashchange')).toBe(0);
+
+    win.dispatch('pageshow');
+    win.dispatch('hashchange');
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
@@ -86,11 +86,24 @@ function addressBarWindow(): Window {
  * the address bar in place. Returns a cleanup function. Note that
  * `history.replaceState` does not fire this event, so writes from
  * `writeSlugToUrl` never trigger it.
+ *
+ * The listener may be attached to the top window while the app lives in an
+ * iframe. The dashboard (Turbo) can replace the iframe without unmounting
+ * React, so `pagehide` also detaches the listener to avoid leaking it on the
+ * top window, and `pageshow` reattaches it on back/forward cache restores.
  */
 export function onSlugChange(listener: () => void): () => void {
   const target = addressBarWindow();
-  target.addEventListener('hashchange', listener);
-  return () => target.removeEventListener('hashchange', listener);
+  const attach = () => target.addEventListener('hashchange', listener);
+  const detach = () => target.removeEventListener('hashchange', listener);
+  attach();
+  window.addEventListener('pagehide', detach);
+  window.addEventListener('pageshow', attach);
+  return () => {
+    detach();
+    window.removeEventListener('pagehide', detach);
+    window.removeEventListener('pageshow', attach);
+  };
 }
 
 export function readSlugFromUrl(): string | null {

--- a/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
@@ -1,0 +1,97 @@
+import { MiskRoute } from '@web-actions/api/responseTypes';
+
+export interface SlugIndex {
+  routeBySlug: Map<string, MiskRoute>;
+  slugByRoute: Map<MiskRoute, string>;
+}
+
+function simpleName(route: MiskRoute): string {
+  const parts = route.actionName.split('.');
+  return parts[parts.length - 1];
+}
+
+/**
+ * Assigns each route a unique, human-readable slug for use in the URL hash.
+ *
+ * The slug is the action's simple class name (e.g. `MyAction`). If multiple
+ * routes share a class name, the HTTP method is appended (e.g. `MyAction:GET`).
+ * If routes still collide, the path is appended (e.g. `MyAction:GET:/my/path`).
+ */
+export function buildSlugIndex(routes: MiskRoute[]): SlugIndex {
+  const byName = new Map<string, MiskRoute[]>();
+  for (const route of routes) {
+    const name = simpleName(route);
+    byName.set(name, [...(byName.get(name) ?? []), route]);
+  }
+
+  const routeBySlug = new Map<string, MiskRoute>();
+  const slugByRoute = new Map<MiskRoute, string>();
+  const assign = (slug: string, route: MiskRoute) => {
+    routeBySlug.set(slug, route);
+    slugByRoute.set(route, slug);
+  };
+
+  for (const [name, group] of byName) {
+    if (group.length === 1) {
+      assign(name, group[0]);
+      continue;
+    }
+    const byMethod = new Map<string, MiskRoute[]>();
+    for (const route of group) {
+      const key = `${name}:${route.httpMethod}`;
+      byMethod.set(key, [...(byMethod.get(key) ?? []), route]);
+    }
+    for (const [methodSlug, methodGroup] of byMethod) {
+      if (methodGroup.length === 1) {
+        assign(methodSlug, methodGroup[0]);
+      } else {
+        for (const route of methodGroup) {
+          assign(`${methodSlug}:${route.path}`, route);
+        }
+      }
+    }
+  }
+
+  return { routeBySlug, slugByRoute };
+}
+
+/**
+ * The app is rendered inside a same-origin iframe on the admin dashboard, so
+ * the URL shown in the browser belongs to the top window, not to this frame.
+ * Falls back to the current window if the top window is cross-origin (e.g.
+ * when embedded somewhere unexpected).
+ */
+function addressBarWindow(): Window {
+  try {
+    // Accessing location on a cross-origin window throws.
+    void window.top!.location.href;
+    return window.top!;
+  } catch {
+    return window;
+  }
+}
+
+export function readSlugFromUrl(): string | null {
+  const hash = addressBarWindow().location.hash;
+  if (!hash || hash === '#') {
+    return null;
+  }
+  try {
+    return decodeURIComponent(hash.substring(1));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSlugToUrl(slug: string): void {
+  const target = addressBarWindow();
+  // `:` and `/` are valid in a URL fragment; keep them readable.
+  const encoded = encodeURIComponent(slug)
+    .replace(/%3A/gi, ':')
+    .replace(/%2F/gi, '/');
+  try {
+    target.history.replaceState(null, '', `#${encoded}`);
+  } catch {
+    // Deep linking is best-effort; never break selection over it.
+  }
+}

--- a/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
@@ -81,6 +81,18 @@ function addressBarWindow(): Window {
   }
 }
 
+/**
+ * Invokes the listener when the URL hash changes, e.g. when the user edits
+ * the address bar in place. Returns a cleanup function. Note that
+ * `history.replaceState` does not fire this event, so writes from
+ * `writeSlugToUrl` never trigger it.
+ */
+export function onSlugChange(listener: () => void): () => void {
+  const target = addressBarWindow();
+  target.addEventListener('hashchange', listener);
+  return () => target.removeEventListener('hashchange', listener);
+}
+
 export function readSlugFromUrl(): string | null {
   const hash = addressBarWindow().location.hash;
   if (!hash || hash === '#') {

--- a/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
@@ -44,9 +44,19 @@ export function buildSlugIndex(routes: MiskRoute[]): SlugIndex {
     for (const [methodSlug, methodGroup] of byMethod) {
       if (methodGroup.length === 1) {
         assign(methodSlug, methodGroup[0]);
-      } else {
-        for (const route of methodGroup) {
-          assign(`${methodSlug}:${route.path}`, route);
+        continue;
+      }
+      const byPath = new Map<string, MiskRoute[]>();
+      for (const route of methodGroup) {
+        const key = `${methodSlug}:${route.path}`;
+        byPath.set(key, [...(byPath.get(key) ?? []), route]);
+      }
+      for (const [pathSlug, pathGroup] of byPath) {
+        // Routes that are still ambiguous (e.g. same action bound twice with
+        // different media types) get no slug: a link that could select the
+        // wrong action is worse than no link.
+        if (pathGroup.length === 1) {
+          assign(pathSlug, pathGroup[0]);
         }
       }
     }
@@ -90,7 +100,9 @@ export function writeSlugToUrl(slug: string): void {
     .replace(/%3A/gi, ':')
     .replace(/%2F/gi, '/');
   try {
-    target.history.replaceState(null, '', `#${encoded}`);
+    // Preserve the existing history state: the dashboard uses Turbo, which
+    // stores a restoration identifier there. Dropping it breaks Back/Forward.
+    target.history.replaceState(target.history.state, '', `#${encoded}`);
   } catch {
     // Deep linking is best-effort; never break selection over it.
   }

--- a/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
+++ b/misk-admin/web-actions/src/web-actions/utils/deepLink.ts
@@ -132,3 +132,16 @@ export function writeSlugToUrl(slug: string): void {
     // Deep linking is best-effort; never break selection over it.
   }
 }
+
+export function clearSlugFromUrl(): void {
+  const target = addressBarWindow();
+  try {
+    target.history.replaceState(
+      target.history.state,
+      '',
+      `${target.location.pathname}${target.location.search}`,
+    );
+  } catch {
+    // Deep linking is best-effort; never break selection over it.
+  }
+}


### PR DESCRIPTION
## Summary

The `/_admin/web-actions/` tab keeps the selected action only in component state, so a selection cannot be shared as a link. This change makes each action deeplinkable:

- When you select an action, the app writes a readable slug to the URL hash of the top window (e.g. `/_admin/web-actions/#MyAction`) via `history.replaceState`.
- When the page loads with a hash, the app resolves the slug and selects the matching action.
- When the hash changes on an open page (a URL-bar edit or back/forward navigation), a `hashchange` listener selects the matching action live, without a reload.

## Slug format

The slug is the action's simple class name. If two routes share a class name, the HTTP method is appended (`MyAction:GET`). If they still collide, the path is appended (`MyAction:GET:/my/path`). The slug index is built deterministically from the fetched metadata, so read and write always agree.

## Why the top window

The React app is served from `/_tab/web-actions/index.html` inside a same-origin iframe on the dashboard, so the address bar belongs to the top window. The code reads and writes `window.top.location`, and falls back to the current window if the top window is cross-origin. No server-side (Kotlin) change is needed.

## Testing

- Added unit tests for the slug index (unique names, method collision, path collision).
- `npm test`: 20 passed. `eslint` and `prettier` pass on the changed files. `webpack --mode production` builds.
- Verified in a browser against the `samples/exemplar` service dashboard at `localhost:8080`:
  - Loading `/_admin/web-actions/#DevCheckReloadAction` auto-selects the action.
  - Selecting a different action updates the URL to `#CronTabRunAction`.
  - Reloading with that URL restores the selection.
  - Editing the hash in the URL bar on an open page switches the selection live.
  - The browser back button restores the previous selection.

## Demo
https://github.com/user-attachments/assets/9d09c451-2985-495d-aee9-cf504e3e0584

