### PR TITLE
Scope saved web-actions request bodies by action and expire after 7 days

### DIFF
--- a/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/RequestBodyStore.ts
@@ -1,21 +1,75 @@
 import { MiskRoute } from '@web-actions/api/responseTypes';
 
-const KEY_PREFIX = 'web-actions.lastBody.v1';
+const KEY_PREFIX = 'web-actions.lastBody.v2';
+const LEGACY_KEY_PREFIXES = ['web-actions.lastBody.v1'];
 const MAX_BODY_LENGTH = 100 * 1024; // 100 KiB
+const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface SavedBody {
+  savedAt: number;
+  body: string;
+}
 
 function storageKeyFor(route: MiskRoute): string {
-  return `${KEY_PREFIX}::${route.httpMethod} ${route.path}`;
+  return `${KEY_PREFIX}::${route.httpMethod} ${route.path} ${route.actionName}`;
+}
+
+function removeStaleEntries() {
+  try {
+    const staleKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key === null) {
+        continue;
+      }
+      if (LEGACY_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        staleKeys.push(key);
+      } else if (key.startsWith(KEY_PREFIX) && parseEntry(key) === null) {
+        staleKeys.push(key);
+      }
+    }
+    staleKeys.forEach((key) => localStorage.removeItem(key));
+  } catch {
+    // localStorage can be unavailable; skipping cleanup is fine.
+  }
+}
+
+function parseEntry(key: string): SavedBody | null {
+  const raw = localStorage.getItem(key);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const entry = JSON.parse(raw) as SavedBody;
+    if (
+      typeof entry.savedAt !== 'number' ||
+      typeof entry.body !== 'string' ||
+      Date.now() - entry.savedAt > TTL_MS
+    ) {
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
 }
 
 export function getSavedRequestBody(route: MiskRoute): string | null {
   try {
-    return localStorage.getItem(storageKeyFor(route));
+    const key = storageKeyFor(route);
+    const entry = parseEntry(key);
+    if (entry === null) {
+      localStorage.removeItem(key);
+      return null;
+    }
+    return entry.body;
   } catch {
     return null;
   }
 }
 
 export function saveRequestBody(route: MiskRoute, body: string) {
+  removeStaleEntries();
   if (body.trim() === '') {
     removeSavedRequestBody(route);
     return;
@@ -23,8 +77,9 @@ export function saveRequestBody(route: MiskRoute, body: string) {
   if (body.length > MAX_BODY_LENGTH) {
     return;
   }
+  const entry: SavedBody = { savedAt: Date.now(), body: body };
   try {
-    localStorage.setItem(storageKeyFor(route), body);
+    localStorage.setItem(storageKeyFor(route), JSON.stringify(entry));
   } catch {
     // localStorage can be unavailable or full; losing the saved body is fine.
   }

--- a/misk-admin/web-actions/src/web-actions/storage/__test__/RequestBodyStore.spec.ts
+++ b/misk-admin/web-actions/src/web-actions/storage/__test__/RequestBodyStore.spec.ts
@@ -5,9 +5,15 @@ import {
 } from '@web-actions/storage/RequestBodyStore';
 import { MiskRoute } from '@web-actions/api/responseTypes';
 
-function fakeRoute(httpMethod: string, path: string): MiskRoute {
-  return { httpMethod, path } as MiskRoute;
+function fakeRoute(
+  httpMethod: string,
+  path: string,
+  actionName: string = 'com.squareup.test.TestAction',
+): MiskRoute {
+  return { httpMethod, path, actionName } as MiskRoute;
 }
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 describe('RequestBodyStore', () => {
   const store = new Map<string, string>();
@@ -18,6 +24,10 @@ describe('RequestBodyStore', () => {
         getItem: (key: string) => store.get(key) ?? null,
         setItem: (key: string, value: string) => store.set(key, value),
         removeItem: (key: string) => store.delete(key),
+        key: (index: number) => Array.from(store.keys())[index] ?? null,
+        get length() {
+          return store.size;
+        },
       },
       configurable: true,
     });
@@ -25,20 +35,65 @@ describe('RequestBodyStore', () => {
 
   beforeEach(() => {
     store.clear();
+    jest.restoreAllMocks();
   });
 
-  it('returns the saved body for the same method and path', () => {
+  it('returns the saved body for the same route', () => {
     const route = fakeRoute('POST', '/things');
     saveRequestBody(route, '{"a": 1}');
     expect(getSavedRequestBody(route)).toBe('{"a": 1}');
   });
 
-  it('keeps bodies separate by method and path', () => {
-    saveRequestBody(fakeRoute('POST', '/things'), '{"a": 1}');
-    saveRequestBody(fakeRoute('PUT', '/things'), '{"b": 2}');
-    expect(getSavedRequestBody(fakeRoute('POST', '/things'))).toBe('{"a": 1}');
-    expect(getSavedRequestBody(fakeRoute('PUT', '/things'))).toBe('{"b": 2}');
+  it('keeps bodies separate by method, path, and action name', () => {
+    const jsonAction = fakeRoute('POST', '/things', 'com.squareup.test.A');
+    const otherAction = fakeRoute('POST', '/things', 'com.squareup.test.B');
+    saveRequestBody(jsonAction, '{"a": 1}');
+    saveRequestBody(otherAction, '{"b": 2}');
+    saveRequestBody(fakeRoute('PUT', '/things'), '{"c": 3}');
+    expect(getSavedRequestBody(jsonAction)).toBe('{"a": 1}');
+    expect(getSavedRequestBody(otherAction)).toBe('{"b": 2}');
+    expect(getSavedRequestBody(fakeRoute('PUT', '/things'))).toBe('{"c": 3}');
     expect(getSavedRequestBody(fakeRoute('POST', '/other'))).toBeNull();
+  });
+
+  it('expires bodies after seven days', () => {
+    const route = fakeRoute('POST', '/things');
+    const savedAt = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt);
+    saveRequestBody(route, '{"a": 1}');
+
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + SEVEN_DAYS_MS - 1);
+    expect(getSavedRequestBody(route)).toBe('{"a": 1}');
+
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + SEVEN_DAYS_MS + 1);
+    expect(getSavedRequestBody(route)).toBeNull();
+    expect(store.size).toBe(0);
+  });
+
+  it('removes legacy and expired entries on save', () => {
+    store.set('web-actions.lastBody.v1::POST /things', '{"a": 1}');
+    const expired = fakeRoute('POST', '/expired');
+    const savedAt = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt);
+    saveRequestBody(expired, '{"old": true}');
+
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + SEVEN_DAYS_MS + 1);
+    saveRequestBody(fakeRoute('POST', '/things'), '{"new": true}');
+
+    expect(store.has('web-actions.lastBody.v1::POST /things')).toBe(false);
+    expect(getSavedRequestBody(expired)).toBeNull();
+    expect(getSavedRequestBody(fakeRoute('POST', '/things'))).toBe(
+      '{"new": true}',
+    );
+    expect(store.size).toBe(1);
+  });
+
+  it('returns null for a corrupt entry', () => {
+    const route = fakeRoute('POST', '/things');
+    saveRequestBody(route, '{"a": 1}');
+    const key = Array.from(store.keys())[0];
+    store.set(key, 'not json');
+    expect(getSavedRequestBody(route)).toBeNull();
   });
 
   it('removes the saved body when an empty body is saved', () => {


### PR DESCRIPTION
## Why
Review follow-up from #3916. The storage key used only HTTP method + path, but Misk distinguishes routes by method + path + action name, so two actions on the same path could overwrite each other's saved bodies. Saved bodies also stayed in localStorage indefinitely, which retains sensitive test data longer than needed.

## What
- Include the qualified action name in the storage key
- Wrap the stored value in `{savedAt, body}` and expire entries after 7 days; expired or corrupt entries are removed on read
- Bump the key prefix to `v2` and remove orphaned `v1` entries on save
- Add tests for key collision, expiry, legacy cleanup, and corrupt entries

## Risk Assessment
Low. The change is limited to the admin dashboard Web Actions UI. The worst failure mode is a lost saved body, which falls back to the generated skeleton.

Linear: HOOD-4592

Generated with [Amp](https://ampcode.com)