### PR TITLE
misk-grpc: bound inbound gRPC message size to prevent decompression-bomb OOM

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -644,10 +644,15 @@ public final class misk/grpc/GrpcKt {
 public final class misk/grpc/GrpcMessageSource : com/squareup/wire/MessageSource, java/io/Closeable {
 	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;)V
 	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;)V
-	public synthetic fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;J)V
+	public synthetic fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun read ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class misk/grpc/GrpcMessageTooLargeException : java/io/IOException {
+	public fun <init> (J)V
 }
 
 public final class misk/grpc/GrpcTimeoutMarshaller {
@@ -1452,7 +1457,8 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZI)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZ)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJ)V
-	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJ)V
+	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()Ljava/lang/Integer;
@@ -1495,13 +1501,14 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun component45 ()I
 	public final fun component46 ()Z
 	public final fun component47 ()J
+	public final fun component48 ()J
 	public final fun component5 ()Lmisk/web/GracefulShutdownConfig;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lmisk/web/WebSslConfig;
 	public final fun component8 ()Lmisk/web/WebUnixDomainSocketConfig;
 	public final fun component9 ()Z
-	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJ)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJIILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJ)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJIILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
@@ -1515,6 +1522,7 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun getEnable_thread_pool_queue_metrics ()Z
 	public final fun getGraceful_shutdown_config ()Lmisk/web/GracefulShutdownConfig;
 	public final fun getGrpcGzip ()Z
+	public final fun getGrpcMaxInboundMessageBytes ()J
 	public final fun getGzip ()Z
 	public final fun getHealth_dedicated_jetty_instance ()Z
 	public final fun getHealth_port ()I

