### PR TITLE
misk-aws2-dynamodb: drop the v1 AWS SDK exception-mapper dependency

### DIFF
--- a/misk-aws2-dynamodb/build.gradle.kts
+++ b/misk-aws2-dynamodb/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
   implementation(libs.aws2Core)
   implementation(libs.aws2Regions)
   implementation(project(":misk-aws-api"))
-  implementation(project(":misk-exceptions-dynamodb"))
   implementation(project(":misk-service"))
 
   testFixturesApi(libs.aws2Dynamodb)
@@ -48,7 +47,6 @@ dependencies {
 
   testFixturesImplementation(libs.aws2Core)
   testFixturesImplementation(libs.aws2Regions)
-  testFixturesImplementation(project(":misk-exceptions-dynamodb"))
   testFixturesImplementation(project(":misk-service"))
 }
 

--- a/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
+++ b/misk-aws2-dynamodb/src/main/kotlin/misk/aws2/dynamodb/RealDynamoDbModule.kt
@@ -8,7 +8,6 @@ import kotlin.reflect.KClass
 import misk.ReadyService
 import misk.ServiceModule
 import misk.cloud.aws.AwsRegion
-import misk.exceptions.dynamodb.DynamoDbExceptionMapperModule
 import misk.inject.KAbstractModule
 import misk.inject.asSingleton
 import misk.inject.keyOf
@@ -98,8 +97,6 @@ constructor(
 
     bind(keyOf<DynamoDbService>(qualifier)).to(keyOf<RealDynamoDbService>(qualifier))
     install(ServiceModule<DynamoDbService>(qualifier).enhancedBy<ReadyService>())
-
-    install(DynamoDbExceptionMapperModule())
   }
 
   private fun createDynamoDbClient(


### PR DESCRIPTION
## What

Removes the v1 AWS SDK exception-mapper dependency (`misk-exceptions-dynamodb`) and the `install(DynamoDbExceptionMapperModule())` call from the **v2** module `misk-aws2-dynamodb`.

## Why it's safe

That module ships two `ExceptionMapper`s keyed on **v1** classes (`com.amazonaws...TransactionCanceledException`, `com.amazonaws...ClientExecutionTimeoutException`). A v2 `DynamoDbClient` only throws v2 types, and Misk matches mappers by exception class — so these could never fire on the v2 path. They were dead code here.

Removing them has no runtime effect and drops `aws-java-sdk-dynamodb` + `aws-java-sdk-core` (v1) from every v2 consumer's classpath. It was an `implementation` dep, so nothing downstream compiled against it; the v1 `misk-aws-dynamodb` module and `misk-exceptions-dynamodb` are untouched.