### PR TITLE
Fix a race condition in TestDatabasePool

### DIFF
--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/MySqlTestDatabasePoolBackend.kt
@@ -53,6 +53,6 @@ class MySqlTestDatabasePoolBackend @Inject constructor(val config: DataSourceCon
   }
 
   private fun Connection.dropDatabase(name: String) {
-    return createStatement().use { statement -> statement.execute("DROP DATABASE $name") }
+    return createStatement().use { statement -> statement.execute("DROP DATABASE IF EXISTS $name") }
   }
 }

--- a/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
+++ b/misk-jdbc/src/testFixtures/kotlin/misk/jdbc/TestDatabasePool.kt
@@ -259,9 +259,7 @@ class TestDatabasePool(val backend: Backend, val clock: Clock, val retention: Du
     fun showDatabases(): Set<String>
 
     /**
-     * Drops the indicated database from the data source.
-     *
-     * Throws [PersistenceException] if the database cannot be dropped (i.e. it does not exist).
+     * Drops the indicated database from the data source, if it exists.
      */
     fun dropDatabase(name: String)
 


### PR DESCRIPTION
Tests running in parallel could try to drop the same database.