### PR TITLE
Add Hikari metrics tracker factory hook

### DIFF
--- a/misk-hibernate/api/misk-hibernate.api
+++ b/misk-hibernate/api/misk-hibernate.api
@@ -147,6 +147,7 @@ public class misk/hibernate/HibernateModule : misk/inject/KAbstractModule {
 	public final fun getReaderConfig ()Lmisk/jdbc/DataSourceConfig;
 	protected fun getReaderTransacterProvider ()Lcom/google/inject/Provider;
 	protected fun getTransacterProvider ()Lcom/google/inject/Provider;
+	public final fun withMetricsTrackerFactory (Lcom/zaxxer/hikari/metrics/MetricsTrackerFactory;)Lmisk/hibernate/HibernateModule;
 }
 
 public final class misk/hibernate/Id : java/io/Serializable, java/lang/Comparable {

--- a/misk-hibernate/build.gradle.kts
+++ b/misk-hibernate/build.gradle.kts
@@ -23,6 +23,7 @@ sourceSets {
 dependencies {
   api(libs.guava)
   api(libs.guice)
+  api(libs.hikariCp)
   api(libs.hibernate5Core)
   api(libs.jakartaInject)
   api(libs.hibernateJpaApi)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/HibernateModule.kt
@@ -2,6 +2,7 @@ package misk.hibernate
 
 import com.google.inject.Injector
 import com.google.inject.Provider
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
 import jakarta.inject.Inject
 import java.time.Clock
 import javax.persistence.OptimisticLockException
@@ -66,6 +67,8 @@ constructor(
   }
 
   val config = config.withDefaults()
+  private var metricsTrackerFactory: MetricsTrackerFactory? = null
+
   val readerConfig = readerConfig?.withDefaults()
 
   constructor(
@@ -134,6 +137,10 @@ constructor(
     jdbcModuleAlreadySetup = jdbcModuleAlreadySetup,
   )
 
+  fun withMetricsTrackerFactory(metricsTrackerFactory: MetricsTrackerFactory): HibernateModule = apply {
+    this.metricsTrackerFactory = metricsTrackerFactory
+  }
+
   override fun configure() {
     if (readerQualifier != null) {
       check(readerConfig != null) { "Reader not configured for datasource $readerQualifier" }
@@ -149,6 +156,7 @@ constructor(
           databasePool = databasePool,
           installHealthCheck = installHealthChecks,
           installSchemaMigrator = installSchemaMigrator,
+          metricsTrackerFactory = metricsTrackerFactory,
         )
       )
     }

--- a/misk-jdbc/api/misk-jdbc.api
+++ b/misk-jdbc/api/misk-jdbc.api
@@ -352,6 +352,7 @@ public final class misk/jdbc/DataSourceService : com/google/common/util/concurre
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lwisp/deployment/Deployment;Ljava/util/Set;Lmisk/jdbc/DatabasePool;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lwisp/deployment/Deployment;Ljava/util/Set;Lmisk/jdbc/DatabasePool;Lio/prometheus/client/CollectorRegistry;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lwisp/deployment/Deployment;Ljava/util/Set;Lmisk/jdbc/DatabasePool;Lio/prometheus/client/CollectorRegistry;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lwisp/deployment/Deployment;Ljava/util/Set;Lmisk/jdbc/DatabasePool;Lio/prometheus/client/CollectorRegistry;Lcom/zaxxer/hikari/metrics/MetricsTrackerFactory;)V
 	public fun config ()Lmisk/jdbc/DataSourceConfig;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljavax/sql/DataSource;
@@ -463,6 +464,7 @@ public final class misk/jdbc/JdbcModule : misk/inject/KAbstractModule {
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;Z)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;ZZ)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;ZZLcom/zaxxer/hikari/metrics/MetricsTrackerFactory;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;)V
 	public synthetic fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/reflect/KClass;Lmisk/jdbc/DataSourceConfig;Lmisk/jdbc/DatabasePool;Z)V

