### PR TITLE
Bump Wire to 7.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ protobuf = "3.25.8"
 retrofit = "3.0.0"
 sqldelight = "2.1.0"
 tempest = "2026.03.24.151442-d6de1b3"
-wire = "7.0.0-alpha09"
+wire = "7.0.1"
 
 [libraries]
 apacheCommonsIo = { module = "commons-io:commons-io", version = "2.20.0" }


### PR DESCRIPTION
Bumps Wire from 7.0.0-alpha09 to 7.0.1.

Release: https://github.com/square/wire/releases/tag/7.0.1

Wire 7.0.0 shipped kotlinpoet 2.4.0, which is built with Kotlin 2.4. Misk compiles with Kotlin 2.2 and cannot read Kotlin 2.4 class metadata. Wire 7.0.1 reverts kotlinpoet to 2.3.0 (square/wire#3716), so no workaround is needed here. An earlier revision of this PR forced kotlinpoet to 2.3.0; the force is gone.

## Verification

Local, at this head:

- `:misk-grpc-reflect:compileKotlin` (kotlinpoet reaches its compile classpath through wire-schema): BUILD SUCCESSFUL.
- `dependencyInsight`: wire-runtime resolves 7.0.1 on `:misk-grpc-reflect` compileClasspath; kotlinpoet resolves 2.3.0 natively, no force.
