### PR TITLE
misk-grpc: guard inbound gRPC decompression ratio on top of the size limit

### DIFF
--- a/misk/api/misk.api
+++ b/misk/api/misk.api
@@ -645,7 +645,8 @@ public final class misk/grpc/GrpcMessageSource : com/squareup/wire/MessageSource
 	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;)V
 	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;)V
 	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;J)V
-	public synthetic fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;JJ)V
+	public synthetic fun <init> (Lokio/BufferedSource;Lcom/squareup/wire/ProtoAdapter;Ljava/lang/String;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun read ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
@@ -1458,7 +1459,8 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZ)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJ)V
 	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJ)V
-	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJJ)V
+	public synthetic fun <init> (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()Ljava/lang/Integer;
@@ -1502,13 +1504,14 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun component46 ()Z
 	public final fun component47 ()J
 	public final fun component48 ()J
+	public final fun component49 ()J
 	public final fun component5 ()Lmisk/web/GracefulShutdownConfig;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lmisk/web/WebSslConfig;
 	public final fun component8 ()Lmisk/web/WebUnixDomainSocketConfig;
 	public final fun component9 ()Z
-	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJ)Lmisk/web/WebConfig;
-	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJIILjava/lang/Object;)Lmisk/web/WebConfig;
+	public final fun copy (IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJJ)Lmisk/web/WebConfig;
+	public static synthetic fun copy$default (Lmisk/web/WebConfig;IJIZLmisk/web/GracefulShutdownConfig;Ljava/lang/String;Lmisk/web/WebSslConfig;Lmisk/web/WebUnixDomainSocketConfig;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIIZLmisk/web/exceptions/ActionExceptionLogLevelConfig;Ljava/lang/Integer;DZZILjava/util/Map;ZLorg/slf4j/event/Level;Lmisk/web/ConcurrencyLimiterConfig;ILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;IIZZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZZLjava/util/List;Lmisk/web/RequestDeadlinesConfig;ZIZJJJIILjava/lang/Object;)Lmisk/web/WebConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptors ()Ljava/lang/Integer;
 	public final fun getAction_exception_log_level ()Lmisk/web/exceptions/ActionExceptionLogLevelConfig;