--- a/misk-jdbc/build.gradle.kts
+++ b/misk-jdbc/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
   implementation(libs.dockerTransportHttpClient)
   implementation(libs.dockerTransportCore)
-  implementation(libs.hikariCp)
+  api(libs.hikariCp)
   implementation(libs.loggingApi)
   implementation(libs.mysql)
   implementation(project(":misk-backoff"))

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/DataSourceService.kt
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.AbstractIdleService
 import com.google.inject.Provider
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
 import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
 import com.zaxxer.hikari.util.DriverDataSource
 import io.prometheus.client.CollectorRegistry
@@ -33,6 +34,20 @@ constructor(
   private val databasePool: DatabasePool,
   private val collectorRegistry: CollectorRegistry? = null,
 ) : AbstractIdleService(), DataSourceConnector, Provider<DataSource> {
+  private var metricsTrackerFactory: MetricsTrackerFactory? = null
+
+  constructor(
+    qualifier: KClass<out Annotation>,
+    baseConfig: DataSourceConfig,
+    deployment: Deployment,
+    dataSourceDecorators: Set<DataSourceDecorator>,
+    databasePool: DatabasePool,
+    collectorRegistry: CollectorRegistry?,
+    metricsTrackerFactory: MetricsTrackerFactory?,
+  ) : this(qualifier, baseConfig, deployment, dataSourceDecorators, databasePool, collectorRegistry) {
+    this.metricsTrackerFactory = metricsTrackerFactory
+  }
+
   private lateinit var config: DataSourceConfig
 
   /** The backing connection pool */
@@ -141,7 +156,9 @@ constructor(
         )
     }
 
-    collectorRegistry?.let { hikariConfig.metricsTrackerFactory = PrometheusMetricsTrackerFactory(it) }
+    (metricsTrackerFactory ?: collectorRegistry?.let(::PrometheusMetricsTrackerFactory))?.let {
+      hikariConfig.metricsTrackerFactory = it
+    }
 
     hikariDataSource = HikariDataSource(hikariConfig)
     _dataSource = decorate(hikariDataSource!!)

--- a/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
+++ b/misk-jdbc/src/main/kotlin/misk/jdbc/JdbcModule.kt
@@ -1,6 +1,7 @@
 package misk.jdbc
 
 import com.google.inject.Provider
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
 import io.opentracing.Tracer
 import io.prometheus.client.CollectorRegistry
 import jakarta.inject.Inject
