### PR TITLE
Populate linkLayerLocalAddress on the WebSocket upgrade path

### DIFF
--- a/misk/src/main/kotlin/misk/web/jetty/JettyWebSocket.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/JettyWebSocket.kt
@@ -157,6 +157,11 @@ internal class JettyWebSocket(val request: JettyServerUpgradeRequest, val respon
       val httpCall =
         ServletHttpCall.create(
           request = request.httpServletRequest,
+          // Without this the upgrade's HttpCall reports a null linkLayerLocalAddress, unlike every ordinary request
+          // (WebActionsServlet.handleCall passes the same thing). Callers that authenticate on the transport a request
+          // arrived over -- a trusted Unix domain socket, or plaintext loopback from a service-mesh sidecar -- cannot
+          // distinguish "no address" from "untrusted address", so they reject every WebSocket upgrade.
+          linkLayerLocalAddress = extractLinkLayerLocalAddress(request.httpServletRequest),
           dispatchMechanism = DispatchMechanism.WEBSOCKET,
           upstreamResponse = realWebSocket.upstreamResponse(),
           webSocket = realWebSocket,

--- a/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
+++ b/misk/src/main/kotlin/misk/web/jetty/WebActionsServlet.kt
@@ -290,8 +290,10 @@ internal fun HttpServletRequest.dispatchMechanism(): DispatchMechanism? {
 }
 
 /** Extracts socket address information from an HttpServletRequest if available. */
-private fun extractLinkLayerLocalAddress(request: HttpServletRequest): SocketAddress? {
-  val jettyRequest = request as? Request ?: return null
+internal fun extractLinkLayerLocalAddress(request: HttpServletRequest): SocketAddress? {
+  // Not a plain cast: on the WebSocket upgrade path Jetty hands us a wrapper rather than the base Request, and a cast
+  // there silently yields null. getBaseRequest unwraps the ServletRequestWrapper chain.
+  val jettyRequest = Request.getBaseRequest(request) ?: return null
   val httpChannel = jettyRequest.httpChannel ?: return null
   val connector = httpChannel.connector ?: return null
 

--- a/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
+++ b/misk/src/test/kotlin/misk/web/WebSocketsTest.kt
@@ -6,6 +6,7 @@ import misk.MiskTestingServiceModule
 import misk.inject.KAbstractModule
 import misk.logging.LogCollector
 import misk.logging.LogCollectorModule
+import misk.scope.ActionScoped
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import misk.web.actions.WebAction
@@ -48,6 +49,24 @@ internal class WebSocketsTest {
       )
   }
 
+  /**
+   * A WebSocket upgrade must report the transport it arrived over, exactly as an ordinary request does. Authenticators
+   * that trust a request because it arrived on a Unix domain socket or on plaintext loopback from a sidecar read this
+   * value first; when it is null they cannot tell "no address" from "untrusted address" and reject the upgrade.
+   */
+  @Test
+  fun webSocketUpgradeReportsLinkLayerLocalAddress() {
+    val client = OkHttpClient()
+
+    val request = Request.Builder().url(jettyService.httpServerUrl.resolve("/socket-address")!!).build()
+
+    val webSocket = client.newWebSocket(request, listener)
+
+    webSocket.send("what transport did I arrive on?")
+    // The test server is a TCP connector, so a correctly populated call reports Network. Before the fix this was null.
+    assertThat(listener.takeMessage()).startsWith("Network:")
+  }
+
   @Test
   fun loggingDisabledByEnv() {
     val client = OkHttpClient()
@@ -69,6 +88,7 @@ internal class WebSocketsTest {
       install(MiskTestingServiceModule())
       install(LogCollectorModule())
       install(WebActionModule.create<EchoWebSocket>())
+      install(WebActionModule.create<SocketAddressWebSocket>())
     }
   }
 }
@@ -96,6 +116,29 @@ class EchoWebSocket @Inject constructor() : WebAction {
       }
 
       override fun toString() = "EchoListener"
+    }
+  }
+}
+
+/** Echoes back the transport the upgrade arrived on, so a test can assert the call carries one. */
+@Singleton
+class SocketAddressWebSocket
+@Inject
+constructor(private val clientHttpCall: @JvmSuppressWildcards ActionScoped<HttpCall>) : WebAction {
+  @ConnectWebSocket("/socket-address")
+  fun connect(@Suppress("UNUSED_PARAMETER") webSocket: WebSocket): WebSocketListener {
+    // Read during upgrade negotiation, which is when an authenticator would read it.
+    val address = clientHttpCall.get().linkLayerLocalAddress
+    val described =
+      when (address) {
+        null -> "null"
+        is SocketAddress.Network -> "Network:${address.port}"
+        is SocketAddress.Unix -> "Unix:${address.path}"
+      }
+    return object : WebSocketListener() {
+      override fun onMessage(webSocket: WebSocket, text: String) {
+        webSocket.send(described)
+      }
     }
   }
 }


### PR DESCRIPTION
An `HttpCall` built for a WebSocket upgrade reports a null `linkLayerLocalAddress`, while every ordinary request reports the real transport.

### Why it matters

Some `MiskCallerAuthenticator`s authenticate on the transport a request arrived over, and read that *before* they read any header: a request that arrived on a trusted Unix domain socket, or on plaintext loopback from a service-mesh sidecar, is trusted to carry identity headers, and one that arrived from anywhere else is not. That check has the shape

```kotlin
when (request.linkLayerLocalAddress) {
  is SocketAddress.Unix    -> /* trusted socket? */
  is SocketAddress.Network -> /* loopback from the sidecar, or a client cert? */
  else                     -> null   // ← null lands here
} ?: return null                     // ← no caller, before a single header is read
```

A null is indistinguishable from an untrusted address, so the authenticator resolves no caller and the upgrade is rejected as unauthenticated — even when it carries a complete identity and arrived on exactly the socket the authenticator trusts.

This is not hypothetical: it makes browser WebSockets unauthenticatable on any deployment using such an authenticator. Measured on one pod, one client, one minute:

```
ws-upgrade  linkLayerLocalAddress = null
plain GET   linkLayerLocalAddress = Unix(path=…)
```

Same connection, same headers, same trusted socket. Only the upgrade fails, and nothing outside misk can fix it.

### Two causes, both needed

1. `JettyWebSocket.Creator` never passed `linkLayerLocalAddress` to `ServletHttpCall.create` at all, so it took its null default. `WebActionsServlet.handleCall` passes it for every other dispatch mechanism.

2. `extractLinkLayerLocalAddress` reached the base Jetty `Request` with `request as? Request`. On the upgrade path Jetty hands the servlet a **wrapper** rather than the base `Request`, so the cast yields null and fix #1 alone changes nothing — the added test still failed. `Request.getBaseRequest` unwraps the `ServletRequestWrapper` chain and is what the servlet path should have been using regardless: an ordinary request behind any servlet filter that wraps has the same silent hole.

### Test

`WebSocketsTest.webSocketUpgradeReportsLinkLayerLocalAddress` opens a WebSocket against an action that reads `ActionScoped<HttpCall>.linkLayerLocalAddress` during upgrade negotiation — the same moment an authenticator would — and asserts it names the transport. It fails with only fix #1 applied, which is how cause #2 was found.

`./bin/gradle :misk:test --tests "misk.web.*"` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