@@ -1522,6 +1525,7 @@ public final class misk/web/WebConfig : misk/config/Config {
 	public final fun getEnable_thread_pool_queue_metrics ()Z
 	public final fun getGraceful_shutdown_config ()Lmisk/web/GracefulShutdownConfig;
 	public final fun getGrpcGzip ()Z
+	public final fun getGrpcMaxDecompressionRatio ()J
 	public final fun getGrpcMaxInboundMessageBytes ()J
 	public final fun getGzip ()Z
 	public final fun getHealth_dedicated_jetty_instance ()Z

--- a/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
+++ b/misk/src/main/kotlin/misk/grpc/GrpcFeatureBinding.kt
@@ -31,6 +31,7 @@ internal class GrpcFeatureBinding(
   private val grpcEncoding: String,
   private val minMessageToCompress: Long,
   private val maxInboundMessageBytes: Long,
+  private val maxDecompressionRatio: Long,
 ) : FeatureBinding {
 
   override fun beforeCall(subject: Subject) {
@@ -41,6 +42,7 @@ internal class GrpcFeatureBinding(
         requestAdapter,
         subject.httpCall.requestHeaders["grpc-encoding"],
         maxInboundMessageBytes,
+        maxDecompressionRatio,
       )
     // TODO: support the "grpc-accept-encoding" header
 
@@ -136,6 +138,8 @@ internal class GrpcFeatureBinding(
 
     private val maxInboundMessageBytes = webConfig.grpcMaxInboundMessageBytes
 
+    private val maxDecompressionRatio = webConfig.grpcMaxDecompressionRatio
+
     override fun create(
       action: Action,
       pathPattern: PathPattern,
@@ -184,6 +188,7 @@ internal class GrpcFeatureBinding(
           grpcEncoding = grpcEncoding,
           minMessageToCompress = minMessageToCompress,
           maxInboundMessageBytes = maxInboundMessageBytes,
+          maxDecompressionRatio = maxDecompressionRatio,
         )
       } else {
         @Suppress("UNCHECKED_CAST") // Assume it's a proto type.
@@ -197,6 +202,7 @@ internal class GrpcFeatureBinding(
           grpcEncoding = grpcEncoding,
           minMessageToCompress = minMessageToCompress,
           maxInboundMessageBytes = maxInboundMessageBytes,
+          maxDecompressionRatio = maxDecompressionRatio,
         )
       }
     }

--- a/misk/src/main/kotlin/misk/grpc/GrpcMessageSource.kt
+++ b/misk/src/main/kotlin/misk/grpc/GrpcMessageSource.kt
@@ -25,6 +25,9 @@ constructor(
   private val grpcEncoding: String? = null,
   // Defaults to gRPC's standard 4 MiB maximum inbound message size.
   private val maxMessageBytes: Long = 4L * 1024 * 1024,
+  // Additional guard on top of maxMessageBytes: a decoded message may exceed a small floor only by this factor over
+  // its on-the-wire size, bounding gzip amplification. Defaults to 100:1.
+  private val maxDecompressionRatio: Long = 100,
 ) : MessageSource<T>, Closeable by source {
   override fun read(): T? {
     if (source.exhausted()) return null
@@ -55,7 +58,10 @@ constructor(
 
     val encodedMessage = Buffer().write(source, encodedLength)
 
-    return LimitedSource(messageDecoding.decode(encodedMessage), maxMessageBytes).buffer().use {
+    // Bound the decoded message by both the absolute size limit and the decompression-ratio guard, so a small
+    // compressed frame cannot inflate into a heap-exhausting message.
+    val maxDecodedBytes = minOf(maxMessageBytes, maxDecodedMessageBytes(encodedLength, maxDecompressionRatio))
+    return LimitedSource(messageDecoding.decode(encodedMessage), maxDecodedBytes).buffer().use {
       messageAdapter.decode(it)
     }
   }

--- a/misk/src/main/kotlin/misk/grpc/LimitedSource.kt
+++ b/misk/src/main/kotlin/misk/grpc/LimitedSource.kt
@@ -27,3 +27,23 @@ internal class LimitedSource(delegate: Source, private val maxBytes: Long) : For
     return read
   }
 }
+
+/** Messages decoding to at most this many bytes are always allowed, regardless of compression ratio. */
+internal const val GRPC_MIN_DECODED_MESSAGE_BYTES = 4L * 1024 * 1024
+
+/**
+ * The largest decoded message allowed for a frame of [compressedBytes] on the wire under [maxDecompressionRatio]. The
+ * decoded size may exceed [GRPC_MIN_DECODED_MESSAGE_BYTES] only by [maxDecompressionRatio] times the on-the-wire size,
+ * so a small compressed frame cannot inflate into a heap-exhausting message while genuinely large (low-ratio) payloads
+ * still pass. A [maxDecompressionRatio] below 1 is treated as 1, and an overflowing product is treated as unbounded.
+ */
+internal fun maxDecodedMessageBytes(compressedBytes: Long, maxDecompressionRatio: Long): Long {
+  val ratio = maxDecompressionRatio.coerceAtLeast(1L)
+  val scaled =
+    try {
+      Math.multiplyExact(compressedBytes, ratio)
+    } catch (e: ArithmeticException) {
+      Long.MAX_VALUE
+    }
+  return maxOf(GRPC_MIN_DECODED_MESSAGE_BYTES, scaled)
+}

--- a/misk/src/main/kotlin/misk/web/WebConfig.kt
+++ b/misk/src/main/kotlin/misk/web/WebConfig.kt
@@ -222,12 +222,19 @@ constructor(
 
   /**
    * The maximum size in bytes of a single inbound gRPC message. Decoding aborts if either the on-the-wire frame or the
-   * decoded message (after decompression) exceeds this limit, guarding against decompression bombs and
-   * oversized-message heap exhaustion. Defaults to 1 GiB, which accepts large messages but provides little protection;
-   * set an explicit lower limit (gRPC's standard is 4 MiB) sized to the largest message a service legitimately
-   * receives.
+   * decoded message (after decompression) exceeds this limit, guarding against oversized-message heap exhaustion.
+   * Defaults to 1 GiB, which accepts large messages but provides little protection; set an explicit lower limit (gRPC's
+   * standard is 4 MiB) sized to the largest message a service legitimately receives.
    */
   val grpcMaxInboundMessageBytes: Long = 1024L * 1024 * 1024,
+
+  /**
+   * An additional guard on top of [grpcMaxInboundMessageBytes]: the decoded size of a compressed inbound gRPC message
+   * may exceed a 4 MiB floor only by this factor over its on-the-wire size. This bounds gzip amplification so a tiny
+   * compressed frame cannot inflate into a heap-exhausting message even when [grpcMaxInboundMessageBytes] is large.
+   * Defaults to 100:1.
+   */
+  val grpcMaxDecompressionRatio: Long = 100,
 ) : Config
 
 data class WebSslConfig

--- a/misk/src/test/kotlin/misk/grpc/GrpcMessageSourceSizeLimitTest.kt
+++ b/misk/src/test/kotlin/misk/grpc/GrpcMessageSourceSizeLimitTest.kt
@@ -53,4 +53,63 @@ class GrpcMessageSourceSizeLimitTest {
 
     assertFailsWith<GrpcMessageTooLargeException> { reader.read() }
   }
+
+  /**
+   * The decompression-ratio guard rejects a bomb whose decoded size exceeds the 4 MiB floor, even when the absolute
+   * size cap is effectively unbounded.
+   */
+  @Test
+  fun decompressionGuardRejectsBombUnderLargeSizeCap() {
+    val encoded = HelloRequest.ADAPTER.encode(HelloRequest("a".repeat(5 * 1024 * 1024)))
+
+    val gzipped = Buffer()
+    GzipSink(gzipped).buffer().use { it.write(encoded) }
+    val compressed = gzipped.readByteString()
+    // The compressed frame is tiny; only the decoded message exceeds the 4 MiB floor.
+    assert(compressed.size.toLong() < GRPC_MIN_DECODED_MESSAGE_BYTES)
+
+    val frame = Buffer()
+    frame.writeByte(1) // gzip
+    frame.writeInt(compressed.size)
+    frame.write(compressed)
+    val reader =
+      GrpcMessageSource(
+        frame,
+        HelloRequest.ADAPTER,
+        "gzip",
+        maxMessageBytes = Long.MAX_VALUE,
+        maxDecompressionRatio = 100,
+      )
+
+    assertFailsWith<GrpcMessageTooLargeException> { reader.read() }
+  }
+
+  /** A decoded message up to the 4 MiB floor is always allowed, regardless of the ratio. */
+  @Test
+  fun ratioFloorAlwaysAllowsSmallMessages() {
+    assertEquals(
+      GRPC_MIN_DECODED_MESSAGE_BYTES,
+      maxDecodedMessageBytes(compressedBytes = 1, maxDecompressionRatio = 100),
+    )
+  }
+
+  /** Above the floor, the allowed decoded size scales with the compressed size. */
+  @Test
+  fun ratioScalesWithCompressedSize() {
+    val compressed = GRPC_MIN_DECODED_MESSAGE_BYTES
+    assertEquals(compressed * 100, maxDecodedMessageBytes(compressed, maxDecompressionRatio = 100))
+  }
+
+  /** A ratio below 1 is clamped to 1. */
+  @Test
+  fun ratioBelowOneIsClampedToOne() {
+    val compressed = 10L * 1024 * 1024
+    assertEquals(compressed, maxDecodedMessageBytes(compressed, maxDecompressionRatio = 0))
+  }
+
+  /** An overflowing product is treated as unbounded. */
+  @Test
+  fun ratioOverflowIsUnbounded() {
+    assertEquals(Long.MAX_VALUE, maxDecodedMessageBytes(compressedBytes = Long.MAX_VALUE, maxDecompressionRatio = 100))
+  }
 }


### PR DESCRIPTION
## What

Adds a **decompression-ratio guard** (`grpcMaxDecompressionRatio`, default `100`) as an *additional* bound on top of the existing absolute inbound message-size cap (`grpcMaxInboundMessageBytes`). Both limits apply independently.

The effective limit on a decoded message is:

```
min(grpcMaxInboundMessageBytes, max(4 MiB floor, compressedBytes × grpcMaxDecompressionRatio))
```

Decoding still rejects an oversized on-the-wire frame before buffering it, and now also aborts with `GrpcMessageTooLargeException` once a message inflates past the ratio bound — whichever limit is hit first.

## Why

The absolute size cap alone is a blunt instrument for a decompression-bomb defense: to allow a legitimately large payload you must raise the ceiling so high that a tiny compressed frame can still inflate into a huge heap allocation. Amplification (gzip up to ~1000:1), not absolute size, is what makes the bomb a cheap DoS.

Keeping the size cap and adding a ratio bound covers both axes:

- the **size cap** bounds the largest message a service will ever accept (per-service, legitimately varies); and
- the **ratio guard** bounds amplification, so a tiny frame that inflates 1000× is rejected even when the size cap is large — an attacker must actually send roughly as many bytes as they want allocated.

A 4 MiB floor keeps the ratio guard from rejecting small messages regardless of how well they compress. The uncompressed (`identity`) path is inherently 1:1 and self-limits.

## Notes

- Public API delta is additive: a new `grpcMaxDecompressionRatio` config field and a new `GrpcMessageSource` constructor overload (appended). The ratio math lives in an `internal` helper.
- Complementary hardening worth considering separately: enabling the concurrency limiter / load shedding, and refusing inbound gzip on services that don't need it.

## Testing

- Unit tests for the ratio/floor/overflow math.
- Integration tests through `GrpcMessageSource`: a normal message decodes, an oversized frame is rejected, a small gzip bomb is rejected mid-decompression under the size cap, and the ratio guard rejects a bomb even when the size cap is effectively unbounded.
- `:misk:apiCheck` and `:misk:test` (grpc) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)