### PR TITLE
misk-grpc: raise default grpcMaxInboundMessageBytes to 1 GiB

### DIFF
--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -223,9 +223,11 @@ constructor(
   /**
    * The maximum size in bytes of a single inbound gRPC message. Decoding aborts if either the on-the-wire frame or the
    * decoded message (after decompression) exceeds this limit, guarding against decompression bombs and
-   * oversized-message heap exhaustion. Defaults to gRPC's standard 4 MiB.
+   * oversized-message heap exhaustion. Defaults to 1 GiB, which accepts large messages but provides little protection;
+   * set an explicit lower limit (gRPC's standard is 4 MiB) sized to the largest message a service legitimately
+   * receives.
    */
-  val grpcMaxInboundMessageBytes: Long = 4L * 1024 * 1024,
+  val grpcMaxInboundMessageBytes: Long = 1024L * 1024 * 1024,
 ) : Config
 
 data class WebSslConfig


### PR DESCRIPTION
## What

Change the default of `WebConfig.grpcMaxInboundMessageBytes` from **4 MiB** to **1 GiB** (`1024L * 1024 * 1024`).

## Why

The inbound gRPC message-size cap (added in #3920) defaulted to gRPC's standard 4 MiB. Misk's gRPC server previously enforced **no** inbound limit, so services that had organically grown to accept larger single messages (image/photo/document uploads, dispute evidence, etc.) would begin rejecting legitimate requests with `GrpcMessageTooLargeException` as soon as they picked up a Misk version containing the cap — with no code change on their side.

Raising the default lets services upgrade Misk without an immediate breakage, and lets them opt into a tighter, correctly-sized limit on their own schedule.

## ⚠️ Security note

**A 1 GiB default is permissive and provides little protection** against the decompression-bomb / oversized-message heap exhaustion that #3920 set out to prevent. It is a migration-friendly default, not a safe one. Services that want the guard should set `grpcMaxInboundMessageBytes` explicitly to the largest message they legitimately receive (gRPC's standard 4 MiB is a good starting point). The intent is to restore the 4 MiB default once known large-message services have set explicit overrides.

## Scope / safety

- Only the default value changes. Services already setting `grpcMaxInboundMessageBytes` explicitly are unaffected.
- Not an ABI change (default values aren't part of `misk.api`); no API file update needed.
- `GrpcMessageSource`'s own constructor fallback stays at 4 MiB (only used for direct construction; production flows through `WebConfig`).
- Existing `GrpcMessageSourceSizeLimitTest` uses explicit `maxMessageBytes` values, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)