### PR TITLE
misk-hibernate: deny-by-default authorization in Database Query admin actions (FRAME-2262)

### DIFF
--- a/misk-admin/src/main/kotlin/misk/web/metadata/database/DatabaseQueryMetadata.kt
+++ b/misk-admin/src/main/kotlin/misk/web/metadata/database/DatabaseQueryMetadata.kt
@@ -13,6 +13,10 @@ constructor(
   val queryWebActionPath: String,
   val allowedCapabilities: Set<String> = setOf(),
   val allowedServices: Set<String> = setOf(),
+  /** When true, any authenticated service may run this query regardless of [allowedServices]. */
+  val allowAnyService: Boolean = false,
+  /** When true, any authenticated user may run this query regardless of [allowedCapabilities]. */
+  val allowAnyUser: Boolean = false,
   val accessAnnotation: String?,
   /** SQL table name */
   val table: String,
@@ -35,6 +39,8 @@ constructor(
     queryWebActionPath: String,
     allowedCapabilities: Set<String> = setOf(),
     allowedServices: Set<String> = setOf(),
+    allowAnyService: Boolean = false,
+    allowAnyUser: Boolean = false,
     accessAnnotation: KClass<out Annotation>? = null,
     table: String,
     entityClass: KClass<*>,
@@ -48,6 +54,8 @@ constructor(
     queryWebActionPath = queryWebActionPath,
     allowedCapabilities = allowedCapabilities,
     allowedServices = allowedServices,
+    allowAnyService = allowAnyService,
+    allowAnyUser = allowAnyUser,
     accessAnnotation = accessAnnotation?.simpleName,
     table = table,
     entityClass = entityClass.simpleName!!, // Assert not null, since this shouldn't be anonymous.

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryDynamicAction.kt
@@ -16,6 +16,7 @@ import misk.hibernate.Transacter
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.checkQueryMatchesAction
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.findDatabaseQueryRegistration
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.getTransacterForDatabaseQueryAction
+import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.isAuthorizedForQuery
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.validateSelectPathsOrDefault
 import misk.logging.getLogger
 import misk.scope.ActionScoped
@@ -54,7 +55,7 @@ constructor(
     val transacter = getTransacterForDatabaseQueryAction(injector, registration.entityClass)
 
     val results =
-      if (caller.isAllowed(metadata.allowedCapabilities, metadata.allowedServices)) {
+      if (isAuthorizedForQuery(caller, metadata)) {
         runDynamicQuery(transacter, caller.principal, request, registration)
       } else {
         throw UnauthorizedException("Unauthorized to query [dbEntity=${metadata.entityClass}]")

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryMetadataFactory.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryMetadataFactory.kt
@@ -23,6 +23,7 @@ import misk.hibernate.Session
 import misk.hibernate.actions.HibernateDatabaseQueryDynamicAction.Companion.HIBERNATE_QUERY_DYNAMIC_WEBACTION_PATH
 import misk.hibernate.actions.HibernateDatabaseQueryStaticAction.Companion.HIBERNATE_QUERY_STATIC_WEBACTION_PATH
 import misk.inject.typeLiteral
+import misk.logging.getLogger
 import misk.security.authz.AccessAnnotationEntry
 import misk.web.MiskWebFormBuilder.Companion.createEnumField
 import misk.web.MiskWebFormBuilder.Companion.createSyntheticEnumField
@@ -46,6 +47,19 @@ constructor(private val accessAnnotationEntries: List<AccessAnnotationEntry>) {
     val accessAnnotationEntry = accessAnnotationEntries.find { it.annotation == accessAnnotationClass }
     val allowedCapabilities = accessAnnotationEntry?.capabilities?.toSet() ?: setOf()
     val allowedServices = accessAnnotationEntry?.services?.toSet() ?: setOf()
+    val allowAnyService = accessAnnotationEntry?.allowAnyService ?: false
+    val allowAnyUser = accessAnnotationEntry?.allowAnyUser ?: false
+
+    // An access annotation that resolves to no access denies all queries for this entity. Warn so the missing
+    // AccessAnnotationEntry is discovered rather than silently locking the entity out.
+    if (allowedCapabilities.isEmpty() && allowedServices.isEmpty() && !allowAnyService && !allowAnyUser) {
+      logger.warn {
+        "Database Query entity [dbEntity=${dbEntityClass.simpleName}] uses access annotation " +
+          "[@${accessAnnotationClass.simpleName}] with no matching AccessAnnotationEntry (or an empty one). " +
+          "Queries for this entity will be denied. Register a multibind<AccessAnnotationEntry>() granting the " +
+          "required capabilities/services, or set allowAnyService/allowAnyUser to grant broad access explicitly."
+      }
+    }
 
     val constraintsResult = mutableListOf<Pair<Type, DatabaseQueryMetadata.ConstraintMetadata>>()
     val ordersResult = mutableListOf<Pair<Type, DatabaseQueryMetadata.OrderMetadata>>()
@@ -84,6 +98,8 @@ constructor(private val accessAnnotationEntries: List<AccessAnnotationEntry>) {
       queryWebActionPath = queryWebActionPath,
       allowedCapabilities = allowedCapabilities,
       allowedServices = allowedServices,
+      allowAnyService = allowAnyService,
+      allowAnyUser = allowAnyUser,
       accessAnnotation = accessAnnotationClass,
       table = table.name,
       entityClass = dbEntityClass,
@@ -259,6 +275,8 @@ constructor(private val accessAnnotationEntries: List<AccessAnnotationEntry>) {
     dbEntityClass.memberProperties.map { memberProperty -> memberProperty.name to memberProperty.returnType }.toMap()
 
   companion object {
+    private val logger = getLogger<HibernateDatabaseQueryMetadataFactory>()
+
     data class DynamicQueryConstraint(val path: String?, val operator: Operator?, val value: String?)
 
     data class DynamicQueryOrder(val path: String?, val ascending: Boolean? = false)

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryStaticAction.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryStaticAction.kt
@@ -18,6 +18,7 @@ import misk.hibernate.actions.HibernateDatabaseQueryMetadataFactory.Companion.QU
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.checkQueryMatchesAction
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.findDatabaseQueryRegistration
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.getTransacterForDatabaseQueryAction
+import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.isAuthorizedForQuery
 import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.validateSelectPathsOrDefault
 import misk.logging.getLogger
 import misk.scope.ActionScoped
@@ -57,7 +58,7 @@ constructor(
     val transacter = getTransacterForDatabaseQueryAction(injector, registration.entityClass)
 
     val results =
-      if (caller.isAllowed(metadata.allowedCapabilities, metadata.allowedServices)) {
+      if (isAuthorizedForQuery(caller, metadata)) {
         runStaticQuery(transacter, caller.principal, request, registration)
       } else {
         throw UnauthorizedException("Unauthorized to query [dbEntity=${metadata.entityClass}]")

--- a/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryWebActionModule.kt
+++ b/misk-hibernate/src/main/kotlin/misk/hibernate/actions/HibernateDatabaseQueryWebActionModule.kt
@@ -5,6 +5,7 @@ import javax.persistence.Transient
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.javaField
+import misk.MiskCaller
 import misk.exceptions.BadRequestException
 import misk.hibernate.DbEntity
 import misk.hibernate.Transacter
@@ -35,6 +36,19 @@ internal class HibernateDatabaseQueryWebActionModule : KAbstractModule() {
       if ((isDynamicAction && !isDynamicQuery) || (!isDynamicAction && isDynamicQuery)) {
         throw BadRequestException("[queryClass=$queryClass] $status a DynamicQuery and should be handled by $action")
       }
+    }
+
+    /**
+     * Deny-by-default per-entity authorization for the Database Query actions. Mirrors [AccessInterceptor]: an entity
+     * whose access annotation resolves to no capabilities/services (and no allowAny*) is denied rather than opened up
+     * to every `@AdminDashboardAccess` holder. Broad access must be granted explicitly via the bound
+     * `AccessAnnotationEntry` (capabilities/services, or `allowAnyService`/`allowAnyUser`).
+     */
+    fun isAuthorizedForQuery(caller: MiskCaller, metadata: DatabaseQueryMetadata): Boolean {
+      if (caller.allowAll) return true
+      if (metadata.allowAnyService && caller.service != null) return true
+      if (metadata.allowAnyUser && caller.user != null) return true
+      return caller.hasCapability(metadata.allowedCapabilities) || caller.isService(metadata.allowedServices)
     }
 
     /** Find the server-side registration (metadata + authoritative KClasses) for a request's query class */

--- a/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryAuthorizationTest.kt
+++ b/misk-hibernate/src/test/kotlin/misk/hibernate/actions/HibernateDatabaseQueryAuthorizationTest.kt
@@ -1,0 +1,73 @@
+package misk.hibernate.actions
+
+import misk.MiskCaller
+import misk.hibernate.DbMovie
+import misk.hibernate.actions.HibernateDatabaseQueryWebActionModule.Companion.isAuthorizedForQuery
+import misk.security.authz.AccessAnnotationEntry
+import misk.web.metadata.database.DatabaseQueryMetadata
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** Authorization semantics for the Database Query actions. See FRAME-2262. */
+class HibernateDatabaseQueryAuthorizationTest {
+  @Retention(AnnotationRetention.RUNTIME)
+  @Target(AnnotationTarget.FUNCTION)
+  annotation class MovieDatabaseAccess
+
+  private fun metadataFor(vararg entries: AccessAnnotationEntry): DatabaseQueryMetadata =
+    HibernateDatabaseQueryMetadataFactory(entries.toList()).fromQuery(DbMovie::class, null, MovieDatabaseAccess::class)
+
+  private fun user(vararg capabilities: String) = MiskCaller(user = "user", capabilities = capabilities.toSet())
+
+  private fun service(name: String) = MiskCaller(service = name)
+
+  @Test
+  fun `denies by default when the access annotation has no registered entry`() {
+    // Regression for FRAME-2262: a missing AccessAnnotationEntry resolves to empty sets, which used to
+    // fail open and grant read access to every @AdminDashboardAccess holder. It must now deny.
+    val metadata = metadataFor()
+    assertThat(metadata.allowedCapabilities).isEmpty()
+    assertThat(metadata.allowedServices).isEmpty()
+    assertThat(metadata.allowAnyService).isFalse()
+    assertThat(metadata.allowAnyUser).isFalse()
+
+    assertThat(isAuthorizedForQuery(user("admin_console"), metadata)).isFalse()
+    assertThat(isAuthorizedForQuery(service("some-service"), metadata)).isFalse()
+  }
+
+  @Test
+  fun `allows only callers holding a granted capability`() {
+    val metadata = metadataFor(AccessAnnotationEntry<MovieDatabaseAccess>(capabilities = listOf("movie_reader")))
+    assertThat(isAuthorizedForQuery(user("admin_console"), metadata)).isFalse()
+    assertThat(isAuthorizedForQuery(user("admin_console", "movie_reader"), metadata)).isTrue()
+  }
+
+  @Test
+  fun `allows only granted services`() {
+    val metadata = metadataFor(AccessAnnotationEntry<MovieDatabaseAccess>(services = listOf("payments")))
+    assertThat(isAuthorizedForQuery(service("fraud"), metadata)).isFalse()
+    assertThat(isAuthorizedForQuery(service("payments"), metadata)).isTrue()
+  }
+
+  @Test
+  fun `allowAnyUser grants any authenticated user but not services`() {
+    val metadata = metadataFor(AccessAnnotationEntry<MovieDatabaseAccess>(allowAnyUser = true))
+    assertThat(metadata.allowAnyUser).isTrue()
+    assertThat(isAuthorizedForQuery(user(), metadata)).isTrue()
+    assertThat(isAuthorizedForQuery(service("payments"), metadata)).isFalse()
+  }
+
+  @Test
+  fun `allowAnyService grants any service but not users`() {
+    val metadata = metadataFor(AccessAnnotationEntry<MovieDatabaseAccess>(allowAnyService = true))
+    assertThat(metadata.allowAnyService).isTrue()
+    assertThat(isAuthorizedForQuery(service("payments"), metadata)).isTrue()
+    assertThat(isAuthorizedForQuery(user("admin_console"), metadata)).isFalse()
+  }
+
+  @Test
+  fun `allowAll caller bypasses per-entity authorization`() {
+    val metadata = metadataFor()
+    assertThat(isAuthorizedForQuery(MiskCaller(service = "trusted", allowAll = true), metadata)).isTrue()
+  }
+}


### PR DESCRIPTION
## Summary

The Hibernate "Database Query" admin actions authorized with the deprecated `MiskCaller.isAllowed()`, which **returns `true` when both the allowed-capabilities and allowed-services sets are empty**. When an entity's access annotation has no matching `AccessAnnotationEntry` — a common `addEntityWithDynamicQuery<Entity, FooAccess>()` without the corresponding `multibind<AccessAnnotationEntry>()` — those sets are empty, so the entity's rows became **readable by any caller holding `@AdminDashboardAccess`** instead of being denied.

This is inconsistent with the primary `AccessInterceptor`, which fails **closed** for the same missing-entry condition. Fixes [FRAME-2262](https://linear.app/squareup/issue/FRAME-2262).

## Fix

- Authorize both query actions through a shared **deny-by-default** helper (`isAuthorizedForQuery`) that mirrors `AccessInterceptor`: empty capability/service sets deny.
- Thread `allowAnyService` / `allowAnyUser` from the `AccessAnnotationEntry` into `DatabaseQueryMetadata`, so a service that intentionally wants broad access can grant it **explicitly** (e.g. `AccessAnnotationEntry<FooAccess>(allowAnyUser = true)`) rather than relying on the fail-open hole. This matches how `AccessInterceptor` already removed the "empty = allow-all" footgun.
- `HibernateDatabaseQueryMetadataFactory` now **warns** when a registration resolves to no access, so a missing entry surfaces instead of silently locking the entity out.

## Does this break existing users?

For correctly-configured services, **no behavior change**:

- Entities on a **custom annotation with a bound `AccessAnnotationEntry`** (non-empty) — `isAllowed` and the new check are identical.
- Entities on the **default `NoAdminDashboardDatabaseAccess`** — `DatabaseDashboardTabModule` binds a non-empty default entry, so the set is never empty.

The only services whose behavior changes are the ones currently relying on the fail-open path — i.e. an access annotation with no (or empty) registered entry. That is exactly the vulnerable case, and it now denies. Such services have a one-line, explicit migration: bind an `AccessAnnotationEntry` with the required capabilities/services, or `allowAnyService`/`allowAnyUser` for broad access.

## Tests

`HibernateDatabaseQueryAuthorizationTest` covers:
- deny-by-default when the access annotation has no registered entry (regression for FRAME-2262)
- capability- and service-scoped grants
- `allowAnyUser` / `allowAnyService` explicit broad grants (and that they don't cross user/service)
- `allowAll` bypass

Existing `HibernateDatabaseQuery{Dynamic,Static}ActionTest` and `HibernateDatabaseQueryMetadataFactoryTest` still pass.

## Not included

`DashboardMetadataAction` uses the same deprecated `isAllowed` to decide dashboard **tab visibility** (not a data gate). Lower severity and a separate UX behavior change, so left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