--- a/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
@@ -30,11 +30,18 @@ internal class GrpcFeatureBinding(
   private val grpcMessageSourceChannelContext: CoroutineContext,
   private val grpcEncoding: String,
   private val minMessageToCompress: Long,
+  private val maxInboundMessageBytes: Long,
 ) : FeatureBinding {
 
   override fun beforeCall(subject: Subject) {
     val requestBody = subject.takeRequestBody()
-    val messageSource = GrpcMessageSource(requestBody, requestAdapter, subject.httpCall.requestHeaders["grpc-encoding"])
+    val messageSource =
+      GrpcMessageSource(
+        requestBody,
+        requestAdapter,
+        subject.httpCall.requestHeaders["grpc-encoding"],
+        maxInboundMessageBytes,
+      )
     // TODO: support the "grpc-accept-encoding" header
 
     if (streamingRequest) {
@@ -127,6 +134,8 @@ internal class GrpcFeatureBinding(
 
     private val minMessageToCompress = webConfig.minGzipSize.toLong()
 
+    private val maxInboundMessageBytes = webConfig.grpcMaxInboundMessageBytes
+
     override fun create(
       action: Action,
       pathPattern: PathPattern,
@@ -174,6 +183,7 @@ internal class GrpcFeatureBinding(
           grpcMessageSourceChannelContext = grpcMessageSourceChannelDispatcher,
           grpcEncoding = grpcEncoding,
           minMessageToCompress = minMessageToCompress,
+          maxInboundMessageBytes = maxInboundMessageBytes,
         )
       } else {
         @Suppress("UNCHECKED_CAST") // Assume it's a proto type.
@@ -186,6 +196,7 @@ internal class GrpcFeatureBinding(
           grpcMessageSourceChannelContext = grpcMessageSourceChannelDispatcher,
           grpcEncoding = grpcEncoding,
           minMessageToCompress = minMessageToCompress,
+          maxInboundMessageBytes = maxInboundMessageBytes,
         )
       }
     }

--- a/misk/src/main/kotlin/misk/grpc/GrpcMessageSource.kt
+++ b/misk/src/main/kotlin/misk/grpc/GrpcMessageSource.kt
@@ -23,6 +23,8 @@ constructor(
   private val source: BufferedSource,
   private val messageAdapter: ProtoAdapter<T>,
   private val grpcEncoding: String? = null,
+  // Defaults to gRPC's standard 4 MiB maximum inbound message size.
+  private val maxMessageBytes: Long = 4L * 1024 * 1024,
 ) : MessageSource<T>, Closeable by source {
   override fun read(): T? {
     if (source.exhausted()) return null
@@ -45,9 +47,17 @@ constructor(
 
     val encodedLength = source.readInt().toLong() and 0xffffffffL
 
+    // Reject an oversized frame before buffering it, and cap the decoded (post-decompression)
+    // message so a small compressed frame cannot inflate into a heap-exhausting message.
+    if (encodedLength > maxMessageBytes) {
+      throw GrpcMessageTooLargeException(maxMessageBytes)
+    }
+
     val encodedMessage = Buffer().write(source, encodedLength)
 
-    return messageDecoding.decode(encodedMessage).buffer().use { messageAdapter.decode(it) }
+    return LimitedSource(messageDecoding.decode(encodedMessage), maxMessageBytes).buffer().use {
+      messageAdapter.decode(it)
+    }
   }
 
   override fun toString() = "GrpcMessageSource"

--- a/misk/src/main/kotlin/misk/grpc/LimitedSource.kt
+++ b/misk/src/main/kotlin/misk/grpc/LimitedSource.kt
@@ -1,0 +1,29 @@
+package misk.grpc
+
+import java.io.IOException
+import okio.Buffer
+import okio.ForwardingSource
+import okio.Source
+
+/** Thrown when an inbound gRPC message exceeds the configured maximum size. */
+class GrpcMessageTooLargeException(maxMessageBytes: Long) :
+  IOException("gRPC message exceeds the maximum allowed size of $maxMessageBytes bytes")
+
+/**
+ * A [Source] that aborts with [GrpcMessageTooLargeException] once more than [maxBytes] bytes have been read from
+ * [delegate]. Because it counts bytes as they are produced, it bounds the memory a decompressing source (such as gzip)
+ * can allocate, preventing a small compressed frame from inflating into an out-of-memory-sized message.
+ */
+internal class LimitedSource(delegate: Source, private val maxBytes: Long) : ForwardingSource(delegate) {
+  private var bytesRead = 0L
+
+  override fun read(sink: Buffer, byteCount: Long): Long {
+    val read = super.read(sink, byteCount)
+    if (read == -1L) return -1L
+    bytesRead += read
+    if (bytesRead > maxBytes) {
+      throw GrpcMessageTooLargeException(maxBytes)
+    }
+    return read
+  }
+}

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -219,6 +219,13 @@ constructor(
 
   /** WebSocket idle timeout in seconds. Defaults to -1 (no timeout). */
   val websocket_idle_timeout_seconds: Long = -1,
+
+  /**
+   * The maximum size in bytes of a single inbound gRPC message. Decoding aborts if either the on-the-wire frame or the
+   * decoded message (after decompression) exceeds this limit, guarding against decompression bombs and
+   * oversized-message heap exhaustion. Defaults to gRPC's standard 4 MiB.
+   */
+  val grpcMaxInboundMessageBytes: Long = 4L * 1024 * 1024,
 ) : Config
 
 data class WebSslConfig

--- a/misk/src/test/kotlin/misk/grpc/GrpcMessageSourceSizeLimitTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcMessageSourceSizeLimitTest.kt
@@ -1,0 +1,56 @@
+package misk.grpc
+
+import com.squareup.protos.test.grpc.HelloRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import okio.Buffer
+import okio.ByteString.Companion.decodeHex
+import okio.GzipSink
+import okio.buffer
+import org.junit.jupiter.api.Test
+
+class GrpcMessageSourceSizeLimitTest {
+  /** A message within the limit still decodes normally. */
+  @Test
+  fun messageWithinLimitDecodes() {
+    val buffer = Buffer()
+    buffer.write("000000000b0a096c6f63616c686f7374".decodeHex())
+    val reader = GrpcMessageSource(buffer, HelloRequest.ADAPTER, maxMessageBytes = 11)
+
+    assertEquals(HelloRequest("localhost"), reader.read())
+  }
+
+  /** An oversized on-the-wire frame is rejected before it is buffered. */
+  @Test
+  fun oversizedFrameIsRejected() {
+    val buffer = Buffer()
+    buffer.writeByte(0) // identity
+    buffer.writeInt(0xff) // declared message length, larger than the limit below
+    val reader = GrpcMessageSource(buffer, HelloRequest.ADAPTER, maxMessageBytes = 8)
+
+    assertFailsWith<GrpcMessageTooLargeException> { reader.read() }
+  }
+
+  /**
+   * A small gzip frame that inflates past the limit is rejected while decompressing, rather than buffering the whole
+   * inflated message into heap.
+   */
+  @Test
+  fun decompressionBombIsRejected() {
+    val encoded = HelloRequest.ADAPTER.encode(HelloRequest("a".repeat(10_000)))
+
+    val gzipped = Buffer()
+    GzipSink(gzipped).buffer().use { it.write(encoded) }
+    val compressed = gzipped.readByteString()
+    // The compressed frame is tiny; only the decoded message exceeds the limit.
+    assert(compressed.size < 100)
+
+    val frame = Buffer()
+    frame.writeByte(1) // gzip
+    frame.writeInt(compressed.size)
+    frame.write(compressed)
+    val reader = GrpcMessageSource(frame, HelloRequest.ADAPTER, "gzip", maxMessageBytes = 100)
+
+    assertFailsWith<GrpcMessageTooLargeException> { reader.read() }
+  }
+}


### PR DESCRIPTION
## Problem

Misk's gRPC decode path streams inbound messages through an **uncapped gzip inflater** (`GzipGrpcDecoder` → bare `okio.GzipSource`) and then lets Wire's `ProtoAdapter.decode` buffer a length-delimited field whose declared length is client-controlled and unbounded. There is no `maxInboundMessageSize` equivalent anywhere on the path (`WebConfig` only caps the HTTP request line/headers).

As a result, a small gzip-compressed gRPC frame (~1.5 MB on the wire) can declare a ~1.5 GiB field backed by inflatable zeros; decoding it forces the server to buffer the whole inflated field into heap, producing an `OutOfMemoryError`. The amplification ratio (~1000:1) is tunable, so a request of roughly `heap / 1000` bytes exhausts any fixed heap.

The decode runs **before** the authorization interceptor:
- `GrpcFeatureBinding.beforeCall` reads/decodes the message (`BoundAction` runs `beforeCall` before the application-interceptor chain, and `AccessInterceptor` is an `ApplicationInterceptor`), so the cost is paid pre-auth on any non-streaming gRPC action.
- The reflection endpoint is auto-bound and `@Unauthenticated`, and calls `requests.read()` directly — reachable anonymously.

Standard gRPC (e.g. grpc-java) defends against exactly this with a default 4 MiB `maxInboundMessageSize` applied to both the on-wire frame and the decompressed message; Misk's hand-rolled gRPC codec had no equivalent.

## Fix

Enforce a configurable maximum inbound message size, defaulting to gRPC's standard **4 MiB**, mirroring grpc-java's two-layer check:

1. **On-the-wire frame cap** — `GrpcMessageSource.read()` rejects a frame whose declared length exceeds the limit *before* buffering it (like grpc-java's `processHeader` `nextFrameSize` check).
2. **Decompressed-size cap** — the decoded stream is wrapped in a new `LimitedSource` that counts bytes as they are produced and aborts with `GrpcMessageTooLargeException` once the decompressed message exceeds the limit (like grpc-java's `SizeEnforcingInputStream`). This bounds heap even when a tiny compressed frame inflates enormously.

Tunable via `WebConfig.grpcMaxInboundMessageBytes`.

## Behavior change

Previously there was **no** limit; now the default is 4 MiB on both the server (inbound requests) and the client (inbound responses), consistent with the gRPC ecosystem default. Services that legitimately send or receive gRPC messages larger than 4 MiB must raise `grpcMaxInboundMessageBytes`. Flagging for reviewer input on the default.

## Testing

- New `GrpcMessageSourceSizeLimitTest`: a within-limit message still decodes; an oversized on-wire frame is rejected before buffering; a small gzip frame that inflates past the limit is rejected while decompressing (the bomb scenario) rather than OOMing.
- Existing `misk-grpc-tests` end-to-end client/server suites pass (11/11).
- Pre-existing `misk-grpc-reflect` failures (`FRAME_SIZE_ERROR` on a ~4.7 MB reflection response) reproduce identically on the base commit and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)