@@ -41,6 +42,8 @@ constructor(
   private val installSchemaMigrator: Boolean = true,
 ) : KAbstractModule() {
   val config = config.withDefaults()
+  private var metricsTrackerFactory: MetricsTrackerFactory? = null
+
   val readerConfig = readerConfig?.withDefaults()
 
   constructor(
@@ -55,6 +58,19 @@ constructor(
     databasePool: DatabasePool = RealDatabasePool,
     installSchemaMigrator: Boolean = true,
   ) : this(qualifier, config, null, null, databasePool, true, installSchemaMigrator)
+
+  constructor(
+    qualifier: KClass<out Annotation>,
+    config: DataSourceConfig,
+    readerQualifier: KClass<out Annotation>?,
+    readerConfig: DataSourceConfig?,
+    databasePool: DatabasePool,
+    installHealthCheck: Boolean,
+    installSchemaMigrator: Boolean,
+    metricsTrackerFactory: MetricsTrackerFactory?,
+  ) : this(qualifier, config, readerQualifier, readerConfig, databasePool, installHealthCheck, installSchemaMigrator) {
+    this.metricsTrackerFactory = metricsTrackerFactory
+  }
 
   override fun configure() {
     if (readerQualifier != null) {
@@ -181,6 +197,7 @@ constructor(
               dataSourceDecorators = dataSourceDecoratorsProvider.get(),
               databasePool = databasePool,
               collectorRegistry = registry,
+              metricsTrackerFactory = metricsTrackerFactory,
             )
           }
         }

--- a/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
+++ b/misk-jdbc/src/test/kotlin/misk/jdbc/DataSourceTransactionIsolationTest.kt
@@ -1,6 +1,9 @@
 package misk.jdbc
 
 import com.google.inject.util.Modules
+import com.zaxxer.hikari.metrics.IMetricsTracker
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
+import com.zaxxer.hikari.metrics.PoolStats
 import jakarta.inject.Inject
 import java.sql.Connection
 import misk.MiskTestingServiceModule
@@ -30,6 +33,11 @@ class DataSourceTransactionIsolationTest {
       assertThat(connection.transactionIsolation).isEqualTo(Connection.TRANSACTION_READ_COMMITTED)
       assertThat(serverSessionIsolation(connection)).isEqualTo("READ-COMMITTED")
     }
+  }
+
+  @Test
+  fun `custom metrics tracker factory instruments the connection pool`() {
+    assertThat(module.metricsTrackerFactory.poolNames).contains("Movies")
   }
 
   @Test
@@ -109,19 +117,41 @@ class DataSourceTransactionIsolationTest {
   ) : Config
 
   class TransactionIsolationTestModule(private val appName: String) : KAbstractModule() {
+    val metricsTrackerFactory = RecordingMetricsTrackerFactory()
+
     override fun configure() {
       install(Modules.override(MiskTestingServiceModule()).with(FakeClockModule(), MockTracingBackendModule()))
       install(DeploymentModule(TESTING))
       val config = MiskConfig.load<RootConfig>(appName, TESTING)
 
       install(JdbcTestingModule(Movies::class))
-      install(JdbcModule(Movies::class, config.read_committed_data_source))
+      install(
+        JdbcModule(
+          qualifier = Movies::class,
+          config = config.read_committed_data_source,
+          readerQualifier = null,
+          readerConfig = null,
+          databasePool = RealDatabasePool,
+          installHealthCheck = true,
+          installSchemaMigrator = true,
+          metricsTrackerFactory = metricsTrackerFactory,
+        )
+      )
 
       install(JdbcTestingModule(Movies2::class))
       install(JdbcModule(Movies2::class, config.default_isolation_data_source))
 
       install(JdbcTestingModule(Movies3::class))
       install(JdbcModule(Movies3::class, config.per_transaction_data_source))
+    }
+  }
+
+  class RecordingMetricsTrackerFactory : MetricsTrackerFactory {
+    val poolNames = mutableListOf<String>()
+
+    override fun create(poolName: String, poolStats: PoolStats): IMetricsTracker {
+      poolNames += poolName
+      return object : IMetricsTracker {}
     }
   }
 }


### PR DESCRIPTION
## Description

Allow JDBC and Hibernate callers to supply a Hikari `MetricsTrackerFactory`. Existing callers retain the Prometheus tracker by default; consumers that need dual-write or alternate metrics backends can opt in without replacing Misk's datasource service.

The Hibernate API uses a fluent method so subclasses such as `LoadSheddingHibernateModule` retain their concrete construction path.

## Testing Strategy

- `bin/gradle :misk-jdbc:test --tests misk.jdbc.DataSourceTransactionIsolationTest`
- `bin/gradle :misk-jdbc:apiCheck :misk-hibernate:apiCheck`
- Compiled cash-server Skim and RoundTable against this checkout with Gradle composite substitution.

## Rollout Strategy and Risk Mitigation

No behavior changes for existing callers: Misk still installs `PrometheusMetricsTrackerFactory` unless a caller explicitly supplies a factory. After this merges and publishes, cash-server will pin the release and opt Skim Hibernate pools into its dual-write Prometheus/OpenTelemetry factory.

## Checklist

- [x] I have reviewed this PR with relevant experts and/or impacted teams.
- [x] I have added tests to have confidence my changes work as expected.
- [x] I have a rollout plan that minimizes risks and includes monitoring for potential issues.