### PR TITLE
Prepopulate web-actions request body from last submit

### DIFF
--- a/misk-admin/web-actions/src/web-actions/hooks/useSubmitRequest.ts
+++ b/misk-admin/web-actions/src/web-actions/hooks/useSubmitRequest.ts
@@ -5,6 +5,7 @@ import {
   JsonValidationError,
 } from '@web-actions/services/ApiService';
 import { APP_EVENTS, appEvents } from '@web-actions/events/appEvents';
+import { saveRequestBody } from '@web-actions/storage/RequestBodyStore';
 import { Header } from 'src/viewState';
 
 export interface SubmitRequestState {
@@ -29,13 +30,17 @@ export function useSubmitRequest(
 
     setLoading(true);
     try {
+      const requestBody = getRequestBody();
       const response = await ApiService.submitRequest({
         route: selectedCallable,
         path: path,
-        requestBody: getRequestBody(),
+        requestBody: requestBody,
         headers: headers,
       });
 
+      if (selectedCallable.httpMethod !== 'GET') {
+        saveRequestBody(selectedCallable, requestBody);
+      }
       setResponse(response);
     } catch (e) {
       if (e instanceof JsonValidationError) {

--- a/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
@@ -1,7 +1,7 @@
 import { MiskRoute } from '@web-actions/api/responseTypes';
 
 const KEY_PREFIX = 'web-actions.lastBody.v1';
-const MAX_BODY_LENGTH = 100 * 1024;
+const MAX_BODY_LENGTH = 100 * 1024; // 100 KiB
 
 function keyFor(route: MiskRoute): string {
   return `${KEY_PREFIX}::${route.httpMethod} ${route.path}`;

--- a/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
@@ -3,13 +3,13 @@ import { MiskRoute } from '@web-actions/api/responseTypes';
 const KEY_PREFIX = 'web-actions.lastBody.v1';
 const MAX_BODY_LENGTH = 100 * 1024; // 100 KiB
 
-function keyFor(route: MiskRoute): string {
+function storageKeyFor(route: MiskRoute): string {
   return `${KEY_PREFIX}::${route.httpMethod} ${route.path}`;
 }
 
 export function getSavedRequestBody(route: MiskRoute): string | null {
   try {
-    return localStorage.getItem(keyFor(route));
+    return localStorage.getItem(storageKeyFor(route));
   } catch {
     return null;
   }
@@ -24,7 +24,7 @@ export function saveRequestBody(route: MiskRoute, body: string) {
     return;
   }
   try {
-    localStorage.setItem(keyFor(route), body);
+    localStorage.setItem(storageKeyFor(route), body);
   } catch {
     // localStorage can be unavailable or full; losing the saved body is fine.
   }
@@ -32,7 +32,7 @@ export function saveRequestBody(route: MiskRoute, body: string) {
 
 export function removeSavedRequestBody(route: MiskRoute) {
   try {
-    localStorage.removeItem(keyFor(route));
+    localStorage.removeItem(storageKeyFor(route));
   } catch {
     // Ignore; see saveRequestBody.
   }

--- a/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
@@ -1,0 +1,39 @@
+import { MiskRoute } from '@web-actions/api/responseTypes';
+
+const KEY_PREFIX = 'web-actions.lastBody.v1';
+const MAX_BODY_LENGTH = 100 * 1024;
+
+function keyFor(route: MiskRoute): string {
+  return `${KEY_PREFIX}::${route.httpMethod} ${route.path}`;
+}
+
+export function getSavedRequestBody(route: MiskRoute): string | null {
+  try {
+    return localStorage.getItem(keyFor(route));
+  } catch {
+    return null;
+  }
+}
+
+export function saveRequestBody(route: MiskRoute, body: string) {
+  if (body.trim() === '') {
+    removeSavedRequestBody(route);
+    return;
+  }
+  if (body.length > MAX_BODY_LENGTH) {
+    return;
+  }
+  try {
+    localStorage.setItem(keyFor(route), body);
+  } catch {
+    // localStorage can be unavailable or full; losing the saved body is fine.
+  }
+}
+
+export function removeSavedRequestBody(route: MiskRoute) {
+  try {
+    localStorage.removeItem(keyFor(route));
+  } catch {
+    // Ignore; see saveRequestBody.
+  }
+}

--- a/misk-admin/web-actions/src/web-actions/storage/__test__/RequestBodyStore.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/__test__/RequestBodyStore.spec.ts
@@ -1,0 +1,63 @@
+import {
+  getSavedRequestBody,
+  removeSavedRequestBody,
+  saveRequestBody,
+} from '@web-actions/storage/RequestBodyStore';
+import { MiskRoute } from '@web-actions/api/responseTypes';
+
+function fakeRoute(httpMethod: string, path: string): MiskRoute {
+  return { httpMethod, path } as MiskRoute;
+}
+
+describe('RequestBodyStore', () => {
+  const store = new Map<string, string>();
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => store.set(key, value),
+        removeItem: (key: string) => store.delete(key),
+      },
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('returns the saved body for the same method and path', () => {
+    const route = fakeRoute('POST', '/things');
+    saveRequestBody(route, '{"a": 1}');
+    expect(getSavedRequestBody(route)).toBe('{"a": 1}');
+  });
+
+  it('keeps bodies separate by method and path', () => {
+    saveRequestBody(fakeRoute('POST', '/things'), '{"a": 1}');
+    saveRequestBody(fakeRoute('PUT', '/things'), '{"b": 2}');
+    expect(getSavedRequestBody(fakeRoute('POST', '/things'))).toBe('{"a": 1}');
+    expect(getSavedRequestBody(fakeRoute('PUT', '/things'))).toBe('{"b": 2}');
+    expect(getSavedRequestBody(fakeRoute('POST', '/other'))).toBeNull();
+  });
+
+  it('removes the saved body when an empty body is saved', () => {
+    const route = fakeRoute('POST', '/things');
+    saveRequestBody(route, '{"a": 1}');
+    saveRequestBody(route, '  ');
+    expect(getSavedRequestBody(route)).toBeNull();
+  });
+
+  it('does not save bodies larger than 100 KB', () => {
+    const route = fakeRoute('POST', '/things');
+    saveRequestBody(route, 'x'.repeat(100 * 1024 + 1));
+    expect(getSavedRequestBody(route)).toBeNull();
+  });
+
+  it('removes the saved body', () => {
+    const route = fakeRoute('POST', '/things');
+    saveRequestBody(route, '{"a": 1}');
+    removeSavedRequestBody(route);
+    expect(getSavedRequestBody(route)).toBeNull();
+  });
+});

--- a/misk-admin/web-actions/src/web-actions/ui/RequestEditor.tsx
+++ b/misk-admin/web-actions/src/web-actions/ui/RequestEditor.tsx
@@ -4,10 +4,14 @@ import ace from 'ace-builds/src-noconflict/ace';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import { ContextAwareCompleter } from '@web-actions/ui/ContextAwareCompleter';
 import { Box, IconButton, Spinner } from '@chakra-ui/react';
-import { CopyIcon } from '@chakra-ui/icons';
+import { CopyIcon, RepeatIcon } from '@chakra-ui/icons';
 import { parseDocument } from '@web-actions/parsing/CommandParser';
 import { MiskFieldDefinition, MiskRoute } from '@web-actions/api/responseTypes';
 import { appEvents, APP_EVENTS } from '@web-actions/events/appEvents';
+import {
+  getSavedRequestBody,
+  removeSavedRequestBody,
+} from '@web-actions/storage/RequestBodyStore';
 
 interface Props {
   display: string;
@@ -23,6 +27,7 @@ export default class RequestEditor extends React.Component<Props, State> {
   public refEditor: HTMLElement | null = null;
   public editor: Ace.Editor | null = null;
   private errorMarkers: number[] = [];
+  private selectedRoute: MiskRoute | null = null;
 
   private readonly completer;
 
@@ -31,6 +36,7 @@ export default class RequestEditor extends React.Component<Props, State> {
     this.state = { isDisabled: false };
 
     this.copyToClipboard = this.copyToClipboard.bind(this);
+    this.resetToDefault = this.resetToDefault.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.completer = new ContextAwareCompleter();
   }
@@ -161,6 +167,7 @@ export default class RequestEditor extends React.Component<Props, State> {
   public setEndpointSelection(action: MiskRoute | undefined) {
     this.completer.setSelection(action ?? null);
     this.editor?.clearSelection();
+    this.selectedRoute = action ?? null;
 
     if (action === undefined) {
       return;
@@ -179,7 +186,8 @@ export default class RequestEditor extends React.Component<Props, State> {
         isDisabled: false,
       });
       this.editor?.setReadOnly(false);
-      const requestBody = this.generateRequestBody(action!);
+      const requestBody =
+        getSavedRequestBody(action) ?? this.generateRequestBody(action);
       this.editor?.setValue(requestBody, -1);
       const lines = this.editor?.session.getLength();
       if (lines) {
@@ -187,6 +195,16 @@ export default class RequestEditor extends React.Component<Props, State> {
       }
       this.editor?.focus();
     }
+  }
+
+  private resetToDefault() {
+    const route = this.selectedRoute;
+    if (!route || route.httpMethod === 'GET') {
+      return;
+    }
+    removeSavedRequestBody(route);
+    this.editor?.setValue(this.generateRequestBody(route), -1);
+    this.editor?.focus();
   }
 
   public focusEditor() {
@@ -276,6 +294,18 @@ export default class RequestEditor extends React.Component<Props, State> {
           onClick={this.copyToClipboard}
         >
           <CopyIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Reset to default request body"
+          title="Reset to default request body"
+          zIndex="100"
+          position="absolute"
+          top="16"
+          right="4"
+          colorScheme={'blackAlpha'}
+          onClick={this.resetToDefault}
+        >
+          <RepeatIcon />
         </IconButton>
         <Box
           width="100%"


### PR DESCRIPTION
## Why
In the admin Web Actions tab, the request editor always starts from a generated skeleton. Users who call the same action repeatedly retype or re-paste the same JSON body each time.

## What
- Save the last JSON body for each action (keyed by HTTP method + path) to localStorage after a submit
- Prepopulate the editor with the saved body when the action is selected again; fall back to the generated skeleton
- Add a reset button to the editor that restores the skeleton and clears the saved entry
- Skip saving for GET actions, empty bodies, and bodies larger than 100 KB; invalid JSON never reaches the save because validation throws first

## Risk Assessment
Low. The change is limited to the admin dashboard Web Actions UI; localStorage failures are caught and fall back to current behavior.

Linear: HOOD-4592

Generated with [Amp](https://ampcode.com